### PR TITLE
Tidy up component interfaces (quick wins)

### DIFF
--- a/packages/docs-site/src/library/pages/components/modal.md
+++ b/packages/docs-site/src/library/pages/components/modal.md
@@ -96,11 +96,25 @@ Modal is a child window that overlays the main parent window.
     Description: 'Custom CSS class to add to the component',
   },
   {
-    Name: 'title',
-    Type: 'string',
+    Name: 'children',
+    Type: 'React.ReactNode',
     Required: 'False',
     Default: '',
-    Description: 'The title to display at the top of the modal',
+    Description: 'Content of the modal',
+  },
+  {
+    Name: 'isOpen',
+    Type: 'boolean',
+    Required: 'False',
+    Default: '',
+    Description: 'An attribute denoting the open / close state of the modal',
+  },
+  {
+    Name: 'onClose',
+    Type: 'Function<any>',
+    Required: 'False',
+    Default: '',
+    Description: 'A callback function invoked when the modal is closed',
   },
   {
     Name: 'primaryButton',
@@ -124,18 +138,11 @@ Modal is a child window that overlays the main parent window.
     Description: 'A collection of props specifying the look and behaviour of the tertiary button',
   },
   {
-    Name: 'onClose',
-    Type: 'Function<any>',
+    Name: 'title',
+    Type: 'string',
     Required: 'False',
     Default: '',
-    Description: 'A callback function invoked when the modal is closed',
-  },
-  {
-    Name: 'isOpen',
-    Type: 'boolean',
-    Required: 'False',
-    Default: '',
-    Description: 'An attribute denoting the open / close state of the modal',
+    Description: 'The title to display at the top of the modal',
   },
 ]} />
 

--- a/packages/docs-site/src/library/pages/components/table.md
+++ b/packages/docs-site/src/library/pages/components/table.md
@@ -113,11 +113,25 @@ Whilst there is no restriction on the number of Table instances that can be used
 ### Column Properties
 <DataTable data={[
   {
+    Name: 'children',
+    Type: 'string',
+    Required: 'True',
+    Default: '',
+    Description: 'Text to be presented in the column header cell.',
+  },
+  {
     Name: 'field',
     Type: 'string',
     Required: 'True',
     Default: '',
     Description: 'Name of the field to be presented in the cell.',
+  },
+  {
+    Name: 'onSortClick',
+    Type: '(field: string) => void',
+    Required: 'False',
+    Default: '',
+    Description: 'Called when the column sort is clicked.',
   },
   {
     Name: 'sortable',
@@ -127,11 +141,11 @@ Whilst there is no restriction on the number of Table instances that can be used
     Description: 'If specified then the column will be sortable.',
   },
   {
-    Name: 'children',
+    Name: 'sortOrder',
     Type: 'string',
-    Required: 'True',
+    Required: 'False',
     Default: '',
-    Description: 'Text to be presented in the column header cell.',
+    Description: 'Order the column will be sorted in `asc` or `desc`',
   },
 ]} />
 

