### PR TITLE
Refactor table sort order constants

### DIFF
--- a/packages/react-component-library/src/components/Table/Column.tsx
+++ b/packages/react-component-library/src/components/Table/Column.tsx
@@ -7,7 +7,7 @@ import {
   IconSortUnsorted,
 } from '@royalnavy/icon-library'
 
-import { ASCENDING, DESCENDING } from './constants'
+import { SORT_ORDER } from './constants'
 
 export interface ColumnProps {
   field: string
@@ -17,15 +17,21 @@ export interface ColumnProps {
   children: string
 }
 
-const icons = {
-  [ASCENDING]: <IconSortAscending data-testid="ascending" />,
-  [DESCENDING]: <IconSortDescending data-testid="descending" />,
+const SORT_ORDER_ICONS_MAP = {
+  [SORT_ORDER.ASCENDING]: <IconSortAscending data-testid="ascending" />,
+  [SORT_ORDER.DESCENDING]: <IconSortDescending data-testid="descending" />,
 }
 
 function getIcon(sortable: boolean, sortOrder: string) {
-  return sortable
-    ? get(icons, sortOrder) || <IconSortUnsorted data-testid="unsorted" />
-    : null
+  if (!sortable) {
+    return null
+  }
+
+  return (
+    get(SORT_ORDER_ICONS_MAP, sortOrder) || (
+      <IconSortUnsorted data-testid="unsorted" />
+    )
+  )
 }
 
 export const Column: React.FC<ColumnProps> = ({

--- a/packages/react-component-library/src/components/Table/constants.ts
+++ b/packages/react-component-library/src/components/Table/constants.ts
@@ -1,7 +1,6 @@
-const ASCENDING = 'asc'
-const DESCENDING = 'desc'
-
-export {
-  ASCENDING,
-  DESCENDING,
+enum SORT_ORDER {
+  ASCENDING = 'asc',
+  DESCENDING = 'desc',
 }
+
+export { SORT_ORDER }

--- a/packages/react-component-library/src/components/Table/useTableData.ts
+++ b/packages/react-component-library/src/components/Table/useTableData.ts
@@ -1,16 +1,19 @@
 import { useState } from 'react'
 import orderBy from 'lodash/orderBy'
 
-import { ASCENDING, DESCENDING } from './constants'
+import { SORT_ORDER } from './constants'
 import { RowProps } from './Table'
 
-function getNextSortOrder (currentSortOrder: 'asc' | 'desc', hasSortFieldChanged: boolean) {
+function getNextSortOrder(
+  currentSortOrder: SORT_ORDER.ASCENDING | SORT_ORDER.DESCENDING,
+  hasSortFieldChanged: boolean
+) {
   if (!currentSortOrder || hasSortFieldChanged) {
-    return DESCENDING
+    return SORT_ORDER.DESCENDING
   }
 
-  if (currentSortOrder === DESCENDING) {
-    return ASCENDING
+  if (currentSortOrder === SORT_ORDER.DESCENDING) {
+    return SORT_ORDER.ASCENDING
   }
 
   return null
@@ -18,12 +21,16 @@ function getNextSortOrder (currentSortOrder: 'asc' | 'desc', hasSortFieldChanged
 
 export function useTableData(data: RowProps[]) {
   const [tableData, setTableData] = useState(data)
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>()
+  const [sortOrder, setSortOrder] = useState<
+    SORT_ORDER.ASCENDING | SORT_ORDER.DESCENDING
+  >()
   const [sortField, setSortField] = useState<string>()
 
   function sortTableData(field: string) {
     const hasSortFieldChanged = field !== sortField
-    const order: 'asc' | 'desc' = getNextSortOrder(sortOrder, hasSortFieldChanged)
+    const order:
+      | SORT_ORDER.ASCENDING
+      | SORT_ORDER.DESCENDING = getNextSortOrder(sortOrder, hasSortFieldChanged)
     const sorted = order ? orderBy(tableData, [field], [order]) : data
 
     setSortOrder(order)


### PR DESCRIPTION
## Related issue
NA

## Overview
Refactoring `SORT_ORDER` constants to use an `enum` and therefore be cleaner when used.

## Reason
This is cleaner code.

## Work carried out
- [x] Refactor `SORT_ORDER`

## Screenshot
No visual difference.