### PR TITLE
Focus on searchbar when it comes into view and hide it when searching

### DIFF
--- a/packages/react-component-library/src/components/Searchbar/Searchbar.test.tsx
+++ b/packages/react-component-library/src/components/Searchbar/Searchbar.test.tsx
@@ -1,7 +1,7 @@
 import 'jest-dom/extend-expect'
 import { JSDOM } from 'jsdom'
 import React from 'react'
-import { fireEvent, render, RenderResult, wait } from '@testing-library/react'
+import { fireEvent, render, RenderResult } from '@testing-library/react'
 
 import { Searchbar, SearchbarProps } from './index'
 
@@ -42,6 +42,10 @@ describe('Searchbar', () => {
 
   it('should render a search bar', () => {
     expect(wrapper.queryByTestId('searchbar-form')).toBeInTheDocument()
+  })
+
+  it('should indicate that the search field has focus', () => {
+    expect(wrapper.queryByTestId('input')).toHaveFocus()
   })
 
   describe('when the user clicks somewhere on the page', () => {

--- a/packages/react-component-library/src/components/Searchbar/index.tsx
+++ b/packages/react-component-library/src/components/Searchbar/index.tsx
@@ -69,6 +69,7 @@ export const Searchbar: React.FC<SearchbarProps> = ({
         onSubmit={onSubmit}
       >
         <TextInput
+          autoFocus
           id="term"
           name="term"
           onChange={event => {

--- a/packages/react-component-library/src/components/TextInput/index.tsx
+++ b/packages/react-component-library/src/components/TextInput/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import uuid from 'uuid'
 
 export interface InputProps {
+  autoFocus?: boolean
   className?: string
   disabled?: boolean
   endAdornment?: React.ReactNode

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.test.tsx
@@ -115,18 +115,28 @@ describe('Masthead', () => {
           )
         })
 
-        it('should use the onSearch method passed to the masthead to search', async () => {
-          const searchbarForm = wrapper.queryByTestId('searchbar-form')
+        describe('when the user submits a search', () => {
+          beforeEach(async () => {
+            const searchbarForm = wrapper.queryByTestId('searchbar-form')
 
-          fireEvent(
-            searchbarForm,
-            new Event('submit', {
-              bubbles: true,
-              cancelable: true,
-            })
-          )
+            fireEvent(
+              searchbarForm,
+              new Event('submit', {
+                bubbles: true,
+                cancelable: true,
+              })
+            )
+          })
 
-          await wait(() => expect(props.onSearch).toHaveBeenCalledTimes(1))
+          it('should use the onSearch method passed to the masthead to search', async () => {
+            await wait(() => expect(props.onSearch).toHaveBeenCalledTimes(1))
+          })
+
+          it('should hide the searchbar from view', async () => {
+            await wait(() =>
+              expect(wrapper.queryByTestId('searchbar')).toBeNull()
+            )
+          })
         })
 
         describe('and the user clicks on the search button again', () => {

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
@@ -54,6 +54,11 @@ export const Masthead: React.FC<MastheadProps> = ({
     setShowSearch(!showSearch)
   }
 
+  const submitSearch = (term: string) => {
+    onSearch(term)
+    setShowSearch(false)
+  }
+
   return (
     <div
       className={classNames('rn-masthead', {
@@ -126,7 +131,7 @@ export const Masthead: React.FC<MastheadProps> = ({
       >
         {onSearch && showSearch && (
           <Searchbar
-            onSearch={onSearch}
+            onSearch={submitSearch}
             searchButton={searchButtonRef}
             searchPlaceholder={searchPlaceholder}
             setShowSearch={setShowSearch}


### PR DESCRIPTION
When the searchbar came into view the user had to click on it to use it, which felt odd. This changes the behaviour to autofocus on the searchbar input when it is shown.

When a user submits a search from the masthead the searchbar is automatically hidden again to indicate a search has taken place.

## Related issue
#256 


![mastheadsearch](https://user-images.githubusercontent.com/48056118/64280526-39281080-cf49-11e9-8462-72afee448f03.gif)


