### PR TITLE
Add alert variants

### DIFF
--- a/packages/css-framework/src/components/_alert.scss
+++ b/packages/css-framework/src/components/_alert.scss
@@ -18,6 +18,13 @@ $_success-alert-title-colour: color("success", 800);
 $_success-alert-close-colour: color("success", 500);
 $_success-alert-description-colour: color("success", 600);
 
+// Warning
+$_warning-alert-background-colour: color("warning", 000);
+$_warning-alert-border-colour: color("warning", 500);
+$_warning-alert-title-colour: color("warning", 800);
+$_warning-alert-close-colour: color("warning", 500);
+$_warning-alert-description-colour: color("warning", 600);
+
 .rn-alert {
   background-color: $_alert-background-colour;
   border-radius: 0px 4px 4px 0px;
@@ -32,6 +39,11 @@ $_success-alert-description-colour: color("success", 600);
   &--success {
     background-color: $_success-alert-background-colour;
     border-left-color: $_success-alert-border-colour;
+  }
+
+  &--warning {
+    background-color: $_warning-alert-background-colour;
+    border-left-color: $_warning-alert-border-colour;
   }
 }
 
@@ -53,6 +65,10 @@ $_success-alert-description-colour: color("success", 600);
   &--success {
     color: $_success-alert-title-colour;
   }
+
+  &--warning {
+    color: $_warning-alert-title-colour;
+  }
 }
 
 .rn-alert__title {
@@ -66,6 +82,10 @@ $_success-alert-description-colour: color("success", 600);
 
   &--success {
     color: $_success-alert-title-colour;
+  }
+
+  &--warning {
+    color: $_warning-alert-title-colour;
   }
 }
 
@@ -91,6 +111,11 @@ $_success-alert-description-colour: color("success", 600);
     color: $_success-alert-close-colour;
     background-color: $_success-alert-background-colour;
   }
+
+  &--warning {
+    color: $_warning-alert-close-colour;
+    background-color: $_warning-alert-background-colour;
+  }
 }
 
 .rn-alert__content {
@@ -108,5 +133,9 @@ $_success-alert-description-colour: color("success", 600);
 
   &--success {
     color: $_success-alert-description-colour;
+  }
+
+  &--warning {
+    color: $_warning-alert-description-colour;
   }
 }

--- a/packages/css-framework/src/components/_alert.scss
+++ b/packages/css-framework/src/components/_alert.scss
@@ -1,7 +1,13 @@
+$_alert-background-colour: color("primary", 000);
+$_alert-border-colour: color("primary", 500);
+$_alert-title-colour: color("primary", 800);
+$_alert-close-colour: color("primary", 500);
+$_alert-description-colour: color("primary", 600);
+
 .rn-alert {
-  background-color: color("primary", 000);
+  background-color: $_alert-background-colour;
   border-radius: 0px 4px 4px 0px;
-  border-left: 4px solid color("primary", 500);
+  border-left: 4px solid $_alert-border-colour;
   padding: 16px;
 }
 
@@ -13,12 +19,12 @@
 .rn-alert__icon {
   display: inline-flex;
   align-items: center;
-  color: color("primary", 800);
+  color: $_alert-title-colour;
   padding-right: 6px;
 }
 
 .rn-alert__title {
-  color: color("primary", 800);
+  color: $_alert-title-colour;
   font-size: font-size(s);
   font-weight: bold;
 }
@@ -29,8 +35,8 @@
   right: spacing(1);
   border: none;
   font-size: font-size(l);
-  color: color("primary", 500);
-  background-color: color("primary", 000);
+  color: $_alert-close-colour;
+  background-color: $_alert-background-colour;
 
   &:hover {
     cursor: pointer;
@@ -43,6 +49,6 @@
 }
 
 .rn-alert__description {
-  color: color("primary", 600);
+  color: $_alert-description-colour;
   font-size: font-size(xs);
 }

--- a/packages/css-framework/src/components/_alert.scss
+++ b/packages/css-framework/src/components/_alert.scss
@@ -11,6 +11,13 @@ $_danger-alert-title-colour: color("danger", 800);
 $_danger-alert-close-colour: color("danger", 500);
 $_danger-alert-description-colour: color("danger", 600);
 
