### PR TITLE
Add default alert component

### DIFF
--- a/packages/css-framework/src/components/_alert.scss
+++ b/packages/css-framework/src/components/_alert.scss
@@ -11,6 +11,8 @@
 }
 
 .rn-alert__icon {
+  display: inline-flex;
+  align-items: center;
   color: color("primary", 800);
   padding-right: 6px;
 }
@@ -36,7 +38,8 @@
 }
 
 .rn-alert__content {
-  display: flex;
+  display: inline-flex;
+  align-items: center;
 }
 
 .rn-alert__description {

--- a/packages/css-framework/src/components/_alert.scss
+++ b/packages/css-framework/src/components/_alert.scss
@@ -21,6 +21,20 @@
   font-weight: bold;
 }
 
+.rn-alert__close {
+  position: absolute;
+  top: spacing(1);
+  right: spacing(1);
+  border: none;
+  font-size: font-size(l);
+  color: color("primary", 500);
+  background-color: color("primary", 000);
+
+  &:hover {
+    cursor: pointer;
+  }
+}
+
 .rn-alert__content {
   display: flex;
 }

--- a/packages/css-framework/src/components/_alert.scss
+++ b/packages/css-framework/src/components/_alert.scss
@@ -1,100 +1,31 @@
-$alert-states: (
-  neutral: (
-    background: color("neutral", 000),
-    border: color("neutral", 100),
-    copy: color("neutral", 600),
-    title: color("neutral", 900),
-  ),
-  primary: (
-    background: color("primary", 000),
-    border: color("primary", 100),
-    copy: color("primary", 800),
-    title: color("primary", 900),
-  ),
-  danger: (
-    background: color("danger", 000),
-    border: color("danger", 100),
-    copy: color("danger", 800),
-    title: color("danger", 900),
-  ),
-  warning: (
-    background: color("warning", 100),
-    border: color("warning", 300),
-    copy: color("warning", 800),
-    title: color("warning", 900),
-  ),
-  success: (
-    background: color("success", 000),
-    border: color("success", 200),
-    copy: color("success", 800),
-    title: color("success", 900),
-  ),
-);
-
 .rn-alert {
-  position: relative;
-  border-radius: 4px;
-  max-width: 600px;
-  padding: spacing(4) spacing(5);
+  background-color: color("primary", 000);
+  border-radius: 0px 4px 4px 0px;
+  border-left: 4px solid color("primary", 500);
+  padding: 16px;
+}
 
-  &__title {
-    @include font-size(s);
-    margin: 0 0 spacing(1) 0;
-  }
-  &__message {
-    @include font-size(xs);
-    margin: 0;
-  }
+.rn-alert__header {
+  display: flex;
+  margin-bottom: spacing(1);
+}
 
-  opacity: 0;
+.rn-alert__icon {
+  color: color("primary", 800);
+  padding-right: 6px;
+}
 
-  &.open {
-    opacity: 100;
-  }
+.rn-alert__title {
+  color: color("primary", 800);
+  font-size: font-size(s);
+  font-weight: bold;
+}
 
-  .content {
-    p {
-      line-height: 1.6;
-    }
-  }
+.rn-alert__content {
+  display: flex;
+}
 
-  .close {
-    position: absolute;
-    top: 15px;
-    right: 10px;
-  }
-
-  @each $state, $variation in $alert-states {
-    &.#{$state} {
-      background: map-get($variation, "background");
-      border: 1px solid map-get($variation, "border");
-      .rn-alert {
-        &__title {
-          color: map-get($variation, "title");
-        }
-        &__message {
-          color: map-get($variation, "copy");
-        }
-      }
-    }
-  }
-
-  &--event {
-    border-radius: 3px;
-    background: color("neutral", 700);
-    border: none;
-    padding: spacing(3) spacing(4);
-    .rn-alert {
-      &__title {
-        display: none;
-      }
-      &__message {
-        color: color("neutral", 000);
-      }
-    }
-  }
-
-  &__close {
-    display: none;
-  }
+.rn-alert__description {
+  color: color("primary", 600);
+  font-size: font-size(xs);
 }

