### PR TITLE
Feature/en 696 use children instead of prop for codehighlighter previews

### DIFF
--- a/packages/docs-site/src/components/presenters/code-highlighter/index.js
+++ b/packages/docs-site/src/components/presenters/code-highlighter/index.js
@@ -9,7 +9,7 @@ import './code-highlighter.scss'
 
 import CopyIcon from './copy-icon.svg'
 
-const CodeHighlighter = ({ example, source, language }) => {
+const CodeHighlighter = ({ source, language, children }) => {
   useEffect(() => {
     Prism.highlightAll()
   }, [])
@@ -31,7 +31,7 @@ const CodeHighlighter = ({ example, source, language }) => {
   return (
     <article className="code-highlighter">
       <header className="code-highlighter__head" data-testid="example">
-        {example}
+        {children}
       </header>
       <section className="code-highlighter__body">
         {typeof document !== 'undefined' &&
@@ -57,13 +57,12 @@ const CodeHighlighter = ({ example, source, language }) => {
 }
 
 CodeHighlighter.propTypes = {
-  example: PropTypes.instanceOf(Object),
   source: PropTypes.string,
   language: PropTypes.string,
+  children: PropTypes.node.isRequired,
 }
 
 CodeHighlighter.defaultProps = {
-  example: {},
   source: '// No source to display',
   language: 'javascript',
 }

--- a/packages/docs-site/src/components/presenters/code-highlighter/index.test.js
+++ b/packages/docs-site/src/components/presenters/code-highlighter/index.test.js
@@ -15,9 +15,10 @@ describe('CodeHighlighter', () => {
       codehighlighter = render(
         <CodeHighlighter
           language="javascript"
-          example={<h1>This is some example JSX</h1>}
           source="function restructureNodes(nodes) { return nodes.map(node => {}) }"
-        />
+        >
+          <h1>This is some example JSX</h1>
+        </CodeHighlighter>
       )
     })
 


### PR DESCRIPTION
## Related Jira issue:

https://rn-nelson.atlassian.net/browse/EN-696

## Overview

Use `props.children` instead of the example prop for code preview JSX.

## Reason

>We want to nest the preview JSX within an MDX file. This is a much better pattern than parsing the contents of the old example prop.

## Work carried out

- [x] Implement change
- [x] Update automated tests
