### PR TITLE
Fix cross dependency build issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,14 @@ orbs:
 
 commands:
   dependencies:
-    description: 'Load dependency cache, get dependencies and update cache'
+    description: "Load dependency cache, get dependencies and update cache"
     steps:
       - restore_cache:
           keys:
             - yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
             - yarn-packages-v1-{{ .Branch }}-
             - yarn-packages-v1-
-      - run: yarn install --frozen-lockfile
+      - run: yarn install
       - save_cache:
           paths:
             - ~/.cache/yarn
@@ -105,6 +105,9 @@ jobs:
     steps:
       - checkout
       - dependencies
+      - run:
+          name: Build Icon Dependency
+          command: yarn --cwd packages/icon-library build
       - run:
           name: Jest
           environment:
@@ -226,6 +229,9 @@ jobs:
       - checkout
       - dependencies
       - run:
+          name: Build Icon Dependency
+          command: yarn --cwd packages/icon-library build
+      - run:
           name: Authenticate NPM
           command: echo "//$NPM_REGISTRY/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
       - run:
@@ -262,6 +268,9 @@ jobs:
       - checkout
       - dependencies
       - run:
+          name: Build Icon Dependency
+          command: yarn --cwd packages/icon-library build
+      - run:
           name: Build React Components
           command: yarn --cwd packages/react-component-library build:dev
       - run:
@@ -286,8 +295,11 @@ jobs:
       - attach_workspace:
           at: ~/standards-toolkit
       - run:
-          name: Build local dependencies
-          command: yarn build
+          name: Build Icon Dependency
+          command: yarn --cwd packages/icon-library build
+      - run:
+          name: Build React Components
+          command: yarn --cwd packages/react-component-library build:dev
       - run:
           name: Build site
           working_directory: packages/docs-site


### PR DESCRIPTION
Final piece in the list of fixes for the build following the introduction of Icons and cross-dependencies.

Before react can be tested we need to create the compiled copy of icons
Before we can test the docs site we also need to compile the icons
Trying to avoid building everything before building docs.


I thought this was in an earlier PR but I must have cherrypicked the wrong commit.