### PR TITLE
Add DatePicker Range Selection

### DIFF
--- a/packages/css-framework/src/components/_date-picker.scss
+++ b/packages/css-framework/src/components/_date-picker.scss
@@ -9,6 +9,7 @@
   border: 0;
   vertical-align: top;
   width: 100%;
+  max-width: 20rem;
 }
 
 .rn-date-picker__outer-wrapper {
@@ -134,10 +135,24 @@
 
 .rn-date-picker__grid {
   display: grid;
-  grid-template-columns: repeat(attr(data-active-month-count), 300px);
-  grid-gap: 0 64px;
-  width: 246px;
+  grid-template-columns: repeat(1, 300px);
+  grid-gap: 0 f.spacing("4");
+  width: auto;
   margin: 1rem;
+}
+
+.rn-date-picker__grid--range {
+  grid-template-columns: repeat(2, 300px);
+}
+
+.rn-date-picker__range-seperator {
+  position: absolute;
+  top: f.spacing("4");
+  left: 50%;
+  transform: translateX(-50%);
+  color: f.color("neutral", "300");
+  width: 1rem;
+  height: 1rem;
 }
 
 .rn-date-picker__header {
@@ -148,6 +163,8 @@
 }
 
 .rn-date-picker__btn-nav {
+  position: absolute;
+  top: f.spacing("3");
   display: inline-flex;
   justify-content: center;
   width: 1.5rem;
@@ -157,6 +174,14 @@
   border-radius: 2px;
   color: f.color("neutral", "300");
   box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.07);
+
+  &:first-of-type {
+    left: f.spacing("4");
+  }
+
+  &:last-of-type {
+    right: f.spacing("4");
+  }
 }
 
 .rn-date-picker__month-label {
@@ -165,7 +190,7 @@
   text-align: center;
   font-size: f.font-size("s");
   color: f.color("neutral", "400");
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .rn-date-picker__day-label-grid {
@@ -212,8 +237,8 @@
   }
 
   &.is-selected {
-    color: f.color("neutral", "white");
-    background-color: f.color("action", "600");
+    color: f.color("neutral", "400");
+    background-color: f.color("action", "100");
   }
 
   &.is-within-range {

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -16,3 +16,13 @@ stories.add('Default', () => {
     />
   )
 })
+
+stories.add('Range', () => {
+  return (
+    <DatePicker
+      onChange={action('onChange')}
+      placement={DATEPICKER_PLACEMENT.BELOW}
+      isRange
+    />
+  )
+})

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -59,6 +59,12 @@ describe('DatePicker', () => {
         wrapper.getByTestId('datepicker-input').focus()
       })
 
+      it('shows the month', () => {
+        expect(wrapper.getByTestId('datepicker-month-label').innerHTML).toBe(
+          'December 2019'
+        )
+      })
+
       it('displays the container', () => {
         expect(
           wrapper.getByTestId('datepicker-input-wrapper').classList
@@ -131,6 +137,11 @@ describe('DatePicker', () => {
 
           it('invokes the onChange callback', () => {
             expect(onChange).toHaveBeenCalledTimes(1)
+            expect(onChange).toHaveBeenCalledWith({
+              endDate: new Date('2019-12-01T00:00:00.000Z'),
+              focusedInput: null,
+              startDate: new Date('2019-12-01T00:00:00.000Z'),
+            })
           })
 
           it('does not hide the container', () => {

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -65,6 +65,12 @@ describe('DatePicker', () => {
         )
       })
 
+      it('does not render a range separator', () => {
+        expect(
+          wrapper.queryAllByTestId('datepicker-range-separator')
+        ).toHaveLength(0)
+      })
+
       it('displays the container', () => {
         expect(
           wrapper.getByTestId('datepicker-input-wrapper').classList
@@ -185,6 +191,119 @@ describe('DatePicker', () => {
 
     it('renders that label accordingly', () => {
       expect(wrapper.getByTestId('datepicker-label').innerHTML).toBe(label)
+    })
+  })
+
+  describe('when selecting a date range', () => {
+    beforeEach(() => {
+      onChange = jest.fn()
+
+      wrapper = render(
+        <DatePicker
+          placement={DATEPICKER_PLACEMENT.BELOW}
+          onChange={onChange}
+          isRange
+        />
+      )
+    })
+
+    describe('when the end user focuses on the Input', () => {
+      beforeEach(() => {
+        wrapper.getByTestId('datepicker-input').focus()
+      })
+
+      it('shows a set of months', () => {
+        const monthLabels = wrapper.getAllByTestId('datepicker-month-label')
+
+        expect(monthLabels[0].innerHTML).toBe('December 2019')
+        expect(monthLabels[1].innerHTML).toBe('January 2020')
+      })
+
+      it('renders a range separator', () => {
+        expect(
+          wrapper.getByTestId('datepicker-range-separator')
+        ).toBeInTheDocument()
+      })
+
+      describe('and the end user clicks on the navigate month buttons', () => {
+        describe('and clicks next', () => {
+          beforeEach(() => {
+            wrapper.getByTestId('datepicker-input').focus()
+
+            click(wrapper.getAllByTestId('datepicker-nav-button')[1])
+          })
+
+          it('changes to the next set of months', () => {
+            const monthLabels = wrapper.getAllByTestId('datepicker-month-label')
+
+            expect(monthLabels[0].innerHTML).toBe('February 2020')
+            expect(monthLabels[1].innerHTML).toBe('March 2020')
+          })
+        })
+
+        describe('and clicks previous', () => {
+          beforeEach(() => {
+            wrapper.getByTestId('datepicker-input').focus()
+
+            click(wrapper.getAllByTestId('datepicker-nav-button')[0])
+          })
+
+          it('changes to the previous set of months', () => {
+            const monthLabels = wrapper.getAllByTestId('datepicker-month-label')
+
+            expect(monthLabels[0].innerHTML).toBe('October 2019')
+            expect(monthLabels[1].innerHTML).toBe('November 2019')
+          })
+        })
+
+        describe('and clicks on a day in the first month', () => {
+          beforeEach(() => {
+            click(wrapper.getAllByTestId('datepicker-day-01')[0])
+          })
+
+          it('set the value of the component to this date', () => {
+            expect(
+              wrapper.getByTestId('datepicker-input').getAttribute('value')
+            ).toBe('12/1/2019')
+          })
+
+          it('invokes the onChange callback', () => {
+            expect(onChange).toHaveBeenCalledTimes(1)
+            expect(onChange).toHaveBeenCalledWith({
+              endDate: undefined,
+              focusedInput: 'endDate',
+              startDate: new Date('2019-12-01T00:00:00.000Z'),
+            })
+          })
+        })
+
+        describe('and clicks on days in both months', () => {
+          beforeEach(() => {
+            click(wrapper.getAllByTestId('datepicker-day-01')[0])
+            click(wrapper.getAllByTestId('datepicker-day-20')[1])
+          })
+
+          it('set the value of the component to this date', () => {
+            expect(
+              wrapper.getByTestId('datepicker-input').getAttribute('value')
+            ).toBe('12/1/2019 - 1/20/2020')
+          })
+
+          it('invokes the onChange callback', () => {
+            expect(onChange).toHaveBeenCalledTimes(2)
+            expect(onChange).toHaveBeenCalledWith({
+              endDate: undefined,
+              focusedInput: 'endDate',
+              startDate: new Date('2019-12-01T00:00:00.000Z'),
+            })
+            expect(onChange).toHaveBeenCalledWith({
+              endDate: new Date('2020-01-20T00:00:00.000Z'),
+              focusedInput: null,
+              startDate: new Date('2019-12-01T00:00:00.000Z'),
+            })
+          })
+        })
+      })
     })
   })
 })

--- a/packages/react-component-library/src/components/DatePicker/Month.tsx
+++ b/packages/react-component-library/src/components/DatePicker/Month.tsx
@@ -1,15 +1,11 @@
 import React from 'react'
 import { useMonth, FirstDayOfWeek } from '@datepicker-react/hooks'
-import { IconChevronLeft, IconChevronRight } from '@royalnavy/icon-library'
 import { Day } from './Day'
-import { NavButton } from './NavButton'
 
 export interface MonthProps extends ComponentWithClass {
   year: number
   month: number
   firstDayOfWeek: FirstDayOfWeek
-  goToPreviousMonths: () => void
-  goToNextMonths: () => void
 }
 
 const dayFormat = {
@@ -34,8 +30,6 @@ export const Month: React.FC<MonthProps> = ({
   year,
   month,
   firstDayOfWeek,
-  goToPreviousMonths,
-  goToNextMonths,
 }) => {
   const { days, weekdayLabels, monthLabel } = useMonth({
     year,
@@ -46,20 +40,12 @@ export const Month: React.FC<MonthProps> = ({
   return (
     <div>
       <div className="rn-date-picker__header">
-        <NavButton onClick={goToPreviousMonths}>
-          <IconChevronLeft />
-        </NavButton>
-
         <div
           className="rn-date-picker__month-label"
           data-testid="datepicker-month-label"
         >
           {monthLabel}
         </div>
-
-        <NavButton onClick={goToNextMonths}>
-          <IconChevronRight />
-        </NavButton>
       </div>
       <div className="rn-date-picker__day-label-grid">
         {weekdayLabels.map(dayLabel => (


### PR DESCRIPTION
## Related issue

https://github.com/Royal-Navy/standards-toolkit/issues/225

## Overview

Add ability to select a range of dates with the DatePicker component by specifying the `range` prop.

## Work carried out

- [x] Implement range functionality
- [ ] Add automated tests

## Screenshot

<img width="853" alt="Screenshot 2019-12-05 at 14 26 01" src="https://user-images.githubusercontent.com/48086589/70243786-2ea92d00-176b-11ea-91fc-a7ff960602fc.png">
