### PR TITLE
Remove underline when hovering over Masthead navigation

### DIFF
--- a/packages/css-framework/src/components/_scrollable-nav.scss
+++ b/packages/css-framework/src/components/_scrollable-nav.scss
@@ -32,6 +32,10 @@ $btn-focus-width: 0.2rem;
   &:focus {
     box-shadow: 0 0 0 $btn-focus-width rgba(color(primary, 700) , 0.5);
   }
+
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 .rn-scrollable-nav__item.is-active .rn-scrollable-nav__link {


### PR DESCRIPTION
The Navigation links in Masthead, provided by ScrollableNav, used browser defaults for the text decoration property on a link. This small change ensures that links do not have an underline when the users mouse hovers over them.

## Related issue
#334 
