### PR TITLE
Remove console.log lint warnings

### DIFF
--- a/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 
@@ -10,12 +11,8 @@ stories.add('Default', () => {
     <Dialog
       title="Dialog Title"
       description="Dialog description."
-      onConfirm={event => {
-        console.log('onConfirm')
-      }}
-      onCancel={event => {
-        console.log('onCancel')
-      }}
+      onConfirm={action('onConfirm')}
+      onCancel={action('onCancel')}
       isOpen
     />
   )
@@ -26,12 +23,8 @@ stories.add('Danger', () => {
     <Dialog
       title="Dialog Title"
       description="Dialog description."
-      onConfirm={event => {
-        console.log('onConfirm')
-      }}
-      onCancel={event => {
-        console.log('onCancel')
-      }}
+      onConfirm={action('onConfirm')}
+      onCancel={action('onCancel')}
       danger
       isOpen
     />

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
+import React from 'react'
 
 import { Bell, Tools } from '../../icons'
 import { Dropdown } from './Dropdown'
@@ -42,7 +43,7 @@ stories.add('Default', () => (
     <Dropdown
       options={options}
       label="Layers"
-      onSelect={value => console.log(value)}
+      onSelect={action('onSelect')}
     />
   </div>
 ))
@@ -52,7 +53,7 @@ stories.add('Icons', () => (
     <Dropdown
       options={iconOptions}
       label="Layers"
-      onSelect={value => console.log(value)}
+      onSelect={action('onSelect')}
     />
   </div>
 ))
@@ -62,7 +63,7 @@ stories.add('Scroll', () => (
     <Dropdown
       options={scrollOptions}
       label="Layers"
-      onSelect={value => console.log(value)}
+      onSelect={action('onSelect')}
     />
   </div>
 ))

--- a/packages/react-component-library/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 
@@ -7,17 +8,17 @@ import { ButtonProps } from '../Button'
 const stories = storiesOf('Modal', module)
 
 const primaryButton: ButtonProps = {
-  onClick: event => console.log('primary'),
+  onClick: action('Clicked primary'),
   children: 'Primary',
 }
 
 const secondaryButton: ButtonProps = {
-  onClick: event => console.log('secondary'),
+  onClick: action('Clicked secondary'),
   children: 'Secondary',
 }
 
 const tertiaryButton: ButtonProps = {
-  onClick: event => console.log('tertiary'),
+  onClick: action('Clicked tertiary'),
   children: 'Tertiary',
 }
 
@@ -28,7 +29,7 @@ stories.add('Default', () => {
       primaryButton={primaryButton}
       secondaryButton={secondaryButton}
       tertiaryButton={tertiaryButton}
-      onClose={() => console.log('close')}
+      onClose={action('onClose')}
       isOpen
     >
       <pre style={{ padding: '1rem' }}>// Arbitrary JSX content</pre>
@@ -42,7 +43,7 @@ stories.add('No header', () => {
       primaryButton={primaryButton}
       secondaryButton={secondaryButton}
       tertiaryButton={tertiaryButton}
-      onClose={() => console.log('close')}
+      onClose={action('onClose')}
       isOpen
     >
       <pre style={{ padding: '1rem' }}>// Arbitrary JSX content</pre>
@@ -52,7 +53,7 @@ stories.add('No header', () => {
 
 stories.add('No buttons', () => {
   return (
-    <Modal title="Modal Header" onClose={() => console.log('close')} isOpen>
+    <Modal title="Modal Header" onClose={action('onClose')} isOpen>
       <pre style={{ padding: '1rem' }}>// Arbitrary JSX content</pre>
     </Modal>
   )

--- a/packages/react-component-library/src/components/Modal/Modal.test.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.test.tsx
@@ -6,17 +6,17 @@ import { ButtonProps } from '../Button'
 import { Modal } from './Modal'
 
 const primaryButton: ButtonProps = {
-  onClick: event => console.log('primary'),
+  onClick: jest.fn(),
   children: 'Primary',
 }
 
 const secondaryButton: ButtonProps = {
-  onClick: event => console.log('secondary'),
+  onClick: jest.fn(),
   children: 'Secondary',
 }
 
 const tertiaryButton: ButtonProps = {
-  onClick: event => console.log('tertiary'),
+  onClick: jest.fn(),
   children: 'Tertiary',
 }
 

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import { Field, Formik, Form } from 'formik'
 import React from 'react'
@@ -18,24 +19,16 @@ const initialValues: Data = {
   gold: 1,
 }
 
-const onSubmit = (data: Data): void => {
-  console.log(`Form Submit ${JSON.stringify(data)}`)
-}
-
-const onCancel = () => {
-  console.log('Cancel')
-}
-
 const FormikNumberInput = withFormik(NumberInput)
 
 stories.add('Vanilla', () => (
   <div style={{ margin: 50 }}>
-    <Formik initialValues={initialValues} onSubmit={onSubmit}>
+    <Formik initialValues={initialValues} onSubmit={action('onSubmit')}>
       <Form>
         <Field component={FormikNumberInput} name="gold" label="Gold bars" />
         <Field component={FormikNumberInput} name="age" label="Age" />
 
-        <Button variant="secondary" onClick={onCancel}>
+        <Button variant="secondary" onClick={action('Cancel')}>
           Cancel
         </Button>
         <Button type="submit" variant="primary">

--- a/packages/react-component-library/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.stories.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
+import React from 'react'
 
 import Pagination from './index'
 
@@ -7,9 +8,7 @@ const stories = storiesOf('Pagination', module)
 
 stories.add('Default', () => (
   <Pagination
-    onChangeCallback={(...args) => {
-      console.log(...args)
-    }}
+    onChangeCallback={action('onChangeCallback')}
     pageSize={10}
     total={1000}
   />

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
+import React from 'react'
 
 import { Select } from './index'
 
@@ -19,7 +20,7 @@ stories.add('Default', () => (
     <Select
       options={options}
       label="Hello"
-      onChange={value => console.log(value)}
+      onChange={action('onChange')}
     />
   </div>
 ))

--- a/packages/react-component-library/src/components/Switch/Switch.stories.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.stories.tsx
@@ -5,7 +5,6 @@ import { storiesOf } from '@storybook/react'
 import { Field, Formik, Form } from 'formik'
 import useFormik from '../../enhancers/withFormik'
 
-import { OptionType } from '../../types/Switch'
 import Switch from './Switch'
 import ResponsiveSwitch from './index'
 
@@ -24,9 +23,7 @@ stories.add('Default', () => (
     value=""
     label="Date Range"
     options={options}
-    onChange={event => {
-      console.log(event)
-    }}
+    onChange={action('onChange')}
   />
 ))
 
@@ -35,9 +32,7 @@ stories.add('No legend', () => (
     name="example-switch-field"
     value=""
     options={options}
-    onChange={event => {
-      console.log(event)
-    }}
+    onChange={action('onChange')}
   />
 ))
 
@@ -47,9 +42,7 @@ stories.add('Responsive', () => (
     value=""
     label="Date Range"
     options={options}
-    onChange={event => {
-      console.log(event)
-    }}
+    onChange={action('onChange')}
   />
 ))
 
@@ -59,9 +52,7 @@ stories.add('Small', () => (
     value=""
     label="Date Range"
     options={options}
-    onChange={event => {
-      console.log(event)
-    }}
+    onChange={action('onChange')}
     size="small"
   />
 ))
@@ -72,9 +63,7 @@ stories.add('Large', () => (
     value=""
     label="Date Range"
     options={options}
-    onChange={event => {
-      console.log(event)
-    }}
+    onChange={action('onChange')}
     size="large"
   />
 ))
@@ -107,7 +96,7 @@ stories.add('Formik', () => (
             options={options}
             onChange={(event: any) => {
               setFieldValue('example-switch-field', event.target.value)
-              console.log(event)
+              action('onChange')(event)
             }}
           />
         </Form>

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
+import React from 'react'
 
 import TabSet from './index'
 import Tab from './Tab'
@@ -7,11 +8,7 @@ import Tab from './Tab'
 const stories = storiesOf('TabSet', module)
 
 stories.add('Default', () => (
-  <TabSet
-    onChangeCallback={(id, name) => {
-      console.log(id, name)
-    }}
-  >
+  <TabSet onChangeCallback={action('onChangeCallback')}>
     <Tab title="Example Tab 1">
       <p>This is some example tab 1 content</p>
     </Tab>

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.stories.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
+import React from 'react'
 
 import { Masthead } from './index'
 
@@ -48,7 +49,7 @@ const CustomLogo = () => (
 
 stories.add('With search', () => (
   <Masthead
-    onSearch={term => console.log(`Search for: ${term}`)}
+    onSearch={action('onSearch')}
     searchPlaceholder="Search..."
     title="Test"
   />
@@ -60,7 +61,7 @@ const popoverContent = <NotificationsPopoverContent />
 stories.add('With search and Avatar', () => (
   <div>
     <Masthead
-      onSearch={term => console.log(`Search for: ${term}`)}
+      onSearch={action('onSearch')}
       searchPlaceholder="Search..."
       title="Test"
       user={user}
@@ -107,7 +108,7 @@ stories.add('all but navigation', () => (
   <Masthead
     homeLink={homeLink}
     NotificationsPopoverContent={popoverContent}
-    onSearch={term => console.log(`Search for: ${term}`)}
+    onSearch={action('onSearch')}
     searchPlaceholder="Search"
     title="Test"
     unreadNotification
@@ -120,7 +121,7 @@ stories.add('With navigation', () => (
     homeLink={homeLink}
     navItems={navItems}
     NotificationsPopoverContent={popoverContent}
-    onSearch={term => console.log(`Search for: ${term}`)}
+    onSearch={action('onSearch')}
     searchPlaceholder="Search"
     title="Test"
     unreadNotification


### PR DESCRIPTION
## Related issue

#302 

## Overview
Removing unnecessary use of `console.log` in Storybook stories and tests.

## Reason
To reduce the number of lint warnings.

## Work carried out
- [x] Removed `console.log` from Storybook stories
- [x] Removed `console.log` from tests

## Screenshot
![Screenshot 2019-10-03 at 12 24 18](https://user-images.githubusercontent.com/56078793/66122890-c27a4380-e5d8-11e9-9f5e-31786018d845.png)
