### PR TITLE
Add variant prop to avatar

### DIFF
--- a/packages/docs-site/src/library/pages/components/avatar.md
+++ b/packages/docs-site/src/library/pages/components/avatar.md
@@ -5,7 +5,7 @@ header: true
 draft: false
 ---
 
-import { Avatar, Tab, TabSet } from '@royalnavy/react-component-library'
+import { Avatar, AVATAR_VARIANT, Tab, TabSet } from '@royalnavy/react-component-library'
 import DataTable from '../../../components/presenters/data-table'
 import CodeHighlighter from '../../../components/presenters/code-highlighter'
 import SketchWidget from '../../../components/presenters/sketch-widget'
@@ -51,12 +51,11 @@ The Avatar component is a simple component that displays the users initials with
 
 ### Basic Usage
 
-<CodeHighlighter source={`
-<Avatar light initials="RT"/>
-<Avatar dark initials="ST"/>
+<CodeHighlighter source={`<Avatar initials="RT" variant={AVATAR_VARIANT.DARK} />
+<Avatar initials="ST" variant={AVATAR_VARIANT.LIGHT} />
 `} language="javascript">
   <div style={{ background: '#A0A0A0', padding: 20 }}>
-    <p><Avatar light initials="RT"/>&nbsp;<Avatar dark initials="ST"/></p>
+    <p><Avatar initials="RT" variant={AVATAR_VARIANT.DARK} />&nbsp;<Avatar initials="ST" variant={AVATAR_VARIANT.LIGHT}/></p>
   </div>
 </CodeHighlighter>
 
@@ -71,13 +70,6 @@ The Avatar component is a simple component that displays the users initials with
     Description: 'Custom css class to add to the Avatar element',
   },
   {
-    Name: 'dark',
-    Type: 'boolean',
-    Required: 'False',
-    Default: '',
-    Description: 'Use the dark style of avatar',
-  },
-  {
     Name: 'initials',
     Type: 'string',
     Required: 'True',
@@ -85,11 +77,11 @@ The Avatar component is a simple component that displays the users initials with
     Description: 'The users initials, a maximum of 2 letters',
   },
   {
-    Name: 'light',
-    Type: 'boolean',
+    Name: 'variant',
+    Type: 'string',
     Required: 'False',
     Default: '',
-    Description: 'Use the light style of avatar',
+    Description: 'Variant of the avatar, can be `dark` or `light`.',
   },
 ]} />
 </Tab>

--- a/packages/react-component-library/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react-component-library/src/components/Avatar/Avatar.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Avatar } from './index'
+import { Avatar, AVATAR_VARIANT } from '.'
 
 const stories = storiesOf('Avatar', module)
 
@@ -12,11 +12,11 @@ stories.add('Default', () => (
 ))
 stories.add('Light', () => (
   <div style={{ background: '#A0A0A0', padding: 20 }}>
-    <Avatar light initials="AT" />
+    <Avatar initials="AT" variant={AVATAR_VARIANT.LIGHT} />
   </div>
 ))
 stories.add('Dark', () => (
   <div style={{ background: '#A0A0A0', padding: 20 }}>
-    <Avatar dark initials="AT" />
+    <Avatar initials="AT" variant={AVATAR_VARIANT.DARK} />
   </div>
 ))

--- a/packages/react-component-library/src/components/Avatar/Avatar.tsx
+++ b/packages/react-component-library/src/components/Avatar/Avatar.tsx
@@ -1,0 +1,22 @@
+import classNames from 'classnames'
+import React from 'react'
+
+import { AVATAR_VARIANT } from '.'
+
+export interface AvatarProps {
+  className?: string
+  initials: string
+  variant?: AVATAR_VARIANT.DARK | AVATAR_VARIANT.LIGHT
+}
+
+export const Avatar: React.FC<AvatarProps> = ({
+  className,
+  initials,
+  variant,
+}) => {
+  const classes = classNames('rn-avatar', className, `rn-avatar--${variant}`)
+
+  return <span className={classes}>{initials}</span>
+}
+
+Avatar.displayName = 'Avatar'

--- a/packages/react-component-library/src/components/Avatar/constants.ts
+++ b/packages/react-component-library/src/components/Avatar/constants.ts
@@ -1,0 +1,6 @@
+enum AVATAR_VARIANT {
+  DARK = 'dark',
+  LIGHT = 'light',
+}
+
+export { AVATAR_VARIANT }

--- a/packages/react-component-library/src/components/Avatar/index.tsx
+++ b/packages/react-component-library/src/components/Avatar/index.tsx
@@ -1,25 +1,2 @@
-import classNames from 'classnames'
-import React from 'react'
-
-export interface AvatarProps {
-  className?: string
-  dark?: boolean
-  initials: string
-  light?: boolean
-}
-
-export const Avatar: React.FC<AvatarProps> = ({
-  className,
-  dark,
-  initials,
-  light,
-}) => {
-  const classes = classNames('rn-avatar', className, {
-    'rn-avatar--dark': dark,
-    'rn-avatar--light': light,
-  })
-
-  return <span className={classes}>{initials}</span>
-}
-
-Avatar.displayName = 'Avatar'
+export * from './Avatar'
+export * from './constants'

--- a/packages/react-component-library/src/components/index.ts
+++ b/packages/react-component-library/src/components/index.ts
@@ -1,5 +1,5 @@
 import { Alert, ALERT_VARIANT } from './Alert'
-import { Avatar } from './Avatar'
+import { Avatar, AVATAR_VARIANT } from './Avatar'
 import Badge from './Badge'
 import Breadcrumbs from './Breadcrumbs'
 import { Button } from './Button'
@@ -33,6 +33,7 @@ export {
   Alert,
   ALERT_VARIANT,
   Avatar,
+  AVATAR_VARIANT,
   Badge,
   Breadcrumbs,
   Button,

--- a/packages/react-component-library/src/fragments/Masthead/UserLink.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/UserLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Avatar, Link } from '../../components'
+import { Avatar, AVATAR_VARIANT, Link } from '../../components'
 
 interface UserLinkProps {
   className?: string
@@ -14,7 +14,7 @@ export const UserLink: React.FC<UserLinkProps> = ({
   user: { initials, ...rest },
 }) => (
   <LinkComponent className={className} {...rest} data-testid="userlink">
-    <Avatar initials={initials} dark />
+    <Avatar initials={initials} variant={AVATAR_VARIANT.DARK} />
   </LinkComponent>
 )
 

--- a/packages/react-component-library/src/fragments/NotificationPanel/Notification.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/Notification.tsx
@@ -3,7 +3,7 @@ import differenceInMinutes from 'date-fns/differenceInMinutes'
 import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 import format from 'date-fns/format'
 
-import { Avatar } from '../../components/Avatar'
+import { Avatar, AVATAR_VARIANT } from '../../components/Avatar'
 
 export interface NotificationProps {
   href: string
@@ -52,7 +52,7 @@ export const Notification: React.FC<NotificationProps> = ({
         <a href={href}>
           <div className="rn-notifications-item">
             <div className="rn-notifications-item__avatar">
-              <Avatar initials={getInitials(name)} dark />
+              <Avatar initials={getInitials(name)} variant={AVATAR_VARIANT.DARK} />
               {!read && (
                 <span
                   className="rn-notification-panel__not-read rn-notification-panel__not-read--notification-item"

--- a/packages/react-component-library/src/index.ts
+++ b/packages/react-component-library/src/index.ts
@@ -1,6 +1,6 @@
 // Components
 import { Alert, ALERT_VARIANT } from './components/Alert'
-import { Avatar } from './components/Avatar'
+import { Avatar, AVATAR_VARIANT } from './components/Avatar'
 import Badge from './components/Badge'
 import Breadcrumbs from './components/Breadcrumbs'
 import { Button } from './components/Button'
@@ -42,6 +42,7 @@ export {
   Alert,
   ALERT_VARIANT,
   Avatar,
+  AVATAR_VARIANT,
   Badge,
   Breadcrumbs,
   Button,


### PR DESCRIPTION
## Related issue
#467 

## Overview
Introduces a `variant` prop to replace both `dark` and `light` `boolean` props.

## Reason
This is consistent with other components and it seems strange to have two props that alter the same class.

## Work carried out
- [x] Introduce `variant` prop

## Screenshot
No visual change.