### PR TITLE
Add scrollable tab set

### DIFF
--- a/packages/css-framework/src/components/_tab-set.scss
+++ b/packages/css-framework/src/components/_tab-set.scss
@@ -10,6 +10,30 @@ $btn-focus-width: 0.2rem;
   border-bottom: 1px solid color(neutral, 100);
 }
 
+.rn-tab-set__scroll {
+  width: spacing(6);
+  height: spacing(12);
+  background: color("neutral", white);
+  border: 1px solid color("neutral", 100);
+  border-radius: 3px;
+  color: color("neutral", 300);
+  cursor: pointer;
+
+  & > svg {
+    position: relative;
+    right: 2px;
+    top: 2px;
+  }
+}
+
+.rn-tab-set__scroll--left {
+  margin-right: spacing(1);
+}
+
+.rn-tab-set__scroll--right {
+  margin-left: spacing(1);
+}
+
 .rn-tab-set__tabs {
   list-style-type: none;
   padding: 0;

--- a/packages/css-framework/src/components/_tab-set.scss
+++ b/packages/css-framework/src/components/_tab-set.scss
@@ -4,6 +4,41 @@ $btn-focus-width: 0.2rem;
 .rn-tab-set {
   display: flex;
   flex-flow: column;
+
+  &.is-scrollable {
+    .rn-tab-set__navigation {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    .rn-tab-set__head {
+      display: flex;
+      flex-direction: row;
+      padding-bottom: spacing(2);
+    }
+
+    .rn-tab-set__tab-item {
+      padding-left: spacing(1);
+    }
+
+    .rn-tab-set__tab-item:last-child {
+      padding-right: spacing(1);
+    }
+
+    .rn-tab-set__tab {
+      border: none;
+      height: spacing(10);
+      padding: 0 spacing(8);
+      border-radius: 6px;
+      background-color: color("neutral", 100);
+
+      &.is-active {
+        background-color: color("primary", 300);
+        color: color("neutral", 000)
+      }
+    }
+  }
 }
 
 .rn-tab-set__head {
@@ -42,27 +77,30 @@ $btn-focus-width: 0.2rem;
 
 .rn-tab-set__tab-item {
   display: inline-block;
-  border-bottom: 4px solid transparent;
-  color: #748999;
-  margin-bottom: 0;
-
-  &.is-active {
-    color: #3e5667;
-    border-color: $active-border-color;
-  }
+  margin-top: spacing(1);
 }
 
 .rn-tab-set__tab {
-  margin: 0 spacing(1);
-  padding: spacing(4) spacing(8);
-  border: none;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  cursor: pointer;
   font-size: font-size(xs);
   font-weight: 700;
-  color: inherit;
-  text-align: center;
+  color: color("neutral", 300);
+
+  // default
+  border: none;
+  border-bottom: 4px solid transparent;
+  padding: spacing(4) spacing(8);
 
   &:focus {
     box-shadow: 0 0 0 $btn-focus-width rgba(color(primary, 700) , 0.5);
+  }
+
+  &.is-active {
+    color: color("neutral", 400);
+    border-color: $active-border-color;
   }
 }
 

--- a/packages/react-component-library/src/components/TabSet/ScrollButton.tsx
+++ b/packages/react-component-library/src/components/TabSet/ScrollButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import {
+  IconKeyboardArrowLeft,
+  IconKeyboardArrowRight,
+} from '@royalnavy/icon-library'
+import classNames from 'classnames'
+
+import { SCROLL_DIRECTION } from './constants'
+
+interface ScrollButtonProps {
+  direction: SCROLL_DIRECTION.LEFT | SCROLL_DIRECTION.RIGHT
+  onClick: () => void
+}
+
+const SCROLL_DIRECTION_ICON_MAP = {
+  [SCROLL_DIRECTION.LEFT]: <IconKeyboardArrowLeft />,
+  [SCROLL_DIRECTION.RIGHT]: <IconKeyboardArrowRight />,
+}
+
+export const ScrollButton: React.FC<ScrollButtonProps> = ({
+  direction,
+  onClick,
+}) => {
+  const classes = classNames(
+    'rn-tab-set__scroll',
+    `rn-tab-set__scroll--${direction}`
+  )
+
+  return (
+    <button
+      className={classes}
+      onClick={onClick}
+      data-testid={`scroll-${direction}`}
+    >
+      {SCROLL_DIRECTION_ICON_MAP[direction]}
+    </button>
+  )
+}

--- a/packages/react-component-library/src/components/TabSet/Tab.tsx
+++ b/packages/react-component-library/src/components/TabSet/Tab.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
 export interface TabProps {
-  title: string
-  children?: any
+  title: React.ReactElement | string
+  children: React.ReactElement | string
 }
 
 export const Tab: React.FC<TabProps> = ({ children }) => {

--- a/packages/react-component-library/src/components/TabSet/TabContent.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabContent.tsx
@@ -12,7 +12,7 @@ export const TabContent: React.FC<TabContentProps> = ({
   isActive,
   children,
 }) => {
-  const classes = classNames('rn-tab-set__content', isActive ? 'is-active' : '')
+  const classes = classNames('rn-tab-set__content', { 'is-active': isActive })
 
   return (
     <div className={classes} data-testid="content">

--- a/packages/react-component-library/src/components/TabSet/TabItem.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabItem.tsx
@@ -1,28 +1,26 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
+import classNames from 'classnames'
 
 interface TabItemProps {
-  onClick: () => void
-  isActive: boolean
+  children: React.ReactElement | string
   index: number
-  children: string
+  active: boolean
+  onClick: () => void
+  scrollable?: boolean
 }
 
-export const TabItem: React.FC<TabItemProps> = ({
-  index,
-  isActive,
-  onClick,
-  children,
-}) => {
-  const classes = `rn-tab-set__tab-item ${isActive ? 'is-active' : ''}`
-  return (
-    <li className={classes} data-testid="tab">
-      <button
-        className="rn-tab-set__tab"
-        onClick={onClick}
-        data-testid={`select-tab-${index}`}
-      >
-        {children}
-      </button>
-    </li>
-  )
-}
+export const TabItem = forwardRef<HTMLLIElement, TabItemProps>(
+  ({ children, index, active, onClick, scrollable }, ref) => {
+    const tabClasses = classNames('rn-tab-set__tab', {
+      'is-active': active,
+    })
+
+    return (
+      <li className="rn-tab-set__tab-item" data-testid="tab" ref={ref}>
+        <button className={tabClasses} onClick={onClick}>
+          <div>{children}</div>
+        </button>
+      </li>
+    )
+  }
+)

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -16,3 +16,80 @@ stories.add('Default', () => (
     </Tab>
   </TabSet>
 ))
+
+interface TabTitleProps {
+  children: string
+  year: number
+}
+
+const TabTitle: React.FC<TabTitleProps> = ({ year, children }) => (
+  <>
+    <div style={{ fontSize: '14px', color: '#3e5667' }}>{children}</div>
+    <div style={{ fontSize: '12px', color: '#748999' }}>{year}</div>
+  </>
+)
+
+stories.add('Scrollable', () => (
+  <TabSet scrollable>
+    <Tab title={<TabTitle year={2019}>01/02</TabTitle>}>
+      <p>This is some example tab 1 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>02/02</TabTitle>}>
+      <p>This is some example tab 2 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>03/02</TabTitle>}>
+      <p>This is some example tab 3 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>04/02</TabTitle>}>
+      <p>This is some example tab 4 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>05/02</TabTitle>}>
+      <p>This is some example tab 5 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>06/02</TabTitle>}>
+      <p>This is some example tab 6 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>07/02</TabTitle>}>
+      <p>This is some example tab 7 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>08/02</TabTitle>}>
+      <p>This is some example tab 8 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>09/02</TabTitle>}>
+      <p>This is some example tab 9 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>10/02</TabTitle>}>
+      <p>This is some example tab 10 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>11/02</TabTitle>}>
+      <p>This is some example tab 11 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>12/02</TabTitle>}>
+      <p>This is some example tab 12 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>13/02</TabTitle>}>
+      <p>This is some example tab 13 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>14/02</TabTitle>}>
+      <p>This is some example tab 14 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>15/02</TabTitle>}>
+      <p>This is some example tab 15 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>16/02</TabTitle>}>
+      <p>This is some example tab 16 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>17/02</TabTitle>}>
+      <p>This is some example tab 17 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>18/02</TabTitle>}>
+      <p>This is some example tab 18 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>19/02</TabTitle>}>
+      <p>This is some example tab 19 content</p>
+    </Tab>
+    <Tab title={<TabTitle year={2019}>20/02</TabTitle>}>
+      <p>This is some example tab 20 content</p>
+    </Tab>
+  </TabSet>
+))

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -1,55 +1,210 @@
 import React from 'react'
