### PR TITLE
Fix fragments index export

### DIFF
--- a/packages/react-component-library/src/fragments/index.ts
+++ b/packages/react-component-library/src/fragments/index.ts
@@ -1,5 +1,15 @@
 import { Masthead } from './Masthead'
-import NotificationPanel from './NotificationPanel'
+import {
+  Notification,
+  NotificationPanel,
+  Notifications,
+} from './NotificationPanel'
 import Sidebar from './Sidebar'
 
-export { Masthead, NotificationPanel, Sidebar }
+export {
+  Masthead,
+  Notification,
+  NotificationPanel,
+  Notifications,
+  Sidebar,
+}


### PR DESCRIPTION
## Related issue
`NotificationPanel` was not being exported correctly.

## Screenshot
![Screenshot 2019-11-08 at 16 14 23](https://user-images.githubusercontent.com/56078793/68492957-70fe4d80-0243-11ea-89bd-35f490e9fc00.png)
