### PR TITLE
Add version badge to masthead

### DIFF
--- a/packages/css-framework/src/components/_badge.scss
+++ b/packages/css-framework/src/components/_badge.scss
@@ -83,6 +83,10 @@ $badge-states: (
     }
   }
 
+  &--no-text-transform {
+    text-transform: none;
+  }
+
   @each $size, $values in $badge-sizes {
     &.rn-badge--#{$size} {
       font-size: map-get($values, "font-size");

--- a/packages/css-framework/src/fragments/_masthead.scss
+++ b/packages/css-framework/src/fragments/_masthead.scss
@@ -36,6 +36,13 @@ $masthead-main-height: 58px;
   }
 }
 
+.rn-masthead__version {
+  flex-grow: 1;
+  display: inline-flex;
+  align-items: center;
+  margin-left: spacing(4);
+}
+
 .rn-masthead__options {
   display: flex;
 }

--- a/packages/docs-site/src/library/pages/components/masthead.md
+++ b/packages/docs-site/src/library/pages/components/masthead.md
@@ -82,6 +82,8 @@ Aside from the active page links (an example of these states is shown in the [Ta
   title="Test" 
   unreadNotification={true}
   user={{ initials: 'XT', href: '/userprofile' }}
+  version="v2.0.0"                   
+  versionLink={{href:'/versions'}}   
 />`} language="javascript">
   <Masthead
     homeLink={{href:'/'}}
@@ -91,12 +93,14 @@ Aside from the active page links (an example of these states is shown in the [Ta
       { label: 'Components', href: '/components' },
       { label: 'About', href: '/about', },
     ]}
-    notifications={null}
+    notificatiosns={null}
     onSearch={term => console.log(`Search for: ${term}`)}
     searchPlaceholder="Search"
     title="Test"
     unreadNotification={true}
     user={{ initials: 'XT', href: '/userprofile' }}
+    version="v2.0.0"
+    versionLink={{href:'/versions'}}
   />
 </CodeHighlighter>
 
@@ -105,7 +109,7 @@ Aside from the active page links (an example of these states is shown in the [Ta
   {
     Name: 'homeLink',
     Type: 'LinkTypes',
-    Required: 'True',
+    Required: 'False',
     Description: 'An object typically containing a `to` or `href` property to indicate the property LinkComponent to send the user back to the homepage for the service.',
   },
   {
@@ -123,7 +127,7 @@ Aside from the active page links (an example of these states is shown in the [Ta
   {
     Name: 'navItems',
     Type: 'NavItem[] ',
-    Required: 'True',
+    Required: 'False',
     Description: 'An array of objects that must at least contain a label. If no custom component is provided then provide a href, otherwise provide the required property associated with the LinkComponent',
   },
   {
@@ -161,6 +165,18 @@ Aside from the active page links (an example of these states is shown in the [Ta
     Type: 'UserType',
     Required: 'False',
     Description: 'If your application has a User Profile page, pass in the User object to add their initials to the Avatar sub-component. This Avatar provides a link to the User’s profile.',
+  },
+  {
+    Name: 'version',
+    Type: 'string',
+    Required: 'False',
+    Description: 'Version of the application.',
+  },
+  {
+    Name: 'versionLink',
+    Type: 'LinkTypes',
+    Required: 'False',
+    Description: 'An object typically containing a `to` or `href` property to indicate the property LinkComponent to send the user to when the version badge is clicked.',
   },
 ]} />
 <br />

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.stories.tsx
@@ -41,6 +41,10 @@ const homeLink: AnchorType = {
   href: '/',
 }
 
+const versionLink: AnchorType = {
+  href: '/versions',
+}
+
 const CustomLogo = () => (
   <svg width="21" height="19" viewBox="0 0 21 19">
     <defs>
@@ -133,6 +137,8 @@ stories.add('all but navigation', () => (
     title="Test"
     unreadNotification
     user={user}
+    version="v2.0.0"
+    versionLink={versionLink}
   />
 ))
 
@@ -152,5 +158,7 @@ stories.add('With navigation', () => (
     title="Test"
     unreadNotification
     user={user}
+    version="v2.0.0"
+    versionLink={versionLink}
   />
 ))

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.test.tsx
@@ -31,6 +31,11 @@ describe('Masthead', () => {
         expect(serviceNameElement.textContent).toEqual('Test masthead')
       })
 
+      it('should render the version', () => {
+        expect(wrapper.queryByTestId('version')).toBeNull()
+        expect(wrapper.queryByText('v2.0.0')).toBeNull()
+      })
+
       it('should render a default icon', () => {
         expect(wrapper.getByTestId('logo')).toBeInTheDocument()
       })
@@ -281,6 +286,20 @@ describe('Masthead', () => {
         expect(wrapper.queryByTestId('scrollable-nav')).toContainHTML(
           'test nav item'
         )
+      })
+    })
+
+    describe('and a version', () => {
+      beforeEach(() => {
+        props.version = 'v2.0.0'
+        props.versionLink = { href: '/versions' }
+
+        wrapper = render(<Masthead {...props} />)
+      })
+
+      it('should render the version', () => {
+        expect(wrapper.queryByTestId('version')).toBeInTheDocument()
+        expect(wrapper.queryByText('v2.0.0')).toBeInTheDocument()
       })
     })
   })

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react'
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import classNames from 'classnames'
 
-import { Link, Searchbar, ScrollableNav } from '../../components'
+import { Link, Searchbar, ScrollableNav, Badge } from '../../components'
 import { Logo as DefaultLogo, Search as SearchIcon } from '../../icons'
 import { UserLink } from './UserLink'
 import {
@@ -22,6 +22,8 @@ export interface MastheadProps {
   title: string
   unreadNotification?: boolean
   user?: UserType
+  version?: string
+  versionLink?: LinkTypes
 }
 
 export const Masthead: React.FC<MastheadProps> = ({
@@ -35,6 +37,8 @@ export const Masthead: React.FC<MastheadProps> = ({
   title,
   unreadNotification,
   user,
+  version,
+  versionLink,
 }) => {
   const [showSearch, setShowSearch] = useState(false)
   const [showNotifications, setShowNotifications] = useState(false)
@@ -82,6 +86,16 @@ export const Masthead: React.FC<MastheadProps> = ({
             {title}
           </span>
         </LinkComponent>
+
+        {version && (
+          <div className="rn-masthead__version">
+            <LinkComponent {...versionLink} data-testid="version">
+              <Badge color="primary" className="rn-badge--no-text-transform">
+                {version}
+              </Badge>
+            </LinkComponent>
+          </div>
+        )}
 
         <div className="rn-masthead__options">
           {onSearch && (


### PR DESCRIPTION
## Related issue
#438 

## Overview
Add version badge to masthead.

## Reason
This is required in the docs site which consumes the masthead.

## Work carried out
- [x] Add version badge
- [x] Update documentation

## Screenshot
![Screenshot 2019-12-02 at 12 48 11](https://user-images.githubusercontent.com/56078793/69960703-08cd1f80-1502-11ea-960a-3ee14abe40e4.png)
