### PR TITLE
Use yarn instead of npm to run the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
       - run:
           name: Build site
           working_directory: packages/docs-site
-          command: npm run build
+          command: yarn build
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
We need to use yarn in order to take advantage of workspaces and resolve other monorepo packages locally.