### PR TITLE
[WIP] Standards Toolkit v2

### DIFF
--- a/packages/css-framework/README.md
+++ b/packages/css-framework/README.md
@@ -51,13 +51,13 @@ In the example above, we are updating the `text 00` value to `#FF0000` (red) and
 
 ---
 
-# Helpers
+# Utility classes
 
-Several different helpers are provided by this framework. This is to ensure consistency when building applications, and to hopefully mitigate any UI bugs that could occour by leaking styles.
+Several different Utility classes are provided by this framework. This is to ensure consistency when building applications, and to hopefully mitigate any UI bugs that could occur by leaking styles.
 
 ## z-index
 
-To ensure correct z-axis stacking in NELSON applications, a z-index helper is provided.
+To ensure correct z-axis stacking in NELSON applications, a z-index Utility class is provided.
 
 z-index can be set via a mixin named z-index:
 ```
@@ -92,7 +92,7 @@ Occasionally, a group alone won't be enough to ensure a correct z-axis stack. An
 
 ## Breakpoints
 
-NELSON applications are built Mobile First. A number of breakpoints are provided by default, and also tie into the Spacing helper classes & variables:
+NELSON applications are built Mobile First. A number of breakpoints are provided by default, and also tie into the Spacing Utility classes & variables:
 ```
 - root: 0px
 - s: 576px

--- a/packages/css-framework/index.scss
+++ b/packages/css-framework/index.scss
@@ -90,16 +90,16 @@ $__states: null;
 @import "src/objects/media";
 @import "src/objects/wrapper";
 
-// Helpers
-@import "src/helpers/clearfix";
-@import "src/helpers/flex";
-@import "src/helpers/position";
-@import "src/helpers/shadows";
-@import "src/helpers/sizing";
-@import "src/helpers/spacing";
-@import "src/helpers/shadows";
-@import "src/helpers/typography";
-@import "src/helpers/visibility";
+// Utilities
+@import "src/utilities/clearfix";
+@import "src/utilities/flex";
+@import "src/utilities/position";
+@import "src/utilities/shadows";
+@import "src/utilities/sizing";
+@import "src/utilities/spacing";
+@import "src/utilities/shadows";
+@import "src/utilities/typography";
+@import "src/utilities/visibility";
 
 // Fragments
 @import "src/fragments/form";

--- a/packages/css-framework/src/_config.scss
+++ b/packages/css-framework/src/_config.scss
@@ -11,7 +11,7 @@ $navy--typography: () !default;
 $navy--zIndex: () !default;
 
 
-// Helper Namespace
-$helper-ns: "h_";
+// Utility Namespace
+$utility-ns: "rn_";
 
 $navy-content-width: 1280px;

--- a/packages/css-framework/src/utilities/_clearfix.scss
+++ b/packages/css-framework/src/utilities/_clearfix.scss
@@ -1,3 +1,3 @@
-.#{$helper-ns}cf {
+.#{$utility-ns}cf {
   @include clearfix;
 }

--- a/packages/css-framework/src/utilities/_flex.scss
+++ b/packages/css-framework/src/utilities/_flex.scss
@@ -55,12 +55,12 @@
 
 @each $_breakpoint, $_breakpoint-val in $__breakpoints {
   @if $_breakpoint == 'root' {
-    .#{$helper-ns}f {
+    .#{$utility-ns}f {
       @include flexSharedStyles;      
     }
   } @else {
     @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
-      .#{$_breakpoint}\:#{$helper-ns}f {        
+      .#{$_breakpoint}\:#{$utility-ns}f {        
           @include flexSharedStyles;
       }
     }

--- a/packages/css-framework/src/utilities/_position.scss
+++ b/packages/css-framework/src/utilities/_position.scss
@@ -20,12 +20,12 @@
 
 @each $_breakpoint, $_breakpoint-val in $__breakpoints {
   @if $_breakpoint == 'root' {
-    .#{$helper-ns} {
+    .#{$utility-ns} {
       @include positionSharedStyles;
     }
   } @else {
     @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
-      .#{$_breakpoint}\:#{$helper-ns} {        
+      .#{$_breakpoint}\:#{$utility-ns} {        
           @include positionSharedStyles;
       }
     }

