### PR TITLE
Fix Textinput state

### DIFF
--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.3",
     "firebase-tools": "^7.3.1",
+    "formik": "^1.5.8",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
     "jsdom": "^15.1.1",

--- a/packages/docs-site/src/library/pages/components/form/input.md
+++ b/packages/docs-site/src/library/pages/components/form/input.md
@@ -4,8 +4,8 @@ description: Text inputs let users enter and edit text.
 header: true
 ---
 
-import { Links, Tab, TabSet, TextInput } from '@royalnavy/react-component-library'
-import Field from '../../../../components/containers/Field'
+import { Links, Tab, TabSet, Formik as FormComponents} from '@royalnavy/react-component-library'
+import { Field, Formik, Form } from 'formik'
 import DataTable from '../../../../components/presenters/data-table'
 import CodeHighlighter from '../../../../components/presenters/code-highlighter'
 import SketchWidget from '../../../../components/presenters/sketch-widget'
@@ -88,11 +88,12 @@ The TextInput component can be used on its own in a regular form if you use the 
   <Field name="search" component={TextInput} placeholder="search" />
 </Form>
 </Formik>`} language="javascript">
-  <div>
-      <Field className="rn-textinput--is-valid" name="colour" component={TextInput} label="My Label" />
+  <Formik initialValues={{name: '', city: '', hero: '', fruit: '', search: ''}} onSubmit={() => {}}> 
+  <Form>fred
+      <Field className="rn-textinput--is-valid" name="colour" component={FormComponents.TextInput} label="My Label" />
       <Field 
         name="name" 
-        component={TextInput} 
+        component={FormComponents.TextInput} 
         label="Name" 
         form={{
           errors: {
@@ -103,11 +104,12 @@ The TextInput component can be used on its own in a regular form if you use the 
           }
         }}
         />
-      <Field name="city" component={TextInput} label="City" />
-      <Field name="hero" component={TextInput} endAdornment={<Icons.Search />} label="Hero" />
-      <Field name="fruit" component={TextInput} startAdornment={<Icons.Search />} label="Fruit" />
-      <Field name="search" component={TextInput} placeholder="search" />
-  </div>
+      <Field name="city" component={FormComponents.TextInput} label="City" />
+      <Field name="hero" component={FormComponents.TextInput} endAdornment={<Icons.Search />} label="Hero" />
+      <Field name="fruit" component={FormComponents.TextInput} startAdornment={<Icons.Search />} label="Fruit" />
+      <Field name="search" component={FormComponents.TextInput} placeholder="search" />
+      </Form>
+  </Formik>
 </CodeHighlighter>
 
 

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -48,6 +48,7 @@
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
+    "@royalnavy/storybook-react-input-state": "^1.5.0",
     "@storybook/addon-actions": "^5.1.11",
     "@storybook/addon-knobs": "^5.1.11",
     "@storybook/addon-links": "^5.1.11",

--- a/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
@@ -1,7 +1,8 @@
-import { Field, Formik, Form } from 'formik'
-import React from 'react'
+import State from '@royalnavy/storybook-react-input-state'
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
+import { Field, Formik, Form } from 'formik'
+import React from 'react'
 import * as yup from 'yup'
 
 import { Search } from '../../icons'
@@ -13,12 +14,14 @@ import withFormik from '../../enhancers/withFormik'
 const stories = storiesOf('TextInput', module)
 
 stories.add('Vanilla', () => (
-  <Form>
-    <TextInput className="is-valid" name="colour" label="My Label" />
-    <TextInput name="name" label="Name" />
-    <TextInput name="hero" label="Hero" startAdornment={<Search />} />
-    <TextInput name="fruit" label="Fruit" endAdornment={<Search />} />
-  </Form>
+  <form>
+    <State>
+      <TextInput className="is-valid" name="colour" label="My Label" />
+      <TextInput name="name" label="Name" />
+      <TextInput name="hero" label="Hero" startAdornment={<Search />} />
+      <TextInput name="fruit" label="Fruit" endAdornment={<Search />} />
+    </State>
+  </form>
 ))
 
 interface Data {

--- a/packages/react-component-library/src/types/StorybookReactInputState.d.ts
+++ b/packages/react-component-library/src/types/StorybookReactInputState.d.ts
@@ -1,0 +1,1 @@
+declare module '@royalnavy/storybook-react-input-state'

--- a/packages/storybook-react-input-state/package.json
+++ b/packages/storybook-react-input-state/package.json
@@ -5,7 +5,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/bundle.js",
+  "main": "dist/index.js",
   "keywords": [
     "storybook",
     "addon",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8795,7 +8795,7 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@1.4.2, eslint-utils@^1.3.1, eslint-utils@^1.4.2:
+eslint-utils@^1.3.1, eslint-utils@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
   integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==


### PR DESCRIPTION
## Related issue
#271 

Fixes an issue with TextInput not holding state in storybook and the docs site. In Storybook we needed to add a stateful container to store the field values and react to changes.

The Docs site needed Formik adding to surround the example form and hold state.

A by-product of the change was a fix to the Storybook plugin.

- [x] Fix state bug in TextInput storybook
- [x] Fix missing Formik wrapper in TextInput documentation
- [x] Fix bug exporting Storybook state plugin