### PR TITLE
Bugfix/docs site fixes

### DIFF
--- a/packages/docs-site/src/library/pages/components/button.md
+++ b/packages/docs-site/src/library/pages/components/button.md
@@ -119,12 +119,12 @@ A button can be one of 3 variants to indicate it's importance and role on a page
 
 <CodeHighlighter 
 source={`<Button onClick={action} variant="primary">Primary</Button>
-<Button onClick{action} variant="secondary">Secondary</Button>
-<Button onClick{action} variant="tertiary">Tertiary</Button>
+<Button onClick={action} variant="secondary">Secondary</Button>
+<Button onClick={action} variant="tertiary">Tertiary</Button>
 
 <Button onClick={action} variant="primary" color="danger">Primary</Button>
-<Button onClick{action} variant="secondary" color="danger">Secondary</Button>
-<Button onClick{action} variant="tertiary" color="danger">Tertiary</Button>
+<Button onClick={action} variant="secondary" color="danger">Secondary</Button>
+<Button onClick={action} variant="tertiary" color="danger">Tertiary</Button>
 `} language="javascript"
 >
   <p>

--- a/packages/docs-site/src/library/pages/components/forms/index.md
+++ b/packages/docs-site/src/library/pages/components/forms/index.md
@@ -1,9 +1,9 @@
 ---
 title: Forms
-description: A description for forms
+description: Forms contain interactive controls for submitting information to a web server.
 header: true
 ---
 
 # Overview
 
-Some text about forms
+Examples and usage guidelines for form control styles, layout options, and custom components for creating a wide variety of forms.

--- a/packages/docs-site/src/library/pages/components/phase-banner.md
+++ b/packages/docs-site/src/library/pages/components/phase-banner.md
@@ -53,7 +53,7 @@ By default simply passing a `label` and `href` will cause a regular anchor tag t
 ### Alternative text
 You can pass custom markup to appear by including it as a child of the component.
 
-<CodeHighlighter source={`<PhaseBanner>Custom html can go here. <strong>This part is in bold!</strong><PhaseBanner/>`} language="javascript">
+<CodeHighlighter source={`<PhaseBanner>Custom html can go here. <strong>This part is in bold!</strong></PhaseBanner>`} language="javascript">
   <PhaseBanner>Custom html can go here. <strong>This part is in bold!</strong></PhaseBanner>
 </CodeHighlighter>
 

--- a/packages/docs-site/src/library/pages/components/phase-banner.md
+++ b/packages/docs-site/src/library/pages/components/phase-banner.md
@@ -24,12 +24,12 @@ The Phase Banner is an indicator that sits at the top of your application. It co
 
 <SketchWidget name="PhaseBanner" href="/standards-toolkit.sketch" />
 
-  ### Anatomy
-  <PhaseBannerAnatomy />
-  
-  1. **Phase Badge**. The Phase Badge indicates the current phase to the user.
-  2. **Phase Message**. Accompanying message to provide additional information to the user
-  3. **Container** The container is a wrapper that stretches to 100% of the viewport.
+### Anatomy
+<PhaseBannerAnatomy />
+
+1. **Phase Badge**. The Phase Badge indicates the current phase to the user.
+2. **Phase Message**. Accompanying message to provide additional information to the user
+3. **Container** The container is a wrapper that stretches to 100% of the viewport.
 
 ### Sizing & Spacing
 The phase banner is a full width component - it is designed to stretch to the size of the viewport. Try to keep the Phase Message concise however.

--- a/packages/docs-site/src/library/pages/components/phase-banner.md
+++ b/packages/docs-site/src/library/pages/components/phase-banner.md
@@ -53,7 +53,9 @@ By default simply passing a `label` and `href` will cause a regular anchor tag t
 ### Alternative text
 You can pass custom markup to appear by including it as a child of the component.
 
-<CodeHighlighter source={`<PhaseBanner>Custom html can go here. <strong>This part is in bold!</strong></PhaseBanner>`} language="javascript">
+<CodeHighlighter source={`<PhaseBanner>
+  Custom html can go here. <strong>This part is in bold!</strong>
+</PhaseBanner>`} language="javascript">
   <PhaseBanner>Custom html can go here. <strong>This part is in bold!</strong></PhaseBanner>
 </CodeHighlighter>
 

--- a/packages/docs-site/src/library/pages/styles/container.md
+++ b/packages/docs-site/src/library/pages/styles/container.md
@@ -16,8 +16,8 @@ The container CSS class wraps all your main application content:
 
 <CodeHighlighter 
 source={`<div class="rn-container">
-    // Main App Content
- </div>`} language="html"
+  // Main App Content
+</div>`} language="html"
 />
 
 ## Available Sizing
@@ -26,14 +26,14 @@ The container class has 3 different variations. The default class has a padding 
 
 <CodeHighlighter 
 source={`<div class="rn-container--large">
-    // Large Container
- </div>`} language="html"
+  // Large Container
+</div>`} language="html"
 />
 
 And a large container that has a padding of `1.25rem`:
 
 <CodeHighlighter 
 source={`<div class="rn-container--small">
-    // Large Container
- </div>`} language="html"
+  // Large Container
+</div>`} language="html"
 />


### PR DESCRIPTION
## Related issues: 

https://github.com/Royal-Navy/standards-toolkit/issues/230
https://github.com/Royal-Navy/standards-toolkit/issues/229
https://github.com/Royal-Navy/standards-toolkit/issues/202

## Overview

Numerous small docs-site fixes.

## Work carried out

- [x] Fix issue with form child components displaying within sidebar correctly
- [x] Fix markdown list not rendering correct for Phase Banner docs
- [x] Fix typos in Button variant code example
- [x] Add some initial form overview content
- [x] Remove additional whitespace on code examples
- [x] Fix broken closing tag
