### PR TITLE
Target node with WebPack build instead of browser

### DIFF
--- a/packages/react-component-library/webpack/common.js
+++ b/packages/react-component-library/webpack/common.js
@@ -2,6 +2,7 @@
 const { resolve } = require('path')
 
 module.exports = {
+  target: 'node',
   entry: ['./index.ts'],
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx'],


### PR DESCRIPTION
Resolves an issue where the WebPack build would try to pass the window object to an IIFE. This is not accessible from the node runtime and would in turn break the docs-site Gatsby prod build (`yarn build`).