### PR TITLE
Make react-component-library tree shakeable downstream

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "npmClient": "yarn"
 }

--- a/packages/css-framework/package.json
+++ b/packages/css-framework/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@royalnavy/css-framework",
   "description": "Foundational CSS Framework for Royal Navy components and applications.",
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -4,7 +4,7 @@
     "node": ">=10.13.0 <13"
   },
   "description": "The documentation site for royalnavy.io",
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "author": "NELSON",
   "license": "Apache-2.0",
   "scripts": {
@@ -39,9 +39,9 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.5.1",
     "@mdx-js/react": "^1.5.1",
-    "@royalnavy/css-framework": "^2.0.1",
-    "@royalnavy/icon-library": "^2.0.1",
-    "@royalnavy/react-component-library": "^2.0.1",
+    "@royalnavy/css-framework": "^2.0.2-alpha.0",
+    "@royalnavy/icon-library": "^2.0.2-alpha.0",
+    "@royalnavy/react-component-library": "^2.0.2-alpha.0",
     "change-case": "^3.1.0",
     "gatsby": "^2.18.8",
     "gatsby-image": "^2.2.34",
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.5",
-    "@royalnavy/eslint-config-react": "^2.0.1",
+    "@royalnavy/eslint-config-react": "^2.0.2-alpha.0",
     "@svgr/cli": "^4.3.3",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@royalnavy/eslint-config-react",
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/icon-library/package.json
+++ b/packages/icon-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@royalnavy/icon-library",
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "author": "NELSON",

--- a/packages/react-component-library/.babelrc
+++ b/packages/react-component-library/.babelrc
@@ -1,11 +1,5 @@
 {
   "presets": [
-    [
-      "@babel/preset-env",
-      {
-        "modules": false
-      }
-    ],
     "@babel/preset-react",
     "@babel/typescript"
   ],
@@ -14,6 +8,23 @@
     "@babel/proposal-object-rest-spread"
   ],
   "env": {
+    "es": {
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "modules": false
+          }
+        ]
+      ]
+    },
+    "cjs": {
+      "presets": [
+        [
+          "@babel/preset-env"
+        ]
+      ]
+    },
     "test": {
       "plugins": [
         "@babel/plugin-transform-modules-commonjs"

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@royalnavy/react-component-library",
   "description": "A collection of react components and helpers to assist in building applications for the Royal Navy",
-  "version": "2.0.1",
+  "version": "2.0.2-alpha.0",
   "publishConfig": {
     "access": "public"
   },
@@ -126,8 +126,8 @@
   ],
   "dependencies": {
     "@datepicker-react/hooks": "^2.1.4",
-    "@royalnavy/css-framework": "^2.0.1",
-    "@royalnavy/icon-library": "^2.0.1",
+    "@royalnavy/css-framework": "^2.0.2-alpha.0",
+    "@royalnavy/icon-library": "^2.0.2-alpha.0",
     "@types/react-responsive": "^8.0.2",
     "classnames": "^2.2.6",
     "date-fns": "^2.8.1",

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -14,17 +14,19 @@
     "starter",
     "boilerplate"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/es/index.js",
+  "types": "dist/types/index.d.ts",
   "sideEffects": false,
   "author": "NELSON",
   "license": "Apache-2.0",
   "scripts": {
     "analyze": "webpack -p --config=webpack/analyze.js",
+    "build": "run-s build:es build:cjs types",
+    "build:cjs": "NODE_ENV=cjs webpack -p --config=webpack/prod.js",
+    "build:es": "NODE_ENV=es babel src --out-dir \"dist/es\" --extensions \".ts,.tsx\"",
     "build:dev": "run-s build:ts:dev types",
     "build:ts:dev": "webpack -p --config=webpack/dev.js",
-    "build:ts": "webpack -p --config=webpack/prod.js",
-    "build": "run-s build:ts types",
     "dev": "concurrently \"webpack --watch --config=webpack/dev.js\" \"yarn types --watch\"",
     "lint-staged": "lint-staged",
     "lint:ci": "eslint -f ../../node_modules/eslint-junit/index.js src/* --ext .js --ext .jsx --ext .ts --ext .tsx",
@@ -34,7 +36,7 @@
     "storybook": "start-storybook -p 6006",
     "test:watch": "NODE_ENV=test jest --watch",
     "test": "NODE_ENV=test jest",
-    "types": "tsc --emitDeclarationOnly --declarationMap --declaration --noEmit false --isolatedMOdules false --allowJs false --outDir dist/"
+    "types": "tsc --emitDeclarationOnly --declarationMap --declaration --noEmit false --isolatedMOdules false --allowJs false --outDir dist/types"
   },
   "lint-staged": {
     "*.@(js|jsx|ts|tsx)": "eslint"

--- a/packages/react-component-library/webpack/analyze.js
+++ b/packages/react-component-library/webpack/analyze.js
@@ -1,4 +1,3 @@
-// production config
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const { resolve } = require('path')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
@@ -11,7 +10,7 @@ module.exports = merge(commonConfig, {
   mode: 'production',
   output: {
     filename: 'index.js',
-    path: resolve(__dirname, '../dist'),
+    path: resolve(__dirname, '../dist/cjs'),
     libraryTarget: 'commonjs2',
   },
   devtool: 'source-map',

--- a/packages/react-component-library/webpack/dev.js
+++ b/packages/react-component-library/webpack/dev.js
@@ -8,7 +8,7 @@ module.exports = merge(commonConfig, {
   mode: 'development',
   output: {
     filename: 'index.js',
-    path: resolve(__dirname, '../dist'),
+    path: resolve(__dirname, '../dist/cjs'),
     libraryTarget: 'commonjs2',
   },
   devtool: 'cheap-module-eval-source-map',

--- a/packages/react-component-library/webpack/prod.js
+++ b/packages/react-component-library/webpack/prod.js
@@ -9,7 +9,7 @@ module.exports = merge(commonConfig, {
   mode: 'production',
   output: {
     filename: 'index.js',
-    path: resolve(__dirname, '../dist'),
+    path: resolve(__dirname, '../dist/cjs'),
     libraryTarget: 'commonjs2',
   },
   devtool: 'source-map',


### PR DESCRIPTION
Generated a transpiled ESM build as well as the CJS WebPack bundle and set `sideEffects` flag.

This makes the library automatically tree shakeable downstream.

I've published 2.0.2-alpha.0 for this and will subsequently be testing the package in an application.