### PR TITLE
Horizontal scrolling docs site fix

### DIFF
--- a/packages/docs-site/src/components/presenters/data-table/data-table.scss
+++ b/packages/docs-site/src/components/presenters/data-table/data-table.scss
@@ -6,6 +6,22 @@ $border-radius: 4px;
 $heading-color: #3e5667;
 $text-color: #748999;
 
+
+.data-table__container {
+  max-width: 100%;
+  overflow-x: scroll;
+  background-image:
+    linear-gradient(to right, white, white),
+    linear-gradient(to right, white, white),
+    linear-gradient(to right, rgba(0,0,0,.07), rgba(255,255,255,0)),
+    linear-gradient(to left, rgba(0,0,0,.07), rgba(255,255,255,0));
+  background-position: left center, right center, left center, right center;
+  background-repeat: no-repeat;
+  background-color: $background-color;
+  background-size: 40px 100%, 40px 100%, 20px 100%, 20px 100%;
+  background-attachment: local, local, scroll, scroll;
+}
+
 .data-table {
   width: 100%;
   border: none;
@@ -51,7 +67,6 @@ $text-color: #748999;
   display: block;
   padding: spacing(8) 0;
   border-bottom: 1px dashed $border-color;
-  background-color: $background-color;
 
   &:first-of-type {
     padding-top: 0;

--- a/packages/docs-site/src/components/presenters/data-table/index.js
+++ b/packages/docs-site/src/components/presenters/data-table/index.js
@@ -23,18 +23,20 @@ const DataTable = ({ data, caption }) => {
   )
 
   return (
-    <table className="data-table">
-      {caption && (
-        <caption className="data-table__caption" data-testid="caption">
-          {caption}
-        </caption>
-      )}
-      <TableHead
-        headings={extractHeadings(tableData)}
-        onClickHeading={sortByColumn}
-      />
-      <TableBody rows={tableData} />
-    </table>
+    <div className="data-table__container">
+      <table className="data-table">
+        {caption && (
+          <caption className="data-table__caption" data-testid="caption">
+            {caption}
+          </caption>
+        )}
+        <TableHead
+          headings={extractHeadings(tableData)}
+          onClickHeading={sortByColumn}
+        />
+        <TableBody rows={tableData} />
+      </table>
+    </div>
   )
 }
 

--- a/packages/docs-site/src/components/presenters/post-article/post-article.scss
+++ b/packages/docs-site/src/components/presenters/post-article/post-article.scss
@@ -17,6 +17,14 @@ $text-color: #748999;
     margin-bottom: 0;
   }
 
+  width: 100%;
+
+  @include breakpoint("s") {
+    // Temporary hack to ensure content doesn't
+    // stretch outside the container
+    width: 100px;
+  }
+
   &__header {
     border-bottom: 1px solid color(neutral, 100);
     padding-top: spacing(6);


### PR DESCRIPTION
## Related issue

#255 

## Overview

Adds horizontal scrolling to the tables on the Develop tab of the component pages to prevent the layout from breaking.

## Work carried out

- [x] Added horizontal scrolling to the tables

## Screenshot

<img width="868" alt="Screenshot 2019-12-04 at 13 18 40" src="https://user-images.githubusercontent.com/48090803/70146037-49ab6c80-1699-11ea-84fd-0d9afba6286a.png">

## Developer Notes
The solution isn't the cleanest as it requires a hack on flexbox to prevent the table from extending outside its parent.
