### PR TITLE
Fix bug in Docs site cache clearance

### DIFF
--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -8,14 +8,14 @@
   "author": "NELSON",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "gatsby build",
+    "build": "rm -rf ./.cache && gatsby build",
     "develop": "gatsby develop",
     "develop:clean": "rm -rf .cache && gatsby develop",
     "format": "prettier --write \"src/**/*.js\"",
     "lint": "eslint src",
     "lint:ci": "eslint -f ../../node_modules/eslint-junit/index.js src",
     "test": "jest",
-    "cache:clear": "rm -rf ./cache"
+    "cache:clear": "rm -rf ./.cache"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
Found a bug in the build scripts. The build:cache script in docs didn't actually clear the cache due to a type.

Fixed