### PR TITLE
Rename callback function prop

### DIFF
--- a/packages/docs-site/src/library/pages/components/pagination.md
+++ b/packages/docs-site/src/library/pages/components/pagination.md
@@ -52,14 +52,14 @@ The Pagination component allows an end user to navigate between pages of records
 
 ### Basic Usage
 <CodeHighlighter source={`<Pagination
-  onChangeCallback={(currentPage, totalPages) => {
+  onChange={(currentPage, totalPages) => {
     console.log(currentPage, totalPages)
   }}
   pageSize={10}
   total={1000}
 />`} language="javascript">
   <Pagination
-    onChangeCallback={(currentPage, totalPages) => {
+    onChange={(currentPage, totalPages) => {
       console.log(currentPage, totalPages)
     }}
     pageSize={10}
@@ -70,7 +70,7 @@ The Pagination component allows an end user to navigate between pages of records
 ### Pagination Properties
 <DataTable data={[
   {
-    Name: 'onChangeCallback',
+    Name: 'onChange',
     Type: 'Function<any>',
     Required: 'False',
     Default: '',

--- a/packages/docs-site/src/library/pages/components/tab-set.md
+++ b/packages/docs-site/src/library/pages/components/tab-set.md
@@ -117,7 +117,7 @@ The TabSet (and companion Tab) component allows the user to switch between diffe
     Description: 'Additional CSS class to modify rn-tab-set',
   },
   {
-    Name: 'onChangeCallback',
+    Name: 'onChange',
     Type: '(id: number) => void',
     Required: 'False',
     Default: '',

--- a/packages/react-component-library/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.stories.tsx
@@ -8,7 +8,7 @@ const stories = storiesOf('Pagination', module)
 
 stories.add('Default', () => (
   <Pagination
-    onChangeCallback={action('onChangeCallback')}
+    onChange={action('onChange')}
     pageSize={10}
     total={1000}
   />

--- a/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
@@ -5,15 +5,15 @@ import Pagination from './index'
 
 describe('Pagination', () => {
   let pagination: RenderResult
-  let onChangeCallback: () => void
+  let onChangeSpy: () => void
 
   describe('when the Pagination is generated with only 2 records and pageSize is 10', () => {
-    onChangeCallback = jest.fn()
+    onChangeSpy = jest.fn()
 
     beforeEach(() => {
       pagination = render(
         <Pagination
-          onChangeCallback={onChangeCallback}
+          onChange={onChangeSpy}
           pageSize={10}
           total={2}
         />
@@ -36,12 +36,12 @@ describe('Pagination', () => {
   })
 
   describe('when the Pagination is generated with 20 records and pageSize is 10', () => {
-    onChangeCallback = jest.fn()
+    onChangeSpy = jest.fn()
 
     beforeEach(() => {
       pagination = render(
         <Pagination
-          onChangeCallback={onChangeCallback}
+          onChange={onChangeSpy}
           pageSize={10}
           total={20}
         />
@@ -53,13 +53,13 @@ describe('Pagination', () => {
     })
   })
 
-  describe('when the Pagination is generated with pageSize, total and onChangeCallback props', () => {
-    onChangeCallback = jest.fn()
+  describe('when the Pagination is generated with pageSize, total and onChange props', () => {
+    onChangeSpy = jest.fn()
 
     beforeEach(() => {
       pagination = render(
         <Pagination
-          onChangeCallback={onChangeCallback}
+          onChange={onChangeSpy}
           pageSize={10}
           total={1000}
         />
@@ -89,8 +89,8 @@ describe('Pagination', () => {
         ).toBe(true)
       })
 
-      it('should invoke the onChangeCallback function', () => {
-        expect(onChangeCallback).toHaveBeenCalledWith(5, 100)
+      it('should invoke the onChange function', () => {
+        expect(onChangeSpy).toHaveBeenCalledWith(5, 100)
       })
     })
   })

--- a/packages/react-component-library/src/components/Pagination/index.tsx
+++ b/packages/react-component-library/src/components/Pagination/index.tsx
@@ -3,13 +3,13 @@ import uuid from 'uuid'
 import { usePageChange, BUMP_LEFT, BUMP_RIGHT } from './usePageChange'
 
 interface PaginationProps {
-  onChangeCallback?: (currentPage: number, totalPages: number) => void
+  onChange?: (currentPage: number, totalPages: number) => void
   pageSize: number
   total: number
 }
 
 const Pagination: React.FC<PaginationProps> = ({
-  onChangeCallback,
+  onChange,
   pageSize,
   total,
 }) => {
@@ -18,7 +18,7 @@ const Pagination: React.FC<PaginationProps> = ({
   const [currentPage, changePage, pageNumbers] = usePageChange(
     1,
     totalPages,
-    onChangeCallback
+    onChange
   )
 
   return (

--- a/packages/react-component-library/src/components/Pagination/usePageChange.tsx
+++ b/packages/react-component-library/src/components/Pagination/usePageChange.tsx
@@ -8,7 +8,7 @@ export const BUMP_RIGHT = BUMP_LEFT
 export const usePageChange = (
   initialPage: number,
   totalPages: number,
-  onChangeCallback?: (currentPage: number, totalPages: number) => void
+  onChange?: (currentPage: number, totalPages: number) => void
 ): [number, (page: string | number) => void, () => any[]] => {
   const [currentPage, setCurrentPage] = useState(initialPage)
 
@@ -29,7 +29,7 @@ export const usePageChange = (
 
   /**
    * Change the page by setting the relevant state and invoking
-   * the provided onChangeCallback callback (if it is provided)
+   * the provided onChange callback (if it is provided)
    */
   function changePage(page: string | number): void {
     let selected
@@ -44,8 +44,8 @@ export const usePageChange = (
 
     setCurrentPage(selected)
 
-    if (typeof onChangeCallback === 'function') {
-      onChangeCallback(selected, totalPages)
+    if (typeof onChange === 'function') {
+      onChange(selected, totalPages)
     }
   }
 

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -65,7 +65,7 @@ describe('TabSet', () => {
       })
     })
 
-    describe('when the onChangeCallback is not provided', () => {
+    describe('when the onChange is not provided', () => {
       beforeEach(() => {
         wrapper = render(
           <TabSet>


### PR DESCRIPTION
## Related issue
#467

## Overview
Removes `callback` from prop name.

## Reason
To be consistent and meet naming best practices.

## Work carried out
- [x] Rename

## Screenshot
No visual change.