### PR TITLE
Import fonts into default layout

### DIFF
--- a/packages/docs-site/src/templates/default.js
+++ b/packages/docs-site/src/templates/default.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Helmet } from 'react-helmet'
 
+import '../helpers/css/fonts.css'
+
 import '@royalnavy/css-framework/index.scss'
 
 import withNavigation from '../components/enhancers/withNavigation'


### PR DESCRIPTION
By importing the font css file into the layout the css is included in the page and it's dependencies, namely the fonts.

<img width="1440" alt="Screenshot 2019-06-12 at 12 06 39" src="https://user-images.githubusercontent.com/48056118/59346877-37b0c880-8d0b-11e9-9a27-3fca420aab5f.png">
