### PR TITLE
Add version badge to docs site masthead

### DIFF
--- a/packages/docs-site/src/components/presenters/Masthead/Masthead.test.js
+++ b/packages/docs-site/src/components/presenters/Masthead/Masthead.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, getByText } from '@testing-library/react'
 
 import Masthead from './index'
+import packageJson from '../../../../package'
 
 describe('Masthead', () => {
   let wrapper
@@ -25,6 +26,17 @@ describe('Masthead', () => {
       ]
 
       wrapper = render(<Masthead navItems={navItems} />)
+    })
+
+    it('should render a versions badge', () => {
+      expect(wrapper.getByText(`v${packageJson.version}`)).toBeInTheDocument()
+    })
+
+    it('should link the versions badge to the versions page', () => {
+      const versionBadge = wrapper.getByText(`v${packageJson.version}`)
+      expect(versionBadge.parentElement.getAttribute('href')).toEqual(
+        '/versions'
+      )
     })
 
     it('should render a navigation section', () => {

--- a/packages/docs-site/src/components/presenters/Masthead/index.js
+++ b/packages/docs-site/src/components/presenters/Masthead/index.js
@@ -1,12 +1,14 @@
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import {
+  Badge,
   Button,
   Icons,
   Nav,
   PhaseBanner,
 } from '@royalnavy/react-component-library'
 
+import packageJson from '../../../../package'
 import SiteLogo from './images/site-logo.svg'
 
 import './masthead.scss'
@@ -28,6 +30,12 @@ const MastHead = ({ navItems }) => {
         <a href="/">
           <SiteLogo className="masthead__logo" />
         </a>
+
+        <div className="masthead__version">
+          <a href="/versions">
+            <Badge color="primary">v{packageJson.version}</Badge>
+          </a>
+        </div>
 
         {hasNavItems && (
           <Button

--- a/packages/docs-site/src/components/presenters/Masthead/masthead.scss
+++ b/packages/docs-site/src/components/presenters/Masthead/masthead.scss
@@ -118,13 +118,18 @@
   width: 210px;
 }
 
+.masthead__version {
+  flex-grow: 1;
+  margin-left: spacing(2);
+
+  .rn-badge {
+    text-transform: none !important;
+  }
+}
+
 @include breakpoint("s") {
   .masthead {
     margin-bottom: 0;
-  }
-
-  .masthead__container {
-    display: block;
   }
 
   .masthead__logo {


### PR DESCRIPTION
## Related issue
#438 

## Overview
Adds the version badge to the doc site. Badge links to the versions page.

## Reason
Users need to see the latest and recent versions with associated documentation and release note.

## Work carried out
- [x] Add badge

## Screenshot
![Screenshot 2019-12-02 at 14 15 48](https://user-images.githubusercontent.com/56078793/69966557-90b92680-150e-11ea-952a-1d566cac9cc3.png)