### PR TITLE
Refactor Badge Storybook examples

### DIFF
--- a/packages/react-component-library/src/components/Badge/Badge.stories.tsx
+++ b/packages/react-component-library/src/components/Badge/Badge.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { text, withKnobs } from '@storybook/addon-knobs'
 
 import {
   Badge,
@@ -7,164 +8,80 @@ import {
   BADGE_COLOR_VARIANT,
   BADGE_SIZE,
   BADGE_VARIANT,
+  BadgeColorType,
+  BadgeSizeType,
 } from '.'
 
 const stories = storiesOf('Badge', module)
+const fadedExamples = storiesOf('Badge/Examples/Faded', module)
+const solidExamples = storiesOf('Badge/Examples/Solid', module)
+const sizesExamples = storiesOf('Badge/Examples/Sizes', module)
+const pillsExamples = storiesOf('Badge/Examples/Pills', module)
 
-stories.add('Faded', () => (
-  <div>
-    <Badge
-      color={BADGE_COLOR.NEUTRAL}
-      colorVariant={BADGE_COLOR_VARIANT.FADED}
-      size={BADGE_SIZE.REGULAR}
-    >
-      Neutral
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.ACTION}
-      colorVariant={BADGE_COLOR_VARIANT.FADED}
-      size={BADGE_SIZE.REGULAR}
-    >
-      Action
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.DANGER}
-      colorVariant={BADGE_COLOR_VARIANT.FADED}
-      size={BADGE_SIZE.REGULAR}
-    >
-      Danger
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.WARNING}
-      colorVariant={BADGE_COLOR_VARIANT.FADED}
-      size={BADGE_SIZE.REGULAR}
-    >
-      Warning
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.SUCCESS}
-      colorVariant={BADGE_COLOR_VARIANT.FADED}
-      size={BADGE_SIZE.REGULAR}
-    >
-      Success
-    </Badge>
-  </div>
-))
+stories.addDecorator(withKnobs)
 
-stories.add('Solid', () => (
-  <div>
-    <Badge
-      color={BADGE_COLOR.NEUTRAL}
-      colorVariant={BADGE_COLOR_VARIANT.SOLID}
-      size={BADGE_SIZE.REGULAR}
-    >
-      Neutral
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.ACTION}
-      colorVariant={BADGE_COLOR_VARIANT.SOLID}
-      size={BADGE_SIZE.REGULAR}
-    >
-      Action
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.DANGER}
-      colorVariant={BADGE_COLOR_VARIANT.SOLID}
-      size={BADGE_SIZE.REGULAR}
-    >
-      Danger
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.WARNING}
-      colorVariant={BADGE_COLOR_VARIANT.SOLID}
-      size={BADGE_SIZE.REGULAR}
-    >
-      Warning
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.SUCCESS}
-      colorVariant={BADGE_COLOR_VARIANT.SOLID}
-      size={BADGE_SIZE.REGULAR}
-    >
-      Success
-    </Badge>
-  </div>
-))
+const badgeColorTextMap = {
+  [BADGE_COLOR.ACTION]: 'Action',
+  [BADGE_COLOR.DANGER]: 'Danger',
+  [BADGE_COLOR.NEUTRAL]: 'Neutral',
+  [BADGE_COLOR.SUCCESS]: 'Success',
+  [BADGE_COLOR.WARNING]: 'Warning',
+}
 
-stories.add('Sizes', () => (
-  <div>
-    <Badge
-      color={BADGE_COLOR.NEUTRAL}
-      colorVariant={BADGE_COLOR_VARIANT.FADED}
-      size={BADGE_SIZE.SMALL}
-    >
-      Small
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.NEUTRAL}
-      colorVariant={BADGE_COLOR_VARIANT.FADED}
-      size={BADGE_SIZE.REGULAR}
-    >
-      Regular
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.NEUTRAL}
-      colorVariant={BADGE_COLOR_VARIANT.FADED}
-      size={BADGE_SIZE.LARGE}
-    >
-      Large
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.NEUTRAL}
-      colorVariant={BADGE_COLOR_VARIANT.FADED}
-      size={BADGE_SIZE.XLARGE}
-    >
-      XLarge
-    </Badge>
-  </div>
-))
+const badgeSizeTextMap = {
+  [BADGE_SIZE.SMALL]: 'Small',
+  [BADGE_SIZE.REGULAR]: 'Regular',
+  [BADGE_SIZE.LARGE]: 'Large',
+  [BADGE_SIZE.XLARGE]: 'XLarge',
+}
 
