### PR TITLE
Refactor Button tests to not use Enzyme

### DIFF
--- a/packages/react-component-library/src/components/Button/Button.test.tsx
+++ b/packages/react-component-library/src/components/Button/Button.test.tsx
@@ -1,37 +1,93 @@
+import '@testing-library/jest-dom/extend-expect'
 import React, { FormEvent } from 'react'
-import { shallow, ShallowWrapper } from 'enzyme'
+import { render, RenderResult, fireEvent } from '@testing-library/react'
 
 import { Button } from './index'
 
 describe('Button', () => {
-  describe('Given a button is created with a listener for onClick', () => {
-    let component: ShallowWrapper
-    let onClick: (event: FormEvent<HTMLButtonElement>) => void
+  let wrapper: RenderResult
+  let onClickSpy: (event: FormEvent<HTMLButtonElement>) => void
+  let blurSpy: jest.SpyInstance
+  let button: HTMLElement
 
+  beforeEach(() => {
+    onClickSpy = jest.fn()
+    blurSpy = jest.fn()
+  })
+
+  describe('default props', () => {
     beforeEach(() => {
-      onClick = jest.fn()
-      component = shallow(<Button onClick={onClick}>Hello World</Button>)
+      wrapper = render(<Button onClick={onClickSpy}>Click me</Button>)
+      button = wrapper.getByText('Click me').parentElement
     })
 
-    describe('and a user clicks on the button', () => {
-      let blurSpy: jest.SpyInstance
+    it('should style the button', () => {
+      expect(button.classList).toContain('rn-btn')
+      expect(button.classList).toContain('rn-btn--regular')
+    })
 
+    it('should default the type to "button"', () => {
+      expect(button).toHaveAttribute('type', 'button')
+    })
+
+    describe('when the button is clicked', () => {
       beforeEach(() => {
-        blurSpy = jest.fn()
-        component.simulate('click', {
-          currentTarget: {
+        fireEvent.click(button, {
+          target: {
             blur: blurSpy,
           },
         })
       })
 
-      it('should call the handler when the button is clicked', () => {
-        expect(onClick).toHaveBeenCalled()
+      it('should blur the button so it does not remain active', () => {
+        expect(blurSpy).toHaveBeenCalledTimes(1)
       })
 
-      it('should blur the button so it does not remain active', () => {
-        expect(blurSpy).toHaveBeenCalled()
+      it('should handle the click event', () => {
+        expect(onClickSpy).toHaveBeenCalledTimes(1)
       })
+    })
+  })
+
+  describe('when the size is specified', () => {
+    it.each`
+      size          | expected
+      ${'small'}    | ${'rn-btn--small'}
+      ${'regular'}  | ${'rn-btn--regular'}
+      ${'large'}    | ${'rn-btn--large'}
+      ${'xlarge'}   | ${'rn-btn--xlarge'}
+    `('styles the button when the size is $size', ({ size, expected }) => {
+      wrapper = render(<Button onClick={onClickSpy} size={size}>Click me</Button>)
+      button = wrapper.getByText('Click me').parentElement
+
+      expect(button.classList).toContain(expected)
+    })
+  })
+
+  describe('when the type is specified', () => {
+    it.each`
+      type        | expected
+      ${'button'} | ${'button'}
+      ${'submit'} | ${'submit'}
+    `('should set the type attribute to $type', ({ type, expected }) => {
+      wrapper = render(<Button onClick={onClickSpy} type={type}>Click me</Button>)
+      button = wrapper.getByText('Click me').parentElement
+
+      expect(button).toHaveAttribute('type', expected)
+    })
+  })
+
+  describe('when the variant is specified', () => {
+    it.each`
+      variant        | expected
+      ${'primary'}   | ${'rn-btn--primary'}
+      ${'secondary'} | ${'rn-btn--secondary'}
+      ${'tertiary'}  | ${'rn-btn--tertiary'}
+    `('styles the button when the variant is $variant', ({ variant, expected }) => {
+      wrapper = render(<Button onClick={onClickSpy} variant={variant}>Click me</Button>)
+      button = wrapper.getByText('Click me').parentElement
+
+      expect(button.classList).toContain(expected)
     })
   })
 })


### PR DESCRIPTION
## Related issue

#301

## Overview

Refactored the Button tests to use React Testing Library rather than Enzyme.

## Reason

The team has been migrating away from Enzyme and this is one of two remaining usages of Enzyme.

## Work carried out

- [x] Refactored tests
- [x] Added test cases for variant, type and size


## Developer notes

Note the usage of `it.each` to quickly test multiple variations.
Enzyme and related dependencies will be removed in another PR.