### PR TITLE
Hotfix/ci running wrong build type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
           command: yarn --cwd packages/icon-library build
       - run:
           name: Build React Components
-          command: yarn --cwd packages/react-component-library build:dev
+          command: yarn --cwd packages/react-component-library build
       - run:
           name: Jest
           environment:
@@ -299,7 +299,7 @@ jobs:
           command: yarn --cwd packages/icon-library build
       - run:
           name: Build React Components
-          command: yarn --cwd packages/react-component-library build:dev
+          command: yarn --cwd packages/react-component-library build
       - run:
           name: Build site
           working_directory: packages/docs-site


### PR DESCRIPTION
CI is running the wrong build type and it's causing a bad bundle to be served to clients.

<img width="1274" alt="Screenshot 2019-10-01 at 14 45 43" src="https://user-images.githubusercontent.com/48086589/65967837-2aeee680-e45a-11e9-8f95-35b4396fa6ec.png">
