### PR TITLE
Adjust the PhaseBanner to go full screen width with content in container

### DIFF
--- a/deprecated/react-component-library/src/components/PhaseBanner/index.js
+++ b/deprecated/react-component-library/src/components/PhaseBanner/index.js
@@ -5,7 +5,7 @@ import Badge from '../Badge'
 
 const PhaseBanner = ({ phase, children, link }) => (
   <div className={`rn-phase-banner rn-phase-banner--${phase}`}>
-    <div className="container">
+    <div className="rn-phase-banner__container">
       <Badge size="small" state="primary" type="solid">
         {phase}
       </Badge>

--- a/packages/css-framework/src/_config.scss
+++ b/packages/css-framework/src/_config.scss
@@ -13,3 +13,5 @@ $navy--zIndex: () !default;
 
 // Helper Namespace
 $helper-ns: "h_";
+
+$navy-content-width: 1280px;

--- a/packages/css-framework/src/components/_phase-banner.scss
+++ b/packages/css-framework/src/components/_phase-banner.scss
@@ -1,20 +1,26 @@
 .rn-phase-banner {
   background-color: color(primary, 100);
-  padding: spacing(1) 0;
+  padding: spacing(2);
+}
+
+.rn-phase-banner__container {
+  padding: 0;
+  margin: 0 auto;
+  max-width: $navy-content-width;
 }
 
 .rn-phase-banner__text {
   display: inline-block;
-  margin-left: spacing(1);
   font-size: font-size(xs);
+  vertical-align: text-bottom
 }
 
 .rn-phase-banner__text a {
   color: color(neutral, black);
 }
 
-.rn-phase-banner .rn-badge--solid {
+.rn-phase-banner .rn-badge {
+  margin: 0;
   text-transform: capitalize;
+  margin-right: spacing(1);
 }
-
-

--- a/packages/react-component-library/src/components/PhaseBanner/index.tsx
+++ b/packages/react-component-library/src/components/PhaseBanner/index.tsx
@@ -13,7 +13,7 @@ const PhaseBanner: React.FC<PhaseBannerProps> = ({
   link = '/feedback',
 }) => (
   <div className={`rn-phase-banner rn-phase-banner--${phase}`}>
-    <div className="container">
+    <div className="rn-phase-banner__container">
       <Badge size="small" color="primary">
         {phase}
       </Badge>


### PR DESCRIPTION
The phase banner was designed to sit inside a container but wouldn't go full screen properly.

Design want the phase to go full screen width but the content is kept inside the content area.

<img width="1904" alt="Screenshot 2019-06-10 at 14 48 58" src="https://user-images.githubusercontent.com/48056118/59201112-94887380-8b91-11e9-915e-a26dbc365795.png">

![Simulator Screen Shot - iPhone Xʀ - 2019-06-10 at 14 50 29](https://user-images.githubusercontent.com/48056118/59201114-97836400-8b91-11e9-98d6-87889a0124c6.png)

![Simulator Screen Shot - iPad Air (3rd generation) - 2019-06-10 at 14 53 53](https://user-images.githubusercontent.com/48056118/59201123-9b16eb00-8b91-11e9-8a56-d7777e5f85a0.png)
