### PR TITLE
Feature/EN-692 implement homepage mdx

### DIFF
--- a/packages/docs-site/src/components/presenters/Masthead/index.js
+++ b/packages/docs-site/src/components/presenters/Masthead/index.js
@@ -55,7 +55,15 @@ const MastHead = ({ navItems }) => {
           </Form>
         </Formik>
       </div>
-      <PhaseBanner className="masthead__phasebanner" />
+      <PhaseBanner className="masthead__phasebanner">
+        <span>
+          Are you a Navy Product Owner or Stakeholder?{' '}
+          <a href="/about-the-design-system">
+            Find out how Standards relates to you
+          </a>
+          .
+        </span>
+      </PhaseBanner>
       {hasNavItems && (
         <div
           data-testid="primary-nav"

--- a/packages/docs-site/src/components/presenters/card/card.scss
+++ b/packages/docs-site/src/components/presenters/card/card.scss
@@ -60,6 +60,12 @@ $card-background-color: #f0f4f8;
   }
 }
 
+.card--borderless .card__body,
+.card--borderless .card__head {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 .card--border {
   border: 1px solid $border-color;
   border-radius: $border-radius;

--- a/packages/docs-site/src/components/presenters/card/index.js
+++ b/packages/docs-site/src/components/presenters/card/index.js
@@ -14,9 +14,10 @@ const Card = ({
   imagePosition,
   linkText,
   linkHref,
+  className,
 }) => {
   return (
-    <article className={`card card--${type}`}>
+    <article className={`card card--${type} ${className}`}>
       <header className="card__head">
         {meta && type === 'coloured' && (
           <span className="card__meta" data-testid="meta">
@@ -62,6 +63,7 @@ Card.propTypes = {
   imagePosition: PropTypes.oneOf(['left', 'right']),
   linkText: PropTypes.string,
   linkHref: PropTypes.string,
+  className: PropTypes.string,
 }
 
 Card.defaultProps = {
@@ -73,6 +75,7 @@ Card.defaultProps = {
   imagePosition: 'left',
   linkText: '',
   linkHref: '#',
+  className: '',
 }
 
 export default Card

--- a/packages/docs-site/src/components/presenters/hero-banner/index.js
+++ b/packages/docs-site/src/components/presenters/hero-banner/index.js
@@ -21,7 +21,7 @@ const HeroBanner = ({ children, className, title, text, ctaLink, ctaText }) => (
         <hr className="hero-banner__rule" />
         <p className="hero-banner__stakeholder-message">
           Are you a Navy Product Owner or Stakeholder{' '}
-          <a className="hero-banner__link" href="/">
+          <a className="hero-banner__link" href="/about-the-design-system">
             Find out how Standards relates to you.
           </a>{' '}
         </p>

--- a/packages/docs-site/src/library/pages/index.md
+++ b/packages/docs-site/src/library/pages/index.md
@@ -10,6 +10,7 @@ index: 0
 ---
 
 import HeroBanner from '../../components/presenters/hero-banner'
+import Card from '../../components/presenters/card'
 
 <HeroBanner 
   title="Design your application using NELSON styles and components" text="Use this design system to build applications and services for the Royal Navy. The website includes guidance, a component library and prototyping tools. Use these to save time and give users a consistent experience that meets the NELSON Standard." 
@@ -17,13 +18,21 @@ import HeroBanner from '../../components/presenters/hero-banner'
   ctaLink="/get-started"
 />
 
-<!-- Styles card -->
-Make your service look like it's for the Royal Navy with guides for applying colour, typography and spacing.
-[View styles](/styles)
+<Card 
+  type="border" 
+  title="Styles" 
+  text="Make your service look like it's for the Royal Navy with guides for applying colour, typography and spacing." 
+  linkText="View styles" 
+  linkHref="/styles" 
+/>
 
-<!-- Components card -->
-Save time with reusable, accessible components for forms, navigation, cards and more.
-[View styles](/components)
+<Card 
+  type="border" 
+  title="Components" 
+  text="Save time with reusable, accessible components for forms, navigation, cards and more." 
+  linkText="View components" 
+  linkHref="/components" 
+/>
 
 ## Latest updates
 

--- a/packages/docs-site/src/library/pages/index.md
+++ b/packages/docs-site/src/library/pages/index.md
@@ -9,17 +9,13 @@ template: default
 index: 0
 ---
 
-<!-- Phase banner -->
-This is a new service – see our [Roadmap](/about-the-design-system/roadmap) for what's coming next.
+import HeroBanner from '../../components/presenters/hero-banner'
 
-<!-- Hero banner -->
-# Design your application using NELSON styles and components
-
-Use this design system to build applications and services for the Royal Navy. The website includes guidance, a component library and prototyping tools. Use these to save time and give users a consistent experience that meets the NELSON Standard.
-
-[Get started](/get-started)
-
-Are you a Navy Product Owner or Stakeholder? [Find out how Standards relates to you](/about-the-design-system).
+<HeroBanner 
+  title="Design your application using NELSON styles and components" text="Use this design system to build applications and services for the Royal Navy. The website includes guidance, a component library and prototyping tools. Use these to save time and give users a consistent experience that meets the NELSON Standard." 
+  ctaText="Get started" 
+  ctaLink="/get-started"
+/>
 
 <!-- Styles card -->
 Make your service look like it's for the Royal Navy with guides for applying colour, typography and spacing.

--- a/packages/docs-site/src/library/pages/index.md
+++ b/packages/docs-site/src/library/pages/index.md
@@ -18,14 +18,14 @@ import Card from '../../components/presenters/card'
   ctaLink="/get-started"
 />
 
-<section class="h_f h_f-align-start h_mt-8 h_mb-8">
+<section class="m:h_f m:h_f-align-start h_mt-8 m:h_mb-8">
   <Card 
     type="border" 
     title="Styles" 
     text="Make your service look like it's for the Royal Navy with guides for applying colour, typography and spacing." 
     linkText="View styles" 
     linkHref="/styles"
-    className="h_f-1 h_mr-4"
+    className="m:h_f-1 m:h_mr-4"
   />
 
   <Card 
@@ -34,7 +34,7 @@ import Card from '../../components/presenters/card'
     text="Save time with reusable, accessible components for forms, navigation, cards and more." 
     linkText="View components" 
     linkHref="/components" 
-    className="h_f-1  h_ml-4"
+    className="m:h_f-1  m:h_ml-4 h_mt-8 m:h_mt-0"
   />
 </section>
 

--- a/packages/docs-site/src/library/pages/index.md
+++ b/packages/docs-site/src/library/pages/index.md
@@ -18,21 +18,25 @@ import Card from '../../components/presenters/card'
   ctaLink="/get-started"
 />
 
-<Card 
-  type="border" 
-  title="Styles" 
-  text="Make your service look like it's for the Royal Navy with guides for applying colour, typography and spacing." 
-  linkText="View styles" 
-  linkHref="/styles" 
-/>
+<section class="h_f h_f-align-start h_mt-8 h_mb-8">
+  <Card 
+    type="border" 
+    title="Styles" 
+    text="Make your service look like it's for the Royal Navy with guides for applying colour, typography and spacing." 
+    linkText="View styles" 
+    linkHref="/styles"
+    className="h_f-1 h_mr-4"
+  />
 
-<Card 
-  type="border" 
-  title="Components" 
-  text="Save time with reusable, accessible components for forms, navigation, cards and more." 
-  linkText="View components" 
-  linkHref="/components" 
-/>
+  <Card 
+    type="border" 
+    title="Components" 
+    text="Save time with reusable, accessible components for forms, navigation, cards and more." 
+    linkText="View components" 
+    linkHref="/components" 
+    className="h_f-1  h_ml-4"
+  />
+</section>
 
 ## Latest updates
 

--- a/packages/docs-site/src/library/pages/index.md
+++ b/packages/docs-site/src/library/pages/index.md
@@ -38,13 +38,23 @@ import Card from '../../components/presenters/card'
   />
 </section>
 
-## Latest updates
+<section class="h_mt-8 h_mb-8">
+  <h2>Latest updates</h2>
 
-<!-- Update card -->
-10th July 2019
-### Standards v1.0.0 released
-This launch includes the new Standards website providing ‘get started’ guides for designers and developers, styling and component usage guidelines, and information about Standards for Royal Navy stakeholders. Please [get in touch](/contact) if you have any feedback.
+  <Card 
+    type="coloured" 
+    title="Standards v1.0.0 released" 
+    meta="10th July 2019"
+    text={<span>This launch includes the new Standards website providing 'get started' guides for designers and developers, styling and component usage guidelines, and information about Standards for Royal Navy stakeholders. Please <a href="/contact">get in touch</a> if you have any feedback.</span>}
+  />
+</section>
 
-## Contact us
-Contact the NELSON Standards team to find out more about design in the Royal Navy, request a new component, ask questions and give feedback.
-[Contact](/contact)
+<section class="h_mt-8 h_mb-8">
+  <Card 
+    type="borderless" 
+    title="Contact us" 
+    text="Contact the NELSON Standards team to find out more about design in the Royal Navy, request a new component, ask questions and give feedback." 
+    linkText="Contact" 
+    linkHref="/contact" 
+  />
+</section>


### PR DESCRIPTION
## Related Jira issue: 

https://rn-nelson.atlassian.net/browse/EN-692

## Overview

Convert the homepage markdown into MDX (use presentational components and apply layout helpers).

## Reason

> The markdown content needs to be presented in a way that is in keeping with the mocks.

## Work carried out

- [x] Consume presentational components and write JSX in place of markdown
- [x] Tweak some component styles
- [x] Add layout helpers for desktop
- [x] Add layout helpers for mobile
- [x] Perform UAT down to Chrome 38 (and various form factors)

## Screenshot

![localhost_8000_](https://user-images.githubusercontent.com/48086589/60276942-8017db00-98f4-11e9-9c80-db288c7a21b0.png)

## Developer notes

Awaiting responsive layout helpers.
