### PR TITLE
Add documentation for versions page

### DIFF
--- a/docs/deploy_documentation.md
+++ b/docs/deploy_documentation.md
@@ -1,0 +1,14 @@
+# Deploy documentation to Netlify
+Ensure you have the [Netlify CLI](https://cli.netlify.com) installed.
+
+1. `git checkout tags/{version_number}`
+2. `cd packages/docs-site`
+3. `yarn build`
+4. `netlify unlink`
+5. `netlify deploy`
+6. Select `Create & configure a new site` when prompted for "What would you like to do?"
+7. Select `standards's team` when prompted for "Team"
+8. Enter `{site_id}-standards` when prompted for "Site name (optional)". `site_id` is from updating the versions page
+8. Enter `public` when prompted for "Publish directory"
+9. `netlify deploy --prod`
+10. Enter `public` when prompted for "Publish directory"

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -4,9 +4,11 @@ NOTE: Fix problems by moving forward (roll a new release with a fix).
 
 - [ ] Check and update dependencies
 - [ ] Create and push new release branch from `develop`, using the convention `release/*.*.*` ([Semver](https://semver.org/))
+- [ ] Update [docs-site Versions page](update_versions_page.md)
 - [ ] Run `yarn lerna:version` (updates package version, linked dependency versions, tags and pushes to remote)
 - [ ] Add draft release notes to GitHub and link to tag
 - [ ] Merge release branch to `master` (Pull Request should include release notes) [2x peer approval]
+- [ ] [Deploy documentation at tag](deploy_documentation.md)
 - [ ] Merge `master` back into `develop`
 - [ ] Check published packages on the [NPM public registry](https://www.npmjs.com/search?q=royalnavy) and the `docs-site` [production deployment](https://docs.royalnavy.io)
 - [ ] Publish GitHub release

--- a/docs/update_versions_page.md
+++ b/docs/update_versions_page.md
@@ -1,0 +1,12 @@
+# Update versions page
+Consumers of older versions of the library may need to view previous versions of the documentation.
+
+1. Generate a new GUID to be used as `site_id` 
+2. Browse to the `versions.md` found in `~/packages/docs-site/src/library/pages`
+3. Add a new version to `versions.md` following the pattern:
+    ````
+    ## {version_number}
+    * [Release note](https://github.com/Royal-Navy/standards-toolkit/releases/tag/{version_number})
+    * [Documentation](https://{site_id}-standards.netlify.com)
+    ````
+4. Commit this change


### PR DESCRIPTION
## Related issue
#484 

## Overview
Adds documentation for adding a version to the versions page and then deploying to Netlify via CLI.

## Reason
This needs to be part of the release process.

## Work carried out
- [x] Add documentation

## Screenshot
No visual change.