### PR TITLE
Fix bug in withFormik not passing through classes

### DIFF
--- a/packages/react-component-library/src/enhancers/withFormik.tsx
+++ b/packages/react-component-library/src/enhancers/withFormik.tsx
@@ -1,9 +1,11 @@
+import classNames from 'classnames'
 import React from 'react'
 
 import FieldProps from '../types/FieldProps'
 import FormProps from '../types/FormProps'
 
 export interface FormikProps {
+  className?: string
   field: FieldProps
   form: FormProps
 }
@@ -11,16 +13,20 @@ export interface FormikProps {
 const withFormik = (FormComponent: React.FC<any>) => ({
   field,
   form: { touched, errors },
+  className,
   ...props
 }: FormikProps) => {
   const hasError = touched[field.name] && errors[field.name]
+  const formComponentClassNames = classNames(className, {
+    'is-invalid': hasError,
+  })
 
   return (
     <>
       <FormComponent
         {...field}
         {...props}
-        className={hasError ? 'is-invalid' : ''}
+        className={formComponentClassNames}
       />
       {hasError && (
         <div className="rn-form__invalid-feedback" data-testid="error">


### PR DESCRIPTION
I discovered that is a classname prop was sent to a field that was enhanced using withFormik it ignored it as it was trying to add it's own class to say if it was valid or not.