+// Success
+$_success-alert-background-colour: color("success", 000);
+$_success-alert-border-colour: color("success", 500);
+$_success-alert-title-colour: color("success", 800);
+$_success-alert-close-colour: color("success", 500);
+$_success-alert-description-colour: color("success", 600);
+
 .rn-alert {
   background-color: $_alert-background-colour;
   border-radius: 0px 4px 4px 0px;
@@ -20,6 +27,11 @@ $_danger-alert-description-colour: color("danger", 600);
   &--danger {
     background-color: $_danger-alert-background-colour;
     border-left-color: $_danger-alert-border-colour;
+  }
+
+  &--success {
+    background-color: $_success-alert-background-colour;
+    border-left-color: $_success-alert-border-colour;
   }
 }
 
@@ -37,6 +49,10 @@ $_danger-alert-description-colour: color("danger", 600);
   &--danger {
     color: $_danger-alert-title-colour;
   }
+
+  &--success {
+    color: $_success-alert-title-colour;
+  }
 }
 
 .rn-alert__title {
@@ -46,6 +62,10 @@ $_danger-alert-description-colour: color("danger", 600);
 
   &--danger {
     color: $_danger-alert-title-colour;
+  }
+
+  &--success {
+    color: $_success-alert-title-colour;
   }
 }
 
@@ -66,6 +86,11 @@ $_danger-alert-description-colour: color("danger", 600);
     color: $_danger-alert-close-colour;
     background-color: $_danger-alert-background-colour;
   }
+
+  &--success {
+    color: $_success-alert-close-colour;
+    background-color: $_success-alert-background-colour;
+  }
 }
 
 .rn-alert__content {
@@ -79,5 +104,9 @@ $_danger-alert-description-colour: color("danger", 600);
 
   &--danger {
     color: $_danger-alert-description-colour;
+  }
+
+  &--success {
+    color: $_success-alert-description-colour;
   }
 }

--- a/packages/css-framework/src/components/_alert.scss
+++ b/packages/css-framework/src/components/_alert.scss
@@ -4,11 +4,23 @@ $_alert-title-colour: color("primary", 800);
 $_alert-close-colour: color("primary", 500);
 $_alert-description-colour: color("primary", 600);
 
+// Danger
+$_danger-alert-background-colour: color("danger", 000);
+$_danger-alert-border-colour: color("danger", 500);
+$_danger-alert-title-colour: color("danger", 800);
+$_danger-alert-close-colour: color("danger", 500);
+$_danger-alert-description-colour: color("danger", 600);
+
 .rn-alert {
   background-color: $_alert-background-colour;
   border-radius: 0px 4px 4px 0px;
   border-left: 4px solid $_alert-border-colour;
   padding: 16px;
+
+  &--danger {
+    background-color: $_danger-alert-background-colour;
+    border-left-color: $_danger-alert-border-colour;
+  }
 }
 
 .rn-alert__header {
@@ -21,12 +33,20 @@ $_alert-description-colour: color("primary", 600);
   align-items: center;
   color: $_alert-title-colour;
   padding-right: 6px;
+
+  &--danger {
+    color: $_danger-alert-title-colour;
+  }
 }
 
 .rn-alert__title {
   color: $_alert-title-colour;
   font-size: font-size(s);
   font-weight: bold;
+
+  &--danger {
+    color: $_danger-alert-title-colour;
+  }
 }
 
 .rn-alert__close {
@@ -41,6 +61,11 @@ $_alert-description-colour: color("primary", 600);
   &:hover {
     cursor: pointer;
   }
+
+  &--danger {
+    color: $_danger-alert-close-colour;
+    background-color: $_danger-alert-background-colour;
+  }
 }
 
 .rn-alert__content {
@@ -51,4 +76,8 @@ $_alert-description-colour: color("primary", 600);
 .rn-alert__description {
   color: $_alert-description-colour;
   font-size: font-size(xs);
+
+  &--danger {
+    color: $_danger-alert-description-colour;
+  }
 }

--- a/packages/react-component-library/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.stories.tsx
@@ -24,3 +24,11 @@ stories.add('Danger', () => {
     </Alert>
   )
 })
