### PR TITLE
Improve Popover

### DIFF
--- a/packages/css-framework/src/components/_popover.scss
+++ b/packages/css-framework/src/components/_popover.scss
@@ -1,18 +1,194 @@
+$lightBackground: color(neutral, white);
+$lightBorder: color(neutral, 100);
+$darkBackground: color(neutral, 700);
+$darkBorder: color(neutral, 700);
+$borderThick: 2px;
+$inner: 8px;
+$outer: $inner + 1;
+$offset: $outer + $borderThick;
+
 .rn-popover {
-  background: color(neutral, 700);
   position: absolute;
-  border-radius: 5px;
-  padding: spacing(4);
 }
 
-.rn-popover:before {
+.rn-popover__content {
+  position: relative;
+  padding: spacing(4);
+  border-radius: 5px;
+}
+
+.rn-popover--light .rn-popover__content {
+  background: $lightBackground;
+  border: $lightBorder solid $borderThick;
+}
+
+.rn-popover--dark .rn-popover__content {
+  background: $darkBackground;
+  border: $darkBorder solid $borderThick;
+  color: color(neutral, white);
+}
+
+.rn-popover__content:before {
+  border-style: solid;
   content: "";
+  display: block;
   position: absolute;
-  right: 100%;
-  bottom: 20px;
   width: 0;
-  height: 0;
-  border-top: 7px solid transparent;
-  border-right: 7px solid color(neutral, 700);
-  border-bottom: 7px solid transparent;
+  z-index: 0;
+}
+
+.rn-popover__content:after {
+  border-style: solid;
+  content: "";
+  display: block;
+  position: absolute;
+  width: 0;
+  z-index: 1;
+}
+
+.rn-popover--top_left .rn-popover__content:before,
+.rn-popover--top_right .rn-popover__content:before {
+  border-width: 0 $outer $outer;
+  margin-left: -$outer;
+  top: -$offset;
+}
+.rn-popover--top_left.rn-popover--light .rn-popover__content:before,
+.rn-popover--top_right.rn-popover--light .rn-popover__content:before {
+  border-color: $lightBorder transparent;
+}
+.rn-popover--top_left.rn-popover--dark .rn-popover__content:before,
+.rn-popover--top_right.rn-popover--dark .rn-popover__content:before {
+  border-color: $darkBorder transparent;
+}
+.rn-popover--top_left .rn-popover__content:after,
+.rn-popover--top_right .rn-popover__content:after {
+  border-width: 0 $inner $inner;
+  margin-left: -$inner;
+  top: -$inner;
+}
+.rn-popover--top_left.rn-popover--light .rn-popover__content:after,
+.rn-popover--top_right.rn-popover--light .rn-popover__content:after {
+  border-color: $lightBackground transparent;
+}
+.rn-popover--top_left.rn-popover--dark .rn-popover__content:after,
+.rn-popover--top_right.rn-popover--dark .rn-popover__content:after {
+  border-color: $darkBackground transparent;
+}
+
+
+.rn-popover--right_top .rn-popover__content:before,
+.rn-popover--right_bottom .rn-popover__content:before {
+  border-width: $outer 0 $outer $outer;
+  right: -$offset;
+  margin-top: -$outer;
+}
+.rn-popover--right_top.rn-popover--light .rn-popover__content:before,
+.rn-popover--right_bottom.rn-popover--light .rn-popover__content:before {
+  border-color: transparent $lightBorder;
+}
+.rn-popover--right_top.rn-popover--dark .rn-popover__content:before,
+.rn-popover--right_bottom.rn-popover--dark .rn-popover__content:before {
+  border-color: transparent $darkBorder;
+}
+.rn-popover--right_top .rn-popover__content:after,
+.rn-popover--right_bottom .rn-popover__content:after {
+  border-width: $inner 0 $inner $inner;
+  right: -$inner;
+  margin-top: -$inner;
+
+}
+.rn-popover--right_top.rn-popover--light .rn-popover__content:after,
+.rn-popover--right_bottom.rn-popover--light .rn-popover__content:after {
+  border-color: transparent $lightBackground;
+}
+.rn-popover--right_top.rn-popover--dark .rn-popover__content:after,
+.rn-popover--right_bottom.rn-popover--dark .rn-popover__content:after {
+  border-color: transparent $darkBackground;
+}
+
+
+.rn-popover--bottom_right .rn-popover__content:before,
+.rn-popover--bottom_left .rn-popover__content:before {
+  border-width: $inner $inner 0;
+  bottom: -$inner - $borderThick;
+  margin-left: -$outer;
+}
+.rn-popover--bottom_right.rn-popover--light .rn-popover__content:before,
+.rn-popover--bottom_left.rn-popover--light .rn-popover__content:before {
+  border-color: $lightBorder transparent;
+}
+.rn-popover--bottom_right.rn-popover--dark .rn-popover__content:before,
+.rn-popover--bottom_left.rn-popover--dark .rn-popover__content:before {
+  border-color: $darkBorder transparent;
+}
+.rn-popover--bottom_right .rn-popover__content:after,
+.rn-popover--bottom_left .rn-popover__content:after {
+  border-width: $inner $inner 0;
+  bottom: -$inner;
+  margin-left: -$outer;
+}
+.rn-popover--bottom_right.rn-popover--light .rn-popover__content:after,
+.rn-popover--bottom_left.rn-popover--light .rn-popover__content:after {
+  border-color: $lightBackground transparent;
+}
+.rn-popover--bottom_right.rn-popover--dark .rn-popover__content:after,
+.rn-popover--bottom_left.rn-popover--dark .rn-popover__content:after {
+  border-color: $darkBackground transparent;
+}
+
+
+.rn-popover--left_bottom .rn-popover__content:before,
+.rn-popover--left_top .rn-popover__content:before {
+  border-width: $outer $outer $outer 0;
+  left: -$offset;
+  margin-top: -$outer;
+}
+.rn-popover--left_bottom.rn-popover--light .rn-popover__content:before,
+.rn-popover--left_top.rn-popover--light .rn-popover__content:before {
+  border-color: transparent $lightBorder;
+}
+.rn-popover--left_bottom.rn-popover--dark .rn-popover__content:before,
+.rn-popover--left_top.rn-popover--dark .rn-popover__content:before {
+  border-color: transparent $darkBorder;
+}
+.rn-popover--left_bottom .rn-popover__content:after,
+.rn-popover--left_top .rn-popover__content:after {
+  border-width: $inner $inner $inner 0;
+  left: -$inner;
+  margin-top: -$inner;
+}
+.rn-popover--left_bottom.rn-popover--light .rn-popover__content:after,
+.rn-popover--left_top.rn-popover--light .rn-popover__content:after {
+  border-color: transparent $lightBackground;
+}
+.rn-popover--left_bottom.rn-popover--dark .rn-popover__content:after,
+.rn-popover--left_top.rn-popover--dark .rn-popover__content:after {
+  border-color: transparent $darkBackground;
+}
+
+
+.rn-popover--left_bottom .rn-popover__content:before,
+.rn-popover--left_bottom .rn-popover__content:after,
+.rn-popover--right_bottom .rn-popover__content:before,
+.rn-popover--right_bottom .rn-popover__content:after {
+  top: 80%;
+}
+
+.rn-popover--left_top .rn-popover__content:before,
+.rn-popover--left_top .rn-popover__content:after,
+.rn-popover--right_top .rn-popover__content:before,
+.rn-popover--right_top .rn-popover__content:after {
+  top: 20%;
+}
+.rn-popover--top_left .rn-popover__content:before,
+.rn-popover--top_left .rn-popover__content:after,
+.rn-popover--bottom_left .rn-popover__content:before,
+.rn-popover--bottom_left .rn-popover__content:after {
+  left: 10%;
+}
+.rn-popover--top_right .rn-popover__content:before,
+.rn-popover--top_right .rn-popover__content:after,
+.rn-popover--bottom_right .rn-popover__content:before,
+.rn-popover--bottom_right .rn-popover__content:after {
+  left: 90%;
 }

--- a/packages/react-component-library/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.stories.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import Popover from './index'
+
+const stories = storiesOf('Popover', module)
+
+stories.add('Dark', () => (
+  <div>
+    <Popover top={100} left={100} height={200} width={200} position="top_left">
+      <p>Top Left</p>
+    </Popover>
+    <Popover top={100} left={350} height={200} width={200} position="top_right">
+      <p>Top Right</p>
+    </Popover>
+
+    <Popover top={200} left={350} height={200} width={200} position="right_top">
+      <p>Right Top</p>
+    </Popover>
+
+    <Popover
+      top={300}
+      left={350}
+      height={200}
+      width={200}
+      position="right_bottom"
+    >
+      <p>Right Bottom</p>
+    </Popover>
+
+    <Popover
+      top={400}
+      left={350}
+      height={200}
+      width={200}
+      position="bottom_right"
+    >
+      <p>Bottom Right</p>
+    </Popover>
+
+    <Popover
+      top={400}
+      left={100}
+      height={200}
+      width={200}
+      position="bottom_left"
+    >
+      <p>Bottom Left</p>
+    </Popover>
+
+    <Popover
+      top={300}
+      left={100}
+      height={200}
+      width={200}
+      position="left_bottom"
+    >
+      <p>Left Bottom</p>
+    </Popover>
+
+    <Popover top={200} left={100} height={200} width={200} position="left_top">
+      <p>Left Top</p>
+    </Popover>
+  </div>
+))
+
+stories.add('Light', () => (
+  <div>
+    <Popover
+      top={100}
+      left={100}
+      height={200}
+      width={200}
+      position="top_left"
+      scheme="light"
+    >
+      <p>Top Left</p>
+    </Popover>
+    <Popover
+      top={100}
+      left={350}
+      height={200}
+      width={200}
+      position="top_right"
+      scheme="light"
+    >
+      <p>Top Right</p>
+    </Popover>
+
+    <Popover
+      top={200}
+      left={350}
+      height={200}
+      width={200}
+      position="right_top"
+      scheme="light"
+    >
+      <p>Right Top</p>
+    </Popover>
+
+    <Popover
+      top={300}
+      left={350}
+      height={200}
+      width={200}
+      position="right_bottom"
+      scheme="light"
+    >
+      <p>Right Bottom</p>
+    </Popover>
+
+    <Popover
+      top={400}
+      left={350}
+      height={200}
+      width={200}
+      position="bottom_right"
+      scheme="light"
+    >
+      <p>Bottom Right</p>
+    </Popover>
+
+    <Popover
+      top={400}
+      left={100}
+      height={200}
+      width={200}
+      position="bottom_left"
+      scheme="light"
+    >
+      <p>Bottom Left</p>
+    </Popover>
+
+    <Popover
+      top={300}
+      left={100}
+      height={200}
+      width={200}
+      position="left_bottom"
+      scheme="light"
+    >
+      <p>Left Bottom</p>
+    </Popover>
+
+    <Popover
+      top={200}
+      left={100}
+      height={200}
+      width={200}
+      position="left_top"
+      scheme="light"
+    >
+      <p>Left Top</p>
+    </Popover>
+  </div>
+))

--- a/packages/react-component-library/src/components/Popover/index.tsx
+++ b/packages/react-component-library/src/components/Popover/index.tsx
@@ -7,29 +7,47 @@ interface PopoverProps {
   right?: number
   bottom?: number
   top?: number
+  position?:
+    | 'left_bottom'
+    | 'left_top'
+    | 'right_bottom'
+    | 'right_top'
+    | 'top_left'
+    | 'top_right'
+    | 'bottom_left'
+    | 'bottom_right'
+  scheme?: 'light' | 'dark'
 }
 
 const Popover: React.FC<PopoverProps> = ({
+  bottom,
   children,
   height,
-  width,
   left,
+  position,
   right,
+  scheme = 'dark',
   top,
-  bottom,
+  width,
 }) => {
   const style = {
-    height,
-    width,
-    top,
     bottom,
+    height,
     left,
     right,
+    top,
+    width,
   }
 
   return (
-    <div className="rn-popover" style={style}>
-      {children}
+    <div
+      className={`rn-popover
+      ${position ? `rn-popover--${position}` : ''}
+      rn-popover--${scheme}
+    `}
+      style={style}
+    >
+      <div className="rn-popover__content">{children}</div>
     </div>
   )
 }

--- a/packages/react-component-library/src/fragments/NotificationSidePanel/index.tsx
+++ b/packages/react-component-library/src/fragments/NotificationSidePanel/index.tsx
@@ -74,8 +74,10 @@ const NotificationSidePanel: React.FC<NotificationSidePanelProps> = ({
       {showNotifications && (
         <Popover
           width={POPOVER_WIDTH}
-          left={BAR_WIDTH - 8}
+          left={BAR_WIDTH + 2}
           bottom={notificationPos}
+          position="left_bottom"
+          scheme="dark"
         >
           {children}
         </Popover>


### PR DESCRIPTION
Popover was introduced with SIdebar to provide an absolutely positioned small container with a speech button type pointer. At that time it only supported a dark background and a pointer in the left bottom corner.

This improved version adds 2 colour versions, dark and light. In addition pointers have been added to all corners.

<img width="493" alt="Screenshot 2019-07-16 at 13 09 47" src="https://user-images.githubusercontent.com/48056118/61294774-7c2df900-a7ce-11e9-90cc-749fecbfadb2.png">

<img width="493" alt="Screenshot 2019-07-16 at 13 09 34" src="https://user-images.githubusercontent.com/48056118/61294781-7f28e980-a7ce-11e9-9d12-9599d3dfc70b.png">
