### PR TITLE
Export icons from React component library

### DIFF
--- a/packages/react-component-library/src/components/Button/Button.stories.tsx
+++ b/packages/react-component-library/src/components/Button/Button.stories.tsx
@@ -3,9 +3,10 @@ import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { withKnobs, text } from '@storybook/addon-knobs'
 
-import { TriangleDown, TriangleUp } from '../../icons'
+import Icons from '../../icons'
 import Button from './index'
 
+const { TriangleDown, TriangleUp } = Icons
 const stories = storiesOf('Button', module)
 
 stories.addDecorator(withKnobs)

--- a/packages/react-component-library/src/components/Nav/Nav.stories.tsx
+++ b/packages/react-component-library/src/components/Nav/Nav.stories.tsx
@@ -3,10 +3,12 @@ import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
 import { withKnobs } from '@storybook/addon-knobs'
 
-import { TriangleDown, TriangleUp } from '../../icons'
+import Icons from '../../icons'
 import CustomLink from '../CustomLink'
 import Button from '../Button'
 import Nav from './index'
+
+const { TriangleDown, TriangleUp } = Icons
 
 const stories = storiesOf('Nav', module)
 
@@ -55,13 +57,13 @@ const navItemsWithChildren = [
           },
           {
             href: 'http://testurl.test',
-            label: 'Child 2'
+            label: 'Child 2',
           },
-        ]
+        ],
       },
-    ]
+    ],
   },
-  ...navItems
+  ...navItems,
 ]
 
 stories.add('Vertical', () => <Nav navItems={navItemsWithChildren} />)

--- a/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
@@ -4,9 +4,11 @@ import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import * as yup from 'yup'
 
-import { Search } from '../../icons'
+import Icons from '../../icons'
 import Button from '../Button'
 import TextInput from './index'
+
+const { Search } = Icons
 
 const stories = storiesOf('TextInput', module)
 

--- a/packages/react-component-library/src/icons/index.ts
+++ b/packages/react-component-library/src/icons/index.ts
@@ -2,4 +2,4 @@ import Search from './Search'
 import TriangleUp from './TriangleUp'
 import TriangleDown from './TriangleDown'
 
-export { Search, TriangleDown, TriangleUp }
+export default { Search, TriangleDown, TriangleUp }

--- a/packages/react-component-library/src/index.ts
+++ b/packages/react-component-library/src/index.ts
@@ -1,7 +1,8 @@
 import Badge from './components/Badge'
 import Button from './components/Button'
+import Icons from './icons'
 import Links from './components/Links'
 import Nav from './components/Nav'
 import PhaseBanner from './components/PhaseBanner'
 
-export { Badge, Button, Links, Nav, PhaseBanner }
+export { Badge, Button, Icons, Links, Nav, PhaseBanner }


### PR DESCRIPTION
Allow the Icons in the React Component Library to be used elsewhere. This will be useful for the Masthead as it will need the arrow up and down icons.