### PR TITLE
Stop TabSet change submitting parent form

### DIFF
--- a/packages/react-component-library/src/components/TabSet/TabItem.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabItem.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React, { forwardRef, MouseEvent } from 'react'
 import classNames from 'classnames'
 
 interface TabItemProps {
@@ -10,14 +10,19 @@ interface TabItemProps {
 }
 
 export const TabItem = forwardRef<HTMLLIElement, TabItemProps>(
-  ({ children, index, isActive, onClick, isScrollable }, ref) => {
+  ({ children, isActive, onClick }, ref) => {
     const tabClasses = classNames('rn-tab-set__tab', {
       'is-active': isActive,
     })
 
+    function handleClick(e: MouseEvent<HTMLButtonElement>) {
+      e.preventDefault()
+      onClick()
+    }
+
     return (
       <li className="rn-tab-set__tab-item" data-testid="tab" ref={ref}>
-        <button className={tabClasses} onClick={onClick}>
+        <button className={tabClasses} onClick={handleClick}>
           <div>{children}</div>
         </button>
       </li>

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -88,6 +88,38 @@ describe('TabSet', () => {
       })
     })
 
+    describe('when the TabSet is wrapped in a form', () => {
+      let clickEventSpy: MouseEvent
+
+      beforeEach(() => {
+        wrapper = render(
+          <form>
+            <TabSet>
+              <Tab title="Title 1">Content 1</Tab>
+              <Tab title="Title 2">Content 2</Tab>
+            </TabSet>
+          </form>
+        )
+      })
+
+      describe('when the user clicks on a tab', () => {
+        beforeEach(() => {
+          clickEventSpy = new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+          })
+
+          Object.assign(clickEventSpy, { preventDefault: jest.fn() })
+
+          fireEvent(wrapper.getByText('Title 2').parentElement, clickEventSpy)
+        })
+
+        it('should invoke preventDefault', () => {
+          expect(clickEventSpy.preventDefault).toHaveBeenCalledTimes(1)
+        })
+      })
+    })
+
     describe('when tabs contain elements', () => {
       beforeEach(() => {
         wrapper = render(


### PR DESCRIPTION
## Related issue

https://github.com/Royal-Navy/standards-toolkit/issues/465

## Overview

Add preventDefault to stop click event submitting parent form.