-stories.add('Pills', () => (
-  <div>
+stories.add('Default', () => <Badge>{text('Children', 'Badge')}</Badge>)
+
+Object.keys(badgeColorTextMap).forEach(key => {
+  fadedExamples.add(badgeColorTextMap[key], () => (
+    <Badge
+      color={key as BadgeColorType}
+      colorVariant={BADGE_COLOR_VARIANT.FADED}
+      size={BADGE_SIZE.REGULAR}
+    >
+      {badgeColorTextMap[key]}
+    </Badge>
+  ))
+})
+
+Object.keys(badgeColorTextMap).forEach(key => {
+  solidExamples.add(badgeColorTextMap[key], () => (
+    <Badge
+      color={key as BadgeColorType}
+      colorVariant={BADGE_COLOR_VARIANT.SOLID}
+      size={BADGE_SIZE.REGULAR}
+    >
+      {badgeColorTextMap[key]}
+    </Badge>
+  ))
+})
+
+Object.keys(badgeSizeTextMap).forEach(key => {
+  sizesExamples.add(badgeSizeTextMap[key], () => (
     <Badge
       color={BADGE_COLOR.NEUTRAL}
-      colorVariant={BADGE_COLOR_VARIANT.SOLID}
-      size={BADGE_SIZE.REGULAR}
-      variant={BADGE_VARIANT.PILL}
+      colorVariant={BADGE_COLOR_VARIANT.FADED}
+      size={key as BadgeSizeType}
     >
-      Neutral
+      {badgeSizeTextMap[key]}
     </Badge>
+  ))
+})
+
+Object.keys(badgeColorTextMap).forEach(key => {
+  pillsExamples.add(badgeColorTextMap[key], () => (
     <Badge
-      color={BADGE_COLOR.ACTION}
+      color={key as BadgeColorType}
       colorVariant={BADGE_COLOR_VARIANT.SOLID}
       size={BADGE_SIZE.REGULAR}
       variant={BADGE_VARIANT.PILL}
     >
-      Action
+      {badgeColorTextMap[key]}
     </Badge>
-    <Badge
-      color={BADGE_COLOR.DANGER}
-      colorVariant={BADGE_COLOR_VARIANT.SOLID}
-      size={BADGE_SIZE.REGULAR}
-      variant={BADGE_VARIANT.PILL}
-    >
-      Danger
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.WARNING}
-      colorVariant={BADGE_COLOR_VARIANT.SOLID}
-      size={BADGE_SIZE.REGULAR}
-      variant={BADGE_VARIANT.PILL}
-    >
-      Warning
-    </Badge>
-    <Badge
-      color={BADGE_COLOR.SUCCESS}
-      colorVariant={BADGE_COLOR_VARIANT.SOLID}
-      size={BADGE_SIZE.REGULAR}
-      variant={BADGE_VARIANT.PILL}
-    >
-      Success
-    </Badge>
-  </div>
-))
+  ))
+})

--- a/packages/react-component-library/src/components/Badge/Badge.tsx
+++ b/packages/react-component-library/src/components/Badge/Badge.tsx
@@ -8,21 +8,25 @@ import {
   BADGE_VARIANT,
 } from './constants'
 
+export type BadgeColorType =
+  | typeof BADGE_COLOR.ACTION
+  | typeof BADGE_COLOR.DANGER
+  | typeof BADGE_COLOR.NEUTRAL
+  | typeof BADGE_COLOR.SUCCESS
+  | typeof BADGE_COLOR.WARNING
+
+export type BadgeSizeType =
+  | typeof BADGE_SIZE.SMALL
+  | typeof BADGE_SIZE.REGULAR
+  | typeof BADGE_SIZE.LARGE
+  | typeof BADGE_SIZE.XLARGE
+
 interface BadgeProps extends ComponentWithClass {
-  color?:
-    | typeof BADGE_COLOR.ACTION
-    | typeof BADGE_COLOR.DANGER
-    | typeof BADGE_COLOR.NEUTRAL
-    | typeof BADGE_COLOR.SUCCESS
-    | typeof BADGE_COLOR.WARNING
+  color?: BadgeColorType
   colorVariant?:
     | typeof BADGE_COLOR_VARIANT.FADED
     | typeof BADGE_COLOR_VARIANT.SOLID
-  size?:
-    | typeof BADGE_SIZE.SMALL
-    | typeof BADGE_SIZE.REGULAR
-    | typeof BADGE_SIZE.LARGE
-    | typeof BADGE_SIZE.XLARGE
+  size?: BadgeSizeType
   variant?: typeof BADGE_VARIANT.PILL
 }
 


### PR DESCRIPTION
## Related issue
#550 

## Overview
Refactors Storybook examples to use a new folder structure.

## Reason
Convention across examples.

## Work carried out
- [x] Refactor

## Screenshot
![Screenshot 2020-01-27 at 10 55 04](https://user-images.githubusercontent.com/56078793/73170996-9e96bc80-40f7-11ea-940a-fe535852a0c4.png)