### PR TITLE
Deprecate Nav component

### DIFF
--- a/packages/docs-site/src/library/pages/components/nav.md
+++ b/packages/docs-site/src/library/pages/components/nav.md
@@ -2,6 +2,7 @@
 title: Nav
 description: A horizontal or vertical navigation component that supports nesting
 header: true
+draft: true
 ---
 
 import { Nav, Tab, TabSet } from '@royalnavy/react-component-library'

--- a/packages/react-component-library/src/components/Nav/Nav.test.tsx
+++ b/packages/react-component-library/src/components/Nav/Nav.test.tsx
@@ -2,9 +2,11 @@ import React from 'react'
 import { render, RenderResult } from '@testing-library/react'
 
 import Nav from './index'
+import packageJson from '../../../package.json'
 
 describe('Nav', () => {
   let wrapper: RenderResult
+  let consoleWarnSpy: jest.SpyInstance
   const navItemsMock = [
     {
       href: 'http://test.com/1',
@@ -23,7 +25,15 @@ describe('Nav', () => {
 
   describe('when there is a flat collection of three items', () => {
     beforeEach(() => {
+      consoleWarnSpy = jest.spyOn(global.console, 'warn')
       wrapper = render(<Nav navItems={navItemsMock} />)
+    })
+
+    it('should warn the consumer that the component is deprecated', () => {
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        `Component \`Nav\` is deprecated in ${packageJson.name}`
+      )
     })
 
     it('should default the orientation to vertical', () => {

--- a/packages/react-component-library/src/components/Nav/index.tsx
+++ b/packages/react-component-library/src/components/Nav/index.tsx
@@ -3,6 +3,7 @@ import uuid from 'uuid'
 
 import Link from '../Link'
 import NavItem from './NavItem'
+import packageJson from '../../../package.json'
 
 interface NavProps {
   className?: string
@@ -47,14 +48,18 @@ const Nav: React.FC<NavProps> = ({
   navItems,
   orientation = 'vertical',
   size = 'regular',
-}) => (
-  <nav
-    className={`rn-nav rn-nav--${orientation} rn-nav--${size} ${className}`}
-    data-testid="nav"
-  >
-    {renderMenu(LinkComponent, navItems)}
-  </nav>
-)
+}) => {
+  console.warn(`Component \`Nav\` is deprecated in ${packageJson.name}`)
+
+  return (
+    <nav
+      className={`rn-nav rn-nav--${orientation} rn-nav--${size} ${className}`}
+      data-testid="nav"
+    >
+      {renderMenu(LinkComponent, navItems)}
+    </nav>
+  )
+}
 
 Nav.displayName = 'Nav'
 


### PR DESCRIPTION
## Related issue
#467 

## Overview
Deprecates `Nav` component as this should not be part of the library at this stage. If it's introduced then we need to rework the existing component.

## Reason
It's not supported.

## Work carried out
- [x] Warn consumer
- [x] Hide docs

## Screenshot
No visual change.