### PR TITLE
Fix references to address lint warnings

### DIFF
--- a/packages/react-component-library/src/components/Nav/NavItem.tsx
+++ b/packages/react-component-library/src/components/Nav/NavItem.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import React, { useState, isValidElement } from 'react'
+import React, { useState } from 'react'
 import Children from 'react-children-utilities'
 
 interface NavItemProps {

--- a/packages/react-component-library/src/components/Searchbar/Searchbar.test.tsx
+++ b/packages/react-component-library/src/components/Searchbar/Searchbar.test.tsx
@@ -60,8 +60,8 @@ describe('Searchbar', () => {
     })
 
     it('should hide the searchbar', () => {
-      expect(props.setShowSearch).toBeCalledTimes(1)
-      expect(props.setShowSearch).toBeCalledWith(false)
+      expect(props.setShowSearch).toHaveBeenCalledTimes(1)
+      expect(props.setShowSearch).toHaveBeenCalledWith(false)
     })
   })
 

--- a/packages/react-component-library/src/components/Switch/Switch.test.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.test.tsx
@@ -4,7 +4,6 @@ import { render, fireEvent, RenderResult } from '@testing-library/react'
 
 import { OptionType } from '../../types/Switch'
 
-import ResponsiveSwitch from './index'
 import Switch from './Switch'
 
 describe('Switch', () => {
@@ -109,6 +108,3 @@ describe('Switch', () => {
   })
 })
 
-describe('ResponsiveSwitch', () => {
-  //
-})

--- a/packages/react-component-library/src/components/Switch/Switch.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.tsx
@@ -19,10 +19,6 @@ const Switch: React.FC<SwitchType> = ({
 
   const id = uuid()
 
-  function getOption(optionLabel: string) {
-    return options.find(item => item.label === optionLabel)
-  }
-
   return (
     <fieldset
       className={`rn-switch rn-switch--${size} ${className}`}

--- a/packages/react-component-library/src/components/TabSet/Tab.tsx
+++ b/packages/react-component-library/src/components/TabSet/Tab.tsx
@@ -5,7 +5,7 @@ interface TabProps {
   children?: any
 }
 
-const Tab: React.FC<TabProps> = ({ title, children }) => {
+const Tab: React.FC<TabProps> = ({ children }) => {
   return <>{children}</>
 }
 

--- a/packages/react-component-library/src/fragments/NotificationPanel/NotificationPanel.test.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/NotificationPanel.test.tsx
@@ -90,7 +90,7 @@ describe('NotificationPanel', () => {
       })
 
       it('should notify the parent the notification is visible', () => {
-        expect(props.onShow).toBeCalled()
+        expect(props.onShow).toHaveBeenCalled()
       })
 
       describe('when the user clicks on the button again', () => {
@@ -113,7 +113,7 @@ describe('NotificationPanel', () => {
         })
 
         it('should notify the parent the notification was hidden', () => {
-          expect(props.onHide).toBeCalled()
+          expect(props.onHide).toHaveBeenCalled()
         })
       })
 

--- a/packages/react-component-library/src/fragments/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/fragments/Sidebar/Sidebar.stories.tsx
@@ -18,12 +18,6 @@ const NotificationsPopoverContent: React.FC = () => {
   )
 }
 
-const UserLink: React.FC = ({ children, ...rest }) => (
-  <Link href="/user" {...rest}>
-    {children}
-  </Link>
-)
-
 const stories = storiesOf('Sidebar', module)
 
 const navData: NavItemAnchorType[] = [


### PR DESCRIPTION
## Related issue

#302 

## Overview
Removed unused references and changed tests to use correct Jest functions.

## Reason
Reduce number of lint warnings.

## Work carried out
- [x] Remove unused references
- [x] Fix Jest functions