### PR TITLE
EN-665 Populate primary nav

### DIFF
--- a/packages/docs-site/jest/__mocks__/gatsby.js
+++ b/packages/docs-site/jest/__mocks__/gatsby.js
@@ -5,9 +5,12 @@ const gatsby = jest.requireActual('gatsby')
 module.exports = {
   ...gatsby,
   graphql: jest.fn(),
-  Link: jest.fn().mockImplementation(({ to, ...rest }) => React.createElement('a', {
-    ...rest,
-    href: to,
-  }) ),
+  Link: jest.fn().mockImplementation(({ to, ...rest }) =>
+    React.createElement('a', {
+      ...rest,
+      href: to,
+    })
+  ),
   StaticQuery: jest.fn(),
+  useStaticQuery: jest.fn(),
 }

--- a/packages/docs-site/jest/data/mockNavData.js
+++ b/packages/docs-site/jest/data/mockNavData.js
@@ -1,0 +1,426 @@
+export default {
+  allMarkdownRemark: {
+    edges: [
+      {
+        node: {
+          id: '7b074bf2-9066-5ccd-8c73-ff4a92ad3dbd',
+          fields: {
+            slug: '/about-the-design-system/',
+          },
+          frontmatter: {
+            title: 'About the design system',
+            status: null,
+            index: 6,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'ae12792e-9914-5db9-bd27-b248102feb0c',
+          fields: {
+            slug: '/about-the-design-system/standards-roadmap/',
+          },
+          frontmatter: {
+            title: 'Standards roadmap',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'e24254c9-597c-5898-a881-a8aa83be098a',
+          fields: {
+            slug: '/',
+          },
+          frontmatter: {
+            title: 'Home',
+            status: '',
+            index: 0,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '70370904-b640-5dad-a201-85b83e18b585',
+          fields: {
+            slug: '/get-started/',
+          },
+          frontmatter: {
+            title: 'Get started',
+            status: null,
+            index: 1,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'e8fae916-349d-55af-98cd-dca2cf0c0d8c',
+          fields: {
+            slug: '/components/alert/',
+          },
+          frontmatter: {
+            title: 'Alert',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'de3c1f48-5b64-5ffa-a628-b491c3073ef8',
+          fields: {
+            slug: '/components/avatar/',
+          },
+          frontmatter: {
+            title: 'Avatar',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'eb09a353-ee2b-5ad3-a7fe-c9c77b330ed9',
+          fields: {
+            slug: '/components/badge/',
+          },
+          frontmatter: {
+            title: 'Badge',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '35488faf-eecd-5c1e-b8e9-29b7745b5b85',
+          fields: {
+            slug: '/components/card/',
+          },
+          frontmatter: {
+            title: 'Card',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'c8a68cb5-a6b6-501e-b11a-cc9049c55c58',
+          fields: {
+            slug: '/components/button/',
+          },
+          frontmatter: {
+            title: 'Button',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'c94cf1da-216f-5477-8505-42dadd2dc28d',
+          fields: {
+            slug: '/components/icon/',
+          },
+          frontmatter: {
+            title: 'Icon',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '352b7737-ff65-5445-9c55-0641885edda8',
+          fields: {
+            slug: '/components/dialog/',
+          },
+          frontmatter: {
+            title: 'Dialog',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '21189af6-cb28-5575-aeaa-6a5e22dbd966',
+          fields: {
+            slug: '/components/list/',
+          },
+          frontmatter: {
+            title: 'List',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '61afc9cf-9718-5ae2-b7c4-023780e37a35',
+          fields: {
+            slug: '/components/',
+          },
+          frontmatter: {
+            title: 'Components',
+            status: null,
+            index: 3,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'ac050288-cca3-54c0-9756-9536b6d6419e',
+          fields: {
+            slug: '/components/modal/',
+          },
+          frontmatter: {
+            title: 'Modal',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '7eadfa65-db79-59da-bc68-19b8fc6d8bae',
+          fields: {
+            slug: '/community/contact-standards-team/',
+          },
+          frontmatter: {
+            title: 'Contact standards team',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '27a112a6-8112-5015-99e4-9534c3c7697c',
+          fields: {
+            slug: '/components/nav/',
+          },
+          frontmatter: {
+            title: 'Nav',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '0c54d8ee-7a71-57aa-bb2b-613c81c05568',
+          fields: {
+            slug: '/components/table/',
+          },
+          frontmatter: {
+            title: 'Table',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '7b73ee48-38a0-502a-839b-ea833100f5ee',
+          fields: {
+            slug: '/styles/',
+          },
+          frontmatter: {
+            title: 'Styles',
+            status: null,
+            index: 2,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'b60c3e44-40ef-565a-a065-dbce67b1e968',
+          fields: {
+            slug: '/components/phase-banner/',
+          },
+          frontmatter: {
+            title: 'Phase Banner',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '42356104-f156-5b16-bef6-7ea3af7d948c',
+          fields: {
+            slug: '/community/',
+          },
+          frontmatter: {
+            title: 'Community',
+            status: null,
+            index: 7,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '9d2cc7d8-a817-59fc-bf47-2a89f872d714',
+          fields: {
+            slug: '/get-started/development/',
+          },
+          frontmatter: {
+            title: 'Development',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '8c9ab721-8eaa-5318-a140-59aab2984fbc',
+          fields: {
+            slug: '/components/forms/dropdown/',
+          },
+          frontmatter: {
+            title: 'Dropdown',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'c4907479-e1f7-56a8-82a5-b5a37d4c1c75',
+          fields: {
+            slug: '/components/progress/',
+          },
+          frontmatter: {
+            title: 'Progress',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '748028f6-9be2-5544-aa82-9d11cfd6a093',
+          fields: {
+            slug: '/components/forms/',
+          },
+          frontmatter: {
+            title: 'Forms',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '0ab7b8f7-9f38-503c-9d7c-f1b47ea509ea',
+          fields: {
+            slug: '/nelson-api-documentation/',
+          },
+          frontmatter: {
+            title: 'NELSON API Documentation',
+            status: null,
+            index: 5,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'b27f988d-cf21-51fb-8193-78bf916e5947',
+          fields: {
+            slug: '/components/forms/toggle/',
+          },
+          frontmatter: {
+            title: 'Toggle',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'b3905e71-bdf8-5e92-8b3f-87e0fec70335',
+          fields: {
+            slug: '/components/forms/input/',
+          },
+          frontmatter: {
+            title: 'Input',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '00217783-6556-50ad-86d9-5f5ead565e59',
+          fields: {
+            slug: '/components/forms/transfer/',
+          },
+          frontmatter: {
+            title: 'Transfer',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: '3a8692a6-acb0-5925-8f2a-94a3e886cf27',
+          fields: {
+            slug: '/get-started/prototyping/',
+          },
+          frontmatter: {
+            title: 'Prototyping',
+            status: null,
+            index: null,
+          },
+          children: [],
+        },
+      },
+      {
+        node: {
+          id: 'c12bdd07-d5ae-5ec9-bf88-8228557eb882',
+          fields: {
+            slug: '/patterns/',
+          },
+          frontmatter: {
+            title: 'Patterns',
+            status: null,
+            index: 4,
+          },
+          children: [],
+        },
+      },
+    ],
+  },
+}

--- a/packages/docs-site/src/components/enhancers/withNavigation.js
+++ b/packages/docs-site/src/components/enhancers/withNavigation.js
@@ -1,73 +1,7 @@
 import { StaticQuery, graphql } from 'gatsby'
 import React from 'react'
-import sortBy from 'lodash/sortBy'
 
-/**
- * Strip trailing slash from a URI, excluding a root node.
- *
- * @param {string} href
- * @returns {string}
- */
-function stripTrailingSlash(href) {
-  return href.endsWith('/') && href !== '/' ? href.slice(0, -1) : href
-}
-
-/**
- * Restructure nodes into something that can be more
- * easily consumed by the application.
- *
- * @param {array} nodes
- * @returns {array}
- */
-function restructureNodes(nodes) {
-  return nodes.map(node => {
-    return {
-      href: stripTrailingSlash(node.node.fields.slug),
-      label: node.node.frontmatter.title,
-    }
-  })
-}
-
-/**
- * Take a flat array of pages and recursively transform
- * into a nested data structure based on URL structure.
- *
- * @param {array} nodes
- * @returns {array}
- */
-function nestByURLStructure(nodes) {
-  const tree = []
-
-  function addToTree(node, parents) {
-    const { href } = node
-
-    parents.forEach(parentNode => {
-      const { href: parentHref } = parentNode
-
-      if (href.includes(`${parentHref}/`)) {
-        const index = parents.findIndex(item => item.href === href)
-
-        // eslint-disable-next-line no-param-reassign
-        parents = parents.splice(0, index)
-
-        addToTree(node, parentNode.children)
-      }
-    })
-
-    parents.push({
-      ...node,
-      children: [],
-    })
-  }
-
-  const sorted = sortBy(nodes, 'node.frontmatter.index')
-
-  restructureNodes(sorted).forEach(node => {
-    addToTree(node, tree)
-  })
-
-  return tree
-}
+import { nestByURLStructure } from '../../utils/nav'
 
 const withNavigation = BaseComponent => props => (
   <StaticQuery

--- a/packages/docs-site/src/components/presenters/Masthead/Masthead.test.js
+++ b/packages/docs-site/src/components/presenters/Masthead/Masthead.test.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import { render, getByText } from '@testing-library/react'
+
+import Masthead from './index'
+
+describe('Masthead', () => {
+  let wrapper
+
+  describe('Given the masthead is called with navigaton items', () => {
+    beforeEach(() => {
+      const navItems = [
+        {
+          active: true,
+          href: '/',
+          label: 'Home',
+        },
+        {
+          href: '/get-started',
+          label: 'Get started',
+        },
+        {
+          href: '/styles',
+          label: 'Styles',
+        },
+      ]
+
+      wrapper = render(<Masthead navItems={navItems} />)
+    })
+
+    it('should render a navigation section', () => {
+      expect(wrapper.getByTestId('primary-nav')).toBeInTheDocument()
+    })
+
+    it('should include links for the top level items', () => {
+      const navContainer = wrapper.getByTestId('primary-nav')
+
+      expect(getByText(navContainer, 'Home')).toHaveAttribute('href', '/')
+      expect(getByText(navContainer, 'Get started')).toHaveAttribute(
+        'href',
+        '/get-started'
+      )
+      expect(getByText(navContainer, 'Styles')).toHaveAttribute(
+        'href',
+        '/styles'
+      )
+    })
+
+    it('should not include links for the child nav items', () => {
+      expect(wrapper.queryByText('-c1c1-')).toBeNull()
+    })
+
+    it('should include a menu button to show/hide the nav items', () => {
+      expect(wrapper.getByTestId('primary-nav-button')).toBeInTheDocument()
+    })
+  })
+
+  describe('Given the Masthead is called with no navigation items', () => {
+    beforeEach(() => {
+      wrapper = render(<Masthead />)
+    })
+
+    it('should not include a navigation section', () => {
+      expect(wrapper.queryByTestId('primary-nav')).toBeNull()
+    })
+
+    it('should not include the menu button', () => {
+      expect(wrapper.queryByTestId('primary-nav-button')).toBeNull()
+    })
+  })
+})

--- a/packages/docs-site/src/components/presenters/Masthead/index.js
+++ b/packages/docs-site/src/components/presenters/Masthead/index.js
@@ -1,3 +1,5 @@
+import { Form, Field, Formik } from 'formik'
+import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import {
   Button,
@@ -5,7 +7,6 @@ import {
   PhaseBanner,
   Icons,
 } from '@royalnavy/react-component-library'
-import { Form, Field, Formik } from 'formik'
 
 import TextInput from '../TextInput'
 import SiteLogo from './images/site-logo.svg'
@@ -14,10 +15,11 @@ import './masthead.scss'
 
 const { Search, TriangleDown, TriangleUp } = Icons
 
-const MastHead = () => {
+const MastHead = ({ navItems }) => {
   const [open, setOpen] = useState(false)
 
   const initialValues = { search: '' }
+  const hasNavItems = navItems.length > 0
 
   const onSubmit = term => {
     console.log('Do a thing:', term)
@@ -26,34 +28,6 @@ const MastHead = () => {
   const toggle = () => {
     setOpen(!open)
   }
-
-  const navItems = [
-    {
-      href: '1',
-      label: 'Get started',
-    },
-    {
-      href: '1',
-      label: 'Styles',
-    },
-    {
-      active: true,
-      href: '1',
-      label: 'Components',
-    },
-    {
-      href: '1',
-      label: 'Patterns',
-    },
-    {
-      href: '1',
-      label: 'Community',
-    },
-    {
-      href: '1',
-      label: 'About',
-    },
-  ]
 
   return (
     <div className="masthead">
@@ -69,25 +43,45 @@ const MastHead = () => {
               placeholder="search"
             />
 
-            <Button
-              onClick={toggle}
-              icon={open ? <TriangleDown /> : <TriangleUp />}
-            >
-              Menu
-            </Button>
+            {hasNavItems && (
+              <Button
+                data-testid="primary-nav-button"
+                onClick={toggle}
+                icon={open ? <TriangleDown /> : <TriangleUp />}
+              >
+                Menu
+              </Button>
+            )}
           </Form>
         </Formik>
       </div>
       <PhaseBanner className="masthead__phasebanner" />
-      <div
-        className={`masthead__container masthead__nav ${
-          open ? 'is-open' : 'is-closed'
-        }`}
-      >
-        <Nav orientation="horizontal" navItems={navItems} />
-      </div>
+      {hasNavItems && (
+        <div
+          data-testid="primary-nav"
+          className={`masthead__container masthead__nav ${
+            open ? 'is-open' : 'is-closed'
+          }`}
+        >
+          <Nav orientation="horizontal" navItems={navItems} />
+        </div>
+      )}
     </div>
   )
+}
+
+MastHead.propTypes = {
+  navItems: PropTypes.arrayOf(
+    PropTypes.shape({
+      active: PropTypes.boolean,
+      href: PropTypes.string,
+      label: PropTypes.string,
+    })
+  ),
+}
+
+MastHead.defaultProps = {
+  navItems: [],
 }
 
 export default MastHead

--- a/packages/docs-site/src/hooks/usePrimaryNavData.js
+++ b/packages/docs-site/src/hooks/usePrimaryNavData.js
@@ -1,12 +1,7 @@
 import { useStaticQuery, graphql } from 'gatsby'
 import startsWith from 'lodash/startsWith'
 
-import {
-  nestByURLStructure,
-  stripLeadingSlash,
-  stripTrailingSlash,
-} from '../utils/nav'
-import { isForXStatement } from '@babel/types'
+import { nestByURLStructure, stripLeadingSlash } from '../utils/nav'
 
 const QUERY = graphql`
   query PrimaryNavigation {

--- a/packages/docs-site/src/hooks/usePrimaryNavData.js
+++ b/packages/docs-site/src/hooks/usePrimaryNavData.js
@@ -1,0 +1,53 @@
+import { useStaticQuery, graphql } from 'gatsby'
+import startsWith from 'lodash/startsWith'
+
+import {
+  nestByURLStructure,
+  stripLeadingSlash,
+  stripTrailingSlash,
+} from '../utils/nav'
+import { isForXStatement } from '@babel/types'
+
+const QUERY = graphql`
+  query PrimaryNavigation {
+    allMarkdownRemark {
+      edges {
+        node {
+          id
+          fields {
+            slug
+          }
+          frontmatter {
+            title
+            status
+            index
+          }
+        }
+      }
+    }
+  }
+`
+
+const usePrimaryNavData = location => {
+  const {
+    allMarkdownRemark: { edges: pages },
+  } = useStaticQuery(QUERY)
+
+  const nested = nestByURLStructure(pages)
+  const parsedCurrentLocation = stripLeadingSlash(location.pathname)
+
+  return nested.map(({ href, label }) => {
+    const parsedLink = stripLeadingSlash(href)
+    const active =
+      (parsedLink.length === 0 && parsedCurrentLocation.length === 0) ||
+      (parsedLink.length > 0 && startsWith(parsedCurrentLocation, parsedLink))
+
+    return {
+      active,
+      href,
+      label,
+    }
+  })
+}
+
+export default usePrimaryNavData

--- a/packages/docs-site/src/hooks/usePrimaryNavData.test.js
+++ b/packages/docs-site/src/hooks/usePrimaryNavData.test.js
@@ -3,7 +3,7 @@ import { useStaticQuery } from 'gatsby'
 import mockNavData from '../../jest/data/mockNavData'
 import usePrimaryNavData from './usePrimaryNavData'
 
-describe.only('usePrimaryNavData', () => {
+describe('usePrimaryNavData', () => {
   let result
 
   beforeEach(() => {

--- a/packages/docs-site/src/hooks/usePrimaryNavData.test.js
+++ b/packages/docs-site/src/hooks/usePrimaryNavData.test.js
@@ -1,0 +1,113 @@
+import { useStaticQuery } from 'gatsby'
+
+import mockNavData from '../../jest/data/mockNavData'
+import usePrimaryNavData from './usePrimaryNavData'
+
+describe.only('usePrimaryNavData', () => {
+  let result
+
+  beforeEach(() => {
+    useStaticQuery.mockReturnValue(mockNavData)
+  })
+
+  describe('when the user is on the home page', () => {
+    beforeEach(() => {
+      const location = {
+        pathname: '/',
+      }
+
+      result = usePrimaryNavData(location)
+    })
+
+    it('should return nav items for the top level things', () => {
+      expect(result).toHaveLength(8)
+      expect(result[0]).toHaveProperty('href', '/')
+      expect(result[0]).toHaveProperty('label', 'Home')
+
+      expect(result[1]).toHaveProperty('href', '/get-started')
+      expect(result[1]).toHaveProperty('label', 'Get started')
+
+      expect(result[2]).toHaveProperty('href', '/styles')
+      expect(result[2]).toHaveProperty('label', 'Styles')
+
+      expect(result[3]).toHaveProperty('href', '/components')
+      expect(result[3]).toHaveProperty('label', 'Components')
+
+      expect(result[4]).toHaveProperty('href', '/patterns')
+      expect(result[4]).toHaveProperty('label', 'Patterns')
+
+      expect(result[5]).toHaveProperty('href', '/nelson-api-documentation')
+      expect(result[5]).toHaveProperty('label', 'NELSON API Documentation')
+
+      expect(result[6]).toHaveProperty('href', '/about-the-design-system')
+      expect(result[6]).toHaveProperty('label', 'About the design system')
+
+      expect(result[7]).toHaveProperty('href', '/community')
+      expect(result[7]).toHaveProperty('label', 'Community')
+    })
+
+    it('should indicate that only the homepage link is active', () => {
+      const activeItems = result.map(({ active }) => active)
+      expect(activeItems).toEqual([
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+      ])
+    })
+  })
+
+  describe('when the user is on the component page', () => {
+    beforeEach(() => {
+      const location = {
+        pathname: '/components',
+      }
+
+      result = usePrimaryNavData(location)
+    })
+
+    it('should indicate that only the component link is active', () => {
+      const activeItems = result.map(({ active }) => active)
+
+      expect(activeItems).toEqual([
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+      ])
+    })
+  })
+
+  describe('when the user is on the components button sub page', () => {
+    beforeEach(() => {
+      const location = {
+        pathname: '/components/button',
+      }
+
+      result = usePrimaryNavData(location)
+    })
+
+    it('should indicate that only the component link is active', () => {
+      const activeItems = result.map(({ active }) => active)
+
+      expect(activeItems).toEqual([
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+      ])
+    })
+  })
+})

--- a/packages/docs-site/src/templates/default.js
+++ b/packages/docs-site/src/templates/default.js
@@ -13,6 +13,7 @@ import Layout from '../components/presenters/layout'
 import PostArticle from '../components/presenters/post-article'
 import Sidebar from '../components/presenters/sidebar'
 import MastHead from '../components/presenters/Masthead'
+import usePrimaryNavData from '../hooks/usePrimaryNavData'
 
 import './default.scss'
 
@@ -29,13 +30,14 @@ export const pageQuery = graphql`
   }
 `
 
-export default function Template({ data }) {
+export default function Template({ data, location }) {
+  const primaryNavData = usePrimaryNavData(location)
   const { markdownRemark: post } = data
 
   return (
     <Layout>
       <Helmet title={`${post.frontmatter.title} | NELSON Standards`} />
-      <MastHead />
+      <MastHead navItems={primaryNavData} />
       <main className="main">
         <PostArticle postData={post} />
         <SidebarWithNavigation
@@ -50,4 +52,5 @@ export default function Template({ data }) {
 
 Template.propTypes = {
   data: PropTypes.instanceOf(Object).isRequired,
+  location: PropTypes.instanceOf(Object).isRequired,
 }

--- a/packages/docs-site/src/utils/nav.js
+++ b/packages/docs-site/src/utils/nav.js
@@ -1,0 +1,78 @@
+import sortBy from 'lodash/sortBy'
+
+/**
+ * Strip trailing slash from a URI, excluding a root node.
+ *
+ * @param {string} href
+ * @returns {string}
+ */
+export function stripTrailingSlash(href) {
+  return href.endsWith('/') && href !== '/' ? href.slice(0, -1) : href
+}
+
+/**
+ * Strip leading slash from a URI, excluding a root node.
+ *
+ * @param {string} href
+ * @returns {string}
+ */
+export function stripLeadingSlash(href) {
+  return href.charAt(0) === '/' ? href.substring(1) : href
+}
+
+/**
+ * Restructure nodes into something that can be more
+ * easily consumed by the application.
+ *
+ * @param {array} nodes
+ * @returns {array}
+ */
+export function restructureNodes(nodes) {
+  return nodes.map(node => {
+    return {
+      href: stripTrailingSlash(node.node.fields.slug),
+      label: node.node.frontmatter.title,
+    }
+  })
+}
+
+/**
+ * Take a flat array of pages and recursively transform
+ * into a nested data structure based on URL structure.
+ *
+ * @param {array} nodes
+ * @returns {array}
+ */
+export function nestByURLStructure(nodes) {
+  const tree = []
+
+  function addToTree(node, parents) {
+    const { href } = node
+
+    parents.forEach(parentNode => {
+      const { href: parentHref } = parentNode
+
+      if (href.includes(`${parentHref}/`)) {
+        const index = parents.findIndex(item => item.href === href)
+
+        // eslint-disable-next-line no-param-reassign
+        parents = parents.splice(0, index)
+
+        addToTree(node, parentNode.children)
+      }
+    })
+
+    parents.push({
+      ...node,
+      children: [],
+    })
+  }
+
+  const sorted = sortBy(nodes, 'node.frontmatter.index')
+
+  restructureNodes(sorted).forEach(node => {
+    addToTree(node, tree)
+  })
+
+  return tree
+}

--- a/packages/react-component-library/src/components/Button/index.tsx
+++ b/packages/react-component-library/src/components/Button/index.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 interface ButtonProps {
   className?: string
   color?: 'danger'
+  testId?: string
   icon?: React.ReactNode
   onClick?: (event: React.SyntheticEvent) => void
   size?: 'small' | 'regular' | 'large' | 'xlarge'
@@ -19,6 +20,7 @@ const Button: React.FC<ButtonProps> = ({
   size,
   type = 'button',
   variant,
+  ...rest
 }) => (
   <button
     className={`rn-btn rn-btn--${variant} ${
@@ -29,6 +31,7 @@ const Button: React.FC<ButtonProps> = ({
       e.currentTarget.blur()
       onClick(e)
     }}
+    {...rest}
   >
     {children}
     {icon && <span className="rn-btn__icon">{icon}</span>}


### PR DESCRIPTION
Adds a hook to the docs-site to fetch navigation data and return the top level navigation items, and mark the current active one.

Implements the new hook into masthead and the default layout so the current navigation options are shown.

Added the ability to add custom props to buttons to help with testing.

<img width="1310" alt="Screenshot 2019-06-14 at 11 42 49" src="https://user-images.githubusercontent.com/48056118/59503981-ac197200-8e99-11e9-949f-c5beb8920b4a.png">
