### PR TITLE
Fix sizing in Select component

### DIFF
--- a/packages/css-framework/src/components/_select.scss
+++ b/packages/css-framework/src/components/_select.scss
@@ -15,6 +15,11 @@
     border-bottom: 0;
   }
 
+  .rn-select__dropdown-indicator {
+    padding-left: (40px - 11px)/2;
+    padding-right: (40px - 11px)/2;
+  }
+
   .rn-select__menu {
     margin-top: 0;
     border-top-left-radius: 0;


### PR DESCRIPTION
The spacing for the Select dropdown indicator had little space around it. This fixes the issue and correctly sizes it.