### PR TITLE
Remove redundant z-index

### DIFF
--- a/packages/css-framework/src/components/_textinput.scss
+++ b/packages/css-framework/src/components/_textinput.scss
@@ -46,7 +46,6 @@
 
 .rn-textinput__label {
   display: block;
-  z-index: 1;
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
Redundant z-index causes the label to display on top of open Select component options.