### PR TITLE
Use ...rest to drill props through Select wrapper

### DIFF
--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -16,11 +16,18 @@ const options = [
 ]
 
 stories.add('Default', () => (
-  <div style={{ margin: 50 }}>
-    <Select
-      options={options}
-      label="Hello"
-      onChange={action('onChange')}
-    />
-  </div>
+  <Select
+    options={options}
+    label="Example Label"
+    onChange={action('onChange')}
+  />
+))
+
+stories.add('Disabled', () => (
+  <Select
+    options={options}
+    label="Example Label"
+    onChange={action('onChange')}
+    isDisabled
+  />
 ))

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { render, RenderResult } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+
+import { Select } from './Select'
+
+const options = [{ value: 'example', label: 'Example', badge: 100 }]
+
+describe('Select', () => {
+  let wrapper: RenderResult
+
+  describe('when passed a prop from `react-select` extended interface', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Select options={options} label="Example Label" isDisabled />
+      )
+    })
+
+    it('drills the prop down to wrapped component', () => {
+      expect(wrapper.container.querySelector('.rn-select').classList).toContain(
+        'rn-select--is-disabled'
+      )
+    })
+  })
+})

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import ReactSelect from 'react-select'
+import ReactSelect, { Props as ReactSelectProps } from 'react-select'
 
 import { DropdownIndicator } from './DropdownIndicator'
 import { Input } from './Input'
-import { Option, SelectOptionWithBadgeType } from './Option'
 import { SingleValue } from './SingleValue'
+import { Option, SelectOptionWithBadgeType } from './Option'
 
-export interface SelectProps {
+export interface SelectProps extends ReactSelectProps<any> {
   label?: string
   name?: string
   onChange?: (event: any) => void
@@ -20,6 +20,7 @@ export const Select: React.FC<SelectProps> = ({
   onChange,
   options,
   value,
+  ...rest
 }) => {
   const onSelectChange = (option: any) => {
     const selectedValue =
@@ -52,6 +53,7 @@ export const Select: React.FC<SelectProps> = ({
       options={options}
       placeholder={null}
       value={selectedOption}
+      {...rest}
     />
   )
 }


### PR DESCRIPTION
The Select component simply wraps a library. Additional props were not being respect by the wrapper.

This fix exposes additional functionality to the end user (in particular `isDisabled`).