### PR TITLE
Fix bug with Breadcrumb type definition

### DIFF
--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumb.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumb.tsx
@@ -8,7 +8,7 @@ interface BreadcrumbProps {
   first?: boolean
   label: string
   last?: boolean
-  LinkComponent?: LinkTypes
+  LinkComponent?: any
 }
 
 const Breadcrumb: React.FC<BreadcrumbProps> = ({

--- a/packages/react-component-library/src/components/Breadcrumbs/index.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/index.tsx
@@ -5,7 +5,7 @@ import Link from '../Link'
 import Breadcrumb from './Breadcrumb'
 
 interface BreadcrumbsProps extends ComponentWithClass {
-  LinkComponent?: LinkTypes
+  LinkComponent?: any
   navItems: any[]
 }
 


### PR DESCRIPTION
The LinkComponent type needs to be any in Breadcrumb, to allow use of React Router Dom Link component

#195 