### PR TITLE
Update footer styles to better switch between mobile and desktop

### DIFF
--- a/packages/docs-site/src/components/presenters/footer/footer.scss
+++ b/packages/docs-site/src/components/presenters/footer/footer.scss
@@ -2,12 +2,21 @@
 
 .rn-footer {
   background: color(primary, 800);
-  padding: spacing(6) spacing(6);
+}
+
+.rn-footer > div {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: spacing(4);
 }
 
 @include breakpoint("s") {
   .rn-footer {
     padding: spacing(6) spacing(10);
+  }
+
+  .rn-footer > div {
+    padding: 0;
   }
 }
 

--- a/packages/docs-site/src/components/presenters/footer/index.js
+++ b/packages/docs-site/src/components/presenters/footer/index.js
@@ -9,22 +9,24 @@ import MonoLogo from './logo.svg'
 
 const Footer = ({ children, links }) => (
   <div className="rn-footer">
-    <MonoLogo />
-    <Links links={links} size="small" />
-    <hr className="rn-footer__divider" />
-    <div className="rn-footer__meta">
-      <p data-testid="message" className="rn-footer__message">
-        {children || (
-          <Fragment>
-            All content is available under the{' '}
-            <a href="https://www.apache.org/licenses/LICENSE-2.0.html">
-              Apache 2.0 licence
-            </a>
-            , except where otherwise stated.
-          </Fragment>
-        )}
-      </p>
-      <p className="rn-footer__copyright">&copy; Crown copyright</p>
+    <div>
+      <MonoLogo />
+      <Links links={links} size="small" />
+      <hr className="rn-footer__divider" />
+      <div className="rn-footer__meta">
+        <p data-testid="message" className="rn-footer__message">
+          {children || (
+            <Fragment>
+              All content is available under the{' '}
+              <a href="https://www.apache.org/licenses/LICENSE-2.0.html">
+                Apache 2.0 licence
+              </a>
+              , except where otherwise stated.
+            </Fragment>
+          )}
+        </p>
+        <p className="rn-footer__copyright">&copy; Crown copyright</p>
+      </div>
     </div>
   </div>
 )


### PR DESCRIPTION
Changed the footer to spread across the whole page and line up with the content section when in desktop mode, and still look good in mobile