### PR TITLE
Feature/sidebar enhancements

### DIFF
--- a/packages/docs-site/src/components/presenters/sidebar/Link.js
+++ b/packages/docs-site/src/components/presenters/sidebar/Link.js
@@ -3,17 +3,14 @@ import PropTypes from 'prop-types'
 
 const Link = ({ children, className = '', href, ...rest }) => {
   return (
-    <>
-      <a
-        className={`rn-link ${className}`}
-        href={href}
-        data-testid="link"
-        {...rest}
-      >
-        {children}
-      </a>
-      {children && <button type="button" className="sidebar__toggle" />}
-    </>
+    <a
+      className={`rn-link ${className}`}
+      href={href}
+      data-testid="link"
+      {...rest}
+    >
+      {children}
+    </a>
   )
 }
 

--- a/packages/docs-site/src/components/presenters/sidebar/Link.js
+++ b/packages/docs-site/src/components/presenters/sidebar/Link.js
@@ -1,16 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const Link = ({ children, className = '', href, ...rest }) => {
+const Link = ({ children, className = '', href, hasChildren, ...rest }) => {
+  const ConditionalTag = hasChildren ? 'span' : 'a'
+
   return (
-    <a
+    <ConditionalTag
       className={`rn-link ${className}`}
       href={href}
       data-testid="link"
       {...rest}
     >
       {children}
-    </a>
+    </ConditionalTag>
   )
 }
 
@@ -18,12 +20,14 @@ Link.propTypes = {
   children: PropTypes.instanceOf(Array),
   className: PropTypes.string,
   href: PropTypes.string,
+  hasChildren: PropTypes.bool,
 }
 
 Link.defaultProps = {
   children: [],
   className: '',
   href: '',
+  hasChildren: false,
 }
 
 Link.displayName = 'Link'

--- a/packages/docs-site/src/components/presenters/sidebar/Link.js
+++ b/packages/docs-site/src/components/presenters/sidebar/Link.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const Link = ({ children, className = '', href, ...rest }) => {
+  return (
+    <>
+      <a
+        className={`rn-link ${className}`}
+        href={href}
+        data-testid="link"
+        {...rest}
+      >
+        {children}
+      </a>
+      {children && <button type="button" className="sidebar__toggle" />}
+    </>
+  )
+}
+
+Link.propTypes = {
+  children: PropTypes.instanceOf(Array),
+  className: PropTypes.string,
+  href: PropTypes.string,
+}
+
+Link.defaultProps = {
+  children: [],
+  className: '',
+  href: '',
+}
+
+Link.displayName = 'Link'
+
+export default Link

--- a/packages/docs-site/src/components/presenters/sidebar/index.js
+++ b/packages/docs-site/src/components/presenters/sidebar/index.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import './sidebar.scss'
-
 import { Nav } from '@royalnavy/react-component-library'
+import Link from './Link'
+
+import './sidebar.scss'
 
 const Sidebar = ({ className, navItems, title }) => (
   <aside data-testid="wrapper" className={`sidebar ${className}`}>
@@ -12,7 +13,12 @@ const Sidebar = ({ className, navItems, title }) => (
         {title}
       </span>
     )}
-    <Nav navItems={navItems} orientation="vertical" size="large" />
+    <Nav
+      navItems={navItems}
+      orientation="vertical"
+      size="large"
+      LinkComponent={Link}
+    />
   </aside>
 )
 

--- a/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
+++ b/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
@@ -48,20 +48,21 @@
     display: block;
   }
 
