### PR TITLE
Allow else if exception for no-else-return

### DIFF
--- a/packages/react-component-library/.eslintrc.js
+++ b/packages/react-component-library/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
     'react/prop-types': 0,
     '@typescript-eslint/ban-ts-ignore': 0,
     '@typescript-eslint/explicit-function-return-type': 0,
+    'no-else-return': ['error', { allowElseIf: true }],
   },
   settings: {
     'import/resolver': {


### PR DESCRIPTION
Let me do this...

```javascript
function foo() {
    if (x) {
        return y;
    } else if (z) {
        return w;
    }

    return t;
}
```

but not this

```javascript
function foo() {
    if (x) {
        return y;
    } else if (z) {
        return w;
    } else { // this last else is unnecessary, as it will just fall through
        return t;
    }
}
```
