### PR TITLE
Bugfix/get tree shaking working

### DIFF
--- a/packages/icon-library/.babelrc
+++ b/packages/icon-library/.babelrc
@@ -1,13 +1,26 @@
 {
-  "presets": [
-    [
-      "@babel/preset-env",
-      {
-        "modules": false
-      }
-    ],
-    "@babel/preset-react",
-    "@babel/typescript"
-  ],
+  "env": {
+    "es": {
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "modules": false
+          }
+        ],
+        "@babel/preset-react",
+        "@babel/typescript"
+      ]
+    },
+    "cjs": {
+      "presets": [
+        [
+          "@babel/preset-env"
+        ],
+        "@babel/preset-react",
+        "@babel/typescript"
+      ]
+    }
+  },
   "plugins": []
 }

--- a/packages/icon-library/generate-exports.sh
+++ b/packages/icon-library/generate-exports.sh
@@ -9,12 +9,5 @@ IFS=$'\n\t'
 for file in src/icons/*; do
   filename=$(basename -- "$file")
   filename_no_ext=${filename%%.*}
-  exports+="Icon${filename_no_ext}, "
-  echo "import Icon${filename_no_ext} from './icons/${filename_no_ext}'" >> src/index.ts
+  echo "export {default as Icon${filename_no_ext}} from './icons/${filename_no_ext}'" >> src/index.ts
 done
-
-cat <<EOF >>src/index.ts
-export {
-  ${exports}
-}
-EOF

--- a/packages/icon-library/package.json
+++ b/packages/icon-library/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@royalnavy/icon-library",
   "version": "1.6.0",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/es/index.js",
   "author": "NELSON",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -10,14 +11,15 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "run-s svgr exports build:ts types",
-    "build:ts": "webpack -p --config=webpack/prod.js",
+    "build": "run-s svgr exports build:es build:cjs types",
+    "build:es": "NODE_ENV=es babel src --out-dir \"dist/es\" --extensions \".ts,.tsx\"",
+    "build:cjs": "NODE_ENV=cjs webpack -p --config=webpack/prod.js",
     "svgr": "rm -rf src/icons; svgr --ext tsx -d src/icons src/assets/**/",
     "exports": "./generate-exports.sh",
-    "types": "tsc --emitDeclarationOnly --declarationMap --declaration --noEmit false --isolatedMOdules false --allowJs false --outDir dist/",
+    "types": "tsc --emitDeclarationOnly --declarationMap --declaration --noEmit false --isolatedMOdules false --allowJs false --outDir dist/types",
     "prepare": "yarn build"
   },
   "dependencies": {

--- a/packages/icon-library/webpack/prod.js
+++ b/packages/icon-library/webpack/prod.js
@@ -9,7 +9,7 @@ module.exports = merge(commonConfig, {
   mode: 'production',
   output: {
     filename: 'index.js',
-    path: resolve(__dirname, '../dist'),
+    path: resolve(__dirname, '../dist/cjs'),
     libraryTarget: 'commonjs2',
   },
   devtool: 'source-map',


### PR DESCRIPTION
## Related issue

https://github.com/Royal-Navy/standards-toolkit/issues/353

## Overview

Generate two different builds for the icon-library package (CJS and ES) in turn making the package completely tree-shakeable.

## Reason

The package was unable to be tree shaken and was causing downstream bundles to be huge.

## Work carried out

* [x] Create CJS build (babel transpiled and webpack bundled into a single file and output to dist/cjs)
* [x] Create ESM build (babel transpiled and output to dist/esm but preserves ES syntax)
* [x] Environment based .babelrc config
* [x] Simplify the exports generation `export {default as IconSomething} from './icons/Something'`

## Screenshot

<img width="1538" alt="Screenshot 2019-10-25 at 10 34 00" src="https://user-images.githubusercontent.com/48086589/67561748-51c8d180-f715-11e9-9a39-d735dad2c0ff.png">
<img src="https://user-images.githubusercontent.com/48086589/67667588-0c4f1300-f966-11e9-8a51-dbac367cbb2a.png">

## Developer notes

We need to also implement this for the react-component-library in order to allow application developers to deliver optimised bundles to clients.