### PR TITLE
EN-501 : Auto publish NPM packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,11 @@ workflows:
             - test_react-component-library
             - test_storybook-react-input-state
             - test_vue-component-library
-      - publish_documentation
+      - publish_documentation:
+          filters:
+            branches:
+              only:
+                - master
       - publish_storybook-react-input-state:
           requires:
             - test_storybook-react-input-state

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,66 @@ jobs:
           name: Upload CC coverage
           working_directory: ~/project
           command: /tmp/cc-test-reporter upload-coverage -i workspace/coverage.json
+  publish_documentation:
+    executor: node
+    steps:
+      - checkout
+      - run:
+          name: Authenticate NPM
+          command: echo "//$NPM_REGISTRY/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+      - run:
+          name: Publish package
+          working_directory: packages/documentation
+          command: npm publish --registry https://$NPM_REGISTRY
+  publish_storybook-react-input-state:
+    executor: node
+    steps:
+      - checkout
+      - dependencies
+      - run:
+          name: Authenticate NPM
+          command: echo "//$NPM_REGISTRY/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+      - run:
+          name: Publish package
+          working_directory: packages/storybook-react-input-state
+          command: npm publish --registry https://$NPM_REGISTRY
+  publish_css-framework:
+    executor: node
+    steps:
+      - checkout
+      - dependencies
+      - run:
+          name: Authenticate NPM
+          command: echo "//$NPM_REGISTRY/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+      - run:
+          name: Publish package
+          working_directory: packages/css-framework
+          command: npm publish --registry https://$NPM_REGISTRY
+  publish_react-component-library:
+    executor: node
+    steps:
+      - checkout
+      - dependencies
+      - run:
+          name: Authenticate NPM
+          command: echo "//$NPM_REGISTRY/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+      - run:
+          name: Publish package
+          working_directory: packages/react-component-library
+          command: npm publish --registry https://$NPM_REGISTRY
+  publish_vue-component-library:
+    executor: node
+    steps:
+      - checkout
+      - dependencies
+      - run:
+          name: Authenticate NPM
+          command: echo "//$NPM_REGISTRY/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+      - run:
+          name: Publish package
+          working_directory: packages/vue-component-library
+          command: npm publish --registry https://$NPM_REGISTRY
+
 workflows:
   version: 2
   build_and_test:
@@ -190,3 +250,34 @@ workflows:
             - test_react-component-library
             - test_storybook-react-input-state
             - test_vue-component-library
+      - publish_documentation
+      - publish_storybook-react-input-state:
+          requires:
+            - test_storybook-react-input-state
+          filters:
+            branches:
+              only:
+                - master
+      - publish_css-framework:
+          requires:
+            - lint_css-framework
+          filters:
+            branches:
+              only:
+                - master
+      - publish_react-component-library:
+          requires:
+            - test_react-component-library
+            - publish_css-framework
+          filters:
+            branches:
+              only:
+                - master
+      - publish_vue-component-library:
+          requires:
+            - test_vue-component-library
+            - publish_css-framework
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
Publishes npm packages to npmjs.com upon merge to master.

Adds instructions to CircleCI config to publish npm packages only if the commit is made to master.
2 Environment settings are added to the CircleCI job to store the hostname that the npm registry sits at, so a private registry can be used for testing, and an authentication key with the ability to publish packages.

Tested with a forked copy of the repo and published to npm.royalnavy.dev

<img width="821" alt="Screenshot 2019-04-17 at 19 03 46" src="https://user-images.githubusercontent.com/48056118/56310334-91e64080-6143-11e9-859b-180fb173b6bd.png">
<img width="847" alt="Screenshot 2019-04-17 at 19 03 30" src="https://user-images.githubusercontent.com/48056118/56310335-927ed700-6143-11e9-9d32-edb8073d2289.png">
