### PR TITLE
Adding develop clean cache task to package.json

### DIFF
--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
+    "develop:clean": "rm -rf .cache && gatsby develop",
     "format": "prettier --write \"src/**/*.js\"",
     "lint": "eslint src",
     "lint:ci": "eslint -f ../../node_modules/eslint-junit/index.js src",


### PR DESCRIPTION
Tiny PR to add the `develop:clean` task to the docs site. This helps tackle the issue of Gatsby's aggressive caching.