### PR TITLE
Change overflow on table wrapper

### DIFF
--- a/packages/css-framework/src/components/_table.scss
+++ b/packages/css-framework/src/components/_table.scss
@@ -59,6 +59,6 @@
 }
 
 .rn-table__wrapper {
-  overflow: scroll;
+  overflow: auto;
   overflow-y: hidden;
 }


### PR DESCRIPTION
## Related issue

https://github.com/Royal-Navy/standards-toolkit/issues/504

## Overview

Stop the scroll bar from showing all the time in some browsers (even when it's not required).