### PR TITLE
Refactor Masthead

### DIFF
--- a/packages/css-framework/src/components/_scrollable-nav.scss
+++ b/packages/css-framework/src/components/_scrollable-nav.scss
@@ -13,7 +13,7 @@ $btn-focus-width: 0.2rem;
   margin: 0;
 }
 
-.rn-scrollable-nav__link {
+.rn-scrollable-nav__item > a {
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
@@ -33,16 +33,13 @@ $btn-focus-width: 0.2rem;
     border-bottom: 4px solid color(primary, 600);
     text-decoration: none;
   }
-  &:focus {    
-    box-shadow: 0 0 0 $btn-focus-width rgba(color(primary, 700) , 0.5);
-  }
 
-  &:hover {
-    text-decoration: none;
+  &:focus {
+    box-shadow: 0 0 0 $btn-focus-width rgba(color(primary, 700), 0.5);
   }
 }
 
-.rn-scrollable-nav__item.is-active .rn-scrollable-nav__link {
+.rn-scrollable-nav__item.is-active > a {
   color: color(neutral, 500);
   font-weight: bold;
   border-bottom: 4px solid color(primary, 600);

--- a/packages/docs-site/src/library/pages/components/masthead.md
+++ b/packages/docs-site/src/library/pages/components/masthead.md
@@ -4,7 +4,7 @@ description: A top level section displayed at the top of the page
 header: true
 ---
 
-import { Icons, Masthead, Tab, TabSet } from '@royalnavy/react-component-library'
+import { Icons, Link, Masthead, MastheadNav, MastheadNavItem, MastheadUser, Tab, TabSet } from '@royalnavy/react-component-library'
 import DataTable from '../../../components/presenters/data-table'
 import CodeHighlighter from '../../../components/presenters/code-highlighter'
 import SketchWidget from '../../../components/presenters/sketch-widget'
@@ -48,71 +48,99 @@ Aside from the active page links (an example of these states is shown in the [Ta
 <Tab title="Develop">
 
 ### Basic
-<CodeHighlighter source={`<Masthead homeLink={{href:'/'}} title="Test" />`} language="javascript">
-  <Masthead homeLink={{href:'/'}} title="Test" />
+<CodeHighlighter source={`<Masthead
+  homeLink={<Link href="/" />}
+  title="Test"
+/>`} language="javascript">
+<Masthead
+  homeLink={<Link href="/" />}
+  title="Test"
+/>
 </CodeHighlighter>
 
 ### Masthead with custom logo
-<CodeHighlighter source={`<Masthead homeLink={{href:'/'}} title="Test" Logo={CustomLogo} />`} language="javascript">
-<Masthead homeLink={{href:'/'}} title="Test" Logo={Icons.Bell} />
+<CodeHighlighter source={`<Masthead
+  homeLink={<Link href="/" />}
+  title="Test"
+  Logo={CustomLogo}
+/>`} language="javascript">
+<Masthead
+  homeLink={<Link href="/" />}
+  title="Test"
+  Logo={Icons.Bell}
+/>
 </CodeHighlighter>
 
 ### Masthead with search
-<CodeHighlighter source={`<Masthead homeLink={{href:'/'}} title="Test" onSearch={onSearch} searchPlaceholder="Search" />`} language="javascript">
-  <Masthead
-    homeLink={{href:'/'}}
-    onSearch={term => console.log(`Search for: ${term}`)}
-    searchPlaceholder="Search"
-    title="Test"
-  />
+<CodeHighlighter source={`<Masthead
+  homeLink={<Link href="/" />}
+  onSearch={() => { /* handle search */ }}
+  searchPlaceholder="Search"
+  title="test"
+/>`} language="javascript">
+<Masthead
+  homeLink={<Link href="/" />}
+  onSearch={() => { /* handle search */ }}
+  searchPlaceholder="Search"
+  title="test"
+/>
 </CodeHighlighter>
 
 ### Fully loaded
-<CodeHighlighter source={`<Masthead 
-  homeLink={{href:'/'}}
-  navItems={[
-    { label: 'Get started', href: '/get-started', active: true,},
-    { label: 'Styles', href: '/styles', },
-    { label: 'Components', href: '/components', },
-    { label: 'About', href: '/about', },
-  ]}
+<CodeHighlighter source={`<Masthead
+  homeLink={<Link href="/" />}
+  nav={(
+    <MastheadNav>
+      <MastheadNavItem link={<Link href="/home">Get started</Link>} isActive />
+      <MastheadNavItem link={<Link href="/styles">Styles</Link>} />
+      <MastheadNavItem link={<Link href="/components">Components</Link>} />
+      <MastheadNavItem link={<Link href="/about">About</Link>} />
+    </MastheadNav>
+  )}
   notifications={notifications}
-  onSearch={onSearch} 
-  searchPlaceholder="Search" 
-  title="Test" 
-  unreadNotification={true}
-  user={{ initials: 'XT', href: '/userprofile' }}
+  onSearch={() => { /* handle search */ }}
+  searchPlaceholder="Search"
+  title="Test"
+  hasUnreadNotification
+  user={
+    <MastheadUser initials="AT" link={<Link href="/user-profile" />} />
+  }
 />`} language="javascript">
-  <Masthead
-    homeLink={{href:'/'}}
-    navItems={[
-      { label: 'Get started', href: '/get-started', active:true, },
-      { label: 'Styles', href: '/styles', },
-      { label: 'Components', href: '/components' },
-      { label: 'About', href: '/about', },
-    ]}
-    notifications={null}
-    onSearch={term => console.log(`Search for: ${term}`)}
-    searchPlaceholder="Search"
-    title="Test"
-    unreadNotification={true}
-    user={{ initials: 'XT', href: '/userprofile' }}
-  />
+<Masthead
+  homeLink={<Link href="/" />}
+  nav={(
+    <MastheadNav>
+      <MastheadNavItem link={<Link href="/home">Get started</Link>} isActive />
+      <MastheadNavItem link={<Link href="/styles">Styles</Link>} />
+      <MastheadNavItem link={<Link href="/components">Components</Link>} />
+      <MastheadNavItem link={<Link href="/about">About</Link>} />
+    </MastheadNav>
+  )}
+  notifications={null}
+  onSearch={() => { /* handle search */ }}
+  searchPlaceholder="Search"
+  title="Test"
+  hasUnreadNotification
+  user={
+    <MastheadUser initials="AT" link={<Link href="/user-profile" />} />
+  }
+/>
 </CodeHighlighter>
 
 ### Properties
-<DataTable data={[
+<DataTable caption="MastHead" data={[
   {
-    Name: 'homeLink',
-    Type: 'LinkTypes',
-    Required: 'True',
-    Description: 'An object typically containing a `to` or `href` property to indicate the property LinkComponent to send the user back to the homepage for the service.',
+    Name: 'hasUnreadNotification',
+    Type: 'boolean',
+    Required: 'False',
+    Default: 'False',
+    Description: 'If there are unread notifications then this will cause a small blue indicator to be displayed to alert the user.',
   },
   {
-    Name: 'LinkComponent',
-    Type: 'Component',
+    Name: 'homeLink',
+    Type: 'React.ReactElement<LinkTypes>',
     Required: 'False',
-    Description: 'A custom component to render links in the Masthead. If nothing is passed a component requiring a href will be used and will render an anchor tag. If using a library such as React Router, than the ‘Link’ component from that library should be passed as a property.',
+    Description: 'A `Link` which will contain the `href` for sending the user back to home.',
   },
   {
     Name: 'Logo',
@@ -121,10 +149,10 @@ Aside from the active page links (an example of these states is shown in the [Ta
     Description: 'A 21x19 logo or if none is provided a default is used.',
   },
   {
-    Name: 'navItems',
-    Type: 'NavItem[] ',
-    Required: 'True',
-    Description: 'An array of objects that must at least contain a label. If no custom component is provided then provide a href, otherwise provide the required property associated with the LinkComponent',
+    Name: 'nav',
+    Type: 'React.ReactElement<ScrollableNavProps>',
+    Required: 'False',
+    Description: 'Navigation for the MastHead.',
   },
   {
     Name: 'notifications',
@@ -151,47 +179,51 @@ Aside from the active page links (an example of these states is shown in the [Ta
     Description: 'A service name that will be displayed next to the logo',
   },
   {
-    Name: 'hasUnreadNotification',
-    Type: 'boolean',
-    Required: 'False',
-    Description: 'If there are unread notifications then this will cause a small blue indicator to be displayed to alert the user.',
-  },
-  {
     Name: 'user',
-    Type: 'UserType',
+    Type: 'React.ReactElement<MastheadUserProps>',
     Required: 'False',
-    Description: 'If your application has a User Profile page, pass in the User object to add their initials to the Avatar sub-component. This Avatar provides a link to the User’s profile.',
+    Description: 'If your application has a User Profile page, specify a `MastheadUser` to add their initials to the Avatar sub-component. This Avatar provides a link to the User’s profile.',
   },
 ]} />
 <br />
-<DataTable caption="NavItem" data={[
+<DataTable caption="MastheadNav" data={[
   {
-    Name: 'label',
-    Type: 'string',
+    Name: 'children',
+    Type: 'React.ReactElement<ScrollableNavItemProps>[]',
     Required: 'True',
     Default: '',
-    Description: 'The text for the link.',
+    Description: 'Each child represents a nav item.',
   },
+]} />
+<br />
+<DataTable caption="MastheadNavItem" data={[
   {
     Name: 'isActive',
     Type: 'boolean',
     Required: 'False',
     Default: 'False',
-    Description: 'Is this the current active link?'
-  }
+    Description: 'Is this the current active item?'
+  },
+  {
+    Name: 'link',
+    Type: 'React.ReactElement<LinkTypes>',
+    Required: 'True',
+    Default: '',
+    Description: 'The `Link` to be rendered.',
+  },
 ]} />
 <br />
-<DataTable caption="UserType" data={[
+<DataTable caption="MastheadUser" data={[
   {
     Name: 'initials',
     Type: 'string',
     Required: 'True',
     Default: '',
-    Description: '',
+    Description: 'Initials of the user.',
   },  
   {
-    Name: 'to or href',
-    Type: 'string',
+    Name: 'link',
+    Type: 'React.ReactElement<LinkTypes>',
     Required: 'True',
     Default: '',
     Description: "A url to send the user to, if they wish to see their profile.",

--- a/packages/react-component-library/src/components/ScrollableNav/ScrollableNav.tsx
+++ b/packages/react-component-library/src/components/ScrollableNav/ScrollableNav.tsx
@@ -1,28 +1,18 @@
 import React from 'react'
 import ScrollContainer from 'react-indiana-drag-scroll'
 
-import { Link } from '..'
-import { ScrollableNavItem } from './ScrollableNavItem'
+import { Nav } from '../../types/Nav'
 
-interface ScrollableNavProps {
-  className?: string
-  LinkComponent?: any
-  navItems: NavItemTypes[]
-}
-
-export const ScrollableNav: React.FC<ScrollableNavProps> = ({
-  className = '',
-  LinkComponent = Link,
-  navItems,
+export const ScrollableNav: React.FC<Nav> = ({
+  children,
+  className,
 }) => (
   <nav
     className={`rn-scrollable-nav ${className}`}
     data-testid="scrollable-nav"
   >
     <ScrollContainer className="rn-scrollable-nav__scroll-container">
-      <ol className="rn-scrollable-nav__items">
-        {navItems.map(navItem => ScrollableNavItem({ LinkComponent, navItem }))}
-      </ol>
+      <ol className="rn-scrollable-nav__items">{children}</ol>
     </ScrollContainer>
   </nav>
 )

--- a/packages/react-component-library/src/components/ScrollableNav/ScrollableNavItem.tsx
+++ b/packages/react-component-library/src/components/ScrollableNav/ScrollableNavItem.tsx
@@ -1,27 +1,14 @@
 import React from 'react'
 import uuid from 'uuid'
+import { NavItem } from '../../types/Nav'
 
-interface ScrollableNavItemProps {
-  LinkComponent?: any
-  navItem: NavItemTypes
-}
-
-export const ScrollableNavItem: React.FC<ScrollableNavItemProps> = ({
-  LinkComponent,
-  navItem: { isActive = false, label, ...rest },
-}) => (
+export const ScrollableNavItem: React.FC<NavItem> = ({ isActive, link }) => (
   <li
     key={uuid()}
     className={`rn-scrollable-nav__item ${isActive ? 'is-active' : ''}`}
     data-testid={isActive ? 'tab-active' : 'tab'}
   >
-    <LinkComponent
-      className="rn-scrollable-nav__link"
-      data-testid="tablink"
-      {...rest}
-    >
-      {label}
-    </LinkComponent>
+    {link}
   </li>
 )
 

--- a/packages/react-component-library/src/components/index.ts
+++ b/packages/react-component-library/src/components/index.ts
@@ -16,7 +16,7 @@ import Pagination from './Pagination'
 import PhaseBanner from './PhaseBanner'
 import { Popover } from './Popover'
 import Radio from './Radio'
-import { ScrollableNav } from './ScrollableNav'
+import { ScrollableNav, ScrollableNavItem } from './ScrollableNav'
 import { Searchbar } from './Searchbar'
 import { Select } from './Select'
 import Sidebar from '../fragments/Sidebar'
@@ -54,6 +54,7 @@ export {
   Popover,
   Radio,
   ScrollableNav,
+  ScrollableNavItem,
   Searchbar,
   Select,
   Sidebar,

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.stories.tsx
@@ -2,15 +2,12 @@ import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 
-import { Masthead } from './index'
 import { Link } from '../../components'
+import { Masthead, MastheadUser } from '.'
 import { Notification, Notifications } from '../NotificationPanel'
+import { MastheadNav, MastheadNavItem } from './MastheadNav'
 
 const stories = storiesOf('Masthead', module)
-
-const homeLink: AnchorType = {
-  href: '/',
-}
 
 const CustomLogo = () => (
   <svg width="21" height="19" viewBox="0 0 21 19">
@@ -33,6 +30,37 @@ const CustomLogo = () => (
   </svg>
 )
 
+const user = <MastheadUser initials="AT" link={<Link href="/user-profile" />} />
+
+const notifications = (
+  <Notifications link={<Link href="notifications" />}>
+    <Notification
+      link={<Link href="notifications/1" />}
+      name="Thomas Stephens"
+      action="added a new comment to your"
+      on="review"
+      when={new Date('2019-11-05T14:25:02.178Z')}
+      description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+    />
+    <Notification
+      link={<Link href="notifications/2" />}
+      name="Thomas Stephens"
+      action="added a new comment to your"
+      on="review"
+      when={new Date('2019-11-01T14:25:02.178Z')}
+      description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+    />
+    <Notification
+      link={<Link href="notifications/3" />}
+      name="Thomas Stephens"
+      action="added a new comment to your"
+      on="review"
+      when={new Date('2019-11-01T14:25:02.178Z')}
+      description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+    />
+  </Notifications>
+)
+
 stories.add('With search', () => (
   <Masthead
     onSearch={action('onSearch')}
@@ -40,8 +68,6 @@ stories.add('With search', () => (
     title="Test"
   />
 ))
-
-const user = { initials: 'XT', href: '/userprofile' }
 
 stories.add('With search and Avatar', () => (
   <div>
@@ -61,65 +87,10 @@ stories.add('Without search', () => <Masthead title="Test" />)
 
 stories.add('Custom logo', () => <Masthead title="Test" Logo={CustomLogo} />)
 
-const navItems: NavItemAnchorType[] = [
-  {
-    label: 'Home',
-    href: '/',
-    isActive: true,
-  },
-  {
-    label: 'Ships',
-    href: '/',
-  },
-  {
-    label: 'Reports',
-    href: '/',
-  },
-  {
-    label: 'Personnel',
-    href: '/',
-  },
-  {
-    label: 'Calendar',
-    href: '/',
-  },
-  {
-    label: 'Messages',
-    href: '/',
-  },
-]
-
 stories.add('all but navigation', () => (
   <Masthead
-    homeLink={homeLink}
-    notifications={(
-      <Notifications link={<Link href="notifications" />}>
-        <Notification
-          link={<Link href="notifications/1" />}
-          name="Thomas Stephens"
-          action="added a new comment to your"
-          on="review"
-          when={new Date('2019-11-05T14:25:02.178Z')}
-          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
-        />
-        <Notification
-          link={<Link href="notifications/2" />}
-          name="Thomas Stephens"
-          action="added a new comment to your"
-          on="review"
-          when={new Date('2019-11-01T14:25:02.178Z')}
-          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
-        />
-        <Notification
-          link={<Link href="notifications/3" />}
-          name="Thomas Stephens"
-          action="added a new comment to your"
-          on="review"
-          when={new Date('2019-11-01T14:25:02.178Z')}
-          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
-        />
-      </Notifications>
-    )}
+    homeLink={<Link href="/" />}
+    notifications={notifications}
     onSearch={action('onSearch')}
     searchPlaceholder="Search"
     title="Test"
@@ -130,36 +101,19 @@ stories.add('all but navigation', () => (
 
 stories.add('With navigation', () => (
   <Masthead
-    homeLink={homeLink}
-    navItems={navItems}
-    notifications={(
-      <Notifications link={<Link href="notifications" />}>
-        <Notification
-          link={<Link href="notifications/1" />}
-          name="Thomas Stephens"
-          action="added a new comment to your"
-          on="review"
-          when={new Date('2019-11-05T14:25:02.178Z')}
-          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+    homeLink={<Link href="/" />}
+    nav={(
+      <MastheadNav>
+        <MastheadNavItem
+          link={<Link href="/home">Get started</Link>}
+          isActive
         />
-        <Notification
-          link={<Link href="notifications/2" />}
-          name="Thomas Stephens"
-          action="added a new comment to your"
-          on="review"
-          when={new Date('2019-11-01T14:25:02.178Z')}
-          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
-        />
-        <Notification
-          link={<Link href="notifications/3" />}
-          name="Thomas Stephens"
-          action="added a new comment to your"
-          on="review"
-          when={new Date('2019-11-01T14:25:02.178Z')}
-          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
-        />
-      </Notifications>
+        <MastheadNavItem link={<Link href="/styles">Styles</Link>} />
+        <MastheadNavItem link={<Link href="/components">Components</Link>} />
+        <MastheadNavItem link={<Link href="/about">About</Link>} />
+      </MastheadNav>
     )}
+    notifications={notifications}
     onSearch={action('onSearch')}
     searchPlaceholder="Search"
     title="Test"

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.test.tsx
@@ -5,6 +5,8 @@ import { fireEvent, render, RenderResult, wait } from '@testing-library/react'
 import { Link } from '../../index'
 import { Masthead, MastheadProps } from './Masthead'
 import { Notification, Notifications } from '../NotificationPanel'
+import { MastheadUser } from './MastheadUser'
+import { MastheadNav, MastheadNavItem } from './MastheadNav'
 
 describe('Masthead', () => {
   let wrapper: RenderResult
@@ -56,17 +58,23 @@ describe('Masthead', () => {
 
     describe('and a user', () => {
       beforeEach(() => {
-        const user: UserType = {
-          initials: 'zt',
-        }
-
-        props.user = user
+        props.user = (
+          <MastheadUser initials="zt" link={<Link href="/user-profile" />} />
+        )
 
         wrapper = render(<Masthead {...props} />)
       })
 
-      it('should render the user link', () => {
-        expect(wrapper.queryByTestId('userlink')).toBeInTheDocument()
+      it('should render the avatar', () => {
+        expect(wrapper.getByText('zt')).toBeInTheDocument()
+      })
+
+      it('should link the avatar', () => {
+        const avatar = wrapper.getByText('zt')
+
+        expect(avatar.parentElement.getAttribute('href')).toEqual(
+          '/user-profile'
+        )
       })
     })
 
@@ -257,31 +265,31 @@ describe('Masthead', () => {
         })
 
         it('should include an unread notification indicator', () => {
-          expect(
-            wrapper.queryByTestId('not-read')
-          ).toBeInTheDocument()
+          expect(wrapper.queryByTestId('not-read')).toBeInTheDocument()
         })
       })
     })
 
     describe('and navigation', () => {
       beforeEach(() => {
-        props.navItems = [
-          {
-            isActive: false,
-            label: 'test nav item',
-            href: '/',
-          },
-        ]
+        props.nav = (
+          <MastheadNav>
+            <MastheadNavItem link={<Link href="/first">First</Link>} />
+            <MastheadNavItem link={<Link href="/second">Second</Link>} />
+          </MastheadNav>
+        )
 
         wrapper = render(<Masthead {...props} />)
       })
 
-      it('should render the nav items', () => {
-        expect(wrapper.queryByTestId('scrollable-nav')).toBeInTheDocument()
-        expect(wrapper.queryByTestId('scrollable-nav')).toContainHTML(
-          'test nav item'
-        )
+      it('should render the first nav item', () => {
+        const firstNavItem = wrapper.getByText('First')
+        expect(firstNavItem.getAttribute('href')).toEqual('/first')
+      })
+
+      it('should render the seconde nav item', () => {
+        const secondNavItem = wrapper.getByText('Second')
+        expect(secondNavItem.getAttribute('href')).toEqual('/second')
       })
     })
   })

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
@@ -2,38 +2,58 @@ import React, { useRef, useState } from 'react'
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import classNames from 'classnames'
 
-import { Link, Searchbar, ScrollableNav } from '../../components'
+import { Searchbar } from '../../components'
 import { Logo as DefaultLogo, Search as SearchIcon } from '../../icons'
-import { UserLink } from './UserLink'
+import { MastheadUserProps } from './MastheadUser'
+import { Nav } from '../../types/Nav'
 import {
+  NOTIFICATION_PLACEMENT,
   NotificationPanel,
   NotificationsProps,
-  NOTIFICATION_PLACEMENT,
 } from '../NotificationPanel'
 
 export interface MastheadProps {
-  homeLink?: LinkTypes
-  LinkComponent?: any
+  hasUnreadNotification?: boolean
+  homeLink?: React.ReactElement<LinkTypes>
   Logo?: React.ComponentType
-  navItems?: NavItemTypes[]
+  nav?: React.ReactElement<Nav>
   notifications?: React.ReactElement<NotificationsProps>
   onSearch?: (term: string) => void
   searchPlaceholder?: string
   title: string
-  hasUnreadNotification?: boolean
-  user?: UserType
+  user?: React.ReactElement<MastheadUserProps>
+}
+
+function getServiceName(
+  homeLink: React.ReactElement<LinkTypes>,
+  Logo: React.ComponentType,
+  title: string
+) {
+  const link = homeLink || <span />
+
+  return React.cloneElement(link as React.ReactElement, {
+    ...link.props,
+    children: (
+      <>
+        <Logo />
+        <span className="rn-masthead__title" data-testid="masthead-servicename">
+          {title}
+        </span>
+      </>
+    ),
+    className: 'rn-masthead__service-name',
+  })
 }
 
 export const Masthead: React.FC<MastheadProps> = ({
+  hasUnreadNotification,
   homeLink,
-  LinkComponent = Link,
   Logo = DefaultLogo,
-  navItems,
+  nav,
   notifications,
   onSearch,
   searchPlaceholder = '',
   title,
-  hasUnreadNotification,
   user,
 }) => {
   const [showSearch, setShowSearch] = useState(false)
@@ -73,15 +93,7 @@ export const Masthead: React.FC<MastheadProps> = ({
       ref={mastheadContainerRef}
     >
       <div className="rn-masthead__main">
-        <LinkComponent {...homeLink} className="rn-masthead__service-name">
-          <Logo />
-          <span
-            className="rn-masthead__title"
-            data-testid="masthead-servicename"
-          >
-            {title}
-          </span>
-        </LinkComponent>
+        {getServiceName(homeLink, Logo, title)}
 
         <div className="rn-masthead__options">
           {onSearch && (
@@ -116,13 +128,7 @@ export const Masthead: React.FC<MastheadProps> = ({
             </NotificationPanel>
           )}
 
-          {user && (
-            <UserLink
-              className="rn-masthead__option"
-              LinkComponent={LinkComponent}
-              user={user}
-            />
-          )}
+          {user}
         </div>
       </div>
 
@@ -143,14 +149,7 @@ export const Masthead: React.FC<MastheadProps> = ({
         )}
       </ReactCSSTransitionGroup>
 
-      {navItems && (
-        <ScrollableNav
-          className="rn-masthead__nav"
-          navItems={navItems}
-          LinkComponent={LinkComponent}
-          data-testid="masthead-nav"
-        />
-      )}
+      {nav}
     </div>
   )
 }

--- a/packages/react-component-library/src/fragments/Masthead/MastheadNav.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/MastheadNav.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import { Nav, NavItem } from '../../types/Nav'
+import {
+  ScrollableNav,
+  ScrollableNavItem,
+} from '../../components/ScrollableNav'
+
+export const MastheadNav: React.FC<Nav> = props => {
+  return (
+    <ScrollableNav {...props} className="rn-masthead__nav">
+      {props.children}
+    </ScrollableNav>
+  )
+}
+
+export const MastheadNavItem: React.FC<NavItem> = props => (
+  <ScrollableNavItem {...props} />
+)

--- a/packages/react-component-library/src/fragments/Masthead/MastheadUser.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/MastheadUser.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from 'react'
+
+import { Avatar, AVATAR_VARIANT } from '../../components'
+
+export interface MastheadUserProps extends ComponentWithClass {
+  initials: string,
+  link: React.ReactElement<LinkTypes>
+}
+
+export const MastheadUser: React.FC<MastheadUserProps> = ({
+  initials,
+  link,
+}) => {
+  return React.cloneElement(link as ReactElement, {
+    ...link.props,
+    className: 'rn-masthead__option',
+    children: <Avatar initials={initials} variant={AVATAR_VARIANT.DARK} />
+  })
+}
+
+MastheadUser.displayName = 'MastheadUser'

--- a/packages/react-component-library/src/fragments/Masthead/index.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/index.tsx
@@ -1,1 +1,3 @@
 export * from './Masthead'
+export * from './MastheadNav'
+export * from './MastheadUser'

--- a/packages/react-component-library/src/fragments/index.ts
+++ b/packages/react-component-library/src/fragments/index.ts
@@ -1,4 +1,9 @@
-import { Masthead } from './Masthead'
+import {
+  Masthead,
+  MastheadNav,
+  MastheadNavItem,
+  MastheadUser,
+} from './Masthead'
 import {
   Notification,
   NotificationPanel,
@@ -8,6 +13,9 @@ import Sidebar from './Sidebar'
 
 export {
   Masthead,
+  MastheadNav,
+  MastheadNavItem,
+  MastheadUser,
   Notification,
   NotificationPanel,
   Notifications,

--- a/packages/react-component-library/src/index.ts
+++ b/packages/react-component-library/src/index.ts
@@ -10,7 +10,12 @@ import { Dialog } from './components/Dialog'
 import { Drawer } from './components/Drawer'
 import { Dropdown } from './components/Dropdown'
 import { Link } from './components/Link'
-import { Masthead } from './fragments/Masthead'
+import {
+  Masthead,
+  MastheadNav,
+  MastheadNavItem,
+  MastheadUser,
+} from './fragments/Masthead'
 import { Modal } from './components/Modal'
 import Nav from './components/Nav'
 import { Notification, Notifications } from './fragments/NotificationPanel'
@@ -56,6 +61,9 @@ export {
   Dropdown,
   Link,
   Masthead,
+  MastheadNav,
+  MastheadNavItem,
+  MastheadUser,
   Modal,
   Nav,
   Notification,

--- a/packages/react-component-library/src/types/Nav.ts
+++ b/packages/react-component-library/src/types/Nav.ts
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export interface Nav extends ComponentWithClass {
+  children: React.ReactElement<NavItem> | React.ReactElement<NavItem>[]
+}
+
+export interface NavItem {
+  isActive?: boolean
+  link: React.ReactElement<LinkTypes>
+}


### PR DESCRIPTION
## Related issue
#467 

## Overview
Refactor the `Masthead` component so that the interface is consistent.

This change includes:
- adding shared types for nav as they all use a similar pattern
- making the component more composable so that the consumer can effectively supply their own nav, 
nav items or user
- consolidating repeated code ie notifications in the stories

## Reason
Part of making interfaces consistent before launching v2.

## Work carried out
- [x] Add `Nav` and `NavItem` shared types
- [x] Refactor `Masthead`

## Screenshot
There should be no visual difference.