### PR TITLE
Bug/icon dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     }
   },
   "scripts": {
-    "build": "lerna run --parallel build",
+    "build": "lerna run --stream --concurrency 1 build",
     "lint": "lerna run --parallel lint",
     "lint-staged": "lerna run --parallel lint-staged",
     "test": "lerna run --parallel test",

--- a/packages/icon-library/package.json
+++ b/packages/icon-library/package.json
@@ -10,6 +10,7 @@
   "files": [
     "dist"
   ],
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "run-s svgr exports build:ts types",
     "build:ts": "webpack -p --config=webpack/prod.js",


### PR DESCRIPTION
Previously the build of packages was done in parallel with no consideration for cross dependencies because this wasn't an issue.

Whilst working on the Dropdown component, which uses icons in storybook and tests, it would fail due to the fact there wasn't a built copy of the icons before it reached building the react code.

The fix is to tell the build script to only build 1 thing at a time and it will analyse their dependencies to figure out the order.