### PR TITLE
Adjust sidebar navigation styles

### DIFF
--- a/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
+++ b/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
@@ -19,7 +19,7 @@ $text-color: #253b5b;
 .sidebar__title {
   display: block;
   padding-bottom: spacing(8);
-  margin-bottom: spacing(8);
+  margin-bottom: spacing(4);
   border-bottom: 1px dashed #8c8c8c;
   font-size: font-size('s');
   font-weight: 600;
@@ -28,11 +28,11 @@ $text-color: #253b5b;
 
 .sidebar .rn-nav__item {
   color: $text-color;
+  padding: spacing(3);
 }
 
 .sidebar .rn-nav__list-item.has-children {
   background-color: #d2dbe5;
-  border: 1px solid #979797;
   border-radius: $border-radius;
 }
 
@@ -43,5 +43,13 @@ $text-color: #253b5b;
 }
 
 .sidebar .rn-nav__list .rn-nav__list {
-  padding: initial;
+  padding: spacing(2);
+}
+
+.sidebar .rn-nav__list-item + .rn-nav__list-item {
+  margin-top: spacing(2);
+}
+
+.sidebar .rn-nav__list .rn-nav__list .rn-nav__list-item + .rn-nav__list-item {
+  margin-top: unset;
 }


### PR DESCRIPTION
## Related Jira issue:

https://rn-nelson.atlassian.net/browse/EN-596

## Overview

Adjust docs-site sidebar styles to match Sketch v1.02 design and fix some spacing issues.

## Reason

Styling issues identified as part of review.

## Work carried out

- [x] Remove border
- [x] Tweak issues with spacing

## Screenshot

<img width="436" alt="Screenshot 2019-06-10 at 15 04 29" src="https://user-images.githubusercontent.com/48086589/59201052-76bb0e80-8b91-11e9-966a-fa3fc890ceb2.png">
<img width="421" alt="Screenshot 2019-06-10 at 15 04 39" src="https://user-images.githubusercontent.com/48086589/59201053-76bb0e80-8b91-11e9-8128-76c57f221c3d.png">

## Developer notes

Following v1.02 screenshots in Jira as source of truth.
