### PR TITLE
Reuse CSS circle for notification panel indicator

### DIFF
--- a/packages/css-framework/src/fragments/_notification-panel.scss
+++ b/packages/css-framework/src/fragments/_notification-panel.scss
@@ -14,21 +14,28 @@
   width: 16px;
 }
 
-.rn-notification-panel__indicator {
+.rn-notification-panel__not-read {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  border-radius: 4px;
+  background: color(primary, 400);
   position: absolute;
-  top: 50%;
-  margin-right: -14px;
-  margin-top: -14px;
+  top: 14px;
+  right: 12px;
+  border: 0;
+
+  &--notification-item {
+    border: 1px solid color(neutral, 700);
+    top: 0;
+    right: 0;
+  }
 }
 
 .rn-notification-panel .rn-iconfill {
   &:hover {
     fill: color(primary, 400);
   }
-}
-
-.rn-notification-panel__indicator > * {
-  fill: color(primary, 400);
 }
 
 .rn-notification__transition-wrapper {
@@ -149,18 +156,6 @@
 
 .rn-notifications-item__avatar {
   position: relative;
-}
-
-.rn-notifications-item__not-read {
-  display: inline-block;
-  width: 9px;
-  height: 9px;
-  border-radius: 4px;
-  border: 1px solid color(neutral, 700);
-  background: color(primary, 400);
-  position: absolute;
-  top: 0;
-  right: 0;
 }
 
 .rn-notifications-item__content {

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.test.tsx
@@ -257,7 +257,7 @@ describe('Masthead', () => {
 
         it('should include an unread notification indicator', () => {
           expect(
-            wrapper.queryByTestId('notification-indicator')
+            wrapper.queryByTestId('not-read')
           ).toBeInTheDocument()
         })
       })

--- a/packages/react-component-library/src/fragments/NotificationPanel/Notification.test.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/Notification.test.tsx
@@ -50,7 +50,7 @@ describe('Notification', () => {
     })
 
     it('should render the not-read indicator', () => {
-      expect(wrapper.getByTestId('not-read')).toBeTruthy()
+      expect(wrapper.getByTestId('not-read-item')).toBeTruthy()
     })
 
     it('should render the name', () => {

--- a/packages/react-component-library/src/fragments/NotificationPanel/Notification.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/Notification.tsx
@@ -55,8 +55,8 @@ export const Notification: React.FC<NotificationProps> = ({
               <Avatar initials={getInitials(name)} dark />
               {!read && (
                 <span
-                  className="rn-notifications-item__not-read"
-                  data-testid="not-read"
+                  className="rn-notification-panel__not-read rn-notification-panel__not-read--notification-item"
+                  data-testid="not-read-item"
                 />
               )}
             </div>

--- a/packages/react-component-library/src/fragments/NotificationPanel/NotificationPanel.test.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/NotificationPanel.test.tsx
@@ -174,7 +174,7 @@ describe('NotificationPanel', () => {
 
       it('should show the unread notification', () => {
         expect(
-          wrapper.getByTestId('notification-indicator')
+          wrapper.getByTestId('not-read')
         ).toBeInTheDocument()
       })
     })

--- a/packages/react-component-library/src/fragments/NotificationPanel/NotificationPanel.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/NotificationPanel.tsx
@@ -114,15 +114,10 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
       >
         <Bell className="rn-notification-panel__icon" />
         {unreadNotification && (
-          <svg
-            data-testid="notification-indicator"
-            className="rn-notification-panel__indicator"
-            width="9px"
-            height="9px"
-            viewBox="0 0 9 9"
-          >
-            <circle cx="4.5" cy="4.5" r="4.5" />
-          </svg>
+          <span
+            className="rn-notification-panel__not-read"
+            data-testid="not-read"
+          />
         )}
       </button>
       <ReactCSSTransitionGroup


### PR DESCRIPTION
## Related issue
#223 

## Overview
Removing use of SCG circle for notification indicator in favour of reusing the CSS circle created for notification items.

## Reason
SVG is not required and this consolidates some code.

## Work carried out
- [x] Reuse CSS circle

## Screenshot
There should be no visual difference.