-  & > .sidebar__toggle {
+  & > .rn-nav__item {
     display: inline-block;
     transform: translateY(2px) translateX(-6px);
     cursor: pointer;
 
-    &::before {
+    &::after {
       display: inline-block;
       content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg version='1.1' viewBox='0 0 12 9' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3EFill 1%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg transform='translate(-243 -768)' fill='%233E5667'%3E%3Cg transform='translate(174 560)'%3E%3Cpath transform='translate(75.192 212.47) scale(1 -1) rotate(180) translate(-75.192 -212.47)' d='m80.601 210.77l-5.4081 5.4081-5.4081-5.4081c-0.45931-0.45931-0.45931-1.204 0-1.6633l1.248e-4 -1.25e-4c0.45948-0.45934 1.2043-0.4593 1.6637 7.9e-5l3.7443 3.7439 3.7443-3.7439c0.45943-0.45938 1.2043-0.45942 1.6637-7.9e-5 0.45938 0.45924 0.45949 1.2039 2.495e-4 1.6633-4.16e-5 4.2e-5 -8.32e-5 8.4e-5 -1.247e-4 1.25e-4z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
       width: 12px;
       height: 7px;
+      margin-left: spacing(2);
     }
   }
 
-  &.is-open > .sidebar__toggle::before {
+  &.is-open > .rn-nav__item::after {
     content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg version='1.1' viewBox='0 0 12 9' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3EFill 1%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg transform='translate(-243 -768)' fill='%233E5667'%3E%3Cg transform='translate(174 560)'%3E%3Cpath transform='translate(75.192 212.47) rotate(180) translate(-75.192 -212.47)' d='m80.601 210.77l-5.4081 5.4081-5.4081-5.4081c-0.45931-0.45931-0.45931-1.204 0-1.6633l1.248e-4 -1.25e-4c0.45948-0.45934 1.2043-0.4593 1.6637 7.9e-5l3.7443 3.7439 3.7443-3.7439c0.45943-0.45938 1.2043-0.45942 1.6637-7.9e-5 0.45938 0.45924 0.45949 1.2039 2.495e-4 1.6633-4.16e-5 4.2e-5 -8.32e-5 8.4e-5 -1.247e-4 1.25e-4z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
   }
 }
@@ -73,8 +74,14 @@
 .sidebar .rn-nav__list-item.has-children > .rn-nav__item {
   font-size: font-size('m');
   color: color(primary, 900);
+  pointer-events: none;
 
   &.is-active {
+    background: none;
+  }
+
+  &:hover {
+    background: color(primary, 300);
     color: color(neutral, white);
   }
 }

--- a/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
+++ b/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
@@ -50,7 +50,7 @@
 
   & > .sidebar__toggle {
     display: inline-block;
-    transform: rotate(180deg);
+    transform: translateY(2px) translateX(-6px);
     cursor: pointer;
 
     &::before {

--- a/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
+++ b/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
@@ -1,12 +1,7 @@
 @import '@royalnavy/css-framework';
 
-$border-radius: 4px;
-$text-color: #253b5b;
-
 .sidebar {
-  background-color: #f0f4f8;
   padding: spacing(3);
-
   display: none;
 }
 
@@ -18,28 +13,45 @@ $text-color: #253b5b;
 
 .sidebar__title {
   display: block;
-  padding-bottom: spacing(8);
-  margin-bottom: spacing(4);
-  border-bottom: 1px dashed #8c8c8c;
-  font-size: font-size('s');
+  padding-bottom: spacing(3);
+  font-size: font-size('m');
   font-weight: 600;
-  color: $text-color;
+  color: color(primary, 900);
 }
 
 .sidebar .rn-nav__item {
-  color: $text-color;
-  padding: spacing(3);
+  display: inline-block;
+  width: auto;
+  color: color(neutral, 400);
+  padding: spacing(2) spacing(3);
+
+  &.is-active {
+    background-color: color(primary, 800);
+  }
 }
 
 .sidebar .rn-nav__list-item.has-children {
-  background-color: #d2dbe5;
-  border-radius: $border-radius;
+  & > .rn-nav__list {
+    display: none;
+    padding: 0 0 0 spacing(4);
+  }
+
+  &.is-open > .rn-nav__list {
+    display: block;
+  }
+}
+
+.sidebar .rn-nav__list-item.has-children .rn-nav__item {
+  margin: spacing(1) 0;
 }
 
 .sidebar .rn-nav__list-item.has-children > .rn-nav__item {
-  background-color: #274776;
-  color: #fff;
-  border-radius: $border-radius;
+  font-size: font-size('m');
+  color: color(primary, 900);
+
+  &.is-active {
+    color: color(neutral, white);
+  }
 }
 
 .sidebar .rn-nav__list .rn-nav__list {

--- a/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
+++ b/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
@@ -78,11 +78,6 @@
   &.is-active {
     background: none;
   }
-
-  &:hover {
-    background: color(primary, 300);
-    color: color(neutral, white);
-  }
 }
 
 .sidebar .rn-nav__list .rn-nav__list {

--- a/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
+++ b/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
@@ -58,6 +58,7 @@
       width: 12px;
       height: 7px;
       margin-left: spacing(2);
+      transform: translateY(-2px);
     }
   }
 
@@ -73,7 +74,6 @@
 .sidebar .rn-nav__list-item.has-children > .rn-nav__item {
   font-size: font-size('m');
   color: color(primary, 900);
-  pointer-events: none;
 
   &.is-active {
     background: none;

--- a/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
+++ b/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
@@ -19,6 +19,12 @@
   color: color(primary, 900);
 }
 
+.sidebar__toggle {
+  border: none;
+  background: none;
+  display: none;
+}
+
 .sidebar .rn-nav__item {
   display: inline-block;
   width: auto;
@@ -31,6 +37,8 @@
 }
 
 .sidebar .rn-nav__list-item.has-children {
+  position: relative;
+
   & > .rn-nav__list {
     display: none;
     padding: 0 0 0 spacing(4);
@@ -38,6 +46,23 @@
 
   &.is-open > .rn-nav__list {
     display: block;
+  }
+
+  & > .sidebar__toggle {
+    display: inline-block;
+    transform: rotate(180deg);
+    cursor: pointer;
+
+    &::before {
+      display: inline-block;
+      content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg version='1.1' viewBox='0 0 12 9' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3EFill 1%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg transform='translate(-243 -768)' fill='%233E5667'%3E%3Cg transform='translate(174 560)'%3E%3Cpath transform='translate(75.192 212.47) scale(1 -1) rotate(180) translate(-75.192 -212.47)' d='m80.601 210.77l-5.4081 5.4081-5.4081-5.4081c-0.45931-0.45931-0.45931-1.204 0-1.6633l1.248e-4 -1.25e-4c0.45948-0.45934 1.2043-0.4593 1.6637 7.9e-5l3.7443 3.7439 3.7443-3.7439c0.45943-0.45938 1.2043-0.45942 1.6637-7.9e-5 0.45938 0.45924 0.45949 1.2039 2.495e-4 1.6633-4.16e-5 4.2e-5 -8.32e-5 8.4e-5 -1.247e-4 1.25e-4z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
+      width: 12px;
+      height: 7px;
+    }
+  }
+
+  &.is-open > .sidebar__toggle::before {
+    content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg version='1.1' viewBox='0 0 12 9' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3EFill 1%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg transform='translate(-243 -768)' fill='%233E5667'%3E%3Cg transform='translate(174 560)'%3E%3Cpath transform='translate(75.192 212.47) rotate(180) translate(-75.192 -212.47)' d='m80.601 210.77l-5.4081 5.4081-5.4081-5.4081c-0.45931-0.45931-0.45931-1.204 0-1.6633l1.248e-4 -1.25e-4c0.45948-0.45934 1.2043-0.4593 1.6637 7.9e-5l3.7443 3.7439 3.7443-3.7439c0.45943-0.45938 1.2043-0.45942 1.6637-7.9e-5 0.45938 0.45924 0.45949 1.2039 2.495e-4 1.6633-4.16e-5 4.2e-5 -8.32e-5 8.4e-5 -1.247e-4 1.25e-4z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
   }
 }
 

--- a/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
+++ b/packages/docs-site/src/components/presenters/sidebar/sidebar.scss
@@ -50,7 +50,6 @@
 
   & > .rn-nav__item {
     display: inline-block;
-    transform: translateY(2px) translateX(-6px);
     cursor: pointer;
 
     &::after {

--- a/packages/docs-site/src/hooks/useSecondaryNavData.js
+++ b/packages/docs-site/src/hooks/useSecondaryNavData.js
@@ -23,16 +23,45 @@ const useSecondaryNavData = location => {
 
   const { children: sectionNavItems } = section
 
-  const navItems = sectionNavItems
+  let navItems = sectionNavItems
     .map(checkActive)
     .map(({ active, children, href, label }) => ({
       active,
-      children: sortBy(children.map(checkActive), 'label'),
+      children: sortBy(children.map(checkActive), ['index', 'label']),
       href,
       label,
     }))
+    .map(({ active, href, label, children }) => {
+      if (children && children.length >= 1) {
+        children.unshift(
+          checkActive({
+            index: 0,
+            label: 'Overview',
+            href,
+          })
+        )
+      }
 
-  return sortBy(navItems, 'label')
+      return {
+        active,
+        href,
+        label,
+        children,
+      }
+    })
+
+  navItems = sortBy(navItems, ['index', 'label'])
+
+  navItems.unshift(
+    checkActive({
+      index: 0,
+      href: section.href,
+      label: 'Overview',
+      children: [],
+    })
+  )
+
+  return navItems
 }
 
 export default useSecondaryNavData

--- a/packages/docs-site/src/hooks/useSecondaryNavData.test.js
+++ b/packages/docs-site/src/hooks/useSecondaryNavData.test.js
@@ -34,20 +34,21 @@ describe('useSecondaryNavData', () => {
     })
 
     it('should return nested items for sub sections', () => {
-      expect(result).toHaveLength(2)
+      expect(result).toHaveLength(3)
 
       expect(result[0]).toStrictEqual({
-        active: false,
+        active: true,
         children: [],
-        href: '/get-started/development',
-        label: 'Development',
+        href: '/get-started',
+        index: 0,
+        label: 'Overview',
       })
 
       expect(result[1]).toStrictEqual({
         active: false,
         children: [],
-        href: '/get-started/prototyping',
-        label: 'Prototyping',
+        href: '/get-started/development',
+        label: 'Development',
       })
     })
   })
@@ -62,20 +63,21 @@ describe('useSecondaryNavData', () => {
     })
 
     it('should return nested items for sub sections', () => {
-      expect(result).toHaveLength(2)
+      expect(result).toHaveLength(3)
 
       expect(result[0]).toStrictEqual({
+        active: false,
+        children: [],
+        href: '/get-started',
+        index: 0,
+        label: 'Overview',
+      })
+
+      expect(result[1]).toStrictEqual({
         active: true,
         children: [],
         href: '/get-started/development',
         label: 'Development',
-      })
-
-      expect(result[1]).toStrictEqual({
-        active: false,
-        children: [],
-        href: '/get-started/prototyping',
-        label: 'Prototyping',
       })
     })
   })
@@ -90,20 +92,21 @@ describe('useSecondaryNavData', () => {
     })
 
     it('should return nested items for sub sections', () => {
-      expect(result).toHaveLength(2)
+      expect(result).toHaveLength(3)
 
       expect(result[0]).toStrictEqual({
+        active: false,
+        children: [],
+        href: '/get-started',
+        index: 0,
+        label: 'Overview',
+      })
+
+      expect(result[1]).toStrictEqual({
         active: true,
         children: [],
         href: '/get-started/development',
         label: 'Development',
-      })
-
-      expect(result[1]).toStrictEqual({
-        active: false,
-        children: [],
-        href: '/get-started/prototyping',
-        label: 'Prototyping',
       })
     })
   })
@@ -118,23 +121,23 @@ describe('useSecondaryNavData', () => {
     })
 
     it('should return items for section', () => {
-      expect(result).toHaveLength(15)
+      expect(result).toHaveLength(16)
     })
 
     it('should return nested items within a section', () => {
       const forms = result.find(item => item.label === 'Forms')
-      expect(forms.children).toHaveLength(3)
+      expect(forms.children).toHaveLength(4)
     })
 
     it('should sort the items', () => {
-      expect(result[0].label).toEqual('Alert')
-      expect(result[14].label).toEqual('Table')
+      expect(result[0].label).toEqual('Overview')
+      expect(result[14].label).toEqual('Progress')
     })
 
     it('should sort the sub children', () => {
       const { children } = result.find(item => item.label === 'Forms')
-      expect(children[0].label).toEqual('Input')
-      expect(children[2].label).toEqual('Transfer')
+      expect(children[0].label).toEqual('Overview')
+      expect(children[2].label).toEqual('Toggle')
     })
   })
 
