### PR TITLE
Fix docs site page title

### DIFF
--- a/packages/docs-site/README.md
+++ b/packages/docs-site/README.md
@@ -14,7 +14,7 @@ The codebase for the royalnavy.io site. It is based on [GatsbyJs](https://www.ga
 
 ### Step one: Installation
 
-In a command line application, simply run `npm install`. This will go and find all therem required dependencies and install them.
+In a command line application, simply run `npm install`. This will go and find all the required dependencies and install them.
 
 > **Note:**  
  This currently contains package dependencies from GitHub.   These may take some time to install and will reside in a  `git_modules` folder. Do not delete this folder.

--- a/packages/docs-site/src/pages/404.js
+++ b/packages/docs-site/src/pages/404.js
@@ -23,7 +23,7 @@ export default function Template() {
 
   return (
     <Layout>
-      <Helmet title="Page not found | NELSON // Standards" />
+      <Helmet title="Page not found | NELSON Standards" />
       <MastHead navItems={primaryNavData} />
       <main className="main rn-container">
         <article className="post-article page-not-found">

--- a/packages/docs-site/src/templates/home.js
+++ b/packages/docs-site/src/templates/home.js
@@ -38,7 +38,7 @@ const HomeTemplate = ({ data: { mdx }, location }) => {
 
   return (
     <Layout>
-      <Helmet title={`${mdx.frontmatter.title} | NELSON // Standards`} />
+      <Helmet title={`${mdx.frontmatter.title} | NELSON Standards`} />
       <MastHead navItems={primaryNavData} />
       <HeroBanner
         title="Design your application using NELSON styles and components"


### PR DESCRIPTION
## Related issue
#237

## Overview
The page title of the docs site is `NELSON // Standards` and it should be `NELSON Standards`.

## Work carried out
- [x] Update page title
- [x] Fix typos

## Screenshot
![Screenshot 2019-10-07 at 20 35 25](https://user-images.githubusercontent.com/56078793/66342847-41a5a980-e942-11e9-84be-c38fe4a54bc9.png)