### PR TITLE
Feature/css helper breakpoints

### DIFF
--- a/packages/css-framework/src/helpers/_flex.scss
+++ b/packages/css-framework/src/helpers/_flex.scss
@@ -1,5 +1,5 @@
 /* stylelint-disable */
-@mixin sharedStyles {
+@mixin flexSharedStyles {
   display: flex !important;
 
   // Direction
@@ -56,12 +56,12 @@
 @each $_breakpoint, $_breakpoint-val in $__breakpoints {
   @if $_breakpoint == 'root' {
     .#{$helper-ns}f {
-      @include sharedStyles;
+      @include flexSharedStyles;      
     }
   } @else {
     @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
       .#{$_breakpoint}\:#{$helper-ns}f {        
-          @include sharedStyles;
+          @include flexSharedStyles;
       }
     }
   }

--- a/packages/css-framework/src/helpers/_flex.scss
+++ b/packages/css-framework/src/helpers/_flex.scss
@@ -1,6 +1,5 @@
 /* stylelint-disable */
-
-.#{$helper-ns}f {
+@mixin sharedStyles {
   display: flex !important;
 
   // Direction
@@ -52,6 +51,18 @@
   &-1 {
     flex: 1 !important;
   }
+}
 
-
+@each $_breakpoint, $_breakpoint-val in $__breakpoints {
+  @if $_breakpoint == 'root' {
+    .#{$helper-ns}f {
+      @include sharedStyles;
+    }
+  } @else {
+    @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
+      .#{$_breakpoint}\:#{$helper-ns}f {        
+          @include sharedStyles;
+      }
+    }
+  }
 }

--- a/packages/css-framework/src/helpers/_position.scss
+++ b/packages/css-framework/src/helpers/_position.scss
@@ -1,7 +1,5 @@
 /* stylelint-disable */
-
-// Position Helper
-.#{$helper-ns} {
+@mixin positionSharedStyles {
   &static {
     position: static !important;
   }
@@ -16,5 +14,20 @@
   }
   &sticky {
     position: sticky !important;
+  }
+}
+
+
+@each $_breakpoint, $_breakpoint-val in $__breakpoints {
+  @if $_breakpoint == 'root' {
+    .#{$helper-ns} {
+      @include positionSharedStyles;
+    }
+  } @else {
+    @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
+      .#{$_breakpoint}\:#{$helper-ns} {        
+          @include positionSharedStyles;
+      }
+    }
   }
 }

--- a/packages/css-framework/src/helpers/_shadows.scss
+++ b/packages/css-framework/src/helpers/_shadows.scss
@@ -2,8 +2,18 @@
 // Shadows Helper
 
 
-@each $_size, $_shadow in $__shadows {
-  .#{$helper-ns}shadow-#{$_size} {
-    box-shadow: #{$_shadow} !important;
+@each $_breakpoint, $_breakpoint-val in $__breakpoints {
+  @each $_size, $_shadow in $__shadows {
+    @if $_breakpoint == 'root' {
+      .#{$helper-ns}-shadow-#{$_size} {
+        box-shadow: #{$_shadow} !important;
+      }
+    } @else {
+      @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
+        .#{$_breakpoint}\:#{$helper-ns}shadow-#{$_size} {        
+            box-shadow: #{$_shadow} !important;
+        }
+      }
+    }
   }
 }

--- a/packages/css-framework/src/helpers/_sizing.scss
+++ b/packages/css-framework/src/helpers/_sizing.scss
@@ -7,10 +7,20 @@ $axes: (
 
 // Build Spacing Helper Classes
 
-@each $_size, $_multiplier in $__spacing {
-  @each $_axis, $_axis-shortname in $axes {
-    .#{$helper-ns}#{$_axis-shortname}-#{$_size} {
-      #{$_axis}: $_multiplier !important;
+@each $_breakpoint, $_breakpoint-val in $__breakpoints {
+  @each $_size, $_multiplier in $__spacing {
+    @each $_axis, $_axis-shortname in $axes {
+      @if $_breakpoint == 'root' {
+        .#{$helper-ns}#{$_axis-shortname}-#{$_size} {
+          #{$_axis}: $_multiplier !important;
+        }
+      } @else {
+        @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
+          .#{$_breakpoint}\:#{$helper-ns}#{$_axis-shortname}-#{$_size} {
+            #{$_axis}: $_multiplier !important;
+          }
+        }
+      }
     }
   }
 }

--- a/packages/css-framework/src/helpers/_spacing.scss
+++ b/packages/css-framework/src/helpers/_spacing.scss
@@ -13,17 +13,37 @@ $sides: (
 );
 
 // Build Spacing Helper Classes