--- a/packages/react-component-library/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import { Alert } from './index'
+
+const stories = storiesOf('Alert', module)
+
+const TITLE = 'Alert Title'
+const DESCRIPTION =
+  'This is the alert description. It provides context to the user, bringing attention to information that needs to be consumed.'
+
+stories.add('Default', () => {
+  return <Alert title={TITLE}>{DESCRIPTION}</Alert>
+})
+
+stories.add('Without title', () => {
+  return <Alert>{DESCRIPTION}</Alert>
+})

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -12,6 +12,10 @@ describe('Alert', () => {
       wrapper = render(<Alert>Description</Alert>)
     })
 
+    it('should render the close button', () => {
+      expect(wrapper.getByTestId('close')).toBeInTheDocument()
+    })
+
     it('should not render the header', () => {
       expect(wrapper.queryAllByTestId('header')).toHaveLength(0)
     })
@@ -28,6 +32,16 @@ describe('Alert', () => {
       expect(wrapper.getByTestId('content-description')).toHaveTextContent(
         'Description'
       )
+    })
+
+    describe('when the close button is clicked', () => {
+      beforeEach(() => {
+        wrapper.getByTestId('close').click()
+      })
+
+      it('should hide the alert', () => {
+        expect(wrapper.queryAllByTestId('alert')).toHaveLength(0)
+      })
     })
   })
 