-import { render, fireEvent, RenderResult } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, RenderResult } from '@testing-library/react'
 
 import { TabSet, Tab } from '.'
 
 describe('TabSet', () => {
-  let tabset: RenderResult
-  let onChangeCallback: () => void
+  let wrapper: RenderResult
+  let onChangeSpy: jest.SpyInstance
 
-  describe('when the TabSet is generated with tabs and onChangeCallback props', () => {
-    onChangeCallback = jest.fn()
-
-    beforeEach(() => {
-      tabset = render(
-        <TabSet onChangeCallback={onChangeCallback}>
-          <Tab title="Example Tab 1">
-            <p>This is some example tab 1 content</p>
-          </Tab>
-          <Tab title="Example Tab 2">
-            <p>This is some example tab 2 content</p>
-          </Tab>
-        </TabSet>
-      )
-    })
-
-    it('should output the correct number of tabs', () => {
-      expect(tabset.queryAllByTestId('tab').length).toEqual(2)
-    })
-
-    it('should output the correct number of content panels', () => {
-      expect(tabset.queryAllByTestId('content').length).toEqual(2)
-    })
-
-    describe('when the user clicks on a tab', () => {
+  describe('when the tab set is not scrollable', () => {
+    describe('when all props are provided', () => {
       beforeEach(() => {
-        fireEvent(
-          tabset.getByTestId('select-tab-0'),
-          new MouseEvent('click', {
-            bubbles: true,
-            cancelable: true,
-          })
+        const props = {
+          className: 'rn-tab-set--modifier',
+          onChangeCallback: () => {},
+        }
+
+        onChangeSpy = jest.spyOn(props, 'onChangeCallback')
+
+        wrapper = render(
+          <TabSet {...props}>
+            <Tab title="Title 1">Content 1</Tab>
+            <Tab title="Title 2">Content 2</Tab>
+          </TabSet>
         )
       })
 
-      it('should apply the `is-active` class to the appropriate tab', () => {
-        expect(
-          tabset.getAllByTestId('tab')[0].classList.contains('is-active')
-        ).toBe(true)
+      it('should add the class name', () => {
+        expect(wrapper.getByTestId('tab-set').classList).toContain(
+          'rn-tab-set--modifier'
+        )
       })
 
-      it('should invoke the onChangeCallback function', () => {
-        expect(onChangeCallback).toHaveBeenCalled()
+      it('should output the correct number of tabs', () => {
+        expect(wrapper.queryAllByTestId('tab').length).toEqual(2)
+      })
+
+      it('should output the correct number of content panels', () => {
+        expect(wrapper.queryAllByTestId('content').length).toEqual(2)
+      })
+
+      describe('when the user clicks on a tab', () => {
+        beforeEach(() => {
+          wrapper.getByText('Title 2').click()
+        })
+
+        it('should apply the `is-active` class to the appropriate tab', () => {
+          expect(
+            wrapper.getByText('Title 2').parentElement.classList
+          ).toContain('is-active')
+        })
+
+        it('should invoke the onChangeCallback function', () => {
+          expect(onChangeSpy).toHaveBeenCalledTimes(1)
+          expect(onChangeSpy).toHaveBeenCalledWith(1)
+        })
+      })
+    })
+
+    describe('when the onChangeCallback is not provided', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <TabSet>
+            <Tab title="Title 1">Content 1</Tab>
+            <Tab title="Title 2">Content 2</Tab>
+          </TabSet>
+        )
+      })
+
+      describe('when the user clicks on a tab', () => {
+        beforeEach(() => {
+          wrapper.getByText('Title 2').click()
+        })
+
+        it('should apply the `is-active` class to the appropriate tab', () => {
+          expect(
+            wrapper.getByText('Title 2').parentElement.classList
+          ).toContain('is-active')
+        })
+      })
+    })
+
+    describe('when tabs contain elements', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <TabSet>
+            <Tab title={<span>Title 1</span>}>
+              <p>Content 1</p>
+            </Tab>
+            <Tab title={<span>Title 2</span>}>
+              <p>Content 2</p>
+            </Tab>
+          </TabSet>
+        )
+      })
+
+      it('should render the elements', () => {
+        expect(wrapper.getByText('Title 1')).toBeInTheDocument()
+        expect(wrapper.getByText('Content 1')).toBeInTheDocument()
+        expect(wrapper.getByText('Title 2')).toBeInTheDocument()
+        expect(wrapper.getByText('Content 2')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when the tab set is scrollable', () => {
+    let scrollToSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      wrapper = render(
+        <TabSet scrollable>
+          <Tab title="Title 1">Content 1</Tab>
+          <Tab title="Title 2">Content 2</Tab>
+          <Tab title="Title 3">Content 3</Tab>
+        </TabSet>
+      )
+
+      const tabs = wrapper.getByTestId('tabs')
+      tabs.scrollTo = () => {}
+      scrollToSpy = jest.spyOn(tabs, 'scrollTo').mockImplementation(x => {
+        Object.defineProperty(tabs, 'scrollLeft', {
+          configurable: true,
+          value: x,
+        })
+      })
+
+      Object.defineProperty(tabs, 'offsetLeft', { value: 50 })
+
+      Object.defineProperty(
+        wrapper.getByText('Title 1').parentElement.parentElement,
+        'offsetLeft',
+        { value: 150 }
+      )
+      Object.defineProperty(
+        wrapper.getByText('Title 2').parentElement.parentElement,
+        'offsetLeft',
+        { value: 250 }
+      )
+      Object.defineProperty(
+        wrapper.getByText('Title 3').parentElement.parentElement,
+        'offsetLeft',
+        { value: 350 }
+      )
+    })
+
+    it('should present a scroll left button', () => {
+      expect(wrapper.getByTestId('scroll-left')).toBeInTheDocument()
+    })
+
+    it('should present a scroll right button', () => {
+      expect(wrapper.getByTestId('scroll-right')).toBeInTheDocument()
+    })
+
+    describe('when scrolling right', () => {
+      describe('when the scroll right button is clicked twice', () => {
+        beforeEach(() => {
+          wrapper.getByTestId('scroll-right').click()
+          wrapper.getByTestId('scroll-right').click()
+        })
+
+        it('should scroll the tabs twice', () => {
+          expect(scrollToSpy).toHaveBeenCalledTimes(2)
+          expect(scrollToSpy).toHaveBeenCalledWith(200, 0)
+          expect(scrollToSpy).toHaveBeenCalledWith(300, 0)
+        })
+      })
+
+      describe('when the scroll right button is clicked three times (once more than available tabs)', () => {
+        beforeEach(() => {
+          wrapper.getByTestId('scroll-right').click()
+          wrapper.getByTestId('scroll-right').click()
+          wrapper.getByTestId('scroll-right').click()
+        })
+
+        it('should scroll the tabs only twice', () => {
+          expect(scrollToSpy).toHaveBeenCalledTimes(2)
+        })
+      })
+    })
+
+    describe('when scrolling left', () => {
+      describe('when scroll right and scroll left buttons are each clicked once', () => {
+        beforeEach(() => {
+          wrapper.getByTestId('scroll-right').click()
+          wrapper.getByTestId('scroll-left').click()
+        })
+
+        it('should scroll the tabs twice', () => {
+          expect(scrollToSpy).toHaveBeenCalledTimes(2)
+          expect(scrollToSpy).toHaveBeenCalledWith(200, 0)
+          expect(scrollToSpy).toHaveBeenCalledWith(100, 0)
+        })
+      })
+
+      describe('when scroll right button is clicked once and scroll left is clicked twice', () => {
+        beforeEach(() => {
+          wrapper.getByTestId('scroll-right').click()
+          wrapper.getByTestId('scroll-left').click()
+          wrapper.getByTestId('scroll-left').click()
+        })
+
+        it('should scroll the tabs twice', () => {
+          expect(scrollToSpy).toHaveBeenCalledTimes(2)
+          expect(scrollToSpy).toHaveBeenCalledWith(200, 0)
+          expect(scrollToSpy).toHaveBeenCalledWith(100, 0)
+        })
       })
     })
   })

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -1,44 +1,82 @@
 import React, { useState, Children } from 'react'
+import classNames from 'classnames'
 
 import { TabProps, TabContent, TabItem } from '.'
+import { ScrollButton } from './ScrollButton'
+import { useScrollableTabSet } from './useScrollableTabSet'
+import { SCROLL_DIRECTION } from './constants'
 
 interface TabSetProps {
   className?: string
-  children?: React.ReactElement<TabProps>[]
-  onChangeCallback?: (id: number, title: string) => void
+  children: React.ReactElement<TabProps>[]
+  onChangeCallback?: (id: number) => void
+  scrollable?: boolean
 }
 
 export const TabSet: React.FC<TabSetProps> = ({
   className = '',
   children,
   onChangeCallback,
+  scrollable,
 }) => {
   const [activeTab, setActiveTab] = useState(0)
+  const { updateCurrentScrollToTab, tabsRef, itemsRef } = useScrollableTabSet(
+    children
+  )
 
-  function handleClick(index: number, title: string) {
+  function handleClick(index: number) {
     setActiveTab(index)
 
     if (onChangeCallback) {
-      onChangeCallback(activeTab, title)
+      onChangeCallback(index)
     }
   }
 
+  const articleClasses = classNames('rn-tab-set', className, {
+    'is-scrollable': scrollable,
+  })
+
   return (
-    <article className={`rn-tab-set ${className}`}>
+    <article className={articleClasses} data-testid="tab-set">
       <header className="rn-tab-set__head">
-        <nav>
+        {scrollable && (
+          <ScrollButton
+            direction={SCROLL_DIRECTION.LEFT}
+            onClick={updateCurrentScrollToTab(
+              currentTabIndex => currentTabIndex - 1
+            )}
+          />
+        )}
+        <div
+          className="rn-tab-set__navigation"
+          ref={tabsRef}
+          data-testid="tabs"
+        >
           <ol className="rn-tab-set__tabs">
             {Children.map(children, ({ props }, index: number) => (
               <TabItem
-                onClick={() => handleClick(index, props.title)}
-                isActive={index === activeTab}
+                onClick={() => handleClick(index)}
+                active={index === activeTab}
                 index={index}
+                scrollable={scrollable}
+                ref={el => {
+                  itemsRef.current[index] = el
+                  return itemsRef.current[index]
+                }}
               >
                 {props.title}
               </TabItem>
             ))}
           </ol>
-        </nav>
+        </div>
+        {scrollable && (
+          <ScrollButton
+            direction={SCROLL_DIRECTION.RIGHT}
+            onClick={updateCurrentScrollToTab(
+              currentTabIndex => currentTabIndex + 1
+            )}
+          />
+        )}
       </header>
       <div className="rn-tab-set__body">
         {Children.map(

--- a/packages/react-component-library/src/components/TabSet/constants.ts
+++ b/packages/react-component-library/src/components/TabSet/constants.ts
@@ -1,0 +1,8 @@
+enum SCROLL_DIRECTION {
+  LEFT = 'left',
+  RIGHT = 'right',
+}
+
+export {
+  SCROLL_DIRECTION,
+}

--- a/packages/react-component-library/src/components/TabSet/useScrollableTabSet.ts
+++ b/packages/react-component-library/src/components/TabSet/useScrollableTabSet.ts
@@ -16,25 +16,18 @@ export function useScrollableTabSet(items: React.ReactElement<TabProps>[]) {
       const nextTab = change(currentScrollToTab)
       const nextTabExists = nextTab > -1 && nextTab < items.length
       if (nextTabExists) {
-        const currentScrollPosition = tabsRef.current.scrollLeft
-        const newScrollPosition =
+        const currentPosition = tabsRef.current.scrollLeft
+        const newPosition =
           itemsRef.current[nextTab].offsetLeft - tabsRef.current.offsetLeft
 
-        tabsRef.current.scrollTo(newScrollPosition, 0)
+        tabsRef.current.scrollTo(newPosition, 0)
 
-        const isScrollPositionTheSame =
-          currentScrollPosition === tabsRef.current.scrollLeft
+        const isPositionTheSame = currentPosition === tabsRef.current.scrollLeft
 
-        if (!isScrollPositionTheSame) {
-          setCurrentScrollToTab(nextTab)
-        }
+        if (!isPositionTheSame) setCurrentScrollToTab(nextTab)
       }
     }
   }
 
-  return {
-    itemsRef,
-    tabsRef,
-    updateCurrentScrollToTab,
-  }
+  return { itemsRef, tabsRef, updateCurrentScrollToTab }
 }

--- a/packages/react-component-library/src/components/TabSet/useScrollableTabSet.ts
+++ b/packages/react-component-library/src/components/TabSet/useScrollableTabSet.ts
@@ -1,0 +1,40 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+import { TabProps } from './Tab'
+
+export function useScrollableTabSet(items: React.ReactElement<TabProps>[]) {
+  const [currentScrollToTab, setCurrentScrollToTab] = useState(0)
+  const itemsRef = useRef<Array<HTMLLIElement>>([])
+  const tabsRef = useRef<HTMLDivElement>()
+
+  useEffect(() => {
+    itemsRef.current = itemsRef.current.slice(0, items.length)
+  }, [items])
+
+  function updateCurrentScrollToTab(change: (currentTab: number) => number) {
+    return () => {
+      const nextTab = change(currentScrollToTab)
+      const nextTabExists = nextTab > -1 && nextTab < items.length
+      if (nextTabExists) {
+        const currentScrollPosition = tabsRef.current.scrollLeft
+        const newScrollPosition =
+          itemsRef.current[nextTab].offsetLeft - tabsRef.current.offsetLeft
+
+        tabsRef.current.scrollTo(newScrollPosition, 0)
+
+        const isScrollPositionTheSame =
+          currentScrollPosition === tabsRef.current.scrollLeft
+
+        if (!isScrollPositionTheSame) {
+          setCurrentScrollToTab(nextTab)
+        }
+      }
+    }
+  }
+
+  return {
+    itemsRef,
+    tabsRef,
+    updateCurrentScrollToTab,
+  }
+}


### PR DESCRIPTION
## Related issue
#225 

## Overview
Adding a scrollable tab set component 

## Reason
When there are a large number of tabs then these need to be scrolled through.

## Work carried out
- [x] Add scroll buttons
- [x] Add scrollable tab set

## Screenshot
![Screenshot 2019-11-27 at 09 28 42](https://user-images.githubusercontent.com/56078793/69711314-c28a5180-10f8-11ea-81c8-012919d836cf.png)

## Developer notes
Still to do:
- Smooth scrolling
- Mobile
- Documentation