### PR TITLE
Fix issue with sidebar position

### DIFF
--- a/packages/css-framework/src/fragments/_sidebar.scss
+++ b/packages/css-framework/src/fragments/_sidebar.scss
@@ -7,12 +7,12 @@ body.has-sidebar {
 }
 
 .rn-sidebar {
-  height: 100%;
+  height: 100vh;
+  position: fixed;
   width: $bar-width;
   display: flex;
   justify-content: space-between;
   flex-direction: column;
-  position: absolute;
   top: 0;
   left: 0;
   background: color(neutral, 600);


### PR DESCRIPTION
Sidebar was only using 100% of the window and also scrolled. This fixes the issue so it's sticky, and stays on screen and is always the screen height
