### PR TITLE
Check document object exists

### DIFF
--- a/packages/docs-site/src/components/presenters/code-highlighter/index.js
+++ b/packages/docs-site/src/components/presenters/code-highlighter/index.js
@@ -34,7 +34,7 @@ const CodeHighlighter = ({ example, source, language }) => {
         {example}
       </header>
       <section className="code-highlighter__body">
-        {document.queryCommandSupported('copy') && (
+        {document && document.queryCommandSupported('copy') && (
           <button
             type="button"
             onClick={copyToClipboard}


### PR DESCRIPTION
Check that the document object exists so that the build doesn't break (there is no document object in node).

```
error Building static HTML failed for path "/"

See our docs page on debugging HTML builds for help https://gatsby.dev/debug-html

  35 |       </header>
  36 |       <section className="code-highlighter__body">
> 37 |         {document.queryCommandSupported('copy') && (
     |          ^
  38 |           <button
  39 |             type="button"
  40 |             onClick={copyToClipboard}


  WebpackError: ReferenceError: document is not defined
```