### PR TITLE
Add support for errors to native form components

### DIFF
--- a/packages/react-component-library/src/components/Checkbox/index.tsx
+++ b/packages/react-component-library/src/components/Checkbox/index.tsx
@@ -2,27 +2,29 @@ import React from 'react'
 import uuid from 'uuid'
 
 interface CheckboxProps {
+  checked?: boolean
   className?: string
+  disabled?: boolean
+  errorMessage?: string
   id?: string
   label: string
-  disabled?: boolean
-  value?: string
   name: string
-  checked?: boolean
+  value?: string
   onChange?: (event: React.FormEvent<HTMLInputElement>) => void
   onBlur?: (event: React.FormEvent<HTMLInputElement>) => void
 }
 
 const Checkbox: React.FC<CheckboxProps> = ({
+  checked = false,
   className = '',
+  disabled = false,
+  errorMessage,
   id = uuid(),
   label,
-  disabled = false,
-  value,
   name,
-  checked = false,
-  onChange,
   onBlur,
+  onChange,
+  value,
   ...rest
 }) => {
   return (
@@ -46,6 +48,11 @@ const Checkbox: React.FC<CheckboxProps> = ({
           {label}
         </label>
       </div>
+      {errorMessage && (
+        <div className="rn-form__invalid-feedback" data-testid="error">
+          {errorMessage}
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -6,6 +6,7 @@ export interface NumberInputProps {
   autoFocus?: boolean
   className?: string
   disabled?: boolean
+  errorMessage?: string
   footnote?: string
   id?: string
   label?: string
@@ -48,6 +49,7 @@ export function calculateNewValue({
 export const NumberInput: React.FC<NumberInputProps> = ({
   className,
   disabled = false,
+  errorMessage,
   footnote,
   id = uuid(),
   label,
@@ -205,6 +207,11 @@ export const NumberInput: React.FC<NumberInputProps> = ({
         >
           {footnote}
         </small>
+      )}
+      {errorMessage && (
+        <div className="rn-form__invalid-feedback" data-testid="error">
+          {errorMessage}
+        </div>
       )}
     </div>
   )

--- a/packages/react-component-library/src/components/Radio/index.tsx
+++ b/packages/react-component-library/src/components/Radio/index.tsx
@@ -3,9 +3,10 @@ import uuid from 'uuid'
 
 interface RadioProps {
   className?: string
+  disabled?: boolean
+  errorMessage?: string
   id?: string
   label: string
-  disabled?: boolean
   name: string
   value?: string
   onChange?: (event: React.FormEvent<HTMLInputElement>) => void
@@ -14,13 +15,14 @@ interface RadioProps {
 
 const Radio: React.FC<RadioProps> = ({
   className = '',
+  disabled = false,
+  errorMessage,
   id = uuid(),
   label,
-  disabled = false,
-  value,
   name,
-  onChange,
   onBlur,
+  onChange,
+  value,
   ...rest
 }) => {
   return (
@@ -43,6 +45,11 @@ const Radio: React.FC<RadioProps> = ({
           {label}
         </label>
       </div>
+      {errorMessage && (
+        <div className="rn-form__invalid-feedback" data-testid="error">
+          {errorMessage}
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -7,6 +7,7 @@ import { Option, SelectOptionWithBadgeType } from './Option'
 import { SingleValue } from './SingleValue'
 
 export interface SelectProps {
+  errorMessage?: string
   label?: string
   name?: string
   onChange?: (event: any) => void
@@ -15,6 +16,7 @@ export interface SelectProps {
 }
 
 export const Select: React.FC<SelectProps> = ({
+  errorMessage,
   label,
   name,
   onChange,
@@ -36,23 +38,30 @@ export const Select: React.FC<SelectProps> = ({
   const selectedOption = options.find(option => option.value === value)
 
   return (
-    <ReactSelect
-      aria-label={label}
-      className="rn-select"
-      classNamePrefix="rn-select"
-      components={{
-        DropdownIndicator,
-        Input,
-        Option,
-        SingleValue,
-      }}
-      isClearable
-      name={name}
-      onChange={onSelectChange}
-      options={options}
-      placeholder={null}
-      value={selectedOption}
-    />
+    <>
+      <ReactSelect
+        aria-label={label}
+        className="rn-select"
+        classNamePrefix="rn-select"
+        components={{
+          DropdownIndicator,
+          Input,
+          Option,
+          SingleValue,
+        }}
+        isClearable
+        name={name}
+        onChange={onSelectChange}
+        options={options}
+        placeholder={null}
+        value={selectedOption}
+      />
+      {errorMessage && (
+        <div className="rn-form__invalid-feedback" data-testid="error">
+          {errorMessage}
+        </div>
+      )}
+    </>
   )
 }
 

--- a/packages/react-component-library/src/components/Switch/Switch.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.tsx
@@ -4,6 +4,7 @@ import uuid from 'uuid'
 import { SwitchType, OptionType } from '../../types/Switch'
 
 const Switch: React.FC<SwitchType> = ({
+  errorMessage,
   label,
   name,
   onChange,
@@ -20,41 +21,48 @@ const Switch: React.FC<SwitchType> = ({
   const id = uuid()
 
   return (
-    <fieldset
-      className={`rn-switch rn-switch--${size} ${className}`}
-      data-testid="wrapper"
-    >
-      {label && (
-        <legend className="rn-switch__legend" data-testid="legend">
-          {label}
-        </legend>
+    <>
+      <fieldset
+        className={`rn-switch rn-switch--${size} ${className}`}
+        data-testid="wrapper"
+      >
+        {label && (
+          <legend className="rn-switch__legend" data-testid="legend">
+            {label}
+          </legend>
+        )}
+        <div className="rn-switch__container">
+          {options.map(({ label: optionLabel, value: optionValue }) => (
+            <label
+              key={uuid()}
+              className={`rn-switch__option ${
+                active === optionLabel ? 'is-active' : ''
+              }`}
+              data-label={optionLabel}
+              htmlFor={`${id}-${optionLabel}`}
+              data-testid="option"
+            >
+              <input
+                id={`${id}-${optionLabel}`}
+                name={name || id}
+                value={optionValue}
+                type="radio"
+                className="rn-switch__radio"
+                onClick={event => {
+                  setActive(optionLabel)
+                  onChange(event)
+                }}
+              />
+            </label>
+          ))}
+        </div>
+      </fieldset>
+      {errorMessage && (
+        <div className="rn-form__invalid-feedback" data-testid="error">
+          {errorMessage}
+        </div>
       )}
-      <div className="rn-switch__container">
-        {options.map(({ label: optionLabel, value: optionValue }) => (
-          <label
-            key={uuid()}
-            className={`rn-switch__option ${
-              active === optionLabel ? 'is-active' : ''
-            }`}
-            data-label={optionLabel}
-            htmlFor={`${id}-${optionLabel}`}
-            data-testid="option"
-          >
-            <input
-              id={`${id}-${optionLabel}`}
-              name={name || id}
-              value={optionValue}
-              type="radio"
-              className="rn-switch__radio"
-              onClick={event => {
-                setActive(optionLabel)
-                onChange(event)
-              }}
-            />
-          </label>
-        ))}
-      </div>
-    </fieldset>
+    </>
   )
 }
 

--- a/packages/react-component-library/src/components/TextInput/index.tsx
+++ b/packages/react-component-library/src/components/TextInput/index.tsx
@@ -6,6 +6,7 @@ export interface InputProps {
   className?: string
   disabled?: boolean
   endAdornment?: React.ReactNode
+  errorMessage?: string
   value?: string
   name: string
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
@@ -38,6 +39,7 @@ const TextInput: React.FC<InputProps> = props => {
     className = '',
     disabled = false,
     endAdornment,
+    errorMessage,
     value,
     name,
     onChange,
@@ -121,6 +123,11 @@ const TextInput: React.FC<InputProps> = props => {
         <small className="rn-textinput__footnote" data-testid="footnote">
           {footnote}
         </small>
+      )}
+      {errorMessage && (
+        <div className="rn-form__invalid-feedback" data-testid="error">
+          {errorMessage}
+        </div>
       )}
     </div>
   )

--- a/packages/react-component-library/src/enhancers/withFormik.tsx
+++ b/packages/react-component-library/src/enhancers/withFormik.tsx
@@ -20,6 +20,7 @@ const withFormik = (FormComponent: React.FC<any>) => ({
   const formComponentClassNames = classNames(className, {
     'is-invalid': hasError,
   })
+  const errorMessage = hasError ? errors[field.name] : undefined
 
   return (
     <>
@@ -27,12 +28,8 @@ const withFormik = (FormComponent: React.FC<any>) => ({
         {...field}
         {...props}
         className={formComponentClassNames}
+        errorMessage={errorMessage}
       />
-      {hasError && (
-        <div className="rn-form__invalid-feedback" data-testid="error">
-          {errors[field.name]}
-        </div>
-      )}
     </>
   )
 }

--- a/packages/react-component-library/src/types/Switch.d.ts
+++ b/packages/react-component-library/src/types/Switch.d.ts
@@ -6,11 +6,12 @@ export interface OptionType {
 }
 
 export interface SwitchType {
-  name: string
-  value: string
-  label?: string
   className?: string
-  onChange?: (event: React.FormEvent<HTMLInputElement>) => void
+  errorMessage?: string
+  label?: string
+  name: string
   options: OptionType[]
   size?: string
+  value: string
+  onChange?: (event: React.FormEvent<HTMLInputElement>) => void
 }


### PR DESCRIPTION
`withFormik` displayed errors outside of a form component, but that means it stripped away the ability to pass an error message into a component and have it displayed. Native form components need to be able to display errors so users can use them in the upcoming redux form components can also take advantage of it without duplicating code.

