### PR TITLE
Use React.Children.map over children.map

### DIFF
--- a/packages/react-component-library/src/components/Table/Table.tsx
+++ b/packages/react-component-library/src/components/Table/Table.tsx
@@ -38,11 +38,14 @@ export const Table: React.FC<TableProps> = ({ data, children }) => {
         <tbody>
           {tableData.map((row: RowProps) => (
             <tr key={getKey(`table-row`, row.id)} data-testid="table-row">
-              {children.map(({ props }) => (
-                <td key={getKey(`table-cell-${props.field}`, row.id)}>
-                  {row[props.field]}
-                </td>
-              ))}
+              {React.Children.map(
+                children,
+                (child: React.ReactElement<TableColumnProps>) => (
+                  <td key={getKey(`table-cell-${child.props.field}`, row.id)}>
+                    {row[child.props.field]}
+                  </td>
+                )
+              )}
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Related issue
NA

## Overview
Preferring `React.Children.map` over `children.map`.

## Reason
The main reason it is preferred is that there will not be an error when `children` is not an array. The reason it has been done here is that it is consistent with other code.

## Work carried out
- [x] Use `React.Children.map`