+
+stories.add('Success', () => {
+  return (
+    <Alert title={TITLE} variant={ALERT_VARIANT.SUCCESS}>
+      {DESCRIPTION}
+    </Alert>
+  )
+})

--- a/packages/react-component-library/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Alert } from './index'
+import { Alert, ALERT_VARIANT } from './index'
 
 const stories = storiesOf('Alert', module)
 
@@ -15,4 +15,12 @@ stories.add('Default', () => {
 
 stories.add('Without title', () => {
   return <Alert>{DESCRIPTION}</Alert>
+})
+
+stories.add('Danger', () => {
+  return (
+    <Alert title={TITLE} variant={ALERT_VARIANT.DANGER}>
+      {DESCRIPTION}
+    </Alert>
+  )
 })

--- a/packages/react-component-library/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.stories.tsx
@@ -32,3 +32,11 @@ stories.add('Success', () => {
     </Alert>
   )
 })
+
+stories.add('Warning', () => {
+  return (
+    <Alert title={TITLE} variant={ALERT_VARIANT.WARNING}>
+      {DESCRIPTION}
+    </Alert>
+  )
+})

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -74,7 +74,7 @@ describe('Alert', () => {
   })
 
   describe('when the variant is specified', () => {
-    describe('when the variant is INFO', () => {
+    describe('when the variant is `INFO`', () => {
       beforeEach(() => {
         wrapper = render(
           <Alert title="Title" variant={ALERT_VARIANT.INFO}>
@@ -85,6 +85,124 @@ describe('Alert', () => {
 
       it('should render the info icon', () => {
         expect(wrapper.getByTestId('icon-info')).toBeInTheDocument()
+      })
+    })
+
+    describe('when the variant is `DANGER`', () => {
+      describe('when the title is specified', () => {
+        beforeEach(() => {
+          wrapper = render(
+            <Alert title="Title" variant={ALERT_VARIANT.DANGER}>
+              Description
+            </Alert>
+          )
+        })
+
+        it('should use the `danger` modifiers', () => {
+          expect(wrapper.getByTestId('alert').classList).toContain(
+            'rn-alert--danger'
+          )
+          expect(wrapper.getByTestId('close').classList).toContain(
+            'rn-alert__close--danger'
+          )
+          expect(wrapper.getByTestId('header-icon').classList).toContain(
+            'rn-alert__icon--danger'
+          )
+          expect(wrapper.getByTestId('header-title').classList).toContain(
+            'rn-alert__title--danger'
+          )
+          expect(wrapper.getByTestId('content-description').classList).toContain(
+            'rn-alert__description--danger'
+          )
+        })
+
+        it('should render the danger icon', () => {
+          expect(wrapper.getByTestId('icon-danger')).toBeInTheDocument()
+        })
+      })
+
+      describe('when the title is not specified', () => {
+        beforeEach(() => {
+          wrapper = render(
+            <Alert variant={ALERT_VARIANT.DANGER}>
+              Description
+            </Alert>
+          )
+        })
+
+        it('should use the `danger` modifiers', () => {
+          expect(wrapper.getByTestId('content-icon').classList).toContain(
+            'rn-alert__icon--danger'
+          )
+        })
+
+        it('should render the danger icon', () => {
+          expect(wrapper.getByTestId('icon-danger')).toBeInTheDocument()
+        })
+      })
+    })
+
+    describe('when the variant is `SUCCESS`', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <Alert title="Title" variant={ALERT_VARIANT.SUCCESS}>
+            Description
+          </Alert>
+        )
+      })
+
+      it('should use the `success` modifiers', () => {
+        expect(wrapper.getByTestId('alert').classList).toContain(
+          'rn-alert--success'
+        )
+        expect(wrapper.getByTestId('close').classList).toContain(
+          'rn-alert__close--success'
+        )
+        expect(wrapper.getByTestId('header-icon').classList).toContain(
+          'rn-alert__icon--success'
+        )
+        expect(wrapper.getByTestId('header-title').classList).toContain(
+          'rn-alert__title--success'
+        )
+        expect(wrapper.getByTestId('content-description').classList).toContain(
+          'rn-alert__description--success'
+        )
+      })
+
+      it('should render the success icon', () => {
+        expect(wrapper.getByTestId('icon-success')).toBeInTheDocument()
+      })
+    })
+
+    describe('when the variant is `WARNING`', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <Alert title="Title" variant={ALERT_VARIANT.WARNING}>
+            Description
+          </Alert>
+        )
+      })
+
+      it('should use the `warning` modifiers', () => {
+        expect(wrapper.getByTestId('alert').classList).toContain(
+          'rn-alert--warning'
+        )
+        expect(wrapper.getByTestId('close').classList).toContain(
+          'rn-alert__close--warning'
+        )
+        expect(wrapper.getByTestId('header-icon').classList).toContain(
+          'rn-alert__icon--warning'
+        )
+        expect(wrapper.getByTestId('header-title').classList).toContain(
+          'rn-alert__title--warning'
+        )
+        expect(wrapper.getByTestId('content-description').classList).toContain(
+          'rn-alert__description--warning'
+        )
+      })
+
+      it('should render the warning icon', () => {
+        expect(wrapper.getByTestId('icon-warning')).toBeInTheDocument()
       })
     })
   })

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -173,6 +173,38 @@ describe('Alert', () => {
         expect(wrapper.getByTestId('icon-success')).toBeInTheDocument()
       })
     })
