### PR TITLE
Update .gitignore to make sure no build files are committed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,15 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules
 
 # testing
 coverage
 test-results
 
 # production
-/build
-/dist
+build
+dist
 
 # misc
 .DS_Store


### PR DESCRIPTION
When working on the react components I realised the gitignore rules for dist and build only covered the top level folder.