### PR TITLE
Add storybook:static task

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lint": "lerna run --parallel lint",
     "lint-staged": "lerna run --parallel lint-staged",
     "test": "lerna run --parallel test",
-    "lerna:version": "lerna version --tag-version-prefix=''",
-    "storybook:static": "lerna run --parallel storybook:static"
+    "storybook:static": "lerna run --parallel storybook:static",
+    "lerna:version": "lerna version --tag-version-prefix=''"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lint": "lerna run --parallel lint",
     "lint-staged": "lerna run --parallel lint-staged",
     "test": "lerna run --parallel test",
-    "lerna:version": "lerna version --tag-version-prefix=''"
+    "lerna:version": "lerna version --tag-version-prefix=''",
+    "storybook:static": "lerna run --parallel storybook:static"
   }
 }

--- a/packages/react-component-library/.gitignore
+++ b/packages/react-component-library/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 public/
+.static_storybook/

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint src/* --ext .js --ext .jsx --ext .ts --ext .tsx",
     "lint:ci": "eslint -f ../../node_modules/eslint-junit/index.js src/* --ext .js --ext .jsx --ext .ts --ext .tsx",
     "storybook": "start-storybook -p 6006",
+    "storybook:static": "build-storybook -c .storybook -o .static_storybook",
     "test": "jest",
     "test:watch": "jest --watch",
     "types": "tsc --emitDeclarationOnly --declarationMap --declaration --noEmit false --isolatedMOdules false --allowJs false --outDir dist/",


### PR DESCRIPTION
## Overview

Automate the deployment (including branch deployments) of a static react-component-library storybook site.

## Work carried out

- [x] Add task to react-component-library
- [x] Add monorepo parallel Lerna task
- [x] gitignore the .static_storybook/ dir

## Developer notes

Won't be fully implemented until the 1.1 release is shipped later today.