-
-@each $_size, $_multiplier in $__spacing {
-  @each $_rule, $_rule-shortname in $rules {
-    .#{$helper-ns}#{$_rule-shortname}-#{$_size} {
-      #{$_rule}: $_multiplier !important;
-    }
-  }
-  @each $_property, $_shortname in $sides {
+@each $_breakpoint, $_breakpoint-val in $__breakpoints {
+  @each $_size, $_multiplier in $__spacing {
     @each $_rule, $_rule-shortname in $rules {
-      .#{$helper-ns}#{$_rule-shortname}#{$_shortname}-#{$_size} {
-        #{$_rule}-#{$_property}: $_multiplier !important;
+      
+      @if $_breakpoint == 'root' {        
+        .#{$helper-ns}#{$_rule-shortname}-#{$_size} {        
+            #{$_rule}: $_multiplier !important;
+        }
+      } @else {
+        .#{$_breakpoint}\:#{$helper-ns}#{$_rule-shortname}-#{$_size} {        
+          @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
+            #{$_rule}: $_multiplier !important;
+          }
+        }
+      }
+
+    }
+    @each $_property, $_shortname in $sides {
+      @each $_rule, $_rule-shortname in $rules {
+
+        @if $_breakpoint == 'root' {        
+          .#{$helper-ns}#{$_rule-shortname}#{$_shortname}-#{$_size} {
+            #{$_rule}-#{$_property}: $_multiplier !important;
+          }
+        } @else {
+          .#{$_breakpoint}\:#{$helper-ns}#{$_rule-shortname}#{$_shortname}-#{$_size} {
+            @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
+              #{$_rule}-#{$_property}: $_multiplier !important;
+            }
+          }
+        }
       }
     }
   }

--- a/packages/css-framework/src/helpers/_typography.scss
+++ b/packages/css-framework/src/helpers/_typography.scss
@@ -10,9 +10,20 @@
 **************************************************************************/
 
 
-@each $_shortname, $_value in $__typography {
-  .#{$helper_ns}text-#{$_shortname} {
-    font-size: $_value !important;
+
+@each $_breakpoint, $_breakpoint-val in $__breakpoints {
+  @each $_shortname, $_value in $__typography {
+    @if $_breakpoint == 'root' {
+      .#{$helper_ns}text-#{$_shortname} {
+        font-size: $_value !important;
+      }
+    } @else {
+      @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
+        .#{$_breakpoint}\:#{$helper_ns}text-#{$_shortname} {
+          font-size: $_value !important;
+        }
+      }
+    }
   }
 }
 
@@ -24,7 +35,7 @@
 
 **************************************************************************/
 
-.#{$helper_ns}text {
+@mixin textSharedStyles {
   &-left {
     text-align: left !important;
   }
@@ -33,5 +44,19 @@
   }
   &-right {
     text-align: right !important;
+  }
+}
+
+@each $_breakpoint, $_breakpoint-val in $__breakpoints {
+  @if $_breakpoint == 'root' {
+    .#{$helper-ns}text {
+      @include textSharedStyles;
+    }
+  } @else {
+    @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
+      .#{$_breakpoint}\:#{$helper-ns}text {
+          @include textSharedStyles;
+      }
+    }
   }
 }

--- a/packages/css-framework/src/helpers/_visibility.scss
+++ b/packages/css-framework/src/helpers/_visibility.scss
@@ -2,7 +2,7 @@
 
 // Visibility Helper
 
-.#{$helper_ns} {
+@mixin visibilitySharedStyles {
   &visible {
     visibility: visible !important;
   }
@@ -11,5 +11,20 @@
   }
   &none {
     display: none !important;
+  }
+}
+
+
+@each $_breakpoint, $_breakpoint-val in $__breakpoints {
+  @if $_breakpoint == 'root' {
+    .#{$helper-ns} {
+      @include visibilitySharedStyles;
+    }
+  } @else {
+    @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
+      .#{$_breakpoint}\:#{$helper-ns} {        
+          @include visibilitySharedStyles;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Overview
This PR adds support for breakpoints to the CSS framework helper classes.

## Reason

Before this, the helper classes in the CSS framework were very much all-or-nothing. There was no way to set them depending on breakpoint sizes. For example, this meant if you used the helper classes to put content inside a flex container on a single line, there was no way to stack these items on mobile. This PR solves this by adding in breakpoint prefixes to all helper classes:

`md:h_mr-4` would add the `margin-right: spacing(4)` class at the `md` and above breakpoint.

## Work carried out

- [x] Spacing Helpers
- [x] Flex Helpers
- [x] Position Helpers
- [x] Shadow Helpers
- [x] visibility helpers
- [x] typography helpers
- [x] Sizing Helpers
- [ ] Purge CSS

## Developer notes

This PR *does not* contain the ability to purge unused styles from the docs site/react component library. More investigation is needed here.
