### PR TITLE
Change Alert examples to different structure

### DIFF
--- a/packages/react-component-library/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.stories.tsx
@@ -5,9 +5,9 @@ import { withKnobs, text } from '@storybook/addon-knobs';
 import { Alert, ALERT_VARIANT } from './index'
 
 const stories = storiesOf('Alert', module)
-const dangerStories = storiesOf('Alert/Danger', module)
-const successStories = storiesOf('Alert/Success', module)
-const warningStories = storiesOf('Alert/Warning', module)
+const dangerStories = storiesOf('Alert/Examples/Danger', module)
+const successStories = storiesOf('Alert/Examples/Success', module)
+const warningStories = storiesOf('Alert/Examples/Warning', module)
 
 stories.addDecorator(withKnobs)
 


### PR DESCRIPTION
## Related issue
#551 

## Overview
Changes Storybook folder structure.

## Reason
Intending for this to be a convention across all examples.

## Work carried out
- [x] Change

## Screenshot
![Screenshot 2020-01-27 at 10 54 39](https://user-images.githubusercontent.com/56078793/73170710-07ca0000-40f7-11ea-8e98-a578e9d04a42.png)