### PR TITLE
Fix minor typo in storybook docs for Phasebanner

### DIFF
--- a/packages/docs-site/src/library/pages/components/phase-banner.md
+++ b/packages/docs-site/src/library/pages/components/phase-banner.md
@@ -4,7 +4,7 @@ description:  A simple banner to indicate the phase of the project.
 header: true
 ---
 
-import { PaseBanner, Tab, TabSet } from '@royalnavy/react-component-library'
+import { PhaseBanner, Tab, TabSet } from '@royalnavy/react-component-library'
 import DataTable from '../../../components/presenters/data-table'
 import CodeHighlighter from '../../../components/presenters/code-highlighter'
 import SketchWidget from '../../../components/presenters/sketch-widget'


### PR DESCRIPTION
## Related issue
#305 


The docs site build had some warnings in its build, turns out it was just a typo in one of the docs.