--- a/packages/react-component-library/src/components/Dropdown/DropdownLabel.test.tsx
+++ b/packages/react-component-library/src/components/Dropdown/DropdownLabel.test.tsx
@@ -173,7 +173,7 @@ describe('Dropdown Label', () => {
   describe('and the option indicates there is right aligned content', () => {
     beforeEach(() => {
       props.label = 'test'
-      props.rightContent = () => <p>right content</p>
+      props.rightContent = <p>right content</p>
       wrapper = render(<DropdownLabel {...props} />)
     })
 

--- a/packages/react-component-library/src/components/Dropdown/DropdownLabel.tsx
+++ b/packages/react-component-library/src/components/Dropdown/DropdownLabel.tsx
@@ -6,19 +6,19 @@ import { DropdownOption } from './DropdownOption'
 export const DropdownLabel: React.FC<DropdownOption> = ({
   isDisabled = false,
   hidden = false,
-  icon: Icon,
+  icon,
   label,
-  rightContent: RightContent,
+  rightContent,
   visible = false,
 }) => {
   return (
     <div className={`rn-dropdownlabel ${isDisabled ? 'is-disabled' : ''}`}>
-      {Icon && (
+      {icon && (
         <span
           className="rn-dropdownlabel__start-adornment"
           data-testid="rn-dropdownlabel__start-adornment"
         >
-          <Icon />
+          {icon}
         </span>
       )}
       <span
@@ -37,12 +37,12 @@ export const DropdownLabel: React.FC<DropdownOption> = ({
           <Visibility className="is-active rn-dropdownlabel__end-adornment" />
         </span>
       )}
-      {RightContent && (
+      {rightContent && (
         <span
           className="rn-dropdownlabel__end-adornment"
           data-testid="rn-dropdownlabel__rightcontent"
         >
-          <RightContent />
+          {rightContent}
         </span>
       )}
     </div>

--- a/packages/react-component-library/src/components/Dropdown/DropdownOption.ts
+++ b/packages/react-component-library/src/components/Dropdown/DropdownOption.ts
@@ -1,9 +1,11 @@
+import React from 'react'
+
 export interface DropdownOption {
   isDisabled?: boolean
   hidden?: boolean
-  icon?: any
+  icon?: React.ReactNode
   label: string
-  rightContent?: any
+  rightContent?: React.ReactNode
   value: string
   visible?: boolean
 }

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -8,24 +8,24 @@ import { Header } from './Header'
 import { Footer } from './Footer'
 
 export interface ModalProps extends ComponentWithClass {
-  children?: any
+  children?: React.ReactNode
+  isOpen?: boolean
   onClose?: (event: React.FormEvent<HTMLButtonElement>) => void
   primaryButton?: ButtonProps
   secondaryButton?: ButtonProps
   tertiaryButton?: ButtonProps
   title?: string
-  isOpen?: boolean
 }
 
 export const Modal: React.FC<ModalProps> = ({
   className = '',
   children,
+  isOpen = false,
   onClose,
   primaryButton,
   secondaryButton,
   tertiaryButton,
   title,
-  isOpen = false,
 }) => {
   const [open, setOpen] = useState(isOpen)
   const mutatedPrimaryButton = primaryButton

--- a/packages/react-component-library/src/components/Select/Option.tsx
+++ b/packages/react-component-library/src/components/Select/Option.tsx
@@ -5,7 +5,7 @@ import { OptionProps } from 'react-select/src/components/Option'
 import Badge from '../Badge'
 
 export interface SelectOptionWithBadgeType {
-  badge?: string | number | undefined
+  badge?: string | number
   label: string
   value: string
 }

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -7,7 +7,7 @@ import { Tab, TabSet } from '.'
 const stories = storiesOf('TabSet', module)
 
 stories.add('Default', () => (
-  <TabSet onChangeCallback={action('onChangeCallback')}>
+  <TabSet onChange={action('onChange')}>
     <Tab title="Example Tab 1">
       <p>This is some example tab 1 content</p>
     </Tab>

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -18,12 +18,12 @@ describe('TabSet', () => {
       beforeEach(() => {
         const props = {
           className: 'rn-tab-set--modifier',
-          onChangeCallback: () => {
+          onChange: () => {
             return true
           },
         }
 
-        onChangeSpy = jest.spyOn(props, 'onChangeCallback')
+        onChangeSpy = jest.spyOn(props, 'onChange')
 
         wrapper = render(
           <TabSet {...props}>
@@ -58,7 +58,7 @@ describe('TabSet', () => {
           ).toContain('is-active')
         })
 
-        it('should invoke the onChangeCallback function', () => {
+        it('should invoke the onChange function', () => {
           expect(onChangeSpy).toHaveBeenCalledTimes(1)
           expect(onChangeSpy).toHaveBeenCalledWith(1)
         })

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -9,14 +9,14 @@ import { SCROLL_DIRECTION } from './constants'
 interface TabSetProps {
   className?: string
   children: React.ReactElement<TabProps>[]
-  onChangeCallback?: (id: number) => void
+  onChange?: (id: number) => void
   scrollable?: boolean
 }
 
 export const TabSet: React.FC<TabSetProps> = ({
   className = '',
   children,
-  onChangeCallback,
+  onChange,
   scrollable,
 }) => {
   const [activeTab, setActiveTab] = useState(0)
@@ -25,8 +25,8 @@ export const TabSet: React.FC<TabSetProps> = ({
   function handleClick(index: number) {
     setActiveTab(index)
 
-    if (onChangeCallback) {
-      onChangeCallback(index)
+    if (onChange) {
+      onChange(index)
     }
   }
 

--- a/packages/react-component-library/src/components/Table/Column.tsx
+++ b/packages/react-component-library/src/components/Table/Column.tsx
@@ -10,11 +10,11 @@ import {
 import { SORT_ORDER } from './constants'
 
 export interface ColumnProps {
-  field: string
-  sortable?: boolean
-  onSortClick?: (field: string) => void
-  sortOrder?: string
   children: string
+  field: string
+  onSortClick?: (field: string) => void
+  sortable?: boolean
+  sortOrder?: SORT_ORDER.ASCENDING | SORT_ORDER.DESCENDING
 }
 
 const SORT_ORDER_ICONS_MAP = {

--- a/packages/react-component-library/src/components/Table/Table.stories.tsx
+++ b/packages/react-component-library/src/components/Table/Table.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 
 import Badge from '../Badge'
-import { Table, Column } from '.'
+import { Table, TableColumn } from '.'
 
 const stories = storiesOf('Table', module)
 
@@ -38,16 +38,16 @@ stories.add('Default', () => {
 
   return (
     <Table data={tableDataMock}>
-      <Column field="first">First column</Column>
-      <Column field="second">Second column</Column>
-      <Column field="third">Third column</Column>
-      <Column field="fourth">Fourth column</Column>
-      <Column field="fifth">Fifth column</Column>
-      <Column field="sixth">Sixth column</Column>
-      <Column field="seventh">Seventh column</Column>
-      <Column field="eighth">Eighth column</Column>
-      <Column field="ninth">Ninth column</Column>
-      <Column field="tenth">Tenth column</Column>
+      <TableColumn field="first">First column</TableColumn>
+      <TableColumn field="second">Second column</TableColumn>
+      <TableColumn field="third">Third column</TableColumn>
+      <TableColumn field="fourth">Fourth column</TableColumn>
+      <TableColumn field="fifth">Fifth column</TableColumn>
+      <TableColumn field="sixth">Sixth column</TableColumn>
+      <TableColumn field="seventh">Seventh column</TableColumn>
+      <TableColumn field="eighth">Eighth column</TableColumn>
+      <TableColumn field="ninth">Ninth column</TableColumn>
+      <TableColumn field="tenth">Tenth column</TableColumn>
     </Table>
   )
 })
@@ -68,8 +68,8 @@ stories.add('Arbitrary cell content', () => {
 
   return (
     <Table data={tableDataMock}>
-      <Column field="first">First column</Column>
-      <Column field="second">Status</Column>
+      <TableColumn field="first">First column</TableColumn>
+      <TableColumn field="second">Status</TableColumn>
     </Table>
   )
 })
@@ -98,15 +98,15 @@ stories.add('Sortable', () => {
 
   return (
     <Table data={tableDataMock}>
-      <Column field="first" sortable>
+      <TableColumn field="first" sortable>
         First column
-      </Column>
-      <Column field="second" sortable>
+      </TableColumn>
+      <TableColumn field="second" sortable>
         Second column
-      </Column>
-      <Column field="third" sortable>
+      </TableColumn>
+      <TableColumn field="third" sortable>
         Third column
-      </Column>
+      </TableColumn>
     </Table>
   )
 })

--- a/packages/react-component-library/src/components/Table/Table.stories.tsx
+++ b/packages/react-component-library/src/components/Table/Table.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 
 import Badge from '../Badge'
-import { Table, Column } from './index'
+import { Table, Column } from '.'
 
 const stories = storiesOf('Table', module)
 

--- a/packages/react-component-library/src/components/Table/Table.test.tsx
+++ b/packages/react-component-library/src/components/Table/Table.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { render, RenderResult } from '@testing-library/react'
 
 import Badge from '../Badge'
-import { Column, Table } from '.'
+import { TableColumn, Table } from '.'
 
 describe('Table', () => {
   let wrapper: RenderResult
@@ -33,9 +33,9 @@ describe('Table', () => {
 
       wrapper = render(
         <Table data={tableDataMock}>
-          <Column field="first">First</Column>
-          <Column field="second">Second</Column>
-          <Column field="third">Third</Column>
+          <TableColumn field="first">First</TableColumn>
+          <TableColumn field="second">Second</TableColumn>
+          <TableColumn field="third">Third</TableColumn>
         </Table>
       )
     })
@@ -88,8 +88,8 @@ describe('Table', () => {
 
       wrapper = render(
         <Table data={tableDataMock}>
-          <Column field="first">First</Column>
-          <Column field="second">Second</Column>
+          <TableColumn field="first">First</TableColumn>
+          <TableColumn field="second">Second</TableColumn>
         </Table>
       )
     })
@@ -125,11 +125,11 @@ describe('Table', () => {
 
       wrapper = render(
         <Table data={tableDataMock}>
-          <Column field="first" sortable>
+          <TableColumn field="first" sortable>
             First
-          </Column>
-          <Column field="second">Second</Column>
-          <Column field="third" sortable>Third</Column>
+          </TableColumn>
+          <TableColumn field="second">Second</TableColumn>
+          <TableColumn field="third" sortable>Third</TableColumn>
         </Table>
       )
     })

--- a/packages/react-component-library/src/components/Table/Table.test.tsx
+++ b/packages/react-component-library/src/components/Table/Table.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { render, RenderResult } from '@testing-library/react'
 
 import Badge from '../Badge'
-import { Column, Table } from './index'
+import { Column, Table } from '.'
 
 describe('Table', () => {
   let wrapper: RenderResult

--- a/packages/react-component-library/src/components/Table/Table.tsx
+++ b/packages/react-component-library/src/components/Table/Table.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { ColumnProps } from '.'
+import { TableColumnProps } from '.'
 import { useTableData } from './useTableData'
 
 export interface RowProps {
@@ -9,7 +9,7 @@ export interface RowProps {
 
 interface TableProps {
   data: RowProps[]
-  children: React.ReactElement<ColumnProps>[]
+  children: React.ReactElement<TableColumnProps>[]
 }
 
 function getKey(prefix: string, id: string) {
@@ -21,7 +21,7 @@ export const Table: React.FC<TableProps> = ({ data, children }) => {
 
   const childrenWithSort = React.Children.map(
     children,
-    (child: React.ReactElement<ColumnProps>) =>
+    (child: React.ReactElement<TableColumnProps>) =>
       React.cloneElement(child, {
         ...child.props,
         sortOrder: sortField === child.props.field ? sortOrder : null,

--- a/packages/react-component-library/src/components/Table/Table.tsx
+++ b/packages/react-component-library/src/components/Table/Table.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { ColumnProps } from './Column'
+import { ColumnProps } from '.'
 import { useTableData } from './useTableData'
 
 export interface RowProps {

--- a/packages/react-component-library/src/components/Table/TableColumn.tsx
+++ b/packages/react-component-library/src/components/Table/TableColumn.tsx
@@ -7,19 +7,19 @@ import {
   IconSortUnsorted,
 } from '@royalnavy/icon-library'
 
-import { SORT_ORDER } from './constants'
+import { TABLE_SORT_ORDER } from './constants'
 
-export interface ColumnProps {
+export interface TableColumnProps {
   children: string
   field: string
   onSortClick?: (field: string) => void
   sortable?: boolean
-  sortOrder?: SORT_ORDER.ASCENDING | SORT_ORDER.DESCENDING
+  sortOrder?: TABLE_SORT_ORDER.ASCENDING | TABLE_SORT_ORDER.DESCENDING
 }
 
 const SORT_ORDER_ICONS_MAP = {
-  [SORT_ORDER.ASCENDING]: <IconSortAscending data-testid="ascending" />,
-  [SORT_ORDER.DESCENDING]: <IconSortDescending data-testid="descending" />,
+  [TABLE_SORT_ORDER.ASCENDING]: <IconSortAscending data-testid="ascending" />,
+  [TABLE_SORT_ORDER.DESCENDING]: <IconSortDescending data-testid="descending" />,
 }
 
 function getIcon(sortable: boolean, sortOrder: string) {
@@ -34,7 +34,7 @@ function getIcon(sortable: boolean, sortOrder: string) {
   )
 }
 
-export const Column: React.FC<ColumnProps> = ({
+export const TableColumn: React.FC<TableColumnProps> = ({
   field,
   sortable,
   onSortClick,

--- a/packages/react-component-library/src/components/Table/constants.ts
+++ b/packages/react-component-library/src/components/Table/constants.ts
@@ -1,6 +1,6 @@
-enum SORT_ORDER {
+enum TABLE_SORT_ORDER {
   ASCENDING = 'asc',
   DESCENDING = 'desc',
 }
 
-export { SORT_ORDER }
+export { TABLE_SORT_ORDER }

--- a/packages/react-component-library/src/components/Table/index.tsx
+++ b/packages/react-component-library/src/components/Table/index.tsx
@@ -1,3 +1,3 @@
-export * from './Column'
+export * from './TableColumn'
 export * from './constants'
 export * from './Table'

--- a/packages/react-component-library/src/components/Table/index.tsx
+++ b/packages/react-component-library/src/components/Table/index.tsx
@@ -1,2 +1,3 @@
 export * from './Column'
+export * from './constants'
 export * from './Table'

--- a/packages/react-component-library/src/components/Table/useTableData.ts
+++ b/packages/react-component-library/src/components/Table/useTableData.ts
@@ -1,8 +1,7 @@
 import { useState } from 'react'
 import orderBy from 'lodash/orderBy'
 
-import { SORT_ORDER } from './constants'
-import { RowProps } from './Table'
+import { RowProps, SORT_ORDER } from '.'
 
 function getNextSortOrder(
   currentSortOrder: SORT_ORDER.ASCENDING | SORT_ORDER.DESCENDING,

--- a/packages/react-component-library/src/components/Table/useTableData.ts
+++ b/packages/react-component-library/src/components/Table/useTableData.ts
@@ -1,18 +1,18 @@
 import { useState } from 'react'
 import orderBy from 'lodash/orderBy'
 
-import { RowProps, SORT_ORDER } from '.'
+import { RowProps, TABLE_SORT_ORDER } from '.'
 
 function getNextSortOrder(
-  currentSortOrder: SORT_ORDER.ASCENDING | SORT_ORDER.DESCENDING,
+  currentSortOrder: TABLE_SORT_ORDER.ASCENDING | TABLE_SORT_ORDER.DESCENDING,
   hasSortFieldChanged: boolean
 ) {
   if (!currentSortOrder || hasSortFieldChanged) {
-    return SORT_ORDER.DESCENDING
+    return TABLE_SORT_ORDER.DESCENDING
   }
 
-  if (currentSortOrder === SORT_ORDER.DESCENDING) {
-    return SORT_ORDER.ASCENDING
+  if (currentSortOrder === TABLE_SORT_ORDER.DESCENDING) {
+    return TABLE_SORT_ORDER.ASCENDING
   }
 
   return null
@@ -21,15 +21,15 @@ function getNextSortOrder(
 export function useTableData(data: RowProps[]) {
   const [tableData, setTableData] = useState(data)
   const [sortOrder, setSortOrder] = useState<
-    SORT_ORDER.ASCENDING | SORT_ORDER.DESCENDING
+    TABLE_SORT_ORDER.ASCENDING | TABLE_SORT_ORDER.DESCENDING
   >()
   const [sortField, setSortField] = useState<string>()
 
   function sortTableData(field: string) {
     const hasSortFieldChanged = field !== sortField
     const order:
-      | SORT_ORDER.ASCENDING
-      | SORT_ORDER.DESCENDING = getNextSortOrder(sortOrder, hasSortFieldChanged)
+      | TABLE_SORT_ORDER.ASCENDING
+      | TABLE_SORT_ORDER.DESCENDING = getNextSortOrder(sortOrder, hasSortFieldChanged)
     const sorted = order ? orderBy(tableData, [field], [order]) : data
 
     setSortOrder(order)

--- a/packages/react-component-library/src/components/index.ts
+++ b/packages/react-component-library/src/components/index.ts
@@ -24,6 +24,7 @@ import Switch from './Switch/Switch'
 import { RangeSlider } from './RangeSlider'
 import ResponsiveSwitch from './Switch'
 import { Tab, TabSet } from './TabSet'
+import { Table, Column, SORT_ORDER } from './Table'
 import TabNav from './TabNav'
 import { TextArea } from './TextArea'
 import TextInput from './TextInput'
@@ -39,6 +40,7 @@ export {
   Button,
   ButtonGroup,
   Checkbox,
+  Column,
   Dialog,
   Drawer,
   Dropdown,
@@ -54,10 +56,12 @@ export {
   Searchbar,
   Select,
   Sidebar,
+  SORT_ORDER,
   Switch,
   RangeSlider,
   ResponsiveSwitch,
   Tab,
+  Table,
   TabSet,
   TabNav,
   TextArea,

--- a/packages/react-component-library/src/components/index.ts
+++ b/packages/react-component-library/src/components/index.ts
@@ -24,7 +24,7 @@ import Switch from './Switch/Switch'
 import { RangeSlider } from './RangeSlider'
 import ResponsiveSwitch from './Switch'
 import { Tab, TabSet } from './TabSet'
-import { Table, Column, SORT_ORDER } from './Table'
+import { Table, TableColumn, TABLE_SORT_ORDER } from './Table'
 import TabNav from './TabNav'
 import { TextArea } from './TextArea'
 import TextInput from './TextInput'
@@ -40,7 +40,6 @@ export {
   Button,
   ButtonGroup,
   Checkbox,
-  Column,
   Dialog,
   Drawer,
   Dropdown,
@@ -56,12 +55,13 @@ export {
   Searchbar,
   Select,
   Sidebar,
-  SORT_ORDER,
   Switch,
   RangeSlider,
   ResponsiveSwitch,
   Tab,
   Table,
+  TableColumn,
+  TABLE_SORT_ORDER,
   TabSet,
   TabNav,
   TextArea,

--- a/packages/react-component-library/src/index.ts
+++ b/packages/react-component-library/src/index.ts
@@ -23,7 +23,7 @@ import Switch from './components/Switch/Switch'
 import { RangeSlider } from './components/RangeSlider'
 import ResponsiveSwitch from './components/Switch'
 import Radio from './components/Radio'
-import { Table, Column } from './components/Table'
+import { Table, Column, SORT_ORDER } from './components/Table'
 import { Tab, TabSet } from './components/TabSet'
 import { TextArea } from './components/TextArea'
 import TextInput from './components/TextInput'
@@ -67,6 +67,7 @@ export {
   Radio,
   Select,
   Sidebar,
+  SORT_ORDER,
   Tab,
   Table,
   TabSet,

--- a/packages/react-component-library/src/index.ts
+++ b/packages/react-component-library/src/index.ts
@@ -23,7 +23,7 @@ import Switch from './components/Switch/Switch'
 import { RangeSlider } from './components/RangeSlider'
 import ResponsiveSwitch from './components/Switch'
 import Radio from './components/Radio'
-import { Table, Column, SORT_ORDER } from './components/Table'
+import { Table, TableColumn, TABLE_SORT_ORDER } from './components/Table'
 import { Tab, TabSet } from './components/TabSet'
 import { TextArea } from './components/TextArea'
 import TextInput from './components/TextInput'
@@ -48,7 +48,6 @@ export {
   Button,
   ButtonGroup,
   Checkbox,
-  Column,
   Dialog,
   Drawer,
   Dropdown,
@@ -67,9 +66,10 @@ export {
   Radio,
   Select,
   Sidebar,
-  SORT_ORDER,
   Tab,
   Table,
+  TableColumn,
+  TABLE_SORT_ORDER,
   TabSet,
   TextArea,
   TextInput,


### PR DESCRIPTION
## Related issue
#467 

## Overview
A series of changes to tidy up component interfaces.

## Reason
This is more consistent and will cause less confusion as a consumer of the library.

## Work carried out
- [x] Rename callback functions
- [x] Tighten props to use enum
- [x] Use ReactNode

## Screenshot
No visual change.