### PR TITLE
EN-655 Doc site layout

### DIFF
--- a/packages/css-framework/src/contexts/_light.scss
+++ b/packages/css-framework/src/contexts/_light.scss
@@ -14,6 +14,10 @@
       breakpoint: 768px,
       baseFontSize: 106%,
     ),
+    l: (
+      breakpoint: 1024px,
+      baseFontSize: 106%,
+    ),
     xl: (
       breakpoint: 1200px,
       baseFontSize: 112%,

--- a/packages/docs-site/src/components/presenters/Masthead/index.js
+++ b/packages/docs-site/src/components/presenters/Masthead/index.js
@@ -79,12 +79,12 @@ const MastHead = () => {
         </Formik>
       </div>
       <PhaseBanner className="masthead__phasebanner" />
-      <div className="masthead__container">
-        <Nav
-          className={open ? 'is-open' : 'is-closed'}
-          orientation="horizontal"
-          navItems={navItems}
-        />
+      <div
+        className={`masthead__container masthead__nav ${
+          open ? 'is-open' : 'is-closed'
+        }`}
+      >
+        <Nav orientation="horizontal" navItems={navItems} />
       </div>
     </div>
   )

--- a/packages/docs-site/src/components/presenters/Masthead/masthead.scss
+++ b/packages/docs-site/src/components/presenters/Masthead/masthead.scss
@@ -4,8 +4,6 @@ $gutter: spacing(3);
 
 .masthead__container {
   box-sizing: content-box;
-  display: flex;
-  flex-direction: column;
   max-width: $navy-content-width;
   margin: $gutter auto;
   padding: 0 $gutter;
@@ -13,7 +11,7 @@ $gutter: spacing(3);
 
 .masthead__logo {
   width: 280px;
-  margin-bottom: spacing(2);
+  margin-bottom: spacing(1);
 }
 
 .masthead__search {
@@ -30,16 +28,17 @@ $gutter: spacing(3);
   margin: 0 0 0 $gutter;
 }
 
-.masthead .rn-nav {
+.masthead__nav {
   display: none;
 }
 
-.masthead .rn-nav.is-open {
+.masthead__nav.is-open {
   display: block;
 }
 
 @include breakpoint("s") {
   .masthead__container {
+    display: flex;
     flex-direction: row;
     justify-content: space-between;
     flex-wrap: wrap;

--- a/packages/docs-site/src/components/presenters/footer/footer.scss
+++ b/packages/docs-site/src/components/presenters/footer/footer.scss
@@ -5,19 +5,9 @@
 }
 
 .rn-footer > div {
-  max-width: 1280px;
+  max-width: $navy-content-width;
   margin: 0 auto;
-  padding: spacing(4);
-}
-
-@include breakpoint("s") {
-  .rn-footer {
-    padding: spacing(6) spacing(10);
-  }
-
-  .rn-footer > div {
-    padding: 0;
-  }
+  padding: spacing(5) spacing(3);
 }
 
 .rn-footer,

--- a/packages/docs-site/src/templates/default.js
+++ b/packages/docs-site/src/templates/default.js
@@ -10,7 +10,9 @@ import Footer from '../components/presenters/footer'
 import Layout from '../components/presenters/layout'
 import PostArticle from '../components/presenters/post-article'
 import Sidebar from '../components/presenters/sidebar'
-import CodeHighlighter from '../components/presenters/code-highlighter'
+import MastHead from '../components/presenters/Masthead'
+
+import './default.scss'
 
 const SidebarWithNavigation = withNavigation(Sidebar)
 
@@ -29,15 +31,16 @@ export default function Template({ data }) {
   const { markdownRemark: post } = data
 
   return (
-    <Layout className="">
+    <Layout>
       <Helmet title={`${post.frontmatter.title} | NELSON Standards`} />
-      <PostArticle postData={post} />
-      <CodeHighlighter
-        language="javascript"
-        example={<h1>This is some example JSX</h1>}
-        source="function restructureNodes(nodes) { return nodes.map(node => {}) }"
-      />
-      <SidebarWithNavigation title="Example sidebar" />
+      <MastHead />
+      <main className="main">
+        <PostArticle postData={post} />
+        <SidebarWithNavigation
+          className="aside aside--primary"
+          title="Example sidebar"
+        />
+      </main>
       <Footer />
     </Layout>
   )

--- a/packages/docs-site/src/templates/default.scss
+++ b/packages/docs-site/src/templates/default.scss
@@ -1,0 +1,50 @@
+@import "@royalnavy/css-framework";
+
+.main {
+  display: flex;
+  flex-flow: column;
+  padding: 0;
+  margin: 0 spacing(3);
+}
+
+.aside {
+  display: none;
+}
+
+@include breakpoint("s") {
+  .main {
+    box-sizing: content-box;
+    flex-flow: row wrap;
+    max-width: $navy-content-width;
+    margin: spacing(3) auto;
+    padding: 0 spacing(3);
+  }
+
+  .post-article {
+    margin: 0;
+    order: 2;
+    flex-grow: 1;
+  }
+
+  .aside {
+    display: block;
+    flex: 1 auto;
+    max-width: 240px;
+  }
+
+  .aside--primary {
+    order: 1;
+    margin-right: spacing(5);
+  }
+
+  .aside--secondary {
+    margin-left: spacing(5);
+    order: 3;
+  }
+}
+
+@include breakpoint("l") {
+  .aside {
+    max-width: 320px;
+  }
+}


### PR DESCRIPTION
Updates the docs site layout to correctly position the masthead, body and footer. Allows for the inclusion of a left and right navs. Currently they are simple included, as the site progresses the left nav component will return null when there is no nav and the layout will adjust for that.

Left nav is not shown in mobile view as it's an enhancement and a user can still achieve their goal without it.

<img width="375" alt="Screenshot 2019-06-11 at 15 28 33" src="https://user-images.githubusercontent.com/48056118/59281272-e77c2c80-8c5e-11e9-8c52-c3df26d5dab5.png">

Mobile

<hr/>

<img width="767" alt="Screenshot 2019-06-11 at 15 29 32" src="https://user-images.githubusercontent.com/48056118/59281731-a9cbd380-8c5f-11e9-9601-0f6ace655ebc.png">

iPad with nav 

<hr/>

<img width="767" alt="Screenshot 2019-06-11 at 15 29 41" src="https://user-images.githubusercontent.com/48056118/59281642-843eca00-8c5f-11e9-955a-bf141f3ffd25.png">
iPad no left nav

<hr/>

![Screenshot 2019-06-11 at 15 33 26](https://user-images.githubusercontent.com/48056118/59281433-2dd18b80-8c5f-11e9-8e2f-042a9c91f4e6.png)
Desktop nav

<hr/>

![Screenshot 2019-06-11 at 15 33 36](https://user-images.githubusercontent.com/48056118/59281434-2e6a2200-8c5f-11e9-9402-321426b761e2.png)
Desktop no nav