+
+    describe('when the variant is `WARNING`', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <Alert title="Title" variant={ALERT_VARIANT.WARNING}>
+            Description
+          </Alert>
+        )
+      })
+
+      it('should use the `warning` modifiers', () => {
+        expect(wrapper.getByTestId('alert').classList).toContain(
+          'rn-alert--warning'
+        )
+        expect(wrapper.getByTestId('close').classList).toContain(
+          'rn-alert__close--warning'
+        )
+        expect(wrapper.getByTestId('header-icon').classList).toContain(
+          'rn-alert__icon--warning'
+        )
+        expect(wrapper.getByTestId('header-title').classList).toContain(
+          'rn-alert__title--warning'
+        )
+        expect(wrapper.getByTestId('content-description').classList).toContain(
+          'rn-alert__description--warning'
+        )
+      })
+
+      it('should render the warning icon', () => {
+        expect(wrapper.getByTestId('icon-warning')).toBeInTheDocument()
+      })
+    })
   })
 
   describe('when the onClose callback is specified', () => {

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -173,38 +173,6 @@ describe('Alert', () => {
         expect(wrapper.getByTestId('icon-success')).toBeInTheDocument()
       })
     })
-
-    describe('when the variant is `WARNING`', () => {
-      beforeEach(() => {
-        wrapper = render(
-          <Alert title="Title" variant={ALERT_VARIANT.WARNING}>
-            Description
-          </Alert>
-        )
-      })
-
-      it('should use the `warning` modifiers', () => {
-        expect(wrapper.getByTestId('alert').classList).toContain(
-          'rn-alert--warning'
-        )
-        expect(wrapper.getByTestId('close').classList).toContain(
-          'rn-alert__close--warning'
-        )
-        expect(wrapper.getByTestId('header-icon').classList).toContain(
-          'rn-alert__icon--warning'
-        )
-        expect(wrapper.getByTestId('header-title').classList).toContain(
-          'rn-alert__title--warning'
-        )
-        expect(wrapper.getByTestId('content-description').classList).toContain(
-          'rn-alert__description--warning'
-        )
-      })
-
-      it('should render the warning icon', () => {
-        expect(wrapper.getByTestId('icon-warning')).toBeInTheDocument()
-      })
-    })
   })
 
   describe('when the onClose callback is specified', () => {

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { IconInfo, IconErrorOutline } from '@royalnavy/icon-library'
+import { IconInfo, IconErrorOutline, IconCheckBox } from '@royalnavy/icon-library'
 import classNames from 'classnames'
 
 import { ALERT_VARIANT } from './constants'
@@ -9,6 +9,7 @@ const VARIANT_ICON_MAP = {
     <IconErrorOutline data-testid={`icon-${ALERT_VARIANT.DANGER}`} />
   ),
   [ALERT_VARIANT.INFO]: <IconInfo data-testid={`icon-${ALERT_VARIANT.INFO}`} />,
+  [ALERT_VARIANT.SUCCESS]: <IconCheckBox data-testid={`icon-${ALERT_VARIANT.SUCCESS}`} />,
 }
 
 interface AlertProps {
@@ -18,6 +19,7 @@ interface AlertProps {
   variant?:
     | ALERT_VARIANT.DANGER
     | ALERT_VARIANT.INFO
+    | ALERT_VARIANT.SUCCESS
 }
 
 export const Alert: React.FC<AlertProps> = ({

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -1,9 +1,13 @@
 import React, { useState } from 'react'
-import { IconInfo } from '@royalnavy/icon-library'
+import { IconInfo, IconErrorOutline } from '@royalnavy/icon-library'
+import classNames from 'classnames'
 
 import { ALERT_VARIANT } from './constants'
 
 const VARIANT_ICON_MAP = {
+  [ALERT_VARIANT.DANGER]: (
+    <IconErrorOutline data-testid={`icon-${ALERT_VARIANT.DANGER}`} />
+  ),
   [ALERT_VARIANT.INFO]: <IconInfo data-testid={`icon-${ALERT_VARIANT.INFO}`} />,
 }
 
@@ -11,7 +15,9 @@ interface AlertProps {
   children: string
   onClose?: (event: React.FormEvent<HTMLButtonElement>) => void
   title?: string
-  variant?: ALERT_VARIANT.INFO
+  variant?:
+    | ALERT_VARIANT.DANGER
+    | ALERT_VARIANT.INFO
 }
 
 export const Alert: React.FC<AlertProps> = ({
@@ -30,11 +36,29 @@ export const Alert: React.FC<AlertProps> = ({
     }
   }
 
+  const classes = classNames('rn-alert', `rn-alert--${variant}`)
+  const closeClasses = classNames(
+    'rn-alert__close',
+    `rn-alert__close--${variant}`
+  )
+  const iconClasses = classNames(
+    'rn-alert__icon',
+    `rn-alert__icon--${variant}`
+  )
+  const titleClasses = classNames(
+    'rn-alert__title',
+    `rn-alert__title--${variant}`
+  )
+  const descriptionClasses = classNames(
+    'rn-alert__description',
+    `rn-alert__description--${variant}`
+  )
+
   return (
     !closed && (
-      <div className="rn-alert" data-testid="alert">
+      <div className={classes} data-testid="alert">
         <button
-          className="rn-alert__close"
+          className={closeClasses}
           onClick={handleClick}
           data-testid="close"
         >
@@ -42,10 +66,10 @@ export const Alert: React.FC<AlertProps> = ({
         </button>
         {title && (
           <div className="rn-alert__header" data-testid="header">
-            <div className="rn-alert__icon" data-testid="header-icon">
+            <div className={iconClasses} data-testid="header-icon">
               {VARIANT_ICON_MAP[variant]}
             </div>
-            <div className="rn-alert__title" data-testid="header-title">
+            <div className={titleClasses} data-testid="header-title">
               {title}
             </div>
           </div>
@@ -57,7 +81,7 @@ export const Alert: React.FC<AlertProps> = ({
             </div>
           )}
           <div
-            className="rn-alert__description"
+            className={descriptionClasses}
             data-testid="content-description"
           >
             {children}

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -1,5 +1,10 @@
 import React, { useState } from 'react'
-import { IconInfo, IconErrorOutline, IconCheckBox } from '@royalnavy/icon-library'
+import {
+  IconInfo,
+  IconErrorOutline,
+  IconCheckBox,
+  IconWarning,
+} from '@royalnavy/icon-library'
 import classNames from 'classnames'
 
 import { ALERT_VARIANT } from './constants'
@@ -9,7 +14,12 @@ const VARIANT_ICON_MAP = {
     <IconErrorOutline data-testid={`icon-${ALERT_VARIANT.DANGER}`} />
   ),
   [ALERT_VARIANT.INFO]: <IconInfo data-testid={`icon-${ALERT_VARIANT.INFO}`} />,
-  [ALERT_VARIANT.SUCCESS]: <IconCheckBox data-testid={`icon-${ALERT_VARIANT.SUCCESS}`} />,
+  [ALERT_VARIANT.SUCCESS]: (
+    <IconCheckBox data-testid={`icon-${ALERT_VARIANT.SUCCESS}`} />
+  ),
+  [ALERT_VARIANT.WARNING]: (
+    <IconWarning data-testid={`icon-${ALERT_VARIANT.WARNING}`} />
+  ),
 }
 
 interface AlertProps {
@@ -20,6 +30,7 @@ interface AlertProps {
     | ALERT_VARIANT.DANGER
     | ALERT_VARIANT.INFO
     | ALERT_VARIANT.SUCCESS
+    | ALERT_VARIANT.WARNING
 }
 
 export const Alert: React.FC<AlertProps> = ({
@@ -43,10 +54,7 @@ export const Alert: React.FC<AlertProps> = ({
     'rn-alert__close',
     `rn-alert__close--${variant}`
   )
-  const iconClasses = classNames(
-    'rn-alert__icon',
-    `rn-alert__icon--${variant}`
-  )
+  const iconClasses = classNames('rn-alert__icon', `rn-alert__icon--${variant}`)
   const titleClasses = classNames(
     'rn-alert__title',
     `rn-alert__title--${variant}`
@@ -82,10 +90,7 @@ export const Alert: React.FC<AlertProps> = ({
               {VARIANT_ICON_MAP[variant]}
             </div>
           )}
-          <div
-            className={descriptionClasses}
-            data-testid="content-description"
-          >
+          <div className={descriptionClasses} data-testid="content-description">
             {children}
           </div>
         </div>

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -86,7 +86,7 @@ export const Alert: React.FC<AlertProps> = ({
         )}
         <div className="rn-alert__content" data-testid="content">
           {!title && (
-            <div className="rn-alert__icon" data-testid="content-icon">
+            <div className={iconClasses} data-testid="content-icon">
               {VARIANT_ICON_MAP[variant]}
             </div>
           )}

--- a/packages/react-component-library/src/components/Alert/constants.ts
+++ b/packages/react-component-library/src/components/Alert/constants.ts
@@ -1,4 +1,5 @@
 enum ALERT_VARIANT {
+  DANGER = 'danger',
   INFO = 'info',
 }
 

--- a/packages/react-component-library/src/components/Alert/constants.ts
+++ b/packages/react-component-library/src/components/Alert/constants.ts
@@ -2,6 +2,7 @@ enum ALERT_VARIANT {
   DANGER = 'danger',
   INFO = 'info',
   SUCCESS = 'success',
+  WARNING = 'warning',
 }
 
 export {

--- a/packages/react-component-library/src/components/Alert/constants.ts
+++ b/packages/react-component-library/src/components/Alert/constants.ts
@@ -1,6 +1,7 @@
 enum ALERT_VARIANT {
   DANGER = 'danger',
   INFO = 'info',
+  SUCCESS = 'success',
 }
 
 export {


### PR DESCRIPTION
## Related issue
#349 

## Overview
Having completed the work to add a `default` variant of the alert component to the library, this change introduces variants `danger`, `success`, `warning`.

## Reason
Multiple variants are required in the component library.

## Work carried out
- [x] Refactor CSS
- [x] Add `danger`
- [x] Add `success`
- [x] Add `warning`

## Screenshot
### Danger
![Screenshot 2019-11-18 at 10 14 33](https://user-images.githubusercontent.com/56078793/69044150-50c15200-09ec-11ea-9c26-1d20d7623a86.png)

### Success
![Screenshot 2019-11-18 at 10 14 43](https://user-images.githubusercontent.com/56078793/69044160-54ed6f80-09ec-11ea-843d-5e5e4bda33c3.png)

### Warning
![Screenshot 2019-11-18 at 10 14 52](https://user-images.githubusercontent.com/56078793/69044172-5a4aba00-09ec-11ea-92a6-14ef86f53a5d.png)

## Developer notes
This change does not include documentation and exporting the component. These items will be done in a follow up.