### PR TITLE
Improve nav component

### DIFF
--- a/packages/docs-site/src/library/pages/components/nav.md
+++ b/packages/docs-site/src/library/pages/components/nav.md
@@ -323,7 +323,7 @@ Nav supports rendering navigation in 4 different sizes
   },
   {
     Name: 'active',
-    Type: 'boolean;,
+    Type: 'boolean',
     Required: 'False',
     Default: 'False',
     Description: 'Is this the current active link?'

--- a/packages/docs-site/src/library/pages/components/nav.md
+++ b/packages/docs-site/src/library/pages/components/nav.md
@@ -89,7 +89,7 @@ The url provided to a navigation link will be used as the 'to' property of a rea
 
 The `Nav` component renders links in either a horizontal or vertical layout. Horizontal nav will switch to vertical when displayed on mobile.
 
-The `Nav` component accepts an array of links. By default a link expects a `label` and `href` and render an anchor tag. If using the component in an application that uses a library like `react-router-dom` the items prop can pass a component to be responsible for rendering the link and pass the properties it needs such as `to`.
+The `Nav` component accepts an array of links. By default a link expects a `label` and `href` and render an anchor tag. If using the component in an application that uses a library like `react-router-dom` the items prop can pass the properties it needs such as `to`. When using a custom component to render the link you need to pass that component to the Nav using the `LinkComponent` property.
 
 ### Basic Usage - Vertical
 <CodeHighlighter source={`const navItems=[
@@ -164,21 +164,18 @@ More often than not an application will use a library such as `React Router` to 
   {
     to: '/',
     label: 'Home',
-    Component: Link
   },
   {
     to: '/components',
     label: 'Components',
-    Component: Link
   },
   {
     to: '/design',
     label: 'Design',
-    Component: Link
   },
 ]
 \n
-<Nav navItems={navItems}/>`} language="javascript">
+<Nav LinkComponent={Link} navItems={navItems}/>`} language="javascript">
   <Nav navItems={[
   {
     href: '/',
@@ -285,6 +282,13 @@ Nav supports rendering navigation in 4 different sizes
     Default: '',
     Description: 'Optional additional css class to associate with the component wrapper',
   },
+    {
+    Name: 'LinkComponent',
+    Type: 'React.ReactNode',
+    Required: 'False',
+    Default: 'Link',
+    Description: 'The React component to render links, defaults to a regular anchor using Link',
+  },
   {
     Name: 'navItems',
     Type: 'NavItem[] ',
@@ -311,35 +315,28 @@ Nav supports rendering navigation in 4 different sizes
 
 <DataTable caption="NavItem" data={[
   {
-    Name: 'Component',
-    Type: 'React.ReactNode',
-    Required: 'False',
-    Default: 'Link',
-    Description: 'The React component to render the link, defaults to a regular anchor using Link',
-  },
-  {
     Name: 'label',
     Type: 'string',
     Required: 'True',
     Default: '',
     Description: 'The text for the link',
   },
+  {
+    Name: 'active',
+    Type: 'boolean;,
+    Required: 'False',
+    Default: 'False',
+    Description: 'Is this the current active link?'
+  }
 ]} />
 
 <DataTable caption="Link" data={[
   {
-    Name: 'active',
-    Type: 'boolean',
-    Required: 'False',
-    Default: 'false',
-    Description: 'Set to true for the currently active navigation item',
-  },
-  {
-    Name: 'label',
-    Type: 'string',
+    Name: 'children',
+    Type: 'string|React.ReactNode',
     Required: 'True',
     Default: '',
-    Description: 'The text for the link',
+    Description: 'The content for the link',
   },
   {
     Name: 'href',

--- a/packages/react-component-library/src/components/Nav/Link.tsx
+++ b/packages/react-component-library/src/components/Nav/Link.tsx
@@ -1,20 +1,17 @@
 import React from 'react'
 
 interface LinkProps {
-  active?: boolean
   className?: string
   href: string
-  label: string
 }
 
 const Link: React.FC<LinkProps> = ({
-  active = false,
+  children,
   className = 'rn-nav__item',
   href,
-  label,
 }) => (
-  <a className={`${className}${active ? ' is-active' : ''}`} href={href}>
-    {label}
+  <a className={className} href={href}>
+    {children}
   </a>
 )
 

--- a/packages/react-component-library/src/components/Nav/Nav.stories.tsx
+++ b/packages/react-component-library/src/components/Nav/Nav.stories.tsx
@@ -94,28 +94,23 @@ stories.add('Sizes', () => (
 
 const customNavItems = [
   {
-    Component: CustomLink,
     to: 'http://testurl.test',
     label: 'Styles',
   },
   {
-    Component: CustomLink,
     to: 'http://testurl.test',
     label: 'Components',
   },
   {
-    Component: CustomLink,
     to: 'http://testurl.test',
     label: 'Patterns',
     active: true,
   },
   {
-    Component: CustomLink,
     to: 'http://testurl.test',
     label: 'Community',
   },
   {
-    Component: CustomLink,
     to: 'http://testurl.test',
     label: 'About',
   },
@@ -139,7 +134,13 @@ const PrimaryNav = () => {
       >
         Menu
       </Button>
-      {open && <Nav navItems={navItems} orientation="horizontal" />}
+      {open && (
+        <Nav
+          navItems={navItems}
+          LinkComponent={CustomLink}
+          orientation="horizontal"
+        />
+      )}
     </div>
   )
 }

--- a/packages/react-component-library/src/components/Nav/NavItem.tsx
+++ b/packages/react-component-library/src/components/Nav/NavItem.tsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-import Link from './Link'
-
-const NavItem: React.FC<any> = ({ Component = Link, ...rest }) => (
-  <Component className="rn-nav__item" {...rest} />
-)
-
-export default NavItem

--- a/packages/react-component-library/src/components/Nav/README.md
+++ b/packages/react-component-library/src/components/Nav/README.md
@@ -1,6 +1,6 @@
 ---
 title: Nav
-description: Navigation components to buid vertial and horizontal menus
+description: Navigation components to build vertical and horizontal menus
 ---
 
 ## Types and usage
@@ -59,24 +59,24 @@ const navItems = [
 ## Properties
 ### Nav
 
-| Name        | Type           | Required | Default  | Description
-| ---------   | -------------- | -------- | -------  | -----------
-| className   | string         | False    |          | Optional extra css class to attach to the wrapper element
-| navItems    | Array\<any\>     | True     |          | An array of navigation items using the format described below |
-| orientation | string (horizontal/vertical)| False    | vertical | The direction to display the items.  |
-| size        | string (small/regular/large/xlarge) | False    | regular  | The font size for items  |
+| Name          | Type           | Required | Default  | Description
+| ---------     | -------------- | -------- | -------  | -----------
+| className     | string         | False    |          | Optional extra css class to attach to the wrapper element
+| LinkComponent | ReactComponent | False    | Link     | The component to render the link          |
+| navItems      | Array\<any\>   | True     |          | An array of navigation items using the format described below |
+| orientation   | string (horizontal/vertical)| False    | vertical | The direction to display the items.  |
+| size          | string (small/regular/large/xlarge) | False    | regular  | The font size for items  |
 
 ### NavItem
 
 The properties required for a nav item depend on the component that will render the item. If no component is passed in with
-the item then the 'Link'component will be used to render the nav item. Any properties in the nav item wil be passed to the
+the item then the 'Link' component will be used to render the nav item. Any properties in the nav item wil be passed to the
 render component. One example of an alternative nav item render component would be a React Router Link component, this 
 requires a 'to' property. The label property is used as the child of the render component. By default a className of 
 'rn-nav__item' is passed to the component.
 
 | Name        | Type            | Required | Default  | Description
 | ---------   | --------------- | -------- | -------  | -----------
-| Component   | ReactNode       | False    | Link     | By default          |
 | label       | string          | True     |          | The text to display |
 
 ### Link
@@ -86,5 +86,5 @@ The default NavItem render component. Renders a link.
 | Name        | Type           | Required | Default  | Description
 | ---------   | -------------- | -------- | -------  | -----------
 | active      | boolean        | False    | false    | Set to true for the currently active navigation item |
-| label       | string         | True     |          | The text to display |
+| children    | ReactNode      | True     |          | The content to display inside the link |
 | href        | string         | True     |          | The url to send the browser to |

--- a/packages/react-component-library/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react-component-library/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -11,47 +11,62 @@ exports[`Nav Given the nav is supplied navItems prop and navItems is a flat coll
       className="rn-nav__list-item "
       key="6"
     >
-      <NavItem
+      <Link
+        className="rn-nav__item "
         href="http://testurl.test"
         label="Styles"
-      />
+      >
+        Styles
+      </Link>
     </li>
     <li
       className="rn-nav__list-item "
       key="7"
     >
-      <NavItem
+      <Link
+        className="rn-nav__item "
         href="http://testurl.test"
         label="Components"
-      />
+      >
+        Components
+      </Link>
     </li>
     <li
       className="rn-nav__list-item "
       key="8"
     >
-      <NavItem
+      <Link
         active={true}
+        className="rn-nav__item is-active"
         href="http://testurl.test"
         label="Patterns"
-      />
+      >
+        Patterns
+      </Link>
     </li>
     <li
       className="rn-nav__list-item "
       key="9"
     >
-      <NavItem
+      <Link
+        className="rn-nav__item "
         href="http://testurl.test"
         label="Community"
-      />
+      >
+        Community
+      </Link>
     </li>
     <li
       className="rn-nav__list-item "
       key="10"
     >
-      <NavItem
+      <Link
+        className="rn-nav__item "
         href="http://testurl.test"
         label="About"
-      />
+      >
+        About
+      </Link>
     </li>
   </ul>
 </nav>

--- a/packages/react-component-library/src/components/Nav/index.tsx
+++ b/packages/react-component-library/src/components/Nav/index.tsx
@@ -1,24 +1,27 @@
 import React from 'react'
 import uuid from 'uuid'
 
-import NavItem from './NavItem'
+import Link from './Link'
 
 interface NavProps {
   className?: string
+  LinkComponent?: any
   navItems: any[]
   orientation?: 'vertical' | 'horizontal'
   size?: 'small' | 'regular' | 'large' | 'xlarge'
 }
 
-function renderMenu(navItems: any[]) {
+function renderMenu(LinkComponent: any, navItems: any[]) {
   return (
     <ul className="rn-nav__list">
       {navItems.map(item => {
-        const hasChildren: boolean = item.children && item.children.length > 0
+        const { active, children, label } = item
+
+        const hasChildren: boolean = children && children.length > 0
         let subMenu: object | undefined
 
         if (hasChildren) {
-          subMenu = renderMenu(item.children)
+          subMenu = renderMenu(LinkComponent, children)
         }
 
         return (
@@ -26,7 +29,12 @@ function renderMenu(navItems: any[]) {
             key={uuid()}
             className={`rn-nav__list-item ${hasChildren ? 'has-children' : ''}`}
           >
-            <NavItem {...item} />
+            <LinkComponent
+              className={`rn-nav__item ${active ? 'is-active' : ''}`}
+              {...item}
+            >
+              {label}
+            </LinkComponent>
             {subMenu}
           </li>
         )
@@ -37,12 +45,13 @@ function renderMenu(navItems: any[]) {
 
 const Nav: React.FC<NavProps> = ({
   className = '',
+  LinkComponent = Link,
   navItems,
   orientation = 'vertical',
   size = 'regular',
 }) => (
   <nav className={`rn-nav rn-nav--${orientation} rn-nav--${size} ${className}`}>
-    {renderMenu(navItems)}
+    {renderMenu(LinkComponent, navItems)}
   </nav>
 )
 


### PR DESCRIPTION
The previous nav component didn't work with React router or Gatsby, it kept rendering links with no content in them. changed the code so now it's simpler and passes the label as a child so the local Link default component acts the same as React router or Gatsby

This also follows the idea from sidebar in that you don't pass the link component in with every single nav item, you just pass it once.