### PR TITLE
Prevent className prop stripping Select component base class

### DIFF
--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactSelect, { Props as ReactSelectProps } from 'react-select'
+import classNames from 'classnames'
 
 import { DropdownIndicator } from './DropdownIndicator'
 import { Input } from './Input'
@@ -12,6 +13,7 @@ export interface SelectProps extends ReactSelectProps<any> {
   onChange?: (event: any) => void
   options: SelectOptionWithBadgeType[]
   value?: string
+  className?: string
 }
 
 export const Select: React.FC<SelectProps> = ({
@@ -20,6 +22,7 @@ export const Select: React.FC<SelectProps> = ({
   onChange,
   options,
   value,
+  className,
   ...rest
 }) => {
   const onSelectChange = (option: any) => {
@@ -36,10 +39,12 @@ export const Select: React.FC<SelectProps> = ({
 
   const selectedOption = options.find(option => option.value === value)
 
+  const classes = classNames('rn-select', className)
+
   return (
     <ReactSelect
       aria-label={label}
-      className="rn-select"
+      className={classes}
       classNamePrefix="rn-select"
       components={{
         DropdownIndicator,


### PR DESCRIPTION
Fix bug introduced by spreading the `...rest` of the props when `className` was not explicitly declared as a prop.

The base `rn-select` class would be removed from the component and all of the other component styles are namespaced by this base selector.

This means the component would default back to the original ReactSelect library styles.