### PR TITLE
Color Swatch Cleanup

### DIFF
--- a/packages/docs-site/src/components/presenters/swatch/_swatch.scss
+++ b/packages/docs-site/src/components/presenters/swatch/_swatch.scss
@@ -1,22 +1,32 @@
 @use "@royalnavy/css-framework" as rn;
 
 .swatch-container {
-  display: inline-block;  
-  margin-right: 20px;
+  display: flex;
+  flex-flow: row wrap;
+  max-width: 100%;
+  margin-top: rn.spacing("10");
 }
 
 .swatch {
-  width: 40px;
-  height: 40px;
-  overflow: hidden;
-  border-radius: 3px;
+  padding: rn.spacing("14") rn.spacing("4") rn.spacing("4") rn.spacing("4");
+  width: 25%;
+  @include rn.breakpoint("m") {
+    width: 20%;
+  }
+
+  color: rn.color("neutral", "600");
+
+  &.dark {
+    color: white;
+  }
 }
 
 .swatch-label {
-  text-align: center;
   font-size: rn.font-size("s");
+  font-weight: 500;
   width: 100%;
   display: block;
-  margin-top: 10px;
-  color: #11202b;
+  &:first-child {
+    margin-bottom: rn.spacing("2");
+  }
 }

--- a/packages/docs-site/src/components/presenters/swatch/index.js
+++ b/packages/docs-site/src/components/presenters/swatch/index.js
@@ -1,16 +1,22 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const Swatch = ({ color, label }) => (
-  <div className="swatch-container">
-    <div className="swatch" style={{ backgroundColor: color }} />
-    <span className="swatch-label">{label}</span>
+const Swatch = ({ color, name, hex, theme }) => (
+  <div className={'swatch ' + theme} style={{ backgroundColor: color }}>
+    <span className="swatch-label">{name}</span>
+    <span className="swatch-label">{color}</span>
   </div>
 )
 
 Swatch.propTypes = {
   color: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  hex: PropTypes.string.isRequired,
+  theme: PropTypes.string,
+}
+
+Swatch.defaultProps = {
+  theme: 'light',
 }
 
 export default Swatch

--- a/packages/docs-site/src/library/pages/styles/colours.md
+++ b/packages/docs-site/src/library/pages/styles/colours.md
@@ -22,18 +22,20 @@ Out-of-the-box Standards Toolkit provides five base colours. We use functional n
 
 Neutral shades provide the base of Standards Toolkit applications. They should be used to build UIs and mostly mostly serve as background, text colour, and border shades for the components. The majority of colours for an application will be from the Neutral Palette.
 
-<Swatch color="#0a141b" label="Black" />
-<Swatch color="#0a141b" label="900" />
-<Swatch color="#0c1720" label="800" />
-<Swatch color="#12202b" label="700" />
-<Swatch color="#1c2d39" label="600" />
-<Swatch color="#233745" label="500" />
-<Swatch color="#3e5667" label="400" />
-<Swatch color="#748999" label="300" />
-<Swatch color="#b8c7d2" label="200" />
-<Swatch color="#e2e9ee" label="100" />
-<Swatch color="#f8fafc" label="000" />
-<Swatch color="#FFFFFF" label="white" />
+<div className="swatch-container">
+  <Swatch color="#0a141b" name="900" theme="dark" />
+  <Swatch color="#0c1720" name="800" theme="dark" />
+  <Swatch color="#12202b" name="700" theme="dark" />
+  <Swatch color="#1c2d39" name="600" theme="dark" />
+  <Swatch color="#233745" name="500" theme="dark" />
+  <Swatch color="#3e5667" name="400" theme="dark" />
+  <Swatch color="#748999" name="300" />
+  <Swatch color="#b8c7d2" name="200" />
+  <Swatch color="#e2e9ee" name="100" />
+  <Swatch color="#f8fafc" name="000" />
+  <Swatch color="#0a141b" name="Black" theme="dark" />
+  <Swatch color="#FFFFFF" name="white" />
+</div>
 
 #### Action
 
@@ -41,16 +43,18 @@ The Action shades are mostly used to indicate the main action of a component. By
 
 Another use for the Action palette is for the components that need to stand out from their neutral background palette. Styling an Alert component with the Action palette will get the user’s attention but it will not have any of the associated connotations that the Success/Warning/Danger has.
 
-<Swatch color="#253b5b" label="900" />
-<Swatch color="#274776" label="800" />
-<Swatch color="#2661a7" label="700" />
-<Swatch color="#2a77c7" label="600" />
-<Swatch color="#3a8fdd" label="500" />
-<Swatch color="#58aae9" label="400" />
-<Swatch color="#85c6f2" label="300" />
-<Swatch color="#b7dff7" label="200" />
-<Swatch color="#ddf4ff" label="100" />
-<Swatch color="#ecf8ff" label="100" />
+<div className="swatch-container">
+  <Swatch color="#253b5b" name="900" theme="dark" />
+  <Swatch color="#274776" name="800" theme="dark" />
+  <Swatch color="#2661a7" name="700" theme="dark" />
+  <Swatch color="#2a77c7" name="600" theme="dark" />
+  <Swatch color="#3a8fdd" name="500" theme="dark" />
+  <Swatch color="#58aae9" name="400" theme="dark" />
+  <Swatch color="#85c6f2" name="300" />
+  <Swatch color="#b7dff7" name="200" />
+  <Swatch color="#ddf4ff" name="100" />
+  <Swatch color="#ecf8ff" name="100" />
+</div>
 
 ### State Colours
 
@@ -58,43 +62,49 @@ State colours are used to improve the semantics of particular Actions. These pal
 
 #### Success
 
-<Swatch color="#3b612c" label="900" />
-<Swatch color="#3b6f33" label="800" />
-<Swatch color="#479442" label="700" />
-<Swatch color="#60b255" label="600" />
-<Swatch color="#76c767" label="500" />
-<Swatch color="#8fd57f" label="400" />
-<Swatch color="#abe39b" label="300" />
-<Swatch color="#c6f3b5" label="200" />
-<Swatch color="#e5ffd9" label="100" />
-<Swatch color="#f4ffef" label="000" />
+<div className="swatch-container">
+  <Swatch color="#3b612c" name="900" theme="dark" />
+  <Swatch color="#3b6f33" name="800" theme="dark" />
+  <Swatch color="#479442" name="700" theme="dark" />
+  <Swatch color="#60b255" name="600" theme="dark" />
+  <Swatch color="#76c767" name="500" theme="dark" />
+  <Swatch color="#8fd57f" name="400" theme="dark" />
+  <Swatch color="#abe39b" name="300" />
+  <Swatch color="#c6f3b5" name="200" />
+  <Swatch color="#e5ffd9" name="100" />
+  <Swatch color="#f4ffef" name="000" />
+</div>
 
 #### Warning
 
-<Swatch color="#693a12" label="900" />
-<Swatch color="#8c4f17" label="800" />
-<Swatch color="#ae6d1d" label="700" />
-<Swatch color="#cf9328" label="600" />
-<Swatch color="#e8c242" label="500" />
-<Swatch color="#f5db54" label="400" />
-<Swatch color="#faed7e" label="300" />
-<Swatch color="#fefbb8" label="200" />
-<Swatch color="#fffddc" label="100" />
-<Swatch color="#ffffee" label="000" />
+
+<div className="swatch-container">
+  <Swatch color="#693a12" name="900" theme="dark" />
+  <Swatch color="#8c4f17" name="800" theme="dark" />
+  <Swatch color="#ae6d1d" name="700" theme="dark" />
+  <Swatch color="#cf9328" name="600" theme="dark" />
+  <Swatch color="#e8c242" name="500" theme="dark" />
+  <Swatch color="#f5db54" name="400" />
+  <Swatch color="#faed7e" name="300" />
+  <Swatch color="#fefbb8" name="200" />
+  <Swatch color="#fffddc" name="100" />
+  <Swatch color="#ffffee" name="000" />
+</div>
 
 ### Danger
 
-<Swatch color="#692524" label="900" />
-<Swatch color="#902727" label="800" />
-<Swatch color="#be2b2b" label="700" />
-<Swatch color="#e13637" label="600" />
-<Swatch color="#f44949" label="500" />
-<Swatch color="#fc7576" label="400" />
-<Swatch color="#fea9a9" label="300" />
-<Swatch color="#fed1d1" label="200" />
-<Swatch color="#feeaec" label="100" />
-<Swatch color="#fff3f4" label="000" />
-
+<div className="swatch-container">
+  <Swatch color="#841c1b" name="900" theme="dark" />
+  <Swatch color="#b22820" name="800" theme="dark" />
+  <Swatch color="#d53229" name="700" theme="dark" />
+  <Swatch color="#ec4138" name="600" theme="dark" />
+  <Swatch color="#f45249" name="500" theme="dark" />
+  <Swatch color="#fc7c75" name="400" theme="dark" />
+  <Swatch color="#fea9a9" name="300" />
+  <Swatch color="#fed1d1" name="200" />
+  <Swatch color="#feeaec" name="100" />
+  <Swatch color="#fff3f4" name="000" />
+</div>
 
 
 ### Supplementary colours
@@ -102,82 +112,94 @@ As the name describes, Supplementary colours are there to _supplement_ the main 
 
 #### Sup A
 
-<Swatch color="#343160" label="900" />
-<Swatch color="#3b3985" label="800" />
-<Swatch color="#4248b6" label="700" />
-<Swatch color="#7392f3" label="400" />
-<Swatch color="#5b73e6" label="500" />
-<Swatch color="#4e5cd3" label="600" />
-<Swatch color="#99b7f9" label="300" />
-<Swatch color="#bbd5fe" label="200" />
-<Swatch color="#deebff" label="100" />
-<Swatch color="#e8f2ff" label="000" />
+<div className="swatch-container">
+  <Swatch color="#343160" name="900" theme="dark" />
+  <Swatch color="#3b3985" name="800" theme="dark" />
+  <Swatch color="#4248b6" name="700" theme="dark" />
+  <Swatch color="#4e5cd3" name="600" theme="dark" />
+  <Swatch color="#5b73e6" name="500" theme="dark" />
+  <Swatch color="#7392f3" name="400" theme="dark" />
+  <Swatch color="#99b7f9" name="300" />
+  <Swatch color="#bbd5fe" name="200" />
+  <Swatch color="#deebff" name="100" />
+  <Swatch color="#e8f2ff" name="000" />
+</div>
 
 #### Sup B
 
-<Swatch color="#3b2d6e" label="900" />
-<Swatch color="#4b358f" label="800" />
-<Swatch color="#603fb8" label="700" />
-<Swatch color="#744fd0" label="600" />
-<Swatch color="#936fe8" label="500" />
-<Swatch color="#ad89f1" label="400" />
-<Swatch color="#d0b5f9" label="300" />
-<Swatch color="#e5d3fd" label="200" />
-<Swatch color="#f2e9ff" label="100" />
-<Swatch color="#f9f3ff" label="000" />
+<div className="swatch-container">
+  <Swatch color="#3b2d6e" name="900" theme="dark" />
+  <Swatch color="#4b358f" name="800" theme="dark" />
+  <Swatch color="#603fb8" name="700" theme="dark" />
+  <Swatch color="#744fd0" name="600" theme="dark" />
+  <Swatch color="#936fe8" name="500" theme="dark" />
+  <Swatch color="#ad89f1" name="400" theme="dark" />
+  <Swatch color="#d0b5f9" name="300" />
+  <Swatch color="#e5d3fd" name="200" />
+  <Swatch color="#f2e9ff" name="100" />
+  <Swatch color="#f9f3ff" name="000" />
+</div>
 
 
 #### Sup C
 
-<Swatch color="#6c2d6e" label="900" />
-<Swatch color="#8c358f" label="800" />
-<Swatch color="#b43fb8" label="700" />
-<Swatch color="#cc4fd0" label="600" />
-<Swatch color="#e46fe8" label="500" />
-<Swatch color="#ee89f1" label="400" />
-<Swatch color="#f7b5f9" label="300" />
-<Swatch color="#fcd3fd" label="200" />
-<Swatch color="#fee9ff" label="100" />
-<Swatch color="#fff3ff" label="000" />
+<div className="swatch-container">
+  <Swatch color="#6c2d6e" name="900" theme="dark" />
+  <Swatch color="#8c358f" name="800" theme="dark" />
+  <Swatch color="#b43fb8" name="700" theme="dark" />
+  <Swatch color="#cc4fd0" name="600" theme="dark" />
+  <Swatch color="#e46fe8" name="500" theme="dark" />
+  <Swatch color="#ee89f1" name="400" theme="dark" />
+  <Swatch color="#f7b5f9" name="300" />
+  <Swatch color="#fcd3fd" name="200" />
+  <Swatch color="#fee9ff" name="100" />
+  <Swatch color="#fff3ff" name="000" />
+</div>
 
 #### Sup D
 
-<Swatch color="#6c2d6e" label="900" />
-<Swatch color="#8c358f" label="800" />
-<Swatch color="#b43fb8" label="700" />
-<Swatch color="#cc4fd0" label="600" />
-<Swatch color="#e46fe8" label="500" />
-<Swatch color="#ee89f1" label="400" />
-<Swatch color="#f7b5f9" label="300" />
-<Swatch color="#fcd3fd" label="200" />
-<Swatch color="#fee9ff" label="100" />
-<Swatch color="#fff3ff" label="000" />
+<div className="swatch-container">
+  <Swatch color="#702232" name="900" theme="dark" />
+  <Swatch color="#972b41" name="800" theme="dark" />
+  <Swatch color="#c43854" name="700" theme="dark" />
+  <Swatch color="#d84b67" name="600" theme="dark" />
+  <Swatch color="#f35d7b" name="500" theme="dark" />
+  <Swatch color="#f77f97" name="400" theme="dark" />
+  <Swatch color="#ffa2b5" name="300" />
+  <Swatch color="#ffcce5" name="200" />
+  <Swatch color="#ffe1f0" name="100" />
+  <Swatch color="#ffeef6" name="000" />
+</div>
 
 #### Sup E
 
-<Swatch color="#853a0c" label="900" />
-<Swatch color="#9d4712" label="800" />
-<Swatch color="#c25c1d" label="700" />
-<Swatch color="#e0712c" label="600" />
-<Swatch color="#f48b49" label="500" />
-<Swatch color="#fca975" label="400" />
-<Swatch color="#fecaa9" label="300" />
-<Swatch color="#fee2d1" label="200" />
-<Swatch color="#fef2ea" label="100" />
-<Swatch color="#fff8f3" label="000" />
+<div className="swatch-container">
+  <Swatch color="#853a0c" name="900" theme="dark" />
+  <Swatch color="#9d4712" name="800" theme="dark" />
+  <Swatch color="#c25c1d" name="700" theme="dark" />
+  <Swatch color="#e0712c" name="600" theme="dark" />
+  <Swatch color="#f48b49" name="500" theme="dark" />
+  <Swatch color="#fca975" name="400" theme="dark" />
+  <Swatch color="#fecaa9" name="300" />
+  <Swatch color="#fee2d1" name="200" />
+  <Swatch color="#fef2ea" name="100" />
+  <Swatch color="#fff8f3" name="000" />
+</div>
 
 #### Sup F
 
-<Swatch color="#1f4a35" label="900" />
-<Swatch color="#245c40" label="800" />
-<Swatch color="#297a4f" label="700" />
-<Swatch color="#31975e" label="600" />
-<Swatch color="#3fb26d" label="500" />
-<Swatch color="#5dcd86" label="400" />
-<Swatch color="#8fe2ab" label="300" />
-<Swatch color="#bff4cf" label="200" />
-<Swatch color="#dfffe9" label="100" />
-<Swatch color="#eefff2" label="000" />
+<div className="swatch-container">
+  <Swatch color="#1f4a35" name="900" theme="dark" />
+  <Swatch color="#245c40" name="800" theme="dark" />
+  <Swatch color="#297a4f" name="700" theme="dark" />
+  <Swatch color="#31975e" name="600" theme="dark" />
+  <Swatch color="#3fb26d" name="500" theme="dark" />
+  <Swatch color="#5dcd86" name="400" theme="dark" />
+  <Swatch color="#8fe2ab" name="300" />
+  <Swatch color="#bff4cf" name="200" />
+  <Swatch color="#dfffe9" name="100" />
+  <Swatch color="#eefff2" name="000" />
+</div>
 
 
 ## Using Colours


### PR DESCRIPTION
Tweaked the design of the Color Swatches on the docs site to include both the framework value, and its hex code.

## Screenshot
<img width="952" alt="Screenshot 2019-11-28 at 11 42 53" src="https://user-images.githubusercontent.com/48090803/69803500-3fd6c480-11d4-11ea-9087-245dfde9f27f.png">