--- a/packages/css-framework/src/utilities/_shadows.scss
+++ b/packages/css-framework/src/utilities/_shadows.scss
@@ -1,16 +1,16 @@
 /* stylelint-disable */
-// Shadows Helper
+// Shadows Utility
 
 
 @each $_breakpoint, $_breakpoint-val in $__breakpoints {
   @each $_size, $_shadow in $__shadows {
     @if $_breakpoint == 'root' {
-      .#{$helper-ns}-shadow-#{$_size} {
+      .#{$utility-ns}-shadow-#{$_size} {
         box-shadow: #{$_shadow} !important;
       }
     } @else {
       @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
-        .#{$_breakpoint}\:#{$helper-ns}shadow-#{$_size} {        
+        .#{$_breakpoint}\:#{$utility-ns}shadow-#{$_size} {        
             box-shadow: #{$_shadow} !important;
         }
       }

--- a/packages/css-framework/src/utilities/_sizing.scss
+++ b/packages/css-framework/src/utilities/_sizing.scss
@@ -1,22 +1,22 @@
 /* stylelint-disable */
-// Sizing Helper
+// Sizing Utility
 $axes: (
   width: w,
   height: h
 );
 
-// Build Spacing Helper Classes
+// Build Spacing Utility Classes
 
 @each $_breakpoint, $_breakpoint-val in $__breakpoints {
   @each $_size, $_multiplier in $__spacing {
     @each $_axis, $_axis-shortname in $axes {
       @if $_breakpoint == 'root' {
-        .#{$helper-ns}#{$_axis-shortname}-#{$_size} {
+        .#{$utility-ns}#{$_axis-shortname}-#{$_size} {
           #{$_axis}: $_multiplier !important;
         }
       } @else {
         @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
-          .#{$_breakpoint}\:#{$helper-ns}#{$_axis-shortname}-#{$_size} {
+          .#{$_breakpoint}\:#{$utility-ns}#{$_axis-shortname}-#{$_size} {
             #{$_axis}: $_multiplier !important;
           }
         }

--- a/packages/css-framework/src/utilities/_spacing.scss
+++ b/packages/css-framework/src/utilities/_spacing.scss
@@ -12,17 +12,17 @@ $sides: (
   left: l
 );
 
-// Build Spacing Helper Classes
+// Build Spacing Utility Classes
 @each $_breakpoint, $_breakpoint-val in $__breakpoints {
   @each $_size, $_multiplier in $__spacing {
     @each $_rule, $_rule-shortname in $rules {
       
       @if $_breakpoint == 'root' {        
-        .#{$helper-ns}#{$_rule-shortname}-#{$_size} {        
+        .#{$utility-ns}#{$_rule-shortname}-#{$_size} {        
             #{$_rule}: $_multiplier !important;
         }
       } @else {
-        .#{$_breakpoint}\:#{$helper-ns}#{$_rule-shortname}-#{$_size} {        
+        .#{$_breakpoint}\:#{$utility-ns}#{$_rule-shortname}-#{$_size} {        
           @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
             #{$_rule}: $_multiplier !important;
           }
@@ -34,11 +34,11 @@ $sides: (
       @each $_rule, $_rule-shortname in $rules {
 
         @if $_breakpoint == 'root' {        
-          .#{$helper-ns}#{$_rule-shortname}#{$_shortname}-#{$_size} {
+          .#{$utility-ns}#{$_rule-shortname}#{$_shortname}-#{$_size} {
             #{$_rule}-#{$_property}: $_multiplier !important;
           }
         } @else {
-          .#{$_breakpoint}\:#{$helper-ns}#{$_rule-shortname}#{$_shortname}-#{$_size} {
+          .#{$_breakpoint}\:#{$utility-ns}#{$_rule-shortname}#{$_shortname}-#{$_size} {
             @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
               #{$_rule}-#{$_property}: $_multiplier !important;
             }

--- a/packages/css-framework/src/utilities/_typography.scss
+++ b/packages/css-framework/src/utilities/_typography.scss
@@ -2,10 +2,10 @@
 
 /**************************************************************************
 
-    Font Size Helpers
+    Font Size Utilities
     =================
 
-    Generates helper classes for font size.
+    Generates Utility classes for font size.
 
 **************************************************************************/
 
@@ -14,12 +14,12 @@
 @each $_breakpoint, $_breakpoint-val in $__breakpoints {
   @each $_shortname, $_value in $__typography {
     @if $_breakpoint == 'root' {
-      .#{$helper_ns}text-#{$_shortname} {
+      .#{$utility-ns}text-#{$_shortname} {
         font-size: $_value !important;
       }
     } @else {
       @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
-        .#{$_breakpoint}\:#{$helper_ns}text-#{$_shortname} {
+        .#{$_breakpoint}\:#{$utility-ns}text-#{$_shortname} {
           font-size: $_value !important;
         }
       }
@@ -31,7 +31,7 @@
 
 /**************************************************************************
 
-    Text Aligning Helpers
+    Text Aligning Utilities
 
 **************************************************************************/
 
@@ -49,12 +49,12 @@
 
 @each $_breakpoint, $_breakpoint-val in $__breakpoints {
   @if $_breakpoint == 'root' {
-    .#{$helper-ns}text {
+    .#{$utility-ns}text {
       @include textSharedStyles;
     }
   } @else {
     @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
-      .#{$_breakpoint}\:#{$helper-ns}text {
+      .#{$_breakpoint}\:#{$utility-ns}text {
           @include textSharedStyles;
       }
     }

--- a/packages/css-framework/src/utilities/_visibility.scss
+++ b/packages/css-framework/src/utilities/_visibility.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable */
 
-// Visibility Helper
+// Visibility Utility
 
 @mixin visibilitySharedStyles {
   &visible {
@@ -17,12 +17,12 @@
 
 @each $_breakpoint, $_breakpoint-val in $__breakpoints {
   @if $_breakpoint == 'root' {
-    .#{$helper-ns} {
+    .#{$utility-ns} {
       @include visibilitySharedStyles;
     }
   } @else {
     @media only screen and (min-width: map-get($_breakpoint-val, 'breakpoint')) {
-      .#{$_breakpoint}\:#{$helper-ns} {        
+      .#{$_breakpoint}\:#{$utility-ns} {        
           @include visibilitySharedStyles;
       }
     }

--- a/packages/docs-site/src/library/pages/get-started/development/sass-css-framework.md
+++ b/packages/docs-site/src/library/pages/get-started/development/sass-css-framework.md
@@ -4,7 +4,7 @@ description: ''
 header: true
 ---
 
-The @royalnavy/css-framework package provides a compiled version of the component CSS, the helper classes and the source SASS.
+The @royalnavy/css-framework package provides a compiled version of the component CSS, the Utility classes and the source SASS.
 
 The source SASS can be used independently of the component library package, allowing you to make use of included functions and mixins.
 
@@ -54,13 +54,13 @@ In the example above, we are updating the `text 00` value to `#FF0000` (red) and
 
 ---
 
-## Helpers
+## Utility Classes
 
-Several different helpers are provided by this framework. This is to ensure consistency when building applications and mitigate any UI bugs that could occur by leaking styles.
+Several different Utility classes are provided by this framework. This is to ensure consistency when building applications and mitigate any UI bugs that could occur by leaking styles.
 
 ## z-index
 
-To ensure correct z-axis stacking in NELSON applications, a z-index helper is provided.
+To ensure correct z-axis stacking in NELSON applications, a z-index Utility class is provided.
 
 z-index can be set via a mixin named z-index:
 ```
@@ -92,7 +92,7 @@ An optional modifier value can be added to the z-index mixin, which will be adde
 
 ## Breakpoints
 
-**NELSON** applications are built Mobile First. A number of breakpoints are provided by default and also tie into the Spacing helper classes and variables:
+**NELSON** applications are built Mobile First. A number of breakpoints are provided by default and also tie into the Spacing Utility classes and variables:
 
 ```
 - root: 0px

--- a/packages/docs-site/src/library/pages/index.md
+++ b/packages/docs-site/src/library/pages/index.md
@@ -12,14 +12,14 @@ header: false
 
 import Card from '../../components/presenters/card'
 
-<section class="m:h_f m:h_f-align-start h_mt-8 m:h_mb-16">
+<section class="m:rn_f m:rn_f-align-start rn_mt-8 m:rn_mb-16">
   <Card 
     type="border" 
     title="Styles" 
     text="Make your service look like it's for the Royal Navy with guides for applying colour, typography and spacing." 
     linkText="View styles" 
     linkHref="/styles"
-    className="m:h_f-1 m:h_mr-4"
+    className="m:rn_f-1 m:rn_mr-4"
   />
 
   <Card 
@@ -28,19 +28,19 @@ import Card from '../../components/presenters/card'
     text="Save time with reusable, accessible components for forms, navigation, cards and more." 
     linkText="View components" 
     linkHref="/components" 
-    className="m:h_f-1  m:h_ml-4 h_mt-8 m:h_mt-0"
+    className="m:rn_f-1  m:rn_ml-4 rn_mt-8 m:rn_mt-0"
   />
 </section>
 
 <section class="home--info">
   <h2 class="home__title">Latest updates</h2>
-  <div class="m:h_f m:h_f-align-start">
+  <div class="m:rn_f m:rn_f-align-start">
   <Card 
     type="coloured" 
     title="Standards v1.0.0 released" 
     meta="25th July 2019"
     text={<span>This launch includes the new <strong>Standards</strong> website providing <strong>'get started'</strong> guides for designers and developers, styling and component usage guidelines, and information about <strong>Standards</strong> for Royal Navy stakeholders. Please <a href="/contact">get in touch</a> if you have any feedback.</span>}
-    className="m:h_f-1 home--updates"
+    className="m:rn_f-1 home--updates"
   />
 
   <Card
@@ -49,7 +49,7 @@ import Card from '../../components/presenters/card'
     text={<span>Contact the <strong>NELSON Standards</strong> team to find out more about design in the Royal Navy. Request a new component, ask questions and give feedback."</span>}
     linkText="Contact" 
     linkHref="/contact"
-    className="m:h_f-1 home--contact"
+    className="m:rn_f-1 home--contact"
   />
   </div>
 </section>

--- a/packages/docs-site/src/library/pages/styles/breakpoints.md
+++ b/packages/docs-site/src/library/pages/styles/breakpoints.md
@@ -64,12 +64,12 @@ source={`@mixin breakpoint('s') {
 />
 
 
-# Helper Classes
+# Utility classes
 
-The **Toolkit** provides Breakpoints for each helper class. Simply prepend a helper class with a breakpoint size.
+The **Toolkit** provides Breakpoints for each Utility class. Simply pre-pend a Utility class with a breakpoint size.
 
 <CodeHighlighter 
-source={`.md:h_mt-4
-.lg:h-mt-10
+source={`.md:rn_mt-4
+.lg:rn_mt-10
 `} language="css"
 />

--- a/packages/docs-site/src/library/pages/styles/dividers.md
+++ b/packages/docs-site/src/library/pages/styles/dividers.md
@@ -12,4 +12,4 @@ header: true
 
 Dividers are single pixel lines that help separate and group content together. They are available in both horizontal and vertical orientation. To use them, the `<hr>` HTML tag should be added. By default, the horizontal divider will be applied. To create a vertical divider, add a `.vertical` class to the `<hr>` tag.
 
-**Note:** The Divider does not have any margins added because the size of the margin should be dictated by the content the `<hr>` is separating. To add appropriate margins to the `<hr>`, use the [Spacing Helper Classes](/styles/spacing/).
+**Note:** The Divider does not have any margins added because the size of the margin should be dictated by the content the `<hr>` is separating. To add appropriate margins to the `<hr>`, use the [Spacing Utility Classes](/styles/spacing/).

--- a/packages/docs-site/src/library/pages/styles/spacing.md
+++ b/packages/docs-site/src/library/pages/styles/spacing.md
@@ -97,14 +97,14 @@ source={`padding: Spacing(4);
 padding: 1rem;`} language="css"
 />
 
-#### Helpers
+#### Utility Classes
 
-The CSS Frameworks Spacing Variables are available in Utility Class form, allowing components to be quickly positioned and manipulated without having to jump into the CSS. All helper classes are prefixed with the namespace `.h_`. This is to prevent them clashing with any custom styles you author.
+The CSS Frameworks Spacing Variables are available in Utility Class form, allowing components to be quickly positioned and manipulated without having to jump into the CSS. All Utility classes are prefixed with the namespace `.rn_`. This is to prevent them clashing with any custom styles you author.
 
-Both margin and padding can be set via helper classes. The class syntax follows this pattern:
+Both margin and padding can be set via Utility classes. The class syntax follows this pattern:
 
 <CodeHighlighter 
-source={`.h_[Property][Direction?]-[Size]`} language="css"
+source={`.rn_[Property][Direction?]-[Size]`} language="css"
 />
 
 <div class="standard-table">
@@ -129,15 +129,15 @@ Property     | Direction  | Size
 
 </div>
 
-For example, adding a class of `.h_mt-10` would result in the following:
+For example, adding a class of `.rn_mt-10` would result in the following:
 
 <CodeHighlighter 
 source={`margin-top: 2.5rem;`} language="css"
 />
 
 
-To use the helper classes in conjunction with [media queries](/styles/breakpoints), add the required breakpoint to the helper class:
+To use the Utility classes in conjunction with [media queries](/styles/breakpoints), add the required breakpoint to the Utility class:
 
 <CodeHighlighter 
-source={`.md:h_mt-10`} language="css"
+source={`.md:rn_mt-10`} language="css"
 />

--- a/packages/docs-site/src/library/pages/styles/typography.md
+++ b/packages/docs-site/src/library/pages/styles/typography.md
@@ -89,16 +89,17 @@ font-size: 1rem;`} language="css"
 />
 
 
-# CSS Helpers
-The CSS Framework's Typography variables are available in Utility Class form, allowing the standard font sizes to be overridden. All helper classes are prefixed with the namespace `.h_`. This is to prevent them clashing with any custom styles you author.
+# Utility Classes
+
+The CSS Framework's Typography variables are available in Utility Class form, allowing the standard font sizes to be overridden. All Utility classes are prefixed with the namespace `.rn_`. This is to prevent them clashing with any custom styles you author.
 
 The class syntax follows this pattern:
 
 <CodeHighlighter 
-source={`.h_[Property]-[Size]`} language="css"
+source={`.rn_[Property]-[Size]`} language="css"
 />
 
-<DataTable className="h_mt-4" data={[
+<DataTable className="rn_mt-4" data={[
   {
     Property: 'text-',
     Size: 'xs',
@@ -146,20 +147,20 @@ source={`.h_[Property]-[Size]`} language="css"
   }
 ]} />
 
-For example, adding a class of `.h_text-xl` would result in the following:
+For example, adding a class of `.rn_text-xl` would result in the following:
 
 <CodeHighlighter 
 source={`margin-top: 1.5rem;`} language="css"
 />
 
-To use the helper classes with [media queries](/styles/breakpoints), add the required breakpoint it:
+To use the Utility classes with [media queries](/styles/breakpoints), add the required breakpoint it:
 
 <CodeHighlighter 
-source={`.md:h_text-xl`} language="css"
+source={`.md:rn_text-xl`} language="css"
 />
 
 
-<DataTable className="h_mt-4" data={[
+<DataTable className="rn_mt-4" data={[
   {
     Property: 'text-',
     Size: 'xs',


### PR DESCRIPTION
## Overview

This PR contains all updates for `v2.0.0` of the Standards Toolkit.

## Link to preview


## Reason

As we're bumping the Toolkit to `v2.0.0`, this PR will contain all breaking changes that cannot be merged into `v1.x.x`.

## Work carried out

- [ ] SCSS Framework changes
    - [ ] Changed the Spacing API to be linear in scale
    - [x] Changed all references of Helper to Utility to be more consistent with the function of these classes
    - [ ] Increased the number of available helpers to include:
        - [ ] Borders
        - [ ] Breakpoints
        - [ ] Clearfix
        - [ ] Colours
        - [ ] Containers
        - [ ] Dividers
        - [ ] Display
        - [ ] Floats 
        - [ ] Overflow
        - [ ] Vertical Align
