### PR TITLE
EN-487 : Enable linting of code and css on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,101 +1,104 @@
-defaults: &defaults
-  docker:
-    - image: circleci/node:10.15.2
-  working_directory: ~/repo
+version: 2.1
 
-version: 2
+commands:
+  dependencies:
+    description: 'Load dependency cache, get dependencies and update cache'
+    steps:
+      - restore_cache:
+          keys:
+            - yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - yarn-packages-v1-{{ .Branch }}-
+            - yarn-packages-v1-
+      - run: yarn install --frozen-lockfile
+      - save_cache:
+          paths:
+            - ~/.cache/yarn
+          key: yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
+
+executors:
+  node:
+    docker:
+      - image: circleci/node:10.15.3
 
 jobs:
-  build:
-    <<: *defaults
-    environment:
-      NODE_ENV: development
+  lint_css-framework:
+    executor: node
     steps:
       - checkout
-
-      - run:
-          name: Install
-          command: yarn install
-
-      - run:
-          name: Lint
-          command: yarn run lint
-
-      - run:
-          name: Run Tests
-          command: yarn run test:ci
-
+      - dependencies
+      - run: mkdir -p test-results/stylelint
+      - run: yarn --silent stylelint --custom-formatter './node_modules/stylelint-junit-formatter/index.js' ./packages/css-framework/index.scss > test-results/stylelint/results.xml
       - store_test_results:
           path: test-results
-  build-react-storybook:
-    <<: *defaults
+      - store_artifacts:
+          path: test-results
+  lint_html-storybook:
+    executor: node
     steps:
       - checkout
+      - dependencies
+      - run: mkdir -p test-results/eslint
       - run:
-          name: Build storybook
-          command: |
-            cd packages/react-component-library
-            yarn install
-            yarn run build-storybook-prod
-      - persist_to_workspace:
-          root: ~/repo
-          paths: 
-            - packages/react-component-library/public
-  deploy-react-storybook:
-    <<: *defaults
-    steps:
-      - checkout:
-          path: ~/repo
-      - attach_workspace:
-          at: ~/repo
-      - run:
-          name: Install Firebase tools
-          command: cd packages/react-component-library && yarn add firebase-tools
-      - run:
-          name: Deploy to Firebase
-          command: cd packages/react-component-library && ./node_modules/.bin/firebase deploy --token=$FIREBASE_DEPLOY_SB_REACT
-  build-vue-storybook:
-    <<: *defaults
+          name: Lint
+          environment:
+            ESLINT_JUNIT_OUTPUT: test-results/eslint/html-storybook-results.xml
+          command: yarn eslint -f ./node_modules/eslint-junit/index.js packages/html-storybook/src
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: test-results
+  lint_react-component-library:
+    executor: node
     steps:
       - checkout
+      - dependencies
+      - run: mkdir -p test-results/eslint
+      - run:
+          name: Lint
+          environment:
+            ESLINT_JUNIT_OUTPUT: test-results/eslint/react-component-results.xml
+          command: yarn eslint -f ./node_modules/eslint-junit/index.js packages/react-component-library/src
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: test-results
+  lint_storybook-react-input-state:
+    executor: node
+    steps:
+      - checkout
+      - dependencies
+      - run: mkdir -p test-results/eslint
+      - run:
+          name: Lint
+          environment:
+            ESLINT_JUNIT_OUTPUT: test-results/eslint/storybook-react-input-state-results.xml
+          command: yarn eslint -f ./node_modules/eslint-junit/index.js packages/storybook-react-input-state/src
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: test-results
+  lint_vue-component-library:
+    executor: node
+    steps:
+      - checkout
+      - dependencies
+      - run: mkdir -p test-results/eslint
+      - run:
+          name: Lint
+          environment:
+            ESLINT_JUNIT_OUTPUT: test-results/eslint/vue-component-results.xml
+          command: yarn eslint -f ./node_modules/eslint-junit/index.js packages/vue-component-library/src
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: test-results
 
-      - run:
-          name: Build storybook
-          command: |
-            cd packages/vue-component-library
-            yarn install
-            yarn run build-storybook-prod
-      - persist_to_workspace:
-          root: ~/repo
-          paths: 
-            - node_modules
-            - .static_storybook
-deploy-vue-storybook:
-    <<: *defaults
-    steps:
-      - checkout:
-          path: ~/repo
-      - attach_workspace:
-          at: ~/repo
-      - run:
-          name: Deploy Master to Firebase
-          command: ./node_modules/.bin/firebase deploy --token=$FIREBASE_DEPLOY_SB_VUE
 workflows:
   version: 2
-  build-and-deploy:
+  lint:
     jobs:
