### PR TITLE
Add support for SVG to React component library

### DIFF
--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -41,6 +41,7 @@
     "@storybook/addon-links": "^5.0.11",
     "@storybook/addons": "^5.0.11",
     "@storybook/react": "^5.0.11",
+    "@svgr/webpack": "^4.2.0",
     "@types/enzyme": "^3.9.2",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest": "^24.0.13",

--- a/packages/react-component-library/src/types/svg.d.ts
+++ b/packages/react-component-library/src/types/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: any
+  export default content
+}

--- a/packages/react-component-library/webpack/common.js
+++ b/packages/react-component-library/webpack/common.js
@@ -48,6 +48,10 @@ module.exports = {
           },
         ],
       },
+      {
+        test: /\.svg$/,
+        use: ['@svgr/webpack'],
+      },
     ],
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2011,7 +2011,7 @@
     merge-deep "^3.0.2"
     svgo "^1.2.1"
 
-"@svgr/webpack@^4.0.3":
+"@svgr/webpack@^4.0.3", "@svgr/webpack@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@svgr/webpack/-/webpack-4.2.0.tgz#b7cdef42ae671a27ed4cfe118a0f2da7f4e9ebed"
   integrity sha512-sm3UUJHmRlqEg8w8bjUT+FAMf5lkgCydxotEapinpd10kzrpQP++Qd+bmuepE3hsIUU68BO24vgQALQ92qBZEw==


### PR DESCRIPTION
Allows SVG files to be included in a component in the form:

```
import MonoLogo from './logo.svg'

const Footer = () => (
  <div className="rn-footer">
    <MonoLogo />
  </div>
)
```