### PR TITLE
Dropdown Component

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,14 @@ orbs:
 
 commands:
   dependencies:
-    description: 'Load dependency cache, get dependencies and update cache'
+    description: "Load dependency cache, get dependencies and update cache"
     steps:
       - restore_cache:
           keys:
             - yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
             - yarn-packages-v1-{{ .Branch }}-
             - yarn-packages-v1-
-      - run: yarn install --frozen-lockfile
+      - run: yarn install
       - save_cache:
           paths:
             - ~/.cache/yarn
@@ -105,6 +105,10 @@ jobs:
     steps:
       - checkout
       - dependencies
+      - run:
+          name: Build Icons
+          working_directory: packages/icon-library
+          command: yarn build
       - run:
           name: Jest
           environment:
@@ -262,6 +266,9 @@ jobs:
       - checkout
       - dependencies
       - run:
+          name: Build Icons
+          command: yarn --cwd packages/icon-library build
+      - run:
           name: Build React Components
           command: yarn --cwd packages/react-component-library build:dev
       - run:
@@ -286,8 +293,11 @@ jobs:
       - attach_workspace:
           at: ~/standards-toolkit
       - run:
-          name: Build local dependencies
-          command: yarn build
+          name: Build Icons
+          command: yarn --cwd packages/icon-library build
+      - run:
+          name: Build React Components
+          command: yarn --cwd packages/react-component-library build:dev
       - run:
           name: Build site
           working_directory: packages/docs-site

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     }
   },
   "scripts": {
-    "build": "lerna run --parallel build",
+    "build": "lerna run --stream --concurrency 1 build",
     "lint": "lerna run --parallel lint",
     "lint-staged": "lerna run --parallel lint-staged",
     "test": "lerna run --parallel test",

--- a/packages/css-framework/src/components/_dropdown.scss
+++ b/packages/css-framework/src/components/_dropdown.scss
@@ -1,124 +1,108 @@
-
-
-$dropdown-btn-sizes: (
-  small: (
-    font-size: font-size(xxs),
-    padding: spacing(2) spacing(3)
-  ),
-  regular: (
-    font-size: font-size(xs),
-    padding: spacing(3) spacing(4)
-  ),
-  large: (
-    font-size: font-size(s),
-    padding: spacing(3) spacing(5)
-  )
-);
-
+$borderThick: 2px;
+$inner: 6px;
+$outer: $inner + 1;
+$offset: $outer + $borderThick;
 
 .rn-dropdown {
-  position: relative;
-  display: inline-block;
+  .rn-dropdown__control {
+    border-color: color(neutral, 200);
+  }
 
-  &__button {
-    color: color(neutral, 700);
+  .rn-dropdown__control--is-focused {
+    border-color: color(primary, 600);
+    box-shadow: 0 0 0 1px color(primary, 600);
+  }
+
+  .rn-dropdown__dropdown-indicator {
+    padding-left: (40px - 11px)/2;
+    padding-right: (40px - 11px)/2;
+  }
+
+  .rn-dropdown__indicator-separator {
+    display: none;
+  }
+
+  .rn-dropdown__menu {
+    @include shadow(1);
+    top: 102%;
+    margin: spacing(3) 0 0 5%;
+    width: 95%;
+  }
+
+  .rn-dropdown__menu-list {
+    border: 2px solid color(primary, 600);
+    border-radius: 4px;
+    padding: spacing(1);
+  }
+
+  .rn-dropdown__menu:before {
+    display: block;
+    border-style: solid;
+    border-width: 0 7px 7px;
+    border-color: color(primary, 600) transparent;
+    position: absolute;
+    top: -7px;
+    left: 98.25%;
+    width: 0;
+    margin-left: -7px;
+    z-index: 0;
+    content: "";
+  }
+
+  .rn-dropdown__menu:after {
+    display: block;
+    border-style: solid;
+    border-width: 0 6px 6px;
+    border-color: color(neutral, white) transparent;
+    position: absolute;
+    top: -4px;
+    left: 98.25%;
+    width: 0;
+    margin-left: -6px;
+    z-index: 1;
+    content: "";
+  }
+
+  .rn-dropdown__option,
+  .rn-dropdown__option--is-selected,
+  .rn-dropdown__option--is-focused {
+    color: color(neutral, 500);
+  }
+
+  .rn-dropdownlabel.is-disabled {
+    opacity: 0.25;
+  }
+
+  .rn-dropdown__option {
+    border-radius: 4px;
+    padding: spacing(3) spacing(2);
+  }
+
+  .rn-dropdown__option--is-selected {
     background-color: color(neutral, white);
-    border: 1px solid color(neutral, 200);
-    font-weight: 500;
-    border-radius: 3px;
+  }
+
+  .rn-dropdown__option--is-focused ,
+  .rn-dropdown__option--is-focused.rn-dropdown__option--is-selected {
+    background-color: color(neutral, 100);
+  }
+
+  .rn-dropdown__single-value .rn-dropdownlabel .rn-dropdownlabel__end-adornment {
+    display: none;
+  }
+
+  .rn-dropdownlabel,
+  .rn-dropdownlabel__start-adornment,
+  .rn-dropdownlabel__end-adornment {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    transition: all 0.3s;
-    line-height: 1;
-    min-width: 140px;
-    cursor: pointer;
-    outline: none;
-    svg {
-      color: color(neutral, 400);
-    }
-    @include hover {
-      box-shadow: 0 0 0 3px color(primary, 100);
-    }
   }
 
-  &__arrow {
-    transition: all 0.3s;
+  .rn-dropdownlabel__start-adornment {
+    padding-right: spacing(2);
   }
 
-  
-
-  &.is-open {
-    .rn-dropdown__button {
-      outline: none;
-      border: 1px solid color(primary, 500);
-      box-shadow: 0 0 0 3px color(primary, 100);
-    }
-    .rn-dropdown__arrow {
-      transform: rotate(180deg);
-    }
-    .rn-dropdown__sheet {
-      opacity: 1;
-      transform: translate3d(0, 0, 0);
-      transition: all 0.1s;
-      .option {
-        pointer-events: auto;
-      }
-    }
-  }
-
-  &__sheet {
-    background-color: color(neutral, white);
-    @include shadow(1);
-    top: calc(100% + 8px);
-    position: absolute;
-    border: 1px solid color(neutral, 200);
-    border-radius: 5px;
-    padding: spacing(1) 0;
-    min-width: 160px;
-    opacity: 0;
-    transform: translate3d(0, -10px, 0);
-    transition: all 0.3s;
-    max-height: 158px;
-    overflow-y: scroll;
-  }
-
-  &__option,
-  &__link {
-    cursor: pointer;
-    @include font-size(xs);
-    padding: spacing(2) spacing(3);
-    display: flex;
-    justify-content: space-between;
-    text-decoration: none;
-    &:hover {
-      color: color(neutral, 800);
-      background-color: color(neutral, 000);
-    }
-    &__label {
-      color: color(neutral, 800);
-      font-weight: 500;
-      white-space: nowrap;
-    }
-    &__helper {
-      white-space: nowrap;
-      color: color(neutral, 500);
-      padding-left: 24px;
-    }
-  }
-
-  // Providing default sizing
-  &__button {
-    font-size: map-deep-get($dropdown-btn-sizes, "regular", "font-size");
-    padding: map-deep-get($dropdown-btn-sizes, "regular", "padding");
-  }
-
-  @each $size, $values in $dropdown-btn-sizes {
-    &.#{$size} {
-      .rn-dropdown__button {
-        font-size: map-get($values, "font-size");
-        padding: map-get($values, "padding");
-      }
-    }
+  .rn-dropdownlabel__label {
+    flex: 1;
   }
 }

--- a/packages/css-framework/src/components/_select.scss
+++ b/packages/css-framework/src/components/_select.scss
@@ -15,6 +15,11 @@
     border-bottom: 0;
   }
 
+  .rn-select__dropdown-indicator {
+    padding-left: (40px - 11px)/2;
+    padding-right: (40px - 11px)/2;
+  }
+
   .rn-select__menu {
     margin-top: 0;
     border-top-left-radius: 0;

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -8,14 +8,14 @@
   "author": "NELSON",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "gatsby build",
+    "build": "rm -rf ./.cache && gatsby build",
     "develop": "gatsby develop",
     "develop:clean": "rm -rf .cache && gatsby develop",
     "format": "prettier --write \"src/**/*.js\"",
     "lint": "eslint src",
     "lint:ci": "eslint -f ../../node_modules/eslint-junit/index.js src",
     "test": "jest",
-    "cache:clear": "rm -rf ./cache"
+    "cache:clear": "rm -rf ./.cache"
   },
   "browserslist": [
     ">0.2%",

--- a/packages/docs-site/src/components/presenters/right-content/index.js
+++ b/packages/docs-site/src/components/presenters/right-content/index.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { IconAcUnit } from '@royalnavy/icon-library'
+
+const RightContent = () => (
+  <span>
+    <IconAcUnit /> 5
+  </span>
+)
+
+export default RightContent

--- a/packages/docs-site/src/library/pages/components/dropdown.md
+++ b/packages/docs-site/src/library/pages/components/dropdown.md
@@ -1,0 +1,154 @@
+---
+title: Dropdown
+description: A component to show a list of actions
+header: true
+---
+
+import { Links, Tab, TabSet, Dropdown } from '@royalnavy/react-component-library'
+import { IconAcUnit } from '@royalnavy/icon-library'
+import Field from '../../../components/containers/Field'
+import DataTable from '../../../components/presenters/data-table'
+import CodeHighlighter from '../../../components/presenters/code-highlighter'
+import RightContent from '../../../components/presenters/right-content'
+import SketchWidget from '../../../components/presenters/sketch-widget'
+
+# Dropdown
+A component to show a list of actions.
+<SelectComponent />
+
+## Usage
+The Dropdown input is useful when the user needs to select an option from a long list, typically more than 7 options. Users can click on a control to let the list drop down and the user can then scroll through the list
+and pick the desired option. Alternatively the control lets a user select the field and start typing and the list of options will appear and is filtered by the value the user has typed.
+
+<TabSet>
+
+<Tab title="Design">
+
+<SketchWidget name="Dropdown" href="/standards-toolkit.sketch" /> 
+TBD
+
+</Tab>
+
+<Tab title="Develop">
+The `Dropdown` component can be used to allow the user to pick an action for a list. When the user selects the dropdown component a list is displayed which can be navigated through. When an option is selected through a mouse click or pressing enter the onSelected property is called.
+
+### Examples
+<CodeHighlighter source={`<Dropdown label="Actions" options={options} onSelect={handleAction} />`}>
+<div style="height: 300px">
+<Dropdown 
+  label="Actions" 
+  options={[
+    { value: 'chocolate', label: 'Chocolate', hidden: true },
+    { value: 'chozbun', label: 'ChozoBun', visible: true },
+    { value: 'melon', label: 'Melon', isDisabled: true },
+    { value: 'strawberry', label: 'Strawberry' },
+    { value: 'vanilla', label: 'Vanilla', rightContent: RightContent},
+  ]} 
+  onSelect={(value) => {console.log(value)}} 
+/> 
+</div>
+</CodeHighlighter>
+
+<CodeHighlighter source={`<Dropdown label="Actions" options={options} onSelect={handleAction} />`}>
+<div style="height: 300px">
+<Dropdown 
+  label="Actions" 
+  options={[
+    { icon: IconAcUnit, value: 'chocolate', label: 'Chocolate', hidden: true },
+    { icon: IconAcUnit, value: 'chozbun', label: 'ChozoBun', visible: true },
+    { icon: IconAcUnit, value: 'melon', label: 'Melon', isDisabled: true },
+    { icon: IconAcUnit, value: 'strawberry', label: 'Strawberry' },
+    { icon: IconAcUnit, value: 'vanilla', label: 'Vanilla' },
+  ]} 
+  onSelect={(value) => {console.log(value)}} 
+/> 
+</div>
+</CodeHighlighter>
+
+### Properties
+The `Dropdown` accepts a label, options and a handler which is called with the value associated with the option that is selected by the user.
+
+<DataTable caption="Dropdown" data={[
+  {
+    Name: 'label',
+    Type: 'string',
+    Required: 'True',
+    Default: '',
+    Description: 'The text to display in the component the user needs to click on to view options',
+  },
+  {
+    Name: 'onSelect',
+    Type: '(value:string) => void',
+    Required: 'True',
+    Default: '',
+    Description: 'When an option is selected the onSelect method is called with the value associated with the option',
+  },
+  {
+    Name: 'options',
+    Type: 'DropdownOption[]',
+    Required: 'True',
+    Default: '',
+    Description: 'An array of options to be displayed when the user opens the dropdown.',
+  },
+]} />
+<br />
+
+Options can consist of a simple label and value, but also have other optional properties to allow
+the user of icons, left or right, and indicate if something is hidden or visible.
+
+An option can also be marked as inactive and is greyed out to show that to the user. Do not mix the use of hidden, visible and rightContent. These three properties can interfere with each other.
+
+<DataTable caption="Option" data={[
+  {
+    Name: 'isDisabled',
+    Type: 'boolean',
+    Required: 'False',
+    Default: 'False',
+    Description: 'A disabled option is displayed with slightly greyed out text and cannot be selected',
+  },
+  {
+    Name: 'hidden',
+    Type: 'boolean',
+    Required: 'False',
+    Default: 'False',
+    Description: 'Should the option display a hidden icon on the right side to indicate a hidden layer or hidden element',
+  },
+  {
+    Name: 'icon',
+    Type: 'ReactComponent',
+    Required: 'False',
+    Default: '',
+    Description: 'A component that renders an icon to the left of the option text',
+  },
+  {
+    Name: 'label',
+    Type: 'string',
+    Required: 'True',
+    Default: '',
+    Description: 'The text to display in the option',
+  },
+  {
+    Name: 'rightContent',
+    Type: 'ReactComponent',
+    Required: 'False',
+    Default: '',
+    Description: 'A component that renders content to show on the right of the option text',
+  },
+  {
+    Name: 'value',
+    Type: 'string',
+    Required: 'True',
+    Default: '',
+    Description: 'The value that it used in the onSelect method to indicate the desired action',
+  },
+  {
+    Name: 'visible',
+    Type: 'boolean',
+    Required: 'False',
+    Default: 'False',
+    Description: 'Should the option display a visible icon on the right side to indicate a visible layer or visible element',
+  },
+]} />
+
+</Tab>
+</TabSet>

--- a/packages/icon-library/package.json
+++ b/packages/icon-library/package.json
@@ -10,6 +10,7 @@
   "files": [
     "dist"
   ],
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "run-s svgr exports build:ts types",
     "build:ts": "webpack -p --config=webpack/prod.js",

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { IconAcUnit, IconExitToApp } from '@royalnavy/icon-library'
+import { storiesOf } from '@storybook/react'
+
+import { Dropdown } from './Dropdown'
+
+const stories = storiesOf('Dropdown', module)
+
+const hotkey5 = () => (
+  <>
+    <IconExitToApp /> 5
+  </>
+)
+
+const options = [
+  { value: 'chocolate', label: 'Chocolate' },
+  { value: 'chozbun', label: 'Chozo Bun', hidden: true },
+  { value: 'melon', label: 'Melon', visible: true, isDisabled: true },
+  { value: 'strawberry', label: 'Strawberry', isDisabled: true },
+  { value: 'vanilla', label: 'Vanilla', rightContent: hotkey5 },
+]
+
+const scrollOptions = [
+  { value: 'chocolate', label: 'Chocolate' },
+  { value: 'chozbun', label: 'Chozo Bun', hidden: true },
+  { value: 'melon', label: 'Melon', visible: true },
+  { value: 'strawberry', label: 'Strawberry' },
+  { value: 'snozberry', label: 'Snozberry' },
+  { value: 'vanilla', label: 'Vanilla', rightContent: hotkey5 },
+  { value: 'Wombat', label: 'Wombat' },
+]
+
+const iconOptions = options.map(option => ({
+  ...option,
+  icon: IconAcUnit,
+}))
+
+stories.add('Default', () => (
+  <div style={{ margin: 50 }}>
+    <Dropdown
+      options={options}
+      label="Layers"
+      onSelect={value => console.log(value)}
+    />
+  </div>
+))
+
+stories.add('Icons', () => (
+  <div style={{ margin: 50 }}>
+    <Dropdown
+      options={iconOptions}
+      label="Layers"
+      onSelect={value => console.log(value)}
+    />
+  </div>
+))
+
+stories.add('Scroll', () => (
+  <div style={{ margin: 50 }}>
+    <Dropdown
+      options={scrollOptions}
+      label="Layers"
+      onSelect={value => console.log(value)}
+    />
+  </div>
+))

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import Select from 'react-select'
+import { ValueType } from 'react-select/src/types'
+
+import { DropdownIndicator } from './DropdownIndicator'
+import { DropdownLabel } from './DropdownLabel'
+import { DropdownOption } from './DropdownOption'
+
+export interface DropdownProps {
+  onSelect: (value: string) => void
+  options: DropdownOption[]
+  label: string
+}
+
+export const Dropdown: React.FC<DropdownProps> = ({
+  onSelect,
+  options,
+  label,
+}) => {
+  const onChange = (option: ValueType<DropdownOption>) => {
+    const dropdownOption = option as DropdownOption
+    onSelect(dropdownOption.value)
+  }
+
+  return (
+    <Select
+      className="rn-dropdown"
+      classNamePrefix="rn-dropdown"
+      components={{ DropdownIndicator }}
+      controlShouldRenderValue={false}
+      formatOptionLabel={DropdownLabel}
+      isSearchable={false}
+      options={options}
+      onChange={onChange}
+      placeholder={label}
+    />
+  )
+}

--- a/packages/react-component-library/src/components/Dropdown/DropdownIndicator.test.tsx
+++ b/packages/react-component-library/src/components/Dropdown/DropdownIndicator.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, RenderResult } from '@testing-library/react'
+
+import { DropdownIndicator } from './DropdownIndicator'
+
+describe('Dropdown Indicator', () => {
+  let wrapper: RenderResult
+  let props: any
+
+  beforeEach(() => {
+    props = {
+      className: 'myclass',
+      clearValue: jest.fn(),
+      cx: jest.fn(),
+      data: { label: 'test label' },
+      getStyles: jest.fn(),
+      getValue: jest.fn(),
+      hasValue: false,
+      innerRef: jest.fn(),
+      isDisabled: false,
+      isFocused: false,
+      isMulti: false,
+      isSelected: false,
+      options: [],
+      selectOption: jest.fn(),
+      selectProps: jest.fn(),
+      setValue: jest.fn(),
+    }
+  })
+
+  describe('and the menu is closed', () => {
+    beforeEach(() => {
+      props.selectProps.menuIsOpen = false
+      wrapper = render(<DropdownIndicator {...props} />)
+    })
+
+    it('should render the indicator points down', () => {
+      expect(wrapper.queryByTestId('TriangleDown')).toBeInTheDocument()
+    })
+
+    it('should not render the indicator points down', () => {
+      expect(wrapper.queryByTestId('TriangleUp')).toBeNull()
+    })
+  })
+
+  describe('and the menu is open', () => {
+    beforeEach(() => {
+      props.selectProps.menuIsOpen = true
+      wrapper = render(<DropdownIndicator {...props} />)
+    })
+
+    it('should not render the indicator points down', () => {
+      expect(wrapper.queryByTestId('TriangleDown')).toBeNull()
+    })
+
+    it('should render the indicator points down', () => {
+      expect(wrapper.queryByTestId('TriangleUp')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/react-component-library/src/components/Dropdown/DropdownIndicator.tsx
+++ b/packages/react-component-library/src/components/Dropdown/DropdownIndicator.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { components } from 'react-select'
+
+import { TriangleDown, TriangleUp } from '../../icons'
+
+export const DropdownIndicator: React.FC<any> = props => {
+  const { menuIsOpen } = props.selectProps
+
+  return (
+    <components.DropdownIndicator {...props}>
+      {!menuIsOpen && (
+        <span data-testid="TriangleDown">
+          <TriangleDown />
+        </span>
+      )}
+      {menuIsOpen && (
+        <span data-testid="TriangleUp">
+          <TriangleUp />
+        </span>
+      )}
+    </components.DropdownIndicator>
+  )
+}
+
+DropdownIndicator.displayName = 'DropdownIndicator'

--- a/packages/react-component-library/src/components/Dropdown/DropdownLabel.test.tsx
+++ b/packages/react-component-library/src/components/Dropdown/DropdownLabel.test.tsx
@@ -1,0 +1,214 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, RenderResult } from '@testing-library/react'
+
+import { DropdownLabel } from './DropdownLabel'
+
+describe('Dropdown Label', () => {
+  let wrapper: RenderResult
+  let props: any
+
+  beforeEach(() => {
+    props = {
+      className: 'myclass',
+      clearValue: jest.fn(),
+      cx: jest.fn(),
+      data: { label: 'test label' },
+      getStyles: jest.fn(),
+      getValue: jest.fn(),
+      hasValue: false,
+      innerRef: jest.fn(),
+      isDisabled: false,
+      isFocused: false,
+      isMulti: false,
+      isSelected: false,
+      options: [],
+      selectOption: jest.fn(),
+      selectProps: jest.fn(),
+      setValue: jest.fn(),
+    }
+  })
+
+  describe('and there is just text to display', () => {
+    beforeEach(() => {
+      props.label = 'test'
+      wrapper = render(<DropdownLabel {...props} />)
+    })
+
+    it('should render the label', () => {
+      expect(wrapper.queryByTestId('dropdownlabel__label')).toBeInTheDocument()
+      expect(wrapper.queryByTestId('dropdownlabel__label')).toHaveTextContent(
+        'test'
+      )
+    })
+
+    it('should not render the left icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__start-adornment')
+      ).toBeNull()
+    })
+
+    it('should not render right content', () => {
+      expect(wrapper.queryByTestId('rn-dropdownlabel__rightcontent')).toBeNull()
+    })
+
+    it('should not render visible icon', () => {
+      expect(wrapper.queryByTestId('rn-dropdownlabel__iconvisible')).toBeNull()
+    })
+
+    it('should not render invisible icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__iconinvisible')
+      ).toBeNull()
+    })
+  })
+
+  describe('and there a left icon to display', () => {
+    beforeEach(() => {
+      props.label = 'test'
+      props.icon = () => <span>thing</span>
+      wrapper = render(<DropdownLabel {...props} />)
+    })
+
+    it('should render the label', () => {
+      expect(wrapper.queryByTestId('dropdownlabel__label')).toBeInTheDocument()
+      expect(wrapper.queryByTestId('dropdownlabel__label')).toHaveTextContent(
+        'test'
+      )
+    })
+
+    it('should render the left icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__start-adornment')
+      ).toBeInTheDocument()
+    })
+
+    it('should not render right content', () => {
+      expect(wrapper.queryByTestId('rn-dropdownlabel__rightcontent')).toBeNull()
+    })
+
+    it('should not render visible icon', () => {
+      expect(wrapper.queryByTestId('rn-dropdownlabel__iconvisible')).toBeNull()
+    })
+
+    it('should not render invisible icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__iconinvisible')
+      ).toBeNull()
+    })
+  })
+
+  describe('and the option indicated a hidden element', () => {
+    beforeEach(() => {
+      props.label = 'test'
+      props.hidden = true
+      wrapper = render(<DropdownLabel {...props} />)
+    })
+
+    it('should render the label', () => {
+      expect(wrapper.queryByTestId('dropdownlabel__label')).toBeInTheDocument()
+      expect(wrapper.queryByTestId('dropdownlabel__label')).toHaveTextContent(
+        'test'
+      )
+    })
+
+    it('should not render the left icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__start-adornment')
+      ).toBeNull()
+    })
+
+    it('should not render right content', () => {
+      expect(wrapper.queryByTestId('rn-dropdownlabel__rightcontent')).toBeNull()
+    })
+
+    it('should not render visible icon', () => {
+      expect(wrapper.queryByTestId('rn-dropdownlabel__iconvisible')).toBeNull()
+    })
+
+    it('should render invisible icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__iconinvisible')
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('and the option indicated a visible element', () => {
+    beforeEach(() => {
+      props.label = 'test'
+      props.visible = true
+      wrapper = render(<DropdownLabel {...props} />)
+    })
+
+    it('should render the label', () => {
+      expect(wrapper.queryByTestId('dropdownlabel__label')).toBeInTheDocument()
+      expect(wrapper.queryByTestId('dropdownlabel__label')).toHaveTextContent(
+        'test'
+      )
+    })
+
+    it('should not render the left icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__start-adornment')
+      ).toBeNull()
+    })
+
+    it('should not render right content', () => {
+      expect(wrapper.queryByTestId('rn-dropdownlabel__rightcontent')).toBeNull()
+    })
+
+    it('should render visible icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__iconvisible')
+      ).toBeInTheDocument()
+    })
+
+    it('should not render invisible icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__iconinvisible')
+      ).toBeNull()
+    })
+  })
+
+  describe('and the option indicates there is right aligned content', () => {
+    beforeEach(() => {
+      props.label = 'test'
+      props.rightContent = () => <p>right content</p>
+      wrapper = render(<DropdownLabel {...props} />)
+    })
+
+    it('should render the label', () => {
+      expect(wrapper.queryByTestId('dropdownlabel__label')).toBeInTheDocument()
+      expect(wrapper.queryByTestId('dropdownlabel__label')).toHaveTextContent(
+        'test'
+      )
+    })
+
+    it('should not render the left icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__start-adornment')
+      ).toBeNull()
+    })
+
+    it('should render right content', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__rightcontent')
+      ).toBeInTheDocument()
+    })
+
+    it('should render visible icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__rightcontent')
+      ).toBeInTheDocument()
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__rightcontent')
+      ).toContainHTML('<p>right content</p>')
+    })
+
+    it('should not render invisible icon', () => {
+      expect(
+        wrapper.queryByTestId('rn-dropdownlabel__iconinvisible')
+      ).toBeNull()
+    })
+  })
+})

