### PR TITLE
Update React Component supported browsers to allow Chrome 38 testing

### DIFF
--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -88,16 +88,12 @@
     "webpack-cli": "^3.3.2",
     "webpack-merge": "^4.2.1"
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 10",
+    "not op_mini all",
+    "ie 11",
+    "chrome >= 38"
+  ]
 }


### PR DESCRIPTION
The dev team can now test their components in Browserstack and one of the acceptance criteria dictates developers test with Chrome 38. Changing the config in the React project means the js produced works back to 38 and can be locally tested now.