### PR TITLE
Bugfix/EN-725 onChangeCallback invoked with incorrect page value

### DIFF
--- a/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
@@ -90,7 +90,7 @@ describe('Pagination', () => {
       })
 
       it('should invoke the onChangeCallback function', () => {
-        expect(onChangeCallback).toHaveBeenCalled()
+        expect(onChangeCallback).toHaveBeenCalledWith(5, 100)
       })
     })
   })

--- a/packages/react-component-library/src/components/Pagination/usePageChange.tsx
+++ b/packages/react-component-library/src/components/Pagination/usePageChange.tsx
@@ -32,16 +32,20 @@ export const usePageChange = (
    * the provided onChangeCallback callback (if it is provided)
    */
   function changePage(page: string | number): void {
+    let selected
+
     if (page === 'previous' && currentPage > 1) {
-      setCurrentPage(currentPage - 1)
+      selected = currentPage - 1
     } else if (page === 'next' && currentPage !== totalPages) {
-      setCurrentPage(currentPage + 1)
+      selected = currentPage + 1
     } else {
-      setCurrentPage(Number(page))
+      selected = Number(page)
     }
 
+    setCurrentPage(selected)
+
     if (typeof onChangeCallback === 'function') {
-      onChangeCallback(currentPage, totalPages)
+      onChangeCallback(selected, totalPages)
     }
   }
 


### PR DESCRIPTION
## Related Jira issue: 

https://rn-nelson.atlassian.net/browse/EN-725

## Overview

Fix issue where onChangeCallback would be invoked with an incorrect current page argument value.

## Work carried out

- [x] Fix bug
- [x] Make automated test more robust
