### PR TITLE
Add ability to mark documentation as draft

### DIFF
--- a/packages/docs-site/gatsby-node.js
+++ b/packages/docs-site/gatsby-node.js
@@ -26,6 +26,7 @@ exports.createPages = ({ actions, graphql }) => {
             }
             frontmatter {
               template
+              draft
             }
           }
         }
@@ -37,6 +38,8 @@ exports.createPages = ({ actions, graphql }) => {
     }
 
     return result.data.allMdx.edges.forEach(({ node }) => {
+      if (node.frontmatter.draft) return
+
       const component = node.frontmatter.template
         ? templateRegister[node.frontmatter.template]
         : templateRegister.default

--- a/packages/docs-site/src/hooks/useNavigationQuery.js
+++ b/packages/docs-site/src/hooks/useNavigationQuery.js
@@ -13,6 +13,7 @@ const QUERY = graphql`
             title
             status
             index
+            draft
           }
         }
       }

--- a/packages/docs-site/src/library/pages/components/avatar.md
+++ b/packages/docs-site/src/library/pages/components/avatar.md
@@ -2,6 +2,7 @@
 title: Avatar
 description: Avatars are simple UI elements that display a user's initials.
 header: true
+draft: false
 ---
 
 import { Avatar, Tab, TabSet } from '@royalnavy/react-component-library'

--- a/packages/docs-site/src/utils/nav.js
+++ b/packages/docs-site/src/utils/nav.js
@@ -22,20 +22,30 @@ export function stripLeadingSlash(href) {
 
 /**
  * Restructure nodes into something that can be more
- * easily consumed by the application (+ filter root).
+ * easily consumed by the application.
  *
  * @param {array} nodes
  * @returns {array}
  */
 export function restructureNodes(nodes) {
+  return nodes.map(node => {
+    return {
+      href: stripTrailingSlash(node.node.fields.slug),
+      label: node.node.frontmatter.title,
+    }
+  })
+}
+
+/**
+ * Filter nodes that should not display in the navigation.
+ *
+ * @param {array} nodes
+ * @returns {array}
+ */
+export function filterNodes(nodes) {
   return nodes
-    .map(node => {
-      return {
-        href: stripTrailingSlash(node.node.fields.slug),
-        label: node.node.frontmatter.title,
-      }
-    })
-    .filter(node => node.href !== '/')
+    .filter(node => stripTrailingSlash(node.node.fields.slug) !== '/')
+    .filter(node => !node.node.frontmatter.draft)
 }
 
 /**
@@ -72,7 +82,7 @@ export function nestByURLStructure(nodes) {
 
   const sorted = sortBy(nodes, 'node.frontmatter.index')
 
-  restructureNodes(sorted).forEach(node => {
+  restructureNodes(filterNodes(sorted)).forEach(node => {
     addToTree(node, tree)
   })
 


### PR DESCRIPTION
## Related issue

https://github.com/Royal-Navy/standards-toolkit/issues/400

## Overview

Add ability to mark documentation as draft and exclude the page from the site build and navigation.

## Reason

>It would be helpful to be able to write a page for the docs site but mark it as 'draft', so it is not published. This would allow design and development documentation to be written at different times and only display the page once complete.

## Work carried out

- [x] Add frontmatter `draft` property

## Developer notes

Simply add frontmatter like so to the relevant MDX file:

```markdown
---
draft: true
---

# This is some MDX content
```


