### PR TITLE
Add dependabot config to repo

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    default_reviewers:
+      - "m7kvqbe1"
+      - "thyhjwb6"
+
+    default_labels:
+      - "devops"
+      - "automation"


### PR DESCRIPTION
Added to repo instead of relying on the dependabot web interface.