### PR TITLE
Add startAdornment to NumberInput

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.9.0",
+  "version": "1.10.0",
   "npmClient": "yarn"
 }

--- a/packages/css-framework/package.json
+++ b/packages/css-framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@royalnavy/css-framework",
   "description": "Foundational CSS Framework for Royal Navy components and applications.",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/css-framework/src/components/_numberinput.scss
+++ b/packages/css-framework/src/components/_numberinput.scss
@@ -144,3 +144,22 @@
   border-color: transparent;
 }
 
+.rn-numberinput__start-adornment {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  text-align: center;
+  padding: spacing(3);
+  order: 0;
+  background-color: color(neutral, 000);
+  border-right: 1px solid color(neutral, 200);
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+  color: color(neutral, 300);
+  font-weight: 600;
+  line-height: 1;
+
+  > svg {
+    color: color(neutral, 300);
+  }
+}

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -4,7 +4,7 @@
     "node": ">=10.13.0 <13"
   },
   "description": "The documentation site for royalnavy.io",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": "NELSON",
   "license": "Apache-2.0",
   "scripts": {
@@ -39,9 +39,9 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.5.1",
     "@mdx-js/react": "^1.5.1",
-    "@royalnavy/css-framework": "^1.9.0",
-    "@royalnavy/icon-library": "^1.9.0",
-    "@royalnavy/react-component-library": "^1.9.0",
+    "@royalnavy/css-framework": "^1.10.0",
+    "@royalnavy/icon-library": "^1.10.0",
+    "@royalnavy/react-component-library": "^1.10.0",
     "change-case": "^3.1.0",
     "eslint-plugin-import": "2.18.2",
     "formik": "^2.0.7",
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.5",
-    "@royalnavy/eslint-config-react": "^1.9.0",
+    "@royalnavy/eslint-config-react": "^1.10.0",
     "@svgr/cli": "^4.3.3",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",

--- a/packages/docs-site/src/library/pages/components/form/number-input.md
+++ b/packages/docs-site/src/library/pages/components/form/number-input.md
@@ -5,6 +5,7 @@ header: true
 ---
 import { Formik, Form, Field } from 'formik'
 import { Icons, Tab, TabSet, Formik as FormikControls } from '@royalnavy/react-component-library'
+import { IconBrightnessHigh } from '@royalnavy/icon-library'
 import DataTable from '../../../../components/presenters/data-table'
 import CodeHighlighter from '../../../../components/presenters/code-highlighter'
 import SketchWidget from '../../../../components/presenters/sketch-widget'
@@ -55,6 +56,7 @@ The Directional Buttons also have state. Clicking on the up arrow will increase 
 
 
 <Tab title="Develop">
+
 The `NumberInput` component acts like a regular input except that it only allows numbers to be entered and
 can use buttons to increase and decrease in increments, defaulted to 1.
 
@@ -87,6 +89,20 @@ The NumberInput can be used in conjunction with `withFormik` to allow it to be u
       name="guns"
       step={5}
     />
+    <Field
+      component={FormikControls.NumberInput}
+      label="Brightness"
+      name="brintness"
+      step={5}
+      startAdornment={<IconBrightnessHigh />}
+    />
+    <Field
+      component={FormikControls.NumberInput}
+      label="Speed"
+      name="speed"
+      step={5}
+      startAdornment="m/s"
+    />
   </Form>
 </Formik>
   `} language="javascript">
@@ -99,28 +115,41 @@ The NumberInput can be used in conjunction with `withFormik` to allow it to be u
             <Field
               className="is-valid"
               component={FormikControls.NumberInput}
-              label="Muskets"
+              label="Ships"
               max={10}
               min={1}
-              name="muskets"
+              name="ships"
             />
             <Field
               className="is-invalid"
               component={FormikControls.NumberInput}
-              label="Pistols"
-              name="pistols"
+              label="Aircraft"
+              name="aircraft"
             />
             <Field
               component={FormikControls.NumberInput}
-              label="Guns"
-              name="guns"
+              label="Cars"
+              name="cars"
               step={5}
+            />
+            <Field
+              component={FormikControls.NumberInput}
+              label="Brightness"
+              name="brintness"
+              step={5}
+              startAdornment={<IconBrightnessHigh />}
+            />
+            <Field
+              component={FormikControls.NumberInput}
+              label="Speed"
+              name="speed"
+              step={5}
+              startAdornment="m/s"
             />
           </Form>
         </Formik>
       </div>
 </CodeHighlighter>
-
 
 ### Properties
 <DataTable caption="NumberInput" data={[
@@ -228,6 +257,13 @@ The NumberInput can be used in conjunction with `withFormik` to allow it to be u
     Required: 'False',
     Default: '',
     Description: 'The value to display',
+  },
+  {
+    Name: 'startAdornment',
+    Type: 'string | ReactNode',
+    Required: 'False',
+    Default: '',
+    Description: 'An adornment to add to the start of the input field.',
   },
 ]} />
 </Tab>

--- a/packages/docs-site/src/library/pages/versions.md
+++ b/packages/docs-site/src/library/pages/versions.md
@@ -10,6 +10,10 @@ excludeFromNavigation: true
 
 # Versions
 
+## 1.10.0
+* [Release note](https://github.com/Royal-Navy/standards-toolkit/releases/tag/1.10.0)
+* [Documentation](https://7203b2405d1b4ce5adf9e58f8e71deb6-standards.netlify.com)
+
 ## 1.9.0
 * [Release note](https://github.com/Royal-Navy/standards-toolkit/releases/tag/1.9.0)
 * [Documentation](https://774b9830314d4414ad772ef80b509f97-standards.netlify.com)

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@royalnavy/eslint-config-react",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/icon-library/package.json
+++ b/packages/icon-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@royalnavy/icon-library",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "author": "NELSON",

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@royalnavy/react-component-library",
   "description": "A collection of react components and helpers to assist in building applications for the Royal Navy",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "publishConfig": {
     "access": "public"
   },
@@ -48,7 +48,7 @@
     "@babel/preset-env": "^7.7.6",
     "@babel/preset-react": "^7.7.4",
     "@babel/preset-typescript": "^7.7.4",
-    "@royalnavy/storybook-react-input-state": "^1.9.0",
+    "@royalnavy/storybook-react-input-state": "^1.10.0",
     "@storybook/addon-actions": "^5.2.8",
     "@storybook/addon-knobs": "^5.2.8",
     "@storybook/addon-links": "^5.2.8",
@@ -123,8 +123,8 @@
     "dist"
   ],
   "dependencies": {
-    "@royalnavy/css-framework": "^1.9.0",
-    "@royalnavy/icon-library": "^1.9.0",
+    "@royalnavy/css-framework": "^1.10.0",
+    "@royalnavy/icon-library": "^1.10.0",
     "@types/react-responsive": "^8.0.2",
     "classnames": "^2.2.6",
     "date-fns": "^2.8.1",

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import { Field, Formik, Form } from 'formik'
 import React from 'react'
-
+import { IconBrightnessHigh } from '@royalnavy/icon-library'
 import withFormik from '../../enhancers/withFormik'
 import { Button } from '../Button'
 import { NumberInput } from './NumberInput'
@@ -27,6 +27,7 @@ stories.add('Vanilla', () => (
       <Form>
         <Field component={FormikNumberInput} name="gold" label="Gold bars" />
         <Field component={FormikNumberInput} name="age" label="Age" />
+        <Field component={FormikNumberInput} name="age" label="Age" />
 
         <Button variant="secondary" onClick={action('Cancel')}>
           Cancel
@@ -37,4 +38,24 @@ stories.add('Vanilla', () => (
       </Form>
     </Formik>
   </div>
+))
+
+stories.add('With start adornment icon', () => (
+  <NumberInput
+    name="example-number-input"
+    label="Example"
+    value={1}
+    onChange={action('onChange')}
+    startAdornment={<IconBrightnessHigh />}
+  />
+))
+
+stories.add('With start adornment text', () => (
+  <NumberInput
+    name="example-number-input"
+    label="Example"
+    value={1}
+    onChange={action('onChange')}
+    startAdornment="Kts"
+  />
 ))

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
@@ -48,6 +48,20 @@ describe('NumberInput', () => {
       })
     })
 
+    describe('and the field has a startAdornment', () => {
+      beforeEach(() => {
+        props.value = 1
+        props.startAdornment = 'Example'
+        wrapper = render(<NumberInput {...props} />)
+      })
+
+      it('should render the text', () => {
+        expect(
+          wrapper.getByTestId('number-input-start-adornment')
+        ).toHaveTextContent('Example')
+      })
+    })
+
     describe('and the field has no value', () => {
       beforeEach(() => {
         wrapper = render(<NumberInput {...props} />)

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -17,6 +17,7 @@ export interface NumberInputProps {
   placeholder?: string
   step?: number
   value?: number
+  startAdornment?: React.ReactNode | string
 }
 
 interface CalculateNewValue {
@@ -59,6 +60,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   placeholder = '',
   step = 1,
   value,
+  startAdornment,
   ...rest
 }) => {
   const inputRef = useRef(null)
@@ -170,6 +172,14 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   return (
     <div className={classes} data-testid="number-input-container">
       <div className="rn-numberinput__outer-wrapper">
+        {startAdornment && (
+          <div
+            className="rn-numberinput__start-adornment"
+            data-testid="number-input-start-adornment"
+          >
+            {startAdornment}
+          </div>
+        )}
         <div
           className="rn-numberinput__input-wrapper"
           data-testid="number-input-wrapper"

--- a/packages/reactapp/package.json
+++ b/packages/reactapp/package.json
@@ -1,10 +1,10 @@
 {
   "name": "reactapp",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "dependencies": {
-    "@royalnavy/css-framework": "^1.9.0",
-    "@royalnavy/react-component-library": "^1.9.0",
+    "@royalnavy/css-framework": "^1.10.0",
+    "@royalnavy/react-component-library": "^1.10.0",
     "formik": "^2.0.7",
     "node-sass": "4.13.0",
     "react": "^16.12.0",

--- a/packages/storybook-react-input-state/package.json
+++ b/packages/storybook-react-input-state/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@royalnavy/storybook-react-input-state",
   "description": "State wrapper for form components in react storybook stories",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "publishConfig": {
     "access": "public"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14470,7 +14470,7 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-mem@^4.0.0:
+mem@^1.1.0, mem@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
   integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==


### PR DESCRIPTION
## Related issue

https://github.com/Royal-Navy/standards-toolkit/issues/470

## Overview

Add start adornment to NumberInput field (accepts both icon-library icons and plaintext).

## Reason

>There is a need for the number field allow the display of the units associated with the number being entered.

## Work carried out

- [x] Add adornment functionality and style
- [x] Add automated test

## Screenshot

<img width="407" alt="Screenshot 2019-12-16 at 10 36 30" src="https://user-images.githubusercontent.com/48086589/70900080-fa95fd80-1fef-11ea-9b70-bc7e122c8a33.png">
<img width="410" alt="Screenshot 2019-12-16 at 10 36 39" src="https://user-images.githubusercontent.com/48086589/70900081-fa95fd80-1fef-11ea-808e-f678a3623a7d.png">
