### PR TITLE
Add smooth scrolling to scrollable tab set

### DIFF
--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -1,7 +1,7 @@
-import React, { useState, Children } from 'react'
+import React, { Children, useState } from 'react'
 import classNames from 'classnames'
 
-import { TabProps, TabContent, TabItem } from '.'
+import { TabContent, TabItem, TabProps } from '.'
 import { ScrollButton } from './ScrollButton'
 import { useScrollableTabSet } from './useScrollableTabSet'
 import { SCROLL_DIRECTION } from './constants'
@@ -20,9 +20,7 @@ export const TabSet: React.FC<TabSetProps> = ({
   scrollable,
 }) => {
   const [activeTab, setActiveTab] = useState(0)
-  const { updateCurrentScrollToTab, tabsRef, itemsRef } = useScrollableTabSet(
-    children
-  )
+  const { scrollToNextTab, tabsRef, itemsRef } = useScrollableTabSet(children)
 
   function handleClick(index: number) {
     setActiveTab(index)
@@ -42,9 +40,7 @@ export const TabSet: React.FC<TabSetProps> = ({
         {scrollable && (
           <ScrollButton
             direction={SCROLL_DIRECTION.LEFT}
-            onClick={updateCurrentScrollToTab(
-              currentTabIndex => currentTabIndex - 1
-            )}
+            onClick={scrollToNextTab(currentTabIndex => currentTabIndex - 1)}
           />
         )}
         <div
@@ -72,9 +68,7 @@ export const TabSet: React.FC<TabSetProps> = ({
         {scrollable && (
           <ScrollButton
             direction={SCROLL_DIRECTION.RIGHT}
-            onClick={updateCurrentScrollToTab(
-              currentTabIndex => currentTabIndex + 1
-            )}
+            onClick={scrollToNextTab(currentTabIndex => currentTabIndex + 1)}
           />
         )}
       </header>


### PR DESCRIPTION
## Related issue
#218 

## Overview
Make scrolling smooth when browsing tabs in scrollable tab set.

## Reason
Without smooth scrolling the user experience is awkward because it feels like the tabs are disappearing.

## Work carried out
- [x] Add smooth scrolling

## Screenshot
![scroll](https://user-images.githubusercontent.com/56078793/69823462-d620df80-1200-11ea-80b9-d948b505001c.gif)
