### PR TITLE
Feature/privacy policy

### DIFF
--- a/packages/docs-site/src/hooks/useNavigationQuery.js
+++ b/packages/docs-site/src/hooks/useNavigationQuery.js
@@ -14,6 +14,7 @@ const QUERY = graphql`
             status
             index
             draft
+            excludeFromNavigation
           }
         }
       }

--- a/packages/docs-site/src/library/pages/index.md
+++ b/packages/docs-site/src/library/pages/index.md
@@ -8,6 +8,7 @@ status: ''
 template: home
 index: 0
 header: false
+excludeFromNavigation: true
 ---
 
 import Card from '../../components/presenters/card'

--- a/packages/docs-site/src/library/pages/privacy.md
+++ b/packages/docs-site/src/library/pages/privacy.md
@@ -1,0 +1,41 @@
+---
+title: Privacy
+description: ''
+tags: public
+pageClass: ''
+template: default
+header: false
+excludeFromNavigation: true
+---
+
+# Your Personal Data
+We ask you to submit personal information about yourself or your organisation (e.g. name and e-mail address) before you make comments or submit suggestions on this hub. This means that we are able to contact you to discuss your ideas further if we need to. In the future, we may offer services including e-mail updates, or request website feedback for which your supplied email address will be used as a contact. This will be communicated when such services become available. In some cases we may invite you to become more involved in the development of a proposal, for example through workshops or working groups but we will only do this if you have ticked the box to say that's ok.
+
+By entering your details in the fields requested, you help us to build up a picture of who is participating in the standards process; only your username will be published with your proposal on the hub. Any personal information you provide to us will only be used by us, our agents and service providers, and will not be disclosed unless we are obliged or permitted to by law to do so.
+
+If you post or send offensive, inappropriate or objectionable content anywhere on this site, we may use whatever information about you is available to us to stop such behaviour.
+
+If you choose to use such services as RSS feeds from this hub, the Standards Hub is not liable for any security invasions to your personal of professional IT equipment that arise from receiving our feeds, you should ensure you have appropriate security software set-up before subscribing to this service.
+
+We will hold your personal information on our systems for as long as you use the service you have requested, and remove it in the event that the purpose has been met or when you no longer wish to continue your subscription.
+
+---
+
+# Feedback
+We very much welcome and actively encourage your feedback on this site. The site is being developed in a phased approach so we encourage you to provide feedback to ensure that future iterations meet your needs. This project is seen by us as a collaborative one between government and you so do get in touch and help shape future direction.
+
+We will not pass on any of your personal information when dealing with your enquiry, unless you have given us permission to do so. Once we have replied to you, we keep a record of your message for audit purposes.
+
+---
+
+# The Data Protection Act
+Under the Data Protection Act 1998, we have a legal duty to protect any information we collect from you. We use leading technologies and encryption software to safeguard your data, and keep strict security standards to prevent any unauthorised access to it.
+
+We will not pass on your personal details to any third party without your permission.
+
+If you wish to see our records of any correspondence you have sent to us, or if you have a query or complaint about this privacy policy or about the site, you can contact us using the contact us form.
+
+---
+
+# Changes to this privacy policy
+If this privacy policy changes in any way, we will place an updated version on this page. Regularly reviewing this page ensures you are always aware of what information we collect, how we use it and under what circumstances, if any, we will share it with other parties.

--- a/packages/docs-site/src/utils/nav.js
+++ b/packages/docs-site/src/utils/nav.js
@@ -46,6 +46,7 @@ export function filterNodes(nodes) {
   return nodes
     .filter(node => stripTrailingSlash(node.node.fields.slug) !== '/')
     .filter(node => !node.node.frontmatter.draft)
+    .filter(node => !node.node.frontmatter.excludeFromNavigation)
 }
 
 /**


### PR DESCRIPTION
## Ensure the doc site has a privacy policy

#369 

## Overview

Took the gov.uk privacy policy and added it into the docs site in markdown format. The page is called privacy.md

## Reason

The site needs a privacy policy so that users know and can accept/reject how we will use information related to a user's browsing of content on the site. We may also need a separate cookie policy as they do on gov.uk sites.

## Work carried out

- [x] Privacy policy content adjusted to fit standards team needs.
- [x] Privacy policy content changed into markdown format.
- [ ] Pop-up cookie banner yet to be completed.

## Screenshot

<img width="1437" alt="Screenshot 2019-11-07 at 14 08 59" src="https://user-images.githubusercontent.com/50871448/68395783-54411780-0168-11ea-9f85-b5a48b337843.png">
