### PR TITLE
Fix modal hide show from side effect

### DIFF
--- a/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
@@ -47,7 +47,7 @@ describe('Modal', () => {
       })
 
       it('should apply the `rn-dialog` class', () => {
-        expect(wrapper.queryByTestId('rn-modal-wrapper')).toHaveClass(
+        expect(wrapper.queryByTestId('modal-wrapper')).toHaveClass(
           'rn-dialog'
         )
       })
@@ -55,7 +55,7 @@ describe('Modal', () => {
       describe('and the primary button is clicked', () => {
         beforeEach(() => {
           fireEvent(
-            wrapper.getByTestId('rn-modal-btn-primary'),
+            wrapper.getByTestId('modal-primary'),
             new MouseEvent('click', {
               bubbles: true,
               cancelable: true,
@@ -71,7 +71,7 @@ describe('Modal', () => {
       describe('and the secondary button is clicked', () => {
         beforeEach(() => {
           fireEvent(
-            wrapper.getByTestId('rn-modal-btn-secondary'),
+            wrapper.getByTestId('modal-secondary'),
             new MouseEvent('click', {
               bubbles: true,
               cancelable: true,
@@ -101,13 +101,13 @@ describe('Modal', () => {
     })
 
     it('should apply the correct modifier class to the wrapper', () => {
-      expect(wrapper.queryByTestId('rn-modal-wrapper')).toHaveClass(
+      expect(wrapper.queryByTestId('modal-wrapper')).toHaveClass(
         'rn-dialog--danger'
       )
     })
 
     it('should apply the correct modifier to the primary button', () => {
-      expect(wrapper.queryByTestId('rn-modal-btn-primary')).toHaveClass(
+      expect(wrapper.queryByTestId('modal-primary')).toHaveClass(
         'rn-btn--danger'
       )
     })

--- a/packages/react-component-library/src/components/Modal/Footer.tsx
+++ b/packages/react-component-library/src/components/Modal/Footer.tsx
@@ -13,14 +13,14 @@ export const Footer: React.FC<FooterProps> = ({
   tertiaryButton,
 }) => {
   return (
-    <footer className="rn-modal__footer" data-testid="rn-modal-footer">
+    <footer className="rn-modal__footer" data-testid="modal-footer">
       {tertiaryButton && (
         <Button
           className="rn-modal__tertiary-button"
           type="button"
           variant="secondary"
           {...tertiaryButton}
-          data-testid="rn-modal-btn-tertiary"
+          data-testid="modal-tertiary"
         />
       )}
       {secondaryButton && (
@@ -29,7 +29,7 @@ export const Footer: React.FC<FooterProps> = ({
           type="button"
           variant="secondary"
           {...secondaryButton}
-          data-testid="rn-modal-btn-secondary"
+          data-testid="modal-secondary"
         />
       )}
       {primaryButton && (
@@ -38,7 +38,7 @@ export const Footer: React.FC<FooterProps> = ({
           type="button"
           variant="primary"
           {...primaryButton}
-          data-testid="rn-modal-btn-primary"
+          data-testid="modal-primary"
         />
       )}
     </footer>

--- a/packages/react-component-library/src/components/Modal/Header.tsx
+++ b/packages/react-component-library/src/components/Modal/Header.tsx
@@ -7,13 +7,13 @@ export interface HeaderProps {
 
 export const Header: React.FC<HeaderProps> = ({ title, onClose }) => {
   return (
-    <header className="rn-modal__header" data-testid="rn-modal-header">
+    <header className="rn-modal__header" data-testid="modal-header">
       <span className="rn-modal__title">{title}</span>
       <button
         className="rn-modal__close-button"
         type="button"
         onClick={onClose}
-        data-testid="rn-modal-close-button"
+        data-testid="modal-close"
       >
         &times;
       </button>

--- a/packages/react-component-library/src/components/Modal/Modal.test.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.test.tsx
@@ -41,15 +41,15 @@ describe('Modal', () => {
       })
 
       it('should apply the `is-open` class', () => {
-        expect(wrapper.queryByTestId('rn-modal-wrapper')).toHaveClass('is-open')
+        expect(wrapper.queryByTestId('modal-wrapper')).toHaveClass('is-open')
       })
 
       it('should not render the Header component', () => {
-        expect(wrapper.queryByTestId('rn-modal-header')).toBeNull()
+        expect(wrapper.queryByTestId('modal-header')).toBeNull()
       })
 
       it('should not render the Footer component', () => {
-        expect(wrapper.queryByTestId('rn-modal-footer')).toBeNull()
+        expect(wrapper.queryByTestId('modal-footer')).toBeNull()
       })
     })
   })
@@ -70,11 +70,11 @@ describe('Modal', () => {
         )
       })
       it('should render the Header component', () => {
-        expect(wrapper.queryByTestId('rn-modal-header')).not.toBeNull()
+        expect(wrapper.queryByTestId('modal-header')).toBeInTheDocument()
       })
 
       it('should render the child JSX', () => {
-        expect(wrapper.queryByTestId('rn-modal-body')).toHaveTextContent(
+        expect(wrapper.queryByTestId('modal-body')).toHaveTextContent(
           'Example child JSX'
         )
       })
@@ -82,7 +82,7 @@ describe('Modal', () => {
       describe('and the close button is clicked', () => {
         beforeEach(() => {
           fireEvent(
-            wrapper.getByTestId('rn-modal-close-button'),
+            wrapper.getByTestId('modal-close'),
             new MouseEvent('click', {
               bubbles: true,
               cancelable: true,
@@ -94,7 +94,7 @@ describe('Modal', () => {
         })
 
         it('should apply the `is-closed` stateful class', () => {
-          expect(wrapper.queryByTestId('rn-modal-wrapper')).toHaveClass(
+          expect(wrapper.queryByTestId('modal-wrapper')).toHaveClass(
             'is-closed'
           )
         })
@@ -117,29 +117,33 @@ describe('Modal', () => {
         })
 
         it('should render the Footer component', () => {
-          expect(wrapper.queryByTestId('rn-modal-footer')).not.toBeNull()
+          expect(wrapper.queryByTestId('modal-footer')).toBeInTheDocument()
         })
 
         it('should render all the buttons', () => {
-          expect(wrapper.queryByTestId('rn-modal-btn-primary')).not.toBeNull()
-          expect(wrapper.queryByTestId('rn-modal-btn-secondary')).not.toBeNull()
-          expect(wrapper.queryByTestId('rn-modal-btn-tertiary')).not.toBeNull()
+          expect(wrapper.queryByTestId('modal-primary')).toBeInTheDocument()
+          expect(wrapper.queryByTestId('modal-secondary')).toBeInTheDocument()
+          expect(wrapper.queryByTestId('modal-tertiary')).toBeInTheDocument()
         })
 
         it('should render primary button as primary variant', () => {
-          expect(wrapper.queryByTestId('rn-modal-btn-primary')).toHaveClass(
+          expect(wrapper.queryByTestId('modal-primary')).toHaveClass(
             'rn-btn--primary'
           )
         })
 
+        it('should render the primary button with an icon', () => {
+          expect(wrapper.queryByTestId('modal-primary-confirm')).toBeInTheDocument()
+        })
+
         it('should render secondary button as secondary variant', () => {
-          expect(wrapper.queryByTestId('rn-modal-btn-secondary')).toHaveClass(
+          expect(wrapper.queryByTestId('modal-secondary')).toHaveClass(
             'rn-btn--secondary'
           )
         })
 
         it('should render tertiary button as secondary variant', () => {
-          expect(wrapper.queryByTestId('rn-modal-btn-tertiary')).toHaveClass(
+          expect(wrapper.queryByTestId('modal-tertiary')).toHaveClass(
             'rn-btn--secondary'
           )
         })

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react'
+import React from 'react'
 import classNames from 'classnames'
 import { IconButtonConfirm } from '@royalnavy/icon-library'
 
 import { ButtonProps } from '../Button'
-
 import { Header } from './Header'
 import { Footer } from './Footer'
+import { useOpenClose } from './useOpenClose'
 
 export interface ModalProps extends ComponentWithClass {
   children?: React.ReactNode
@@ -18,43 +18,36 @@ export interface ModalProps extends ComponentWithClass {
 }
 
 export const Modal: React.FC<ModalProps> = ({
-  className = '',
+  className,
   children,
-  isOpen = false,
+  isOpen,
   onClose,
   primaryButton,
   secondaryButton,
   tertiaryButton,
   title,
 }) => {
-  const [open, setOpen] = useState(isOpen)
-  const mutatedPrimaryButton = primaryButton
-
-  function handleOnClose(event: React.FormEvent<HTMLButtonElement>) {
-    setOpen(false)
-    onClose(event)
-  }
-
-  if (mutatedPrimaryButton) {
-    mutatedPrimaryButton.icon = <IconButtonConfirm />
-  }
-
-  const classes = classNames(className, {
-    'rn-modal': true,
+  const { handleOnClose, open } = useOpenClose(isOpen, onClose)
+  const classes = classNames('rn-modal', {
     'is-open': open,
     'is-closed': !open,
-  })
+  }, className)
+
+  const primaryButtonWithIcon = primaryButton && {
+    ...primaryButton,
+    icon: <IconButtonConfirm data-testid="modal-primary-confirm" />,
+  }
 
   return (
-    <div className={classes} data-testid="rn-modal-wrapper">
+    <div className={classes} data-testid="modal-wrapper">
       <article className="rn-modal__main">
         {title && <Header title={title} onClose={handleOnClose} />}
-        <section className="rn-modal__body" data-testid="rn-modal-body">
+        <section className="rn-modal__body" data-testid="modal-body">
           {children}
         </section>
         {(primaryButton || secondaryButton || tertiaryButton) && (
           <Footer
-            primaryButton={mutatedPrimaryButton}
+            primaryButton={primaryButtonWithIcon}
             secondaryButton={secondaryButton}
             tertiaryButton={tertiaryButton}
           />

--- a/packages/react-component-library/src/components/Modal/useOpenClose.ts
+++ b/packages/react-component-library/src/components/Modal/useOpenClose.ts
@@ -1,10 +1,14 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 export function useOpenClose(
   isOpen: boolean,
   onClose: (event: React.FormEvent<HTMLButtonElement>) => void
 ) {
   const [open, setOpen] = useState(isOpen)
+
+  useEffect(() => {
+    setOpen(isOpen)
+  }, [isOpen])
 
   function handleOnClose(event: React.FormEvent<HTMLButtonElement>) {
     setOpen(false)

--- a/packages/react-component-library/src/components/Modal/useOpenClose.ts
+++ b/packages/react-component-library/src/components/Modal/useOpenClose.ts
@@ -1,0 +1,18 @@
+import React, { useState } from 'react'
+
+export function useOpenClose(
+  isOpen: boolean,
+  onClose: (event: React.FormEvent<HTMLButtonElement>) => void
+) {
+  const [open, setOpen] = useState(isOpen)
+
+  function handleOnClose(event: React.FormEvent<HTMLButtonElement>) {
+    setOpen(false)
+    onClose(event)
+  }
+
+  return {
+    open,
+    handleOnClose,
+  }
+}


### PR DESCRIPTION
## Related issue
#505 

## Overview
If the modal visibility is being controlled by a side effect then the rendered output will not change.

## Reason
Components need to use `useEffect` hook when side effects update state.

## Work carried out
- [x] Fix

## Screenshot
Visual appearance should not change.

## Developer notes
This is the same fix for the recent table bug.