### PR TITLE
Update "Latest updates" section on docs site

### DIFF
--- a/packages/docs-site/src/library/pages/index.md
+++ b/packages/docs-site/src/library/pages/index.md
@@ -12,6 +12,7 @@ excludeFromNavigation: true
 ---
 
 import Card from '../../components/presenters/card'
+import packageJson from '../../../package.json'
 
 <section class="m:h_f m:h_f-align-start h_mt-8 m:h_mb-16">
   <Card 
@@ -38,9 +39,8 @@ import Card from '../../components/presenters/card'
   <div class="m:h_f m:h_f-align-start">
   <Card 
     type="coloured" 
-    title="Standards v1.0.0 released" 
-    meta="25th July 2019"
-    text={<span>This launch includes the new <strong>Standards</strong> website providing <strong>'get started'</strong> guides for designers and developers, styling and component usage guidelines, and information about <strong>Standards</strong> for Royal Navy stakeholders. Please <a href="/contact">get in touch</a> if you have any feedback.</span>}
+    title={`Standards v${packageJson.version} released`}
+    text={<span>The latest release is on <a href="https://www.npmjs.com/package/@royalnavy/react-component-library">NPM</a> and the source is available on <a href="https://github.com/Royal-Navy/standards-toolkit">GitHub</a>. Please <a href="/contact">get in touch</a> if you have any feedback.</span>}
     className="m:h_f-1 home--updates"
   />
 


### PR DESCRIPTION
## Related issue
#438 

## Overview
Updates the `Latest updates` section on docs site homepage to be more generic.

## Reason
Current copy was out of date.

## Work carried out
- [x] Update section

## Screenshot
![Screenshot 2019-12-03 at 15 41 26](https://user-images.githubusercontent.com/56078793/70065681-68e7c280-15e3-11ea-8d9f-7c5e1ca83e40.png)