### PR TITLE
Refactor Notifications to use Link

### DIFF
--- a/packages/docs-site/src/library/pages/components/notifications.md
+++ b/packages/docs-site/src/library/pages/components/notifications.md
@@ -4,7 +4,7 @@ description: A component to easily alert users to new notifications.
 header: true
 ---
 
-import { Icons, Sidebar, Tab, TabSet } from '@royalnavy/react-component-library'
+import { Link, Notification, Notifications, Tab, TabSet } from '@royalnavy/react-component-library'
 import DataTable from '../../../components/presenters/data-table'
 import CodeHighlighter from '../../../components/presenters/code-highlighter'
 import SketchWidget from '../../../components/presenters/sketch-widget'
@@ -74,13 +74,32 @@ The Notification Sheet should only be used in the Sidebar or Masthead.
     description="A long description that will be shortened again"
   />
 </Notifications>
-`} language="javascript" />
+`} language="javascript">
+<Notifications link={<Link href="notifications" />}>
+  <Notification
+    link={<Link href="notifications/1" />}
+    name="Thomas Stephens"
+    action="added a new comment to your"
+    on="review"
+    when={new Date('2019-11-05T10:57:00.000Z')}
+    description="A long description that will be shortened"
+  />
+  <Notification
+    link={<Link href="notifications/2" />}
+    name="Thomas Stephens"
+    action="added a new comment to your"
+    on="review"
+    when={new Date('2019-11-04T10:23:00.000Z')}
+    description="A long description that will be shortened again"
+  />
+</Notifications>
+</CodeHighlighter>
 
 ### Notifications Properties
 <DataTable data={[
   {
-    Name: 'href',
-    Type: 'string',
+    Name: 'link',
+    Type: 'React.ReactElement<LinkTypes>',
     Required: 'True',
     Default: '',
     Description: 'For linking to a list of all notifications.',
@@ -97,8 +116,8 @@ The Notification Sheet should only be used in the Sidebar or Masthead.
 ### Notification Properties
 <DataTable data={[
   {
-    Name: 'href',
-    Type: 'string',
+    Name: 'link',
+    Type: 'React.ReactElement<LinkTypes>',
     Required: 'True',
     Default: '',
     Description: 'For linking to the notification.',

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.stories.tsx
@@ -3,39 +3,10 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 
 import { Masthead } from './index'
+import { Link } from '../../components'
 import { Notification, Notifications } from '../NotificationPanel'
 
 const stories = storiesOf('Masthead', module)
-
-const notifications = [
-  {
-    href: 'notifications/1',
-    name: 'Thomas Stephens',
-    action: 'added a new comment to your',
-    on: 'review',
-    when: new Date('2019-11-05T14:25:02.178Z'),
-    description:
-      'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores',
-  },
-  {
-    href: 'notifications/2',
-    name: 'Thomas Stephens',
-    action: 'added a new comment to your',
-    on: 'review',
-    when: new Date('2019-11-01T14:25:02.178Z'),
-    description:
-      'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores',
-  },
-  {
-    href: 'notifications/3',
-    name: 'Thomas Stephens',
-    action: 'added a new comment to your',
-    on: 'review',
-    when: new Date('2019-11-01T14:25:02.178Z'),
-    description:
-      'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores',
-  },
-]
 
 const homeLink: AnchorType = {
   href: '/',
@@ -122,10 +93,31 @@ stories.add('all but navigation', () => (
   <Masthead
     homeLink={homeLink}
     notifications={(
-      <Notifications href="notifications">
-        {notifications.map(notification => (
-          <Notification {...notification} />
-        ))}
+      <Notifications link={<Link href="notifications" />}>
+        <Notification
+          link={<Link href="notifications/1" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-05T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
+        <Notification
+          link={<Link href="notifications/2" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-01T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
+        <Notification
+          link={<Link href="notifications/3" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-01T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
       </Notifications>
     )}
     onSearch={action('onSearch')}
@@ -141,10 +133,31 @@ stories.add('With navigation', () => (
     homeLink={homeLink}
     navItems={navItems}
     notifications={(
-      <Notifications href="notifications">
-        {notifications.map(notification => (
-          <Notification {...notification} />
-        ))}
+      <Notifications link={<Link href="notifications" />}>
+        <Notification
+          link={<Link href="notifications/1" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-05T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
+        <Notification
+          link={<Link href="notifications/2" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-01T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
+        <Notification
+          link={<Link href="notifications/3" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-01T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
       </Notifications>
     )}
     onSearch={action('onSearch')}

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { fireEvent, render, RenderResult, wait } from '@testing-library/react'
 
+import { Link } from '../../index'
 import { Masthead, MastheadProps } from './Masthead'
 import { Notification, Notifications } from '../NotificationPanel'
 
@@ -169,7 +170,7 @@ describe('Masthead', () => {
       beforeEach(() => {
         const notification = (
           <Notification
-            href="notifications/1"
+            link={<Link href="notifications/1" />}
             name="Thomas Stephens"
             action="added a new comment to your"
             on="review"
@@ -179,7 +180,7 @@ describe('Masthead', () => {
         )
 
         props.notifications = (
-          <Notifications href="notifications">
+          <Notifications link={<Link href="notifications" />}>
             {notification}
             {notification}
           </Notifications>

--- a/packages/react-component-library/src/fragments/NotificationPanel/Notification.test.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/Notification.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render, RenderResult } from '@testing-library/react'
 
+import { Link } from '../../components'
 import { Notification } from '.'
 
 const NOW = '2019-11-05T11:00:00.000Z'
@@ -23,7 +24,7 @@ describe('Notification', () => {
     beforeEach(() => {
       wrapper = render(
         <Notification
-          href="notifications/1"
+          link={<Link href="notifications/1" />}
           name="Thomas Stephens"
           action="added a new comment to your"
           on="review"
@@ -84,7 +85,7 @@ describe('Notification', () => {
     beforeEach(() => {
       wrapper = render(
         <Notification
-          href="notifications/1"
+          link={<Link href="notifications/1" />}
           name="Thomas Stephens"
           action="added a new comment to your"
           on="review"
@@ -103,7 +104,7 @@ describe('Notification', () => {
     beforeEach(() => {
       wrapper = render(
         <Notification
-          href="notifications/1"
+          link={<Link href="notifications/1" />}
           name="Thomas Stephens"
           action="added a new comment to your"
           on="review"
@@ -122,7 +123,7 @@ describe('Notification', () => {
     beforeEach(() => {
       wrapper = render(
         <Notification
-          href="notifications/1"
+          link={<Link href="notifications/1" />}
           name="Thomas Double-Barrelled"
           action="added a new comment to your"
           on="review"
@@ -141,7 +142,7 @@ describe('Notification', () => {
     beforeEach(() => {
       wrapper = render(
         <Notification
-          href="notifications/1"
+          link={<Link href="notifications/1" />}
           name="Thomas Stephens"
           isRead
           action="added a new comment to your"

--- a/packages/react-component-library/src/fragments/NotificationPanel/Notification.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/Notification.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
 import differenceInMinutes from 'date-fns/differenceInMinutes'
 import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 import format from 'date-fns/format'
@@ -6,7 +6,7 @@ import format from 'date-fns/format'
 import { Avatar, AVATAR_VARIANT } from '../../components/Avatar'
 
 export interface NotificationProps {
-  href: string
+  link: React.ReactElement<LinkTypes>
   name: string
   isRead?: boolean
   action: string
@@ -38,7 +38,7 @@ function formatWhen(when: Date) {
 }
 
 export const Notification: React.FC<NotificationProps> = ({
-  href,
+  link,
   name,
   isRead,
   action,
@@ -49,36 +49,42 @@ export const Notification: React.FC<NotificationProps> = ({
   return (
     <li>
       <div className="rn-notifications-item-wrapper">
-        <a href={href}>
-          <div className="rn-notifications-item">
-            <div className="rn-notifications-item__avatar">
-              <Avatar initials={getInitials(name)} variant={AVATAR_VARIANT.DARK} />
-              {!isRead && (
-                <span
-                  className="rn-notification-panel__not-read rn-notification-panel__not-read--notification-item"
-                  data-testid="not-read-item"
+        {React.cloneElement(link as ReactElement, {
+          ...link.props,
+          children: (
+            <div className="rn-notifications-item">
+              <div className="rn-notifications-item__avatar">
+                <Avatar
+                  initials={getInitials(name)}
+                  variant={AVATAR_VARIANT.DARK}
                 />
-              )}
-            </div>
-            <div className="rn-notifications-item__content">
-              <span className="rn-notifications-item__content-strong">
-                {name}
-              </span>
-              {` ${action} `}
-              <span className="rn-notifications-item__content-strong">
-                {on}
-              </span>
-              <span
-                className="rn-notifications-item__content-circle"
-                data-testid="circle"
-              />
-              <span>{formatWhen(when)}</span>
-              <div className="rn-notifications-item__content-description">
-                {description.substring(0, 38)}...
+                {!isRead && (
+                  <span
+                    className="rn-notification-panel__not-read rn-notification-panel__not-read--notification-item"
+                    data-testid="not-read-item"
+                  />
+                )}
+              </div>
+              <div className="rn-notifications-item__content">
+                <span className="rn-notifications-item__content-strong">
+                  {name}
+                </span>
+                {` ${action} `}
+                <span className="rn-notifications-item__content-strong">
+                  {on}
+                </span>
+                <span
+                  className="rn-notifications-item__content-circle"
+                  data-testid="circle"
+                />
+                <span>{formatWhen(when)}</span>
+                <div className="rn-notifications-item__content-description">
+                  {description.substring(0, 38)}...
+                </div>
               </div>
             </div>
-          </div>
-        </a>
+          ),
+        })}
       </div>
     </li>
   )

--- a/packages/react-component-library/src/fragments/NotificationPanel/NotificationPanel.test.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/NotificationPanel.test.tsx
@@ -8,6 +8,7 @@ import {
   waitForElementToBeRemoved,
 } from '@testing-library/react'
 
+import { Link } from '../../components'
 import {
   Notification,
   NOTIFICATION_PLACEMENT,
@@ -17,7 +18,7 @@ import {
 
 const MOCK_NOTIFICATION = (
   <Notification
-    href="notifications/1"
+    link={<Link href="notifications/1" />}
     name="Thomas Stephens"
     action="added a new comment to your"
     on="review"
@@ -34,8 +35,12 @@ describe('NotificationPanel', () => {
   describe('when all props are specified, "notificationPlacement" is right', () => {
     beforeEach(() => {
       const props = {
-        onHide: () => { return true },
-        onShow: () => { return true },
+        onHide: () => {
+          return true
+        },
+        onShow: () => {
+          return true
+        },
       }
 
       onShowSpy = jest.spyOn(props, 'onShow')
@@ -49,7 +54,7 @@ describe('NotificationPanel', () => {
           notificationPlacement={NOTIFICATION_PLACEMENT.RIGHT}
           {...props}
         >
-          <Notifications href="notifications">
+          <Notifications link={<Link href="notifications" />}>
             {MOCK_NOTIFICATION}
             {MOCK_NOTIFICATION}
           </Notifications>
@@ -149,7 +154,7 @@ describe('NotificationPanel', () => {
     beforeEach(() => {
       wrapper = render(
         <NotificationPanel>
-          <Notifications href="notifications">
+          <Notifications link={<Link href="notifications" />}>
             {MOCK_NOTIFICATION}
             {MOCK_NOTIFICATION}
           </Notifications>
@@ -192,7 +197,7 @@ describe('NotificationPanel', () => {
     beforeEach(() => {
       wrapper = render(
         <NotificationPanel notificationPlacement={NOTIFICATION_PLACEMENT.BELOW}>
-          <Notifications href="notifications">
+          <Notifications link={<Link href="notifications" />}>
             {MOCK_NOTIFICATION}
             {MOCK_NOTIFICATION}
           </Notifications>
@@ -221,7 +226,7 @@ describe('NotificationPanel', () => {
         <div>
           <p data-testid="outside">Some text outside</p>
           <NotificationPanel>
-            <Notifications href="notifications">
+            <Notifications link={<Link href="notifications" />}>
               {MOCK_NOTIFICATION}
               {MOCK_NOTIFICATION}
             </Notifications>

--- a/packages/react-component-library/src/fragments/NotificationPanel/Notifications.test.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/Notifications.test.tsx
@@ -2,10 +2,11 @@ import React from 'react'
 import { render, RenderResult } from '@testing-library/react'
 
 import { Notification, Notifications } from '.'
+import { Link } from '../../components'
 
 const MOCK_NOTIFICATION = (
   <Notification
-    href="notifications/1"
+    link={<Link href="notifications/1" />}
     name="Thomas Stephens"
     action="added a new comment to your"
     on="review"
@@ -20,7 +21,7 @@ describe('Notifications', () => {
 
     beforeEach(() => {
       wrapper = render(
-        <Notifications href="notifications">
+        <Notifications link={<Link href="notifications" />}>
           {MOCK_NOTIFICATION}
           {MOCK_NOTIFICATION}
         </Notifications>

--- a/packages/react-component-library/src/fragments/NotificationPanel/Notifications.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/Notifications.tsx
@@ -1,24 +1,32 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
 import { IconKeyboardArrowRight } from '@royalnavy/icon-library'
 
 import { NotificationProps } from '.'
 
 export interface NotificationsProps {
-  href: string
-  children: React.ReactElement<NotificationProps>[]
+  link: React.ReactElement<LinkTypes>
+  children:
+    | React.ReactElement<NotificationProps>
+    | React.ReactElement<NotificationProps>[]
 }
 
 export const Notifications: React.FC<NotificationsProps> = ({
-  href,
+  link,
   children,
 }) => (
   <>
-    <ol className="rn-notifications" data-testid="notifications">{children}</ol>
+    <ol className="rn-notifications" data-testid="notifications">
+      {children}
+    </ol>
     <span className="rn-notifications__view-all">
-      <a href={href}>
-        View all notifications
-        <IconKeyboardArrowRight />
-      </a>
+      {React.cloneElement(link as ReactElement, {
+        children: (
+          <>
+            View all notifications
+            <IconKeyboardArrowRight />
+          </>
+        ),
+      })}
     </span>
   </>
 )

--- a/packages/react-component-library/src/fragments/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/fragments/Sidebar/Sidebar.stories.tsx
@@ -6,36 +6,6 @@ import Sidebar from './index'
 import { Graph, House, Tools } from '../../icons'
 import { Notification, Notifications } from '../NotificationPanel'
 
-const notifications = [
-  {
-    href: 'notifications/1',
-    name: 'Thomas Stephens',
-    action: 'added a new comment to your',
-    on: 'review',
-    when: new Date('2019-11-05T14:25:02.178Z'),
-    description:
-      'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores',
-  },
-  {
-    href: 'notifications/2',
-    name: 'Thomas Stephens',
-    action: 'added a new comment to your',
-    on: 'review',
-    when: new Date('2019-11-01T14:25:02.178Z'),
-    description:
-      'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores',
-  },
-  {
-    href: 'notifications/3',
-    name: 'Thomas Stephens',
-    action: 'added a new comment to your',
-    on: 'review',
-    when: new Date('2019-11-01T14:25:02.178Z'),
-    description:
-      'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores',
-  },
-]
-
 const stories = storiesOf('Sidebar', module)
 
 const navData: NavItemAnchorType[] = [
@@ -57,16 +27,37 @@ const navData: NavItemAnchorType[] = [
   },
 ]
 
-const user = { initials: 'XT', href: '/userprofile' }
+const user = { initials: 'XT', href: '/user-profile' }
 
 stories.add('With notifications', () => (
   <Sidebar
     navItems={navData}
     notifications={(
-      <Notifications href="notifications">
-        {notifications.map(notification => (
-          <Notification {...notification} />
-        ))}
+      <Notifications link={<Link href="notifications" />}>
+        <Notification
+          link={<Link href="notifications/1" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-05T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
+        <Notification
+          link={<Link href="notifications/2" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-01T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
+        <Notification
+          link={<Link href="notifications/3" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-01T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
       </Notifications>
     )}
     unreadNotification
@@ -79,10 +70,31 @@ stories.add('No notifications', () => (
     user={user}
     navItems={navData}
     notifications={(
-      <Notifications href="notifications">
-        {notifications.map(notification => (
-          <Notification {...notification} />
-        ))}
+      <Notifications link={<Link href="notifications" />}>
+        <Notification
+          link={<Link href="notifications/1" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-05T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
+        <Notification
+          link={<Link href="notifications/2" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-01T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
+        <Notification
+          link={<Link href="notifications/3" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-01T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
       </Notifications>
     )}
   />
@@ -97,10 +109,31 @@ stories.add('With custom Link component', () => (
     LinkComponent={Link}
     navItems={navData}
     notifications={(
-      <Notifications href="notifications">
-        {notifications.map(notification => (
-          <Notification {...notification} />
-        ))}
+      <Notifications link={<Link href="notifications" />}>
+        <Notification
+          link={<Link href="notifications/1" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-05T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
+        <Notification
+          link={<Link href="notifications/2" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-01T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
+        <Notification
+          link={<Link href="notifications/3" />}
+          name="Thomas Stephens"
+          action="added a new comment to your"
+          on="review"
+          when={new Date('2019-11-01T14:25:02.178Z')}
+          description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+        />
       </Notifications>
     )}
     unreadNotification


### PR DESCRIPTION
## Related issue
#467 

## Overview
Refactor `Notifications` to use `Link` rather than just `href`.

## Reason
This is consistent with how other links are supplied. Gives the possibility to specify other link types.

## Work carried out
- [x] Refactor

## Screenshot
No visual change.