### PR TITLE
Fix Dialog docs-site example positioning

### DIFF
--- a/packages/docs-site/src/components/presenters/layout/globals.scss
+++ b/packages/docs-site/src/components/presenters/layout/globals.scss
@@ -14,8 +14,6 @@ body {
 
   .rn-modal__main {
     position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
   }
 }
 


### PR DESCRIPTION
<img width="1470" alt="Screenshot 2019-11-12 at 15 34 51" src="https://user-images.githubusercontent.com/48086589/68685436-0b230600-0562-11ea-8da1-88d93d245656.png">
<img width="1470" alt="Screenshot 2019-11-12 at 15 34 15" src="https://user-images.githubusercontent.com/48086589/68685435-0b230600-0562-11ea-8e99-6955c4c17561.png">