--- a/packages/react-component-library/src/components/Dropdown/DropdownLabel.tsx
+++ b/packages/react-component-library/src/components/Dropdown/DropdownLabel.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { IconVisibility, IconVisibilityOff } from '@royalnavy/icon-library'
+
+import { DropdownOption } from './DropdownOption'
+
+export const DropdownLabel: React.FC<DropdownOption> = ({
+  isDisabled = false,
+  hidden = false,
+  icon: Icon,
+  label,
+  rightContent: RightContent,
+  visible = false,
+}) => {
+  return (
+    <div className={`rn-dropdownlabel ${isDisabled ? 'is-disabled' : ''}`}>
+      {Icon && (
+        <span
+          className="rn-dropdownlabel__start-adornment"
+          data-testid="rn-dropdownlabel__start-adornment"
+        >
+          <Icon />
+        </span>
+      )}
+      <span
+        className="rn-dropdownlabel__label"
+        data-testid="dropdownlabel__label"
+      >
+        {label}
+      </span>
+      {hidden && (
+        <span data-testid="rn-dropdownlabel__iconinvisible">
+          <IconVisibilityOff className="rn-dropdownlabel__end-adornment" />
+        </span>
+      )}
+      {visible && (
+        <span data-testid="rn-dropdownlabel__iconvisible">
+          <IconVisibility className="is-active rn-dropdownlabel__end-adornment" />
+        </span>
+      )}
+      {RightContent && (
+        <span
+          className="rn-dropdownlabel__end-adornment"
+          data-testid="rn-dropdownlabel__rightcontent"
+        >
+          <RightContent />
+        </span>
+      )}
+    </div>
+  )
+}

