### PR TITLE
Bugfix/add formik enhancer exports

### DIFF
--- a/packages/react-component-library/src/components/index.ts
+++ b/packages/react-component-library/src/components/index.ts
@@ -3,6 +3,7 @@ import Badge from './Badge'
 import Breadcrumbs from './Breadcrumbs'
 import Button from './Button'
 import Checkbox from './Checkbox'
+import Link from './Link'
 import Nav from './Nav'
 import Pagination from './Pagination'
 import PhaseBanner from './PhaseBanner'
@@ -11,14 +12,16 @@ import Sidebar from '../fragments/Sidebar'
 import Radio from './Radio'
 import Tab from './TabSet/Tab'
 import TabSet from './TabSet'
+import TabNav from './TabNav'
 import TextInput from './TextInput'
 
-export default {
+export {
   Avatar,
   Badge,
   Breadcrumbs,
   Button,
   Checkbox,
+  Link,
   Nav,
   Pagination,
   PhaseBanner,
@@ -27,5 +30,6 @@ export default {
   Sidebar,
   Tab,
   TabSet,
+  TabNav,
   TextInput,
 }

--- a/packages/react-component-library/src/components/index.ts
+++ b/packages/react-component-library/src/components/index.ts
@@ -3,27 +3,29 @@ import Badge from './Badge'
 import Breadcrumbs from './Breadcrumbs'
 import Button from './Button'
 import Checkbox from './Checkbox'
-import Link from './Link'
 import Nav from './Nav'
+import Pagination from './Pagination'
 import PhaseBanner from './PhaseBanner'
 import Popover from './Popover'
-import TabSet from './TabSet'
-import TabNav from './TabNav'
+import Sidebar from '../fragments/Sidebar'
+import Radio from './Radio'
 import Tab from './TabSet/Tab'
+import TabSet from './TabSet'
 import TextInput from './TextInput'
 
-export {
+export default {
   Avatar,
   Badge,
   Breadcrumbs,
   Button,
   Checkbox,
-  Link,
   Nav,
+  Pagination,
   PhaseBanner,
   Popover,
+  Radio,
+  Sidebar,
   Tab,
-  TabNav,
   TabSet,
-  TextInput
+  TextInput,
 }

--- a/packages/react-component-library/src/components/index.ts
+++ b/packages/react-component-library/src/components/index.ts
@@ -1,4 +1,3 @@
-// Components
 import Avatar from './Avatar'
 import Badge from './Badge'
 import Breadcrumbs from './Breadcrumbs'
@@ -13,9 +12,6 @@ import TabNav from './TabNav'
 import Tab from './TabSet/Tab'
 import TextInput from './TextInput'
 
-// Enhancers
-import withFormik from '../enhancers/withFormik'
-
 export {
   Avatar,
   Badge,
@@ -29,7 +25,5 @@ export {
   Tab,
   TabNav,
   TabSet,
-  TextInput,
-
-  withFormik
+  TextInput
 }

--- a/packages/react-component-library/src/enhancers/index.tsx
+++ b/packages/react-component-library/src/enhancers/index.tsx
@@ -1,4 +1,4 @@
-import Components from '../components'
+import * as Components from '../components'
 import withFormik from './withFormik'
 
 const Formik: object = {

--- a/packages/react-component-library/src/enhancers/index.tsx
+++ b/packages/react-component-library/src/enhancers/index.tsx
@@ -6,8 +6,8 @@ const Formik: object = {
   // ...
 }
 
-for (const key of Object.keys(Components)) {
+Object.keys(Components).forEach(key => {
   Formik[key] = withFormik(Components[key])
-}
+})
 
 export { Formik, withFormik }

--- a/packages/react-component-library/src/enhancers/index.tsx
+++ b/packages/react-component-library/src/enhancers/index.tsx
@@ -1,7 +1,4 @@
-import TextInput from '../components/TextInput'
-import Checkbox from '../components/Checkbox'
-import Radio from '../components/Radio'
-
+import { TextInput, Checkbox, Radio } from '../components'
 import withFormik from './withFormik'
 
 const Formik: object = {

--- a/packages/react-component-library/src/enhancers/index.tsx
+++ b/packages/react-component-library/src/enhancers/index.tsx
@@ -1,13 +1,19 @@
-import * as Components from '../components'
+import TextInput from '../components/TextInput'
+import Checkbox from '../components/Checkbox'
+import Radio from '../components/Radio'
+
 import withFormik from './withFormik'
 
 const Formik: object = {
   // Enhanced components
+  TextInput,
+  Checkbox,
+  Radio,
   // ...
 }
 
-Object.keys(Components).forEach(key => {
-  Formik[key] = withFormik(Components[key])
+Object.keys(Formik).forEach(key => {
+  Formik[key] = withFormik(Formik[key])
 })
 
 export { Formik, withFormik }

--- a/packages/react-component-library/src/enhancers/index.tsx
+++ b/packages/react-component-library/src/enhancers/index.tsx
@@ -6,8 +6,8 @@ const Formik: object = {
   // ...
 }
 
-Object.keys(Components).map((key: string) => {
+for (let key of Object.keys(Components)) {
   Formik[key] = withFormik(Components[key])
-})
+}
 
 export { Formik, withFormik }

--- a/packages/react-component-library/src/enhancers/index.tsx
+++ b/packages/react-component-library/src/enhancers/index.tsx
@@ -6,7 +6,7 @@ const Formik: object = {
   // ...
 }
 
-for (let key of Object.keys(Components)) {
+for (const key of Object.keys(Components)) {
   Formik[key] = withFormik(Components[key])
 }
 

--- a/packages/react-component-library/src/enhancers/index.tsx
+++ b/packages/react-component-library/src/enhancers/index.tsx
@@ -1,0 +1,13 @@
+import Components from '../components'
+import withFormik from './withFormik'
+
+const Formik: object = {
+  // Enhanced components
+  // ...
+}
+
+Object.keys(Components).map((key: string) => {
+  Formik[key] = withFormik(Components[key])
+})
+
+export { Formik, withFormik }

--- a/packages/react-component-library/src/index.ts
+++ b/packages/react-component-library/src/index.ts
@@ -17,8 +17,8 @@ import TextInput from './components/TextInput'
 // Icons
 import * as Icons from './icons'
 
-// Enhancers
-import withFormik from './enhancers/withFormik'
+// Enhanced & Enhancers
+import { Formik, withFormik } from './enhancers'
 
 export {
   Avatar,
@@ -38,5 +38,6 @@ export {
 
   Icons,
 
+  Formik,
   withFormik
 }

--- a/packages/react-component-library/src/index.ts
+++ b/packages/react-component-library/src/index.ts
@@ -1,4 +1,4 @@
-import * as Icons from './icons'
+// Components
 import Avatar from './components/Avatar'
 import Badge from './components/Badge'
 import Breadcrumbs from './components/Breadcrumbs'
@@ -14,13 +14,18 @@ import Tab from './components/TabSet/Tab'
 import TabSet from './components/TabSet'
 import TextInput from './components/TextInput'
 
+// Icons
+import * as Icons from './icons'
+
+// Enhancers
+import withFormik from './enhancers/withFormik'
+
 export {
   Avatar,
   Badge,
   Breadcrumbs,
   Button,
   Checkbox,
-  Icons,
   Nav,
   Pagination,
   PhaseBanner,
@@ -30,4 +35,8 @@ export {
   Tab,
   TabSet,
   TextInput,
+
+  Icons,
+
+  withFormik
 }

--- a/packages/react-component-library/tsconfig.json
+++ b/packages/react-component-library/tsconfig.json
@@ -14,7 +14,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "preserve",
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "suppressImplicitAnyIndexErrors": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Related issue

https://github.com/Royal-Navy/standards-toolkit/issues/241

## Overview

Fix issues with Formik enhancer exports and export pre-enhanced components.

## Reason

Exports were previously added to the incorrect index.

## Work carried out

- [x] Tidy up stale component exports
- [x] Export `withFormik` enhancer correctly
- [x] Pre-enhance components and export via `Formik` object
- [x] Add `suppressImplicitAnyIndexErrors` to TS config

## Developer notes

`suppressImplicitAnyIndexErrors` has been added in order to allow developer access to dictionary objects that aren't under the developers control going forward.

