### PR TITLE
Fix bug with sub nav sizing in docs site

### DIFF
--- a/packages/docs-site/src/components/presenters/post-article/index.js
+++ b/packages/docs-site/src/components/presenters/post-article/index.js
@@ -1,19 +1,11 @@
+import MDXRenderer from 'gatsby-mdx/mdx-renderer'
 import PropTypes from 'prop-types'
 import React from 'react'
-import MDXRenderer from 'gatsby-mdx/mdx-renderer'
 
-import './post-article.scss'
-
-const PostArticle = ({ mdx, className, children }) => {
+const PostArticle = ({ mdx, className }) => {
   return (
     <article className={`post-article ${className}`}>
-      <div className="post-article__content">
-        <div className="post-article__copy post-md">
-          <MDXRenderer>{mdx}</MDXRenderer>
-        </div>
-        <nav className="post-article__links" />
-      </div>
-      {children && <div className="post-article__children">{children}</div>}
+      <MDXRenderer>{mdx}</MDXRenderer>
     </article>
   )
 }
@@ -21,12 +13,10 @@ const PostArticle = ({ mdx, className, children }) => {
 PostArticle.propTypes = {
   className: PropTypes.string,
   mdx: PropTypes.instanceOf(Object).isRequired,
-  children: PropTypes.instanceOf(Array),
 }
 
 PostArticle.defaultProps = {
   className: '',
-  children: [],
 }
 
 export default PostArticle

--- a/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
+++ b/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
@@ -5,7 +5,7 @@ $text-color: #253b5b;
 
 .sidebar {
   background-color: #f0f4f8;
-  padding: spacing(10);
+  padding: spacing(3);
 
   display: none;
 }

--- a/packages/docs-site/src/templates/default.scss
+++ b/packages/docs-site/src/templates/default.scss
@@ -2,7 +2,6 @@
 
 .main {
   display: flex;
-  flex-flow: column;
 }
 
 .aside {
@@ -10,10 +9,6 @@
 }
 
 @include breakpoint("s") {
-  .main {
-    flex-flow: row wrap;
-  }
-
   .post-article {
     margin: 0;
     order: 2;
@@ -22,8 +17,7 @@
 
   .aside {
     display: block;
-    flex: 1 auto;
-    max-width: 240px;
+    flex: 0 0 180px;
   }
 
   .aside--primary {
@@ -39,6 +33,6 @@
 
 @include breakpoint("l") {
   .aside {
-    max-width: 320px;
+    flex: 0 0 320px;
   }
 }


### PR DESCRIPTION
Some pages on the docs site with a left nav show the main content below it, this was due to an issue with flexbox sizing.  Also simplified the article code to only include what is needed and reduced padding on navigation to make it fit on iPad.

<img width="770" alt="Screenshot 2019-07-01 at 17 48 48" src="https://user-images.githubusercontent.com/48056118/60453374-e40a0e80-9c28-11e9-85e0-af7e01a12732.png">
