### PR TITLE
Fix Popover test intermittently failing

### DIFF
--- a/packages/react-component-library/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.stories.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { POPOVER_PLACEMENT } from './constants'
 import { FLOATING_BOX_SCHEME } from '../../primitives/FloatingBox'
 
-import { Popover } from '.'
+import { Popover, POPOVER_PLACEMENT } from '.'
 
 const stories = storiesOf('Popover', module)
 const examples = storiesOf('Popover/Examples', module)

--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -2,16 +2,12 @@ import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { renderToStaticMarkup } from 'react-dom/server'
 
-import {
-  render,
-  RenderResult,
-  cleanup,
-  fireEvent,
-} from '@testing-library/react'
+import { render, RenderResult, fireEvent, wait } from '@testing-library/react'
 
 import { Popover } from '.'
 import { POPOVER_PLACEMENT } from './constants'
-import { FLOATING_BOX_SCHEME } from '../../primitives/FloatingBox'
+
+const HOVER_ON_ME = 'Hover on me!'
 
 describe('Popover', () => {
   let wrapper: RenderResult
@@ -30,7 +26,7 @@ describe('Popover', () => {
               backgroundColor: '#c9c9c9',
             }}
           >
-            Hover on me!
+            {HOVER_ON_ME}
           </div>
         </Popover>
       )
@@ -38,7 +34,7 @@ describe('Popover', () => {
 
     describe('and the user hovers on the target element', () => {
       beforeEach(() => {
-        fireEvent.mouseOver(wrapper.getByText('Hover on me!'))
+        fireEvent.mouseEnter(wrapper.getByText(HOVER_ON_ME))
       })
 
       it('to be visible to the end user', () => {
@@ -53,51 +49,18 @@ describe('Popover', () => {
         )
       })
 
-      describe.skip('and the user unhovers from the target element', () => {
+      describe('and the user unhovers from the target element', () => {
         beforeEach(() => {
-          fireEvent.mouseLeave(wrapper.getByText('Hover on me!'))
-          jest.runAllTimers()
+          fireEvent.mouseOut(wrapper.getByText(HOVER_ON_ME))
         })
 
-        it('to not be visible to the end user', () => {
-          /**
-           * Having to use setTimeout 0 hack to ensure the assertion is at
-           * the bottom of the callstack. Unable to async await the handler.
-           *
-           * NOTE: Coverage incorrectly flags up lines that have been hit.
-           */
-          setTimeout(() => {
+        it('to not be visible to the end user', async () => {
+          await wait(() => {
             expect(wrapper.getByTestId('floating-box').classList).not.toContain(
               'is-visible'
             )
-          }, 0)
+          })
         })
-      })
-    })
-
-    describe('where the scheme prop is supplied', () => {
-      beforeEach(() => {
-        cleanup()
-
-        children = <pre>This is some arbitrary JSX</pre>
-
-        wrapper = render(
-          <Popover
-            placement={POPOVER_PLACEMENT.BELOW}
-            content={children}
-            scheme={FLOATING_BOX_SCHEME.DARK}
-          >
-            <div
-              style={{
-                display: 'inline-block',
-                padding: '1rem',
-                backgroundColor: '#c9c9c9',
-              }}
-            >
-              Hover on me!
-            </div>
-          </Popover>
-        )
       })
     })
   })

--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -4,8 +4,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 
 import { render, RenderResult, fireEvent, wait } from '@testing-library/react'
 
-import { Popover } from '.'
-import { POPOVER_PLACEMENT } from './constants'
+import { Popover, POPOVER_PLACEMENT } from '.'
 
 const HOVER_ON_ME = 'Hover on me!'
 

--- a/packages/react-component-library/src/components/Popover/index.ts
+++ b/packages/react-component-library/src/components/Popover/index.ts
@@ -1,1 +1,2 @@
+export * from './constants'
 export * from './Popover'

--- a/packages/react-component-library/src/components/index.ts
+++ b/packages/react-component-library/src/components/index.ts
@@ -22,7 +22,7 @@ import Nav from './Nav'
 import { NumberInput } from './NumberInput'
 import Pagination from './Pagination'
 import PhaseBanner from './PhaseBanner'
-import { Popover } from './Popover'
+import { Popover, POPOVER_PLACEMENT } from './Popover'
 import Radio from './Radio'
 import { ScrollableNav, ScrollableNavItem } from './ScrollableNav'
 import { Searchbar } from './Searchbar'
@@ -67,6 +67,7 @@ export {
   Pagination,
   PhaseBanner,
   Popover,
+  POPOVER_PLACEMENT,
   Radio,
   ScrollableNav,
   ScrollableNavItem,

--- a/packages/react-component-library/src/index.ts
+++ b/packages/react-component-library/src/index.ts
@@ -23,7 +23,7 @@ import Nav from './components/Nav'
 import { NumberInput } from './components/NumberInput'
 import Pagination from './components/Pagination'
 import PhaseBanner from './components/PhaseBanner'
-import { Popover } from './components/Popover'
+import { Popover, POPOVER_PLACEMENT } from './components/Popover'
 import { Select } from './components/Select'
 import Switch from './components/Switch/Switch'
 import { RangeSlider } from './components/RangeSlider'
@@ -94,6 +94,7 @@ export {
   Pagination,
   PhaseBanner,
   Popover,
+  POPOVER_PLACEMENT,
   Switch,
   RangeSlider,
   ResponsiveSwitch,


### PR DESCRIPTION
## Related issue
#561 

## Overview
A `Popover` test was intermittently failing because assertions happened before a downstream `setTimeout`.

This fix waits until the assertion is satisfied.

## Reason
The test is intermittently failing which is causing friction in the CI process.

## Work carried out
- [x] Fix with `wait`
- [x] Expose `Popover` constants