### PR TITLE
Site Background

### DIFF
--- a/packages/css-framework/src/components/_layout.scss
+++ b/packages/css-framework/src/components/_layout.scss
@@ -1,5 +1,5 @@
 .rn-layout {
-
+  
   &.vertical {
     .rn-layout {
       &__app {

--- a/packages/docs-site/src/components/presenters/Masthead/masthead.scss
+++ b/packages/docs-site/src/components/presenters/Masthead/masthead.scss
@@ -2,14 +2,15 @@
 
 .masthead {
   margin-bottom: spacing(3);
+  background: white;
 }
 
 .masthead__container {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: spacing(3);
-  margin-bottom: spacing(3);
+  padding-top: spacing(3);
+  padding-bottom: spacing(3);
 }
 
 .masthead .masthead__button {
@@ -18,8 +19,8 @@
 
 .masthead__nav {
   display: none;
-  margin-top: spacing(3);
-  margin-bottom: spacing(3);
+  padding-top: spacing(3);
+  padding-bottom: spacing(3);
 }
 
 .masthead__nav.is-open {

--- a/packages/docs-site/src/components/presenters/layout/globals.scss
+++ b/packages/docs-site/src/components/presenters/layout/globals.scss
@@ -1,0 +1,9 @@
+@import "@royalnavy/css-framework";
+
+body {
+  background-color: color(primary, 900);  
+}
+
+.layout {
+  background: white;  
+}

--- a/packages/docs-site/src/components/presenters/layout/index.js
+++ b/packages/docs-site/src/components/presenters/layout/index.js
@@ -15,7 +15,7 @@ const Layout = ({ children, className }) => (
         }
       }
     `}
-    render={() => <div className={className}>{children}</div>}
+    render={() => <div className={`layout ${className}`}>{children}</div>}
   />
 )
 


### PR DESCRIPTION
## Overview

Adding the footer background colour to site so footer bleeds to bottom of viewport

## Work carried out

- [x] Added footer background to the `body`

## Screenshot
<img width="1385" alt="Screenshot 2019-07-26 at 14 11 53" src="https://user-images.githubusercontent.com/48090803/61953924-8199f900-afaf-11e9-8c0c-357444422732.png">