--- a/packages/react-component-library/src/components/Dropdown/DropdownOption.ts
+++ b/packages/react-component-library/src/components/Dropdown/DropdownOption.ts
@@ -1,0 +1,9 @@
+export interface DropdownOption {
+  isDisabled?: boolean
+  hidden?: boolean
+  icon?: any
+  label: string
+  rightContent?: any
+  value: string
+  visible?: boolean
+}

--- a/packages/react-component-library/src/components/Dropdown/index.tsx
+++ b/packages/react-component-library/src/components/Dropdown/index.tsx
@@ -1,0 +1,2 @@
+export * from './Dropdown'
+export * from './DropdownOption'

--- a/packages/react-component-library/src/components/index.ts
+++ b/packages/react-component-library/src/components/index.ts
@@ -3,6 +3,7 @@ import Badge from './Badge'
 import Breadcrumbs from './Breadcrumbs'
 import Button from './Button'
 import Checkbox from './Checkbox'
+import { Dropdown } from './Dropdown'
 import Link from './Link'
 import Nav from './Nav'
 import Pagination from './Pagination'
@@ -26,6 +27,7 @@ export {
   Breadcrumbs,
   Button,
   Checkbox,
+  Dropdown,
   Link,
   Nav,
   Pagination,

--- a/packages/react-component-library/src/index.ts
+++ b/packages/react-component-library/src/index.ts
@@ -4,6 +4,7 @@ import Badge from './components/Badge'
 import Breadcrumbs from './components/Breadcrumbs'
 import Button from './components/Button'
 import Checkbox from './components/Checkbox'
+import { Dropdown } from './components/Dropdown'
 import { Masthead } from './fragments/Masthead'
 import Nav from './components/Nav'
 import Pagination from './components/Pagination'
@@ -33,6 +34,7 @@ export {
   Breadcrumbs,
   Button,
   Checkbox,
+  Dropdown,
   Masthead,
   Nav,
   Pagination,
@@ -46,9 +48,7 @@ export {
   Tab,
   TabSet,
   TextInput,
-
   Icons,
-
   Formik,
 
   withFormik


### PR DESCRIPTION
## Related issue
#222

## Overview
New Dropdown component designed to show a link that when clicked on shows a list of actions that can be issued.

### How
The component uses the same 3rd party tool as the `Select` component, to provide a select like experience that can be used by mouse of keyboard navigation. The different between the two is that this component has no text input, cannot be used in a form and does not show the selected value in the main label area.