-      - build-react-storybook
-      - deploy-react-storybook:
-          requires:
-            - build-react-storybook
-          filters:
-            branches:
-              only: master
-      # Vue not ready yet 
-      # - build-vue-storybook
-      # - deploy-vue-storybook:
-      #     requires:
-      #       - build-vue-storybook
-      #     filters:
-      #       branches:
-      #         only: master
+      - lint_css-framework
+      - lint_html-storybook
+      - lint_react-component-library
+      - lint_storybook-react-input-state
+      - lint_vue-component-library

--- a/packages/css-framework/package.json
+++ b/packages/css-framework/package.json
@@ -37,6 +37,7 @@
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",
     "stylelint": "^9.10.1",
+    "stylelint-junit-formatter": "^0.2.1",
     "stylelint-webpack-plugin": "^0.10.5",
     "webpack": "^4.29.5",
     "webpack-cli": "^3.2.3",

--- a/packages/html-storybook/package.json
+++ b/packages/html-storybook/package.json
@@ -64,6 +64,7 @@
     "eslint": "^5.15.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-junit": "^1.0.1",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.12.4",

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -74,6 +74,7 @@
     "eslint": "^5.15.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-junit": "^1.0.1",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.12.4",

--- a/packages/storybook-react-input-state/package.json
+++ b/packages/storybook-react-input-state/package.json
@@ -57,6 +57,7 @@
     "eslint": "^5.15.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^4.1.0",
+    "eslint-junit": "^1.0.1",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-prettier": "^3.0.1",

--- a/packages/vue-component-library/package.json
+++ b/packages/vue-component-library/package.json
@@ -72,6 +72,7 @@
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^4.1.0",
+    "eslint-junit": "^1.0.1",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-prettier": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7420,6 +7420,15 @@ eslint-import-resolver-webpack@^0.10.1:
     resolve "^1.4.0"
     semver "^5.3.0"
 
+eslint-junit@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-junit/-/eslint-junit-1.0.1.tgz#cca1f5b1812ba553bd424871008555c26a00edea"
+  integrity sha1-zKH1sYErpVO9QkhxAIVVwmoA7eo=
+  dependencies:
+    mkdirp "^0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
 eslint-loader@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-2.1.2.tgz#453542a1230d6ffac90e4e7cb9cadba9d851be68"
@@ -17303,6 +17312,13 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
+stylelint-junit-formatter@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/stylelint-junit-formatter/-/stylelint-junit-formatter-0.2.1.tgz#8cddde6b3d3a93189f5b3b1b419dcf3c338038ab"
+  integrity sha512-C1n8dBpqMwUeJGmyL8tGVB1DKQISnEMhynzCzo38kTpjXybxLLYPrblbm41q5fEHwbaLjE5bPhZpZyMoHaJhIQ==
+  dependencies:
+    xmlbuilder "^10.0.0"
+
 stylelint-webpack-plugin@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/stylelint-webpack-plugin/-/stylelint-webpack-plugin-0.10.5.tgz#0b6e0d373ff5e03baa8197ebe0f2625981bd266b"
@@ -18999,6 +19015,11 @@ xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
+
+xmlbuilder@^10.0.0:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-10.1.1.tgz#8cae6688cc9b38d850b7c8d3c0a4161dcaf475b0"
+  integrity sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==
 
 xregexp@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Migrated to CircleCI 2.1 to take advantage of user defined commands and common executor (docker/node)

Defines seperate jobs for each linting activithy and a workflow to combine them. This granular approach allows jobs to run in parallel.

Reporting of linting errors has been improved and uses junit formatters so that CircleCI can parse the results and make them easier to navigate.

https://circleci.com/gh/Royal-Navy/workflows/standards-toolkit/tree/circle-lint

Screenshots below show what happens when linting fails on part of the application and note that Github is able to report exactly what part of the circle ci process failed.

<img width="1058" alt="Screenshot 2019-04-11 at 23 32 01" src="https://user-images.githubusercontent.com/48056118/55997604-04be6a00-5cb3-11e9-9b98-26a3627adf88.png">

<img width="1354" alt="Screenshot 2019-04-11 at 23 33 50" src="https://user-images.githubusercontent.com/48056118/55997606-04be6a00-5cb3-11e9-9b42-cbbbb765f970.png">

<img width="1354" alt="Screenshot 2019-04-11 at 23 34 04" src="https://user-images.githubusercontent.com/48056118/55997607-04be6a00-5cb3-11e9-929b-a1ed9324d189.png">

<img width="684" alt="Screenshot 2019-04-11 at 23 38 11" src="https://user-images.githubusercontent.com/48056118/55997608-05570080-5cb3-11e9-89f4-13f64e71f5fe.png">
