### PR TITLE
Feature/update ci config for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,17 +184,6 @@ jobs:
           name: Upload CC coverage
           working_directory: ~/project
           command: /tmp/cc-test-reporter upload-coverage -i workspace/coverage.json
-  publish_documentation:
-    executor: node
-    steps:
-      - checkout
-      - run:
-          name: Authenticate NPM
-          command: echo "//$NPM_REGISTRY/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
-      - run:
-          name: Publish package
-          working_directory: packages/documentation
-          command: npm publish --registry https://$NPM_REGISTRY
   publish_storybook-react-input-state:
     executor: node
     steps:
@@ -332,11 +321,6 @@ workflows:
             - test_react-component-library
             - test_storybook-react-input-state
             - test_vue-component-library
-      - publish_documentation:
-          filters:
-            branches:
-              only:
-                - master
       - publish_storybook-react-input-state:
           requires:
             - test_storybook-react-input-state
@@ -384,7 +368,6 @@ workflows:
                 - develop
       - deploy_docs_site_production:
           requires:
-            - publish_documentation
             - publish_css-framework
             - publish_react-component-library
             - publish_vue-component-library

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,14 +343,14 @@ workflows:
             branches:
               only:
                 - master
-      - publish_vue-component-library:
-          requires:
-            - test_vue-component-library
-            - publish_css-framework
-          filters:
-            branches:
-              only:
-                - master
+      # - publish_vue-component-library:
+      #     requires:
+      #       - test_vue-component-library
+      #       - publish_css-framework
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
       - test_docs-site:
           requires:
             - test_react-component-library
@@ -370,7 +370,7 @@ workflows:
           requires:
             - publish_css-framework
             - publish_react-component-library
-            - publish_vue-component-library
+            # - publish_vue-component-library
             - build_docs-site
           filters:
             branches:

--- a/packages/css-framework/package.json
+++ b/packages/css-framework/package.json
@@ -25,7 +25,8 @@
     "build": "sass --style=compressed index.scss dist/styles.css",
     "lint": "stylelint ./index.scss",
     "lint-staged": "lint-staged",
-    "watch": "sass --watch index.scss dist/styles.css"
+    "watch": "sass --watch index.scss dist/styles.css",
+    "prepare": "yarn build"
   },
   "lint-staged": {
     "*.@(scss)": "stylelint"

--- a/packages/css-framework/package.json
+++ b/packages/css-framework/package.json
@@ -2,6 +2,9 @@
   "name": "@royalnavy/css-framework",
   "description": "Foundational CSS Framework for Royal Navy components and applications.",
   "version": "0.1.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "NELSON",
   "contributors": [
     "hxltrhuxze <hxltrhuxze@royalnavy.io> (royalnavy.io)",
@@ -14,9 +17,6 @@
   "homepage": "https://github.com/Royal-Navy/standards-toolkit/tree/develop/packages/css-framework#readme",
   "license": "MIT",
   "main": "index.scss",
-  "publishConfig": {
-    "access": "public"
-  },
   "files": [
     "dist",
     "src"

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@royalnavy/eslint-config-react",
   "version": "0.1.1",
-  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=10.13.0 <11"
   },

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -30,7 +30,8 @@
     "storybook": "start-storybook -p 6006",
     "test": "jest",
     "test:watch": "jest --watch",
-    "types": "tsc --emitDeclarationOnly --declarationMap --declaration --noEmit false --isolatedMOdules false --allowJs false --outDir dist/"
+    "types": "tsc --emitDeclarationOnly --declarationMap --declaration --noEmit false --isolatedMOdules false --allowJs false --outDir dist/",
+    "prepare": "yarn build"
   },
   "lint-staged": {
     "*.@(js|jsx|ts|tsx)": "eslint"

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -2,6 +2,9 @@
   "name": "@royalnavy/react-component-library",
   "description": "A collection of react components and helpers to assist in building applications for the Royal Navy",
   "version": "1.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "react",
     "webpack",

--- a/packages/storybook-react-input-state/package.json
+++ b/packages/storybook-react-input-state/package.json
@@ -28,10 +28,10 @@
     "lint": "eslint src",
     "lint-staged": "lint-staged",
     "postinstall": "yarn build",
-    "prepublish": "yarn build",
     "storybook": "start-storybook -p 6006",
     "release": "release-it",
-    "test": "jest --silent --no-cache"
+    "test": "jest --silent --no-cache",
+    "prepare": "yarn build"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/packages/storybook-react-input-state/package.json
+++ b/packages/storybook-react-input-state/package.json
@@ -2,6 +2,9 @@
   "name": "@royalnavy/storybook-react-input-state",
   "description": "State wrapper for form components in react storybook stories",
   "version": "0.1.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "dist/bundle.js",
   "keywords": [
     "storybook",
@@ -18,9 +21,6 @@
   "homepage": "https://github.com/Royal-Navy/nelson-frontend-component-library",
   "bugs": {
     "url": "https://github.com/Royal-Navy/nelson-frontend-component-library/issues"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "scripts": {
     "build": "webpack --config webpack/webpack.prod.js",

--- a/packages/vue-component-library/package.json
+++ b/packages/vue-component-library/package.json
@@ -2,6 +2,9 @@
   "name": "@royalnavy/vue-component-library",
   "description": "A collection of react components and helpers to assist in building applications for the Royal Navy",
   "version": "0.1.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "vue",
     "components"
@@ -22,10 +25,6 @@
   "files": [
     "dist"
   ],
-  "private": false,
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "vue-cli-service build --target lib --name bundle ./src/index.ts",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
## Overview

Updates to CI / CD configuration ahead of `1.0.0` tag and release.

## Reason

> Try to make automation work first time round - it has been a while and lots has changed.

## Work carried out

- [x] Remove publish documentation job
- [x] Disable publish `vue-component-library` job
- [x] Ensure dist build is generated as part of publish jobs (add `prepare` npm tasks)
- [x] Make sure that `--access public` flag is set for publish jobs (`publicConfig`)
