### PR TITLE
Exclude tests from Code Climate checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,4 @@
+exclude_patterns:
+- "dist/"
+- "**/node_modules/"
+- "*.test.tsx"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,4 @@
 exclude_patterns:
 - "dist/"
 - "**/node_modules/"
-- "*.test.tsx"
+- "*.test.*"


### PR DESCRIPTION
Need to exclude tests from the Code Climate checks.

Had to manually add an exclusion for ours as the default doesn't catch them.

Also excluded vendor stuff and release artefacts (would have been handled by defaults previously).