@@ -71,6 +85,26 @@ describe('Alert', () => {
 
       it('should render the info icon', () => {
         expect(wrapper.getByTestId('icon-info')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when the onClose callback is specified', () => {
+    let onCloseSpy: (event: React.FormEvent<HTMLButtonElement>) => void
+
+    beforeEach(() => {
+      onCloseSpy = jest.fn()
+
+      wrapper = render(<Alert onClose={onCloseSpy}>Description</Alert>)
+    })
+
+    describe('when the close button is clicked', () => {
+      beforeEach(() => {
+        wrapper.getByTestId('close').click()
+      })
+
+      it('should call the callback once', () => {
+        expect(onCloseSpy).toBeCalledTimes(1)
       })
     })
   })

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, RenderResult } from '@testing-library/react'
+
+import { Alert, ALERT_VARIANT } from '.'
+
+describe('Alert', () => {
+  let wrapper: RenderResult
+
+  describe('when only the description is specified', () => {
+    beforeEach(() => {
+      wrapper = render(<Alert>Description</Alert>)
+    })
+
+    it('should not render the header', () => {
+      expect(wrapper.queryAllByTestId('header')).toHaveLength(0)
+    })
+
+    it('should render the content icon', () => {
+      expect(wrapper.getByTestId('content-icon')).toBeInTheDocument()
+    })
+
+    it('should render the default info icon', () => {
+      expect(wrapper.getByTestId('icon-info')).toBeInTheDocument()
+    })
+
+    it('should render the content description', () => {
+      expect(wrapper.getByTestId('content-description')).toHaveTextContent(
+        'Description'
+      )
+    })
+  })
+
+  describe('when the title is specified', () => {
+    beforeEach(() => {
+      wrapper = render(<Alert title="Title">Description</Alert>)
+    })
+
+    it('should render the header icon', () => {
+      expect(wrapper.getByTestId('header-icon')).toBeInTheDocument()
+    })
+
+    it('should render the default info icon', () => {
+      expect(wrapper.getByTestId('icon-info')).toBeInTheDocument()
+    })
+
+    it('should render the header title', () => {
+      expect(wrapper.getByTestId('header-title')).toHaveTextContent('Title')
+    })
+
+    it('should not render the content icon', () => {
+      expect(wrapper.queryAllByTestId('content-icon')).toHaveLength(0)
+    })
+
+    it('should render the content description', () => {
+      expect(wrapper.getByTestId('content-description')).toHaveTextContent(
+        'Description'
+      )
+    })
+  })
+
+  describe('when the variant is specified', () => {
+    describe('when the variant is INFO', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <Alert title="Title" variant={ALERT_VARIANT.INFO}>
+            Description
+          </Alert>
+        )
+      })
+
+      it('should render the info icon', () => {
+        expect(wrapper.getByTestId('icon-info')).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { IconInfo } from '@royalnavy/icon-library'
+
+import { ALERT_VARIANT } from './constants'
+
+const VARIANT_ICON_MAP = {
+  [ALERT_VARIANT.INFO]: <IconInfo data-testid={`icon-${ALERT_VARIANT.INFO}`} />,
+}
+
+interface AlertProps {
+  children: string
+  title?: string
+  variant?: ALERT_VARIANT.INFO
+}
+
+export const Alert: React.FC<AlertProps> = ({
+  children,
+  title,
+  variant = ALERT_VARIANT.INFO,
+}) => {
+  return (
+    <div className="rn-alert">
+      {title && (
+        <div className="rn-alert__header" data-testid="header">
+          <div className="rn-alert__icon" data-testid="header-icon">
+            {VARIANT_ICON_MAP[variant]}
+          </div>
+          <div className="rn-alert__title" data-testid="header-title">
+            {title}
+          </div>
+        </div>
+      )}
+      <div className="rn-alert__content" data-testid="content">
+        {!title && (
+          <div className="rn-alert__icon" data-testid="content-icon">
+            {VARIANT_ICON_MAP[variant]}
+          </div>
+        )}
+        <div
+          className="rn-alert__description"
+          data-testid="content-description"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { IconInfo } from '@royalnavy/icon-library'
 
 import { ALERT_VARIANT } from './constants'
@@ -9,40 +9,61 @@ const VARIANT_ICON_MAP = {
 
 interface AlertProps {
   children: string
+  onClose?: (event: React.FormEvent<HTMLButtonElement>) => void
   title?: string
   variant?: ALERT_VARIANT.INFO
 }
 
 export const Alert: React.FC<AlertProps> = ({
   children,
+  onClose,
   title,
   variant = ALERT_VARIANT.INFO,
 }) => {
+  const [closed, setClosed] = useState(false)
+
+  function handleClick(event: React.FormEvent<HTMLButtonElement>) {
+    setClosed(true)
+
+    if (onClose) {
+      onClose(event)
+    }
+  }
+
   return (
-    <div className="rn-alert">
-      {title && (
-        <div className="rn-alert__header" data-testid="header">
-          <div className="rn-alert__icon" data-testid="header-icon">
-            {VARIANT_ICON_MAP[variant]}
-          </div>
-          <div className="rn-alert__title" data-testid="header-title">
-            {title}
-          </div>
-        </div>
-      )}
-      <div className="rn-alert__content" data-testid="content">
-        {!title && (
-          <div className="rn-alert__icon" data-testid="content-icon">
-            {VARIANT_ICON_MAP[variant]}
+    !closed && (
+      <div className="rn-alert" data-testid="alert">
+        <button
+          className="rn-alert__close"
+          onClick={handleClick}
+          data-testid="close"
+        >
+          &times;
+        </button>
+        {title && (
+          <div className="rn-alert__header" data-testid="header">
+            <div className="rn-alert__icon" data-testid="header-icon">
+              {VARIANT_ICON_MAP[variant]}
+            </div>
+            <div className="rn-alert__title" data-testid="header-title">
+              {title}
+            </div>
           </div>
         )}
-        <div
-          className="rn-alert__description"
-          data-testid="content-description"
-        >
-          {children}
+        <div className="rn-alert__content" data-testid="content">
+          {!title && (
+            <div className="rn-alert__icon" data-testid="content-icon">
+              {VARIANT_ICON_MAP[variant]}
+            </div>
+          )}
+          <div
+            className="rn-alert__description"
+            data-testid="content-description"
+          >
+            {children}
+          </div>
         </div>
       </div>
-    </div>
+    )
   )
 }

--- a/packages/react-component-library/src/components/Alert/constants.ts
+++ b/packages/react-component-library/src/components/Alert/constants.ts
@@ -1,0 +1,7 @@
+enum ALERT_VARIANT {
+  INFO = 'info',
+}
+
+export {
+  ALERT_VARIANT,
+}

--- a/packages/react-component-library/src/components/Alert/index.tsx
+++ b/packages/react-component-library/src/components/Alert/index.tsx
@@ -1,0 +1,2 @@
+export * from './Alert'
+export * from './constants'


### PR DESCRIPTION
## Related issue
#349 

## Overview
Add an alert component which defaults to the information colour blue. When the close button is clicked, it hides the alert and calls and optional callback.

## Reason
This is a component required in dependent applications.

## Work carried out
- [x] Add alert component
- [x] Handle close click

## Screenshot
### With title
![Screenshot 2019-11-14 at 16 55 02](https://user-images.githubusercontent.com/56078793/68878526-c9c85d00-06ff-11ea-9462-76844e38790b.png)

### Without title
![Screenshot 2019-11-14 at 16 55 12](https://user-images.githubusercontent.com/56078793/68878551-d5b41f00-06ff-11ea-9b35-a7ca41dbca0f.png)

## Developer notes
Subsequent PRs will include more alert variants and documentation.