@@ -149,7 +152,7 @@ describe('useSecondaryNavData', () => {
 
     it('should mark the input page as active', () => {
       const { children } = result.find(item => item.label === 'Forms')
-      expect(children[0].active).toEqual(true)
+      expect(children[1].active).toEqual(true)
     })
 
     it('should not mark the forms page as active', () => {

--- a/packages/docs-site/src/templates/default.js
+++ b/packages/docs-site/src/templates/default.js
@@ -40,6 +40,8 @@ const PageTemplate = ({ data: { mdx }, location }) => {
   const primaryNavData = usePrimaryNavData(location)
   const secondaryNavData = useSecondaryNavData(location)
   const hasSecondaryNav = secondaryNavData && secondaryNavData.length > 0
+  const activeTopLevel = primaryNavData.find(item => item.active)
+  const sidebarTitle = (activeTopLevel && activeTopLevel.label) || ''
 
   return (
     <Layout>
@@ -77,6 +79,7 @@ const PageTemplate = ({ data: { mdx }, location }) => {
           <Sidebar
             className="aside aside--primary"
             navItems={secondaryNavData}
+            title={sidebarTitle}
           />
         )}
       </main>

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -117,5 +117,8 @@
   ],
   "files": [
     "dist"
-  ]
+  ],
+  "dependencies": {
+    "react-children-utilities": "^1.3.1"
+  }
 }

--- a/packages/react-component-library/src/components/Nav/NavItem.tsx
+++ b/packages/react-component-library/src/components/Nav/NavItem.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import React, { useState } from 'react'
+import React, { useState, isValidElement } from 'react'
+import Children from 'react-children-utilities'
 
 interface NavItemProps {
   children?: any
@@ -8,13 +9,19 @@ interface NavItemProps {
 }
 
 const NavItem: React.FC<NavItemProps> = ({ children, hasChildren = false }) => {
-  const [isOpen, setIsOpen] = useState(false)
+  // @ts-ignore
+  const foundActive = !!Children.deepFind(children, ({ props }) => props.active)
+  const [isOpen, setIsOpen] = useState(foundActive)
+
+  const classes = `
+    rn-nav__list-item
+    ${hasChildren ? 'has-children' : ''}
+    ${isOpen ? 'is-open' : ''}
+  `
 
   return (
     <li
-      className={`rn-nav__list-item ${hasChildren ? 'has-children' : ''} ${
-        isOpen ? 'is-open' : ''
-      }`}
+      className={classes}
       onClick={() => {
         setIsOpen(hasChildren && !isOpen)
       }}

--- a/packages/react-component-library/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react-component-library/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -39,7 +39,11 @@ exports[`Nav Given the nav is supplied navItems prop and navItems is a flat coll
         key="6"
       >
         <li
-          className="rn-nav__list-item  "
+          className="
+    rn-nav__list-item
+    
+    
+  "
           onClick={[Function]}
         >
           <Link
@@ -62,7 +66,11 @@ exports[`Nav Given the nav is supplied navItems prop and navItems is a flat coll
         key="7"
       >
         <li
-          className="rn-nav__list-item  "
+          className="
+    rn-nav__list-item
+    
+    
+  "
           onClick={[Function]}
         >
           <Link
@@ -85,7 +93,11 @@ exports[`Nav Given the nav is supplied navItems prop and navItems is a flat coll
         key="8"
       >
         <li
-          className="rn-nav__list-item  "
+          className="
+    rn-nav__list-item
+    
+    is-open
+  "
           onClick={[Function]}
         >
           <Link
@@ -110,7 +122,11 @@ exports[`Nav Given the nav is supplied navItems prop and navItems is a flat coll
         key="9"
       >
         <li
-          className="rn-nav__list-item  "
+          className="
+    rn-nav__list-item
+    
+    
+  "
           onClick={[Function]}
         >
           <Link
@@ -133,7 +149,11 @@ exports[`Nav Given the nav is supplied navItems prop and navItems is a flat coll
         key="10"
       >
         <li
-          className="rn-nav__list-item  "
+          className="
+    rn-nav__list-item
+    
+    
+  "
           onClick={[Function]}
         >
           <Link

--- a/packages/react-component-library/src/components/Nav/index.tsx
+++ b/packages/react-component-library/src/components/Nav/index.tsx
@@ -29,6 +29,7 @@ function renderMenu(LinkComponent: any, navItems: any[]) {
           <NavItem key={uuid()} hasChildren={hasChildren}>
             <LinkComponent
               className={`rn-nav__item ${active ? 'is-active' : ''}`}
+              hasChildren={hasChildren}
               {...item}
             >
               {label}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19199,6 +19199,11 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-children-utilities@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-children-utilities/-/react-children-utilities-1.3.1.tgz#fe8c13ea7cc6ceb3c45907865e71b30aeb10e906"
+  integrity sha512-2u24HWf0IJlgpbDncAKHr/3ud0afj0UGp8RSQv+qSxKlWqs5+s8JOu4gNMagEtGVVVKm2fi7vlikdbAR52VklA==
+
 react-clientside-effect@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"


### PR DESCRIPTION
## Related issue

https://github.com/Royal-Navy/standards-toolkit/issues/239

## Overview

Adjust the styling of the sidebar based on approved high fidelity mock.

## Reason

Users were getting confused the highlighted parent sidebar item that looked like an active state.

## Work carried out

- [x] Implement collapsable functionality for nested items.
- [x] Adjust styling in line with approved mock.
- [x] Add additional 'Overview' menu items
- [x] Render a branch of the sidebar as open if a child has active state

## Screenshot

![2019-09-03 14 48 29](https://user-images.githubusercontent.com/48086589/64178788-fc312080-ce59-11e9-9413-b42bcf414c1c.gif)

## Developer notes

I've used preset from the CSS framework for all spacing, colours and font-sizes. I think there might be a few inconsistencies between these and the font sizing in the Sketch mock.
