### PR TITLE
Use more specific FormEvent over SyntheticEvent

### DIFF
--- a/packages/react-component-library/src/components/Button/Button.test.tsx
+++ b/packages/react-component-library/src/components/Button/Button.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FormEvent } from 'react'
 import { shallow, ShallowWrapper } from 'enzyme'
 
 import { Button } from './index'
@@ -6,7 +6,7 @@ import { Button } from './index'
 describe('Button', () => {
   describe('Given a button is created with a listener for onClick', () => {
     let component: ShallowWrapper
-    let onClick: (event: React.SyntheticEvent) => void
+    let onClick: (event: FormEvent<HTMLButtonElement>) => void
 
     beforeEach(() => {
       onClick = jest.fn()

--- a/packages/react-component-library/src/components/Button/Button.tsx
+++ b/packages/react-component-library/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FormEvent } from 'react'
 import classNames from 'classnames'
 
 export interface ButtonProps extends ComponentWithClass {
@@ -6,7 +6,7 @@ export interface ButtonProps extends ComponentWithClass {
   color?: 'danger'
   testId?: string
   icon?: React.ReactNode
-  onClick?: (event: React.SyntheticEvent) => void
+  onClick?: (event: FormEvent<HTMLButtonElement>) => void
   size?: 'small' | 'regular' | 'large' | 'xlarge'
   type?: 'button' | 'submit'
   variant?: 'primary' | 'secondary' | 'tertiary'

--- a/packages/react-component-library/src/components/Button/README.md
+++ b/packages/react-component-library/src/components/Button/README.md
@@ -60,7 +60,7 @@ a record.
 | className | string         | False    |         | Custom css class to add to the button element
 | color     | string         | False    |         | (danger) An alternative color style to use, danger is the only alternative currently supported      
 | icon      | ReactNode      | False    |         | Icon to display to the right of text in the button. Accepts any Node but ideally would be an image or svg tag                       
-| onClick   | (event: React.SyntheticEvent):void | True     |         | Function to call when a user clicks on a button
+| onClick   | (event: React.FormEvent<HTMLInputElement>):void | True     |         | Function to call when a user clicks on a button
 | size      | string         | False    | regular | (small/regular/large/xlarge) The size for the button
 | variant   | string         | False    | teriary | (primary/secondary/tertiary) The style of button
                                                                                  

--- a/packages/react-component-library/src/components/Checkbox/index.tsx
+++ b/packages/react-component-library/src/components/Checkbox/index.tsx
@@ -9,8 +9,8 @@ interface CheckboxProps {
   value?: string
   name: string
   checked?: boolean
-  onChange?: (event: React.SyntheticEvent) => void
-  onBlur?: (event: React.SyntheticEvent) => void
+  onChange?: (event: React.FormEvent<HTMLInputElement>) => void
+  onBlur?: (event: React.FormEvent<HTMLInputElement>) => void
 }
 
 const Checkbox: React.FC<CheckboxProps> = ({

--- a/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
@@ -8,8 +8,8 @@ describe('Modal', () => {
   let wrapper: RenderResult
   let title: string
   let description: string
-  let onConfirm: (event: any) => void
-  let onCancel: (event: any) => void
+  let onConfirm: (event: React.FormEvent<HTMLButtonElement>) => void
+  let onCancel: (event: React.FormEvent<HTMLButtonElement>) => void
   let isOpen: boolean
 
   beforeEach(() => {

--- a/packages/react-component-library/src/components/Dialog/Dialog.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.tsx
@@ -7,8 +7,8 @@ export interface DialogProps extends ComponentWithClass {
   title?: string
   description?: string
   danger?: boolean
-  onConfirm?: (event: React.SyntheticEvent) => void
-  onCancel?: (event: React.SyntheticEvent) => void
+  onConfirm?: (event: React.FormEvent<HTMLButtonElement>) => void
+  onCancel?: (event: React.FormEvent<HTMLButtonElement>) => void
   isOpen?: boolean
 }
 

--- a/packages/react-component-library/src/components/Modal/Header.tsx
+++ b/packages/react-component-library/src/components/Modal/Header.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export interface HeaderProps {
   title?: string
-  onClose?: (event: React.SyntheticEvent) => void
+  onClose?: (event: React.FormEvent<HTMLButtonElement>) => void
 }
 
 export const Header: React.FC<HeaderProps> = ({ title, onClose }) => {

--- a/packages/react-component-library/src/components/Modal/Modal.test.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.test.tsx
@@ -23,7 +23,7 @@ const tertiaryButton: ButtonProps = {
 describe('Modal', () => {
   let wrapper: RenderResult
   let title: string
-  let onClose: (event: any) => void
+  let onClose: (event: React.FormEvent<HTMLButtonElement>) => void
   let isOpen: boolean
 
   beforeEach(() => {

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -9,7 +9,7 @@ import { Footer } from './Footer'
 
 export interface ModalProps extends ComponentWithClass {
   children?: any
-  onClose?: (event: React.SyntheticEvent) => void
+  onClose?: (event: React.FormEvent<HTMLButtonElement>) => void
   primaryButton?: ButtonProps
   secondaryButton?: ButtonProps
   tertiaryButton?: ButtonProps
@@ -30,7 +30,7 @@ export const Modal: React.FC<ModalProps> = ({
   const [open, setOpen] = useState(isOpen)
   const mutatedPrimaryButton = primaryButton
 
-  function handleOnClose(event: React.SyntheticEvent) {
+  function handleOnClose(event: React.FormEvent<HTMLButtonElement>) {
     setOpen(false)
     onClose(event)
   }

--- a/packages/react-component-library/src/components/Radio/index.tsx
+++ b/packages/react-component-library/src/components/Radio/index.tsx
@@ -8,8 +8,8 @@ interface RadioProps {
   disabled?: boolean
   name: string
   value?: string
-  onChange?: (event: React.SyntheticEvent) => void
-  onBlur?: (event: React.SyntheticEvent) => void
+  onChange?: (event: React.FormEvent<HTMLInputElement>) => void
+  onBlur?: (event: React.FormEvent<HTMLInputElement>) => void
 }
 
 const Radio: React.FC<RadioProps> = ({

--- a/packages/react-component-library/src/components/Switch/Switch.stories.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.stories.tsx
@@ -94,8 +94,8 @@ stories.add('Formik', () => (
             label="Date Range"
             component={FormikSwitch}
             options={options}
-            onChange={(event: any) => {
-              setFieldValue('example-switch-field', event.target.value)
+            onChange={(event: React.FormEvent<HTMLInputElement>) => {
+              setFieldValue('example-switch-field', event.currentTarget.value)
               action('onChange')(event)
             }}
           />

--- a/packages/react-component-library/src/components/Switch/Switch.test.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.test.tsx
@@ -11,7 +11,7 @@ describe('Switch', () => {
   let value: string
   let label: string
   let className: string
-  let onChange: (event: any) => void
+  let onChange: (event: React.FormEvent<HTMLInputElement>) => void
   let options: OptionType[]
   let size: string
   let component: RenderResult

--- a/packages/react-component-library/src/types/Switch.d.ts
+++ b/packages/react-component-library/src/types/Switch.d.ts
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export interface OptionType {
   label: string
   value: string
@@ -8,7 +10,7 @@ export interface SwitchType {
   value: string
   label?: string
   className?: string
-  onChange?: (event: any) => void
+  onChange?: (event: React.FormEvent<HTMLInputElement>) => void
   options: OptionType[]
   size?: string
 }


### PR DESCRIPTION
## Related issue
#302 

## Overview
Uses the more specific `FormEvent<T>` rather than `SyntheticEvent`.

## Reason
Addresses some of the lint warnings.

## Work carried out
- [x] Replace `SyntheticEvent`