### PR TITLE
EN-714 remove search from docs site masthead

### DIFF
--- a/packages/docs-site/src/components/presenters/Masthead/Masthead.test.js
+++ b/packages/docs-site/src/components/presenters/Masthead/Masthead.test.js
@@ -6,7 +6,7 @@ import Masthead from './index'
 describe('Masthead', () => {
   let wrapper
 
-  describe('Given the masthead is called with navigaton items', () => {
+  describe('Given the masthead is called with navigation items', () => {
     beforeEach(() => {
       const navItems = [
         {

--- a/packages/docs-site/src/components/presenters/Masthead/images/site-logo.svg
+++ b/packages/docs-site/src/components/presenters/Masthead/images/site-logo.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="0 0 405 39" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg height="39" width="405" viewBox="0 0 405 39" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-615.000000, -129.000000)">
           <g transform="translate(598.810092, 120.433430)">

--- a/packages/docs-site/src/components/presenters/Masthead/index.js
+++ b/packages/docs-site/src/components/presenters/Masthead/index.js
@@ -1,4 +1,3 @@
-import { Form, Field, Formik } from 'formik'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import {
@@ -6,24 +5,18 @@ import {
   Icons,
   Nav,
   PhaseBanner,
-  TextInput,
 } from '@royalnavy/react-component-library'
 
 import SiteLogo from './images/site-logo.svg'
 
 import './masthead.scss'
 
-const { Search, TriangleDown, TriangleUp } = Icons
+const { TriangleDown, TriangleUp } = Icons
 
 const MastHead = ({ navItems }) => {
   const [open, setOpen] = useState(false)
 
-  const initialValues = { search: '' }
   const hasNavItems = navItems.length > 0
-
-  const onSubmit = term => {
-    console.log('Do a thing:', term)
-  }
 
   const toggle = () => {
     setOpen(!open)
@@ -33,27 +26,18 @@ const MastHead = ({ navItems }) => {
     <div className="masthead">
       <div className="masthead__container rn-container">
         <SiteLogo className="masthead__logo" />
-        <Formik initialValues={initialValues} onSubmit={onSubmit}>
-          <Form className="masthead__search">
-            <Field
-              component={TextInput}
-              endAdornment={<Search />}
-              id="searcbar"
-              name="search"
-              placeholder="search"
-            />
 
-            {hasNavItems && (
-              <Button
-                data-testid="primary-nav-button"
-                onClick={toggle}
-                icon={open ? <TriangleDown /> : <TriangleUp />}
-              >
-                Menu
-              </Button>
-            )}
-          </Form>
-        </Formik>
+        {hasNavItems && (
+          <Button
+            className="masthead__button"
+            data-testid="primary-nav-button"
+            onClick={toggle}
+            icon={open ? <TriangleDown /> : <TriangleUp />}
+            variant="secondary"
+          >
+            Menu
+          </Button>
+        )}
       </div>
       <PhaseBanner className="masthead__phasebanner">
         <span>

--- a/packages/docs-site/src/components/presenters/Masthead/masthead.scss
+++ b/packages/docs-site/src/components/presenters/Masthead/masthead.scss
@@ -5,29 +5,15 @@
 }
 
 .masthead__container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-top: spacing(3);
   margin-bottom: spacing(3);
 }
 
-.masthead__logo {
-  width: 280px;
-  height: auto;
-  margin-bottom: spacing(1);
-  overflow: visible;
-}
-
-.masthead__search {
-  display: flex;
-  flex-direction: row;
-  margin: spacing(1) 0;
-}
-
-.masthead__search .rn-textinput {
-  margin: 0;
-}
-
-.masthead__search .rn-btn {
-  margin: 0 0 0 spacing(3);
+.masthead .masthead__button {
+  margin-left: spacing(3);
 }
 
 .masthead__nav {
@@ -42,10 +28,7 @@
 
 @include breakpoint("s") {
   .masthead__container {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    flex-wrap: wrap;
+    display: block;
   }
 
   .masthead__logo {
@@ -54,11 +37,7 @@
     margin-bottom: 0;
   }
 
-  .masthead__search {
-    margin: 0;
-  }
-
-  .masthead__search .rn-btn {
+  .masthead .masthead__button {
     display: none;
   }
 


### PR DESCRIPTION
Removed search from the docs site and managed to move the primary nav mobile button inline with the logo to save some space.

<img width="2560" alt="Screenshot 2019-07-03 at 16 30 33" src="https://user-images.githubusercontent.com/48056118/60604911-7d176180-9db0-11e9-8058-08b9ed88ff66.png">
