### PR TITLE
Remove use of `react-addons-css-transition-group` in favour of `react-transition-group`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "resolutions": {
     "**/**/handlebars": "^4.5.3",
+    "**/**/@hapi/hoek": "^8.5.1",
     "**/**/mem": "^4.0.0",
     "**/**/terser-webpack-plugin": "^1.4.2"
   },

--- a/packages/css-framework/src/components/_searchbar.scss
+++ b/packages/css-framework/src/components/_searchbar.scss
@@ -76,12 +76,12 @@
   transition: opacity 300ms;
 }
 
-.rn-searchbar-leave {
+.rn-searchbar-exit {
   position: absolute;
   opacity: 1;
 }
 
-.rn-searchbar-leave.rn-searchbar-leave-active {
+.rn-searchbar-exit.rn-searchbar-exit-active {
   opacity: 0;
   transition: opacity 300ms;
 }

--- a/packages/css-framework/src/fragments/_notification-panel.scss
+++ b/packages/css-framework/src/fragments/_notification-panel.scss
@@ -69,10 +69,6 @@
   background: white;
 }
 
-.rn-notification-leave {
-  opacity: 0;
-}
-
 .rn-notification-enter {
   opacity: 0;
 }
@@ -82,11 +78,11 @@
   transition: opacity 300ms;
 }
 
-.rn-notification-leave {
+.rn-notification-exit {
   opacity: 1;
 }
 
-.rn-notification-leave.rn-notification-leave-active {
+.rn-notification-exit.rn-notification-exit-active {
   opacity: 0;
   transition: opacity 300ms;
 }

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -67,9 +67,9 @@
     "@types/lodash": "^4.14.149",
     "@types/node": "^12.12.25",
     "@types/react": "^16.9.19",
-    "@types/react-addons-css-transition-group": "^15.0.5",
     "@types/react-dom": "^16.9.5",
     "@types/react-select": "^3.0.10",
+    "@types/react-transition-group": "^4.2.3",
     "@types/storybook__react": "^4.0.2",
     "@types/uuid": "^3.4.6",
     "@types/yup": "^0.26.28",
@@ -133,12 +133,12 @@
     "@types/react-responsive": "^8.0.2",
     "classnames": "^2.2.6",
     "date-fns": "^2.9.0",
-    "react-addons-css-transition-group": "^15.6.2",
     "react-children-utilities": "^1.3.3",
     "react-compound-slider": "^2.5.0",
     "react-indiana-drag-scroll": "^1.5.5",
     "react-responsive": "^8.0.3",
     "react-select": "^3.0.8",
-    "react-tether": "^2.0.7"
+    "react-tether": "^2.0.7",
+    "react-transition-group": "^4.3.0"
   }
 }

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
@@ -2,15 +2,16 @@ import React, { useRef, useState } from 'react'
 import classNames from 'classnames'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 
-import { Searchbar } from '../../components'
 import { Logo as DefaultLogo, Search as SearchIcon } from '../../icons'
-import { MastheadUserProps } from './MastheadUser'
+import { MastheadUserProps } from '.'
 import { Nav } from '../../types/Nav'
 import {
   NOTIFICATION_PLACEMENT,
   NotificationPanel,
   NotificationsProps,
 } from '../NotificationPanel'
+import { Searchbar } from '../../components'
+import { useMastheadSearch } from './useMastheadSearch'
 
 export interface MastheadProps {
   hasUnreadNotification?: boolean
@@ -56,27 +57,30 @@ export const Masthead: React.FC<MastheadProps> = ({
   title,
   user,
 }) => {
-  const [showSearch, setShowSearch] = useState(false)
   const [showNotifications, setShowNotifications] = useState(false)
   const searchButtonRef = useRef<HTMLButtonElement>(null)
-  const mastheadContainerRef = useRef<HTMLDivElement>(null)
-  const [containerWidth, setContainerWidth] = useState(0)
 
-  const toggleSearch = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
-    event.currentTarget.blur()
-    const newShowSearch = !showSearch
+  const {
+    containerWidth,
+    mastheadContainerRef,
+    setShowSearch,
+    showSearch,
+    toggleSearch,
+  } = useMastheadSearch()
 
-    // if opening the searchbar then get the container width and set that
-    // as the width of the searchbar so that it does not spill
-    // over to other parts of the page, such as the sidebar.
-    if (newShowSearch === true) {
-      setContainerWidth(mastheadContainerRef.current.offsetWidth)
+  const classes = classNames('rn-masthead', {
+    'rn-masthead--show-search': showSearch,
+    'rn-masthead--show-notifications': showNotifications,
+  })
+
+  const searchButtonClasses = classNames(
+    'rn-masthead__option',
+    'rn-searchbar__btn',
+    {
+      'is-active': showSearch,
+      'is-inactive': !showSearch,
     }
-
-    setShowSearch(!showSearch)
-  }
+  )
 
   const submitSearch = (term: string) => {
     onSearch(term)
@@ -84,14 +88,7 @@ export const Masthead: React.FC<MastheadProps> = ({
   }
 
   return (
-    <div
-      className={classNames('rn-masthead', {
-        'rn-masthead--show-search': showSearch,
-        'rn-masthead--show-notifications': showNotifications,
-      })}
-      data-testid="masthead"
-      ref={mastheadContainerRef}
-    >
+    <div className={classes} data-testid="masthead" ref={mastheadContainerRef}>
       <div className="rn-masthead__main">
         {getServiceName(homeLink, Logo, title)}
 
@@ -99,9 +96,7 @@ export const Masthead: React.FC<MastheadProps> = ({
           {onSearch && (
             <>
               <button
-                className={`rn-masthead__option rn-searchbar__btn ${
-                  showSearch ? 'is-active' : 'is-inactive'
-                }`}
+                className={searchButtonClasses}
                 onClick={toggleSearch}
                 ref={searchButtonRef}
                 data-testid="masthead-search-button"

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from 'react'
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import classNames from 'classnames'
+import { CSSTransition, TransitionGroup } from 'react-transition-group'
 
 import { Searchbar } from '../../components'
 import { Logo as DefaultLogo, Search as SearchIcon } from '../../icons'
@@ -132,22 +132,22 @@ export const Masthead: React.FC<MastheadProps> = ({
         </div>
       </div>
 
-      <ReactCSSTransitionGroup
-        className="rn-searchbar__overlay"
-        transitionName="rn-searchbar"
-        transitionEnterTimeout={300}
-        transitionLeaveTimeout={300}
-      >
+      <TransitionGroup>
         {onSearch && showSearch && (
-          <Searchbar
-            onSearch={submitSearch}
-            searchButton={searchButtonRef}
-            searchPlaceholder={searchPlaceholder}
-            setShowSearch={setShowSearch}
-            style={{ width: containerWidth }}
-          />
+          <CSSTransition
+            classNames="rn-searchbar"
+            timeout={{ enter: 300, exit: 300 }}
+          >
+            <Searchbar
+              onSearch={submitSearch}
+              searchButton={searchButtonRef}
+              searchPlaceholder={searchPlaceholder}
+              setShowSearch={setShowSearch}
+              style={{ width: containerWidth }}
+            />
+          </CSSTransition>
         )}
-      </ReactCSSTransitionGroup>
+      </TransitionGroup>
 
       {nav}
     </div>

--- a/packages/react-component-library/src/fragments/Masthead/useMastheadSearch.ts
+++ b/packages/react-component-library/src/fragments/Masthead/useMastheadSearch.ts
@@ -1,0 +1,31 @@
+import React, { useRef, useState } from 'react'
+
+export function useMastheadSearch() {
+  const [showSearch, setShowSearch] = useState(false)
+  const [containerWidth, setContainerWidth] = useState(0)
+  const mastheadContainerRef = useRef<HTMLDivElement>(null)
+
+  function toggleSearch(
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) {
+    event.currentTarget.blur()
+    const newShowSearch = !showSearch
+
+    // if opening the searchbar then get the container width and set that
+    // as the width of the searchbar so that it does not spill
+    // over to other parts of the page, such as the sidebar.
+    if (newShowSearch === true) {
+      setContainerWidth(mastheadContainerRef.current.offsetWidth)
+    }
+
+    setShowSearch(!showSearch)
+  }
+
+  return {
+    containerWidth,
+    mastheadContainerRef,
+    setShowSearch,
+    showSearch,
+    toggleSearch,
+  }
+}

--- a/packages/react-component-library/src/fragments/NotificationPanel/NotificationPanel.tsx
+++ b/packages/react-component-library/src/fragments/NotificationPanel/NotificationPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
+import { CSSTransition, TransitionGroup } from 'react-transition-group'
 
 import {
   NOTIFICATION_PLACEMENT,
@@ -63,24 +63,26 @@ export const NotificationPanel: React.FC<NotificationPanelProps> = ({
           />
         )}
       </button>
-      <ReactCSSTransitionGroup
-        className="rn-notification__transition-wrapper"
-        transitionName="rn-notification"
-        transitionEnterTimeout={300}
-        transitionLeaveTimeout={300}
-      >
+
+      <TransitionGroup className="rn-notification__transition-wrapper">
         {showNotifications && (
-          <FloatingBox
-            className="rn-notification-panel__container"
-            {...notificationPosition}
-            width={NOTIFICATION_CONTAINER_WIDTH}
-            scheme="dark"
-            position={notificationArrowPosition}
+          <CSSTransition
+            classNames="rn-notification"
+            timeout={{ enter: 300, exit: 300 }}
           >
-            {children}
-          </FloatingBox>
+            <FloatingBox
+              className="rn-notification-panel__container"
+              {...notificationPosition}
+              width={NOTIFICATION_CONTAINER_WIDTH}
+              scheme="dark"
+              position={notificationArrowPosition}
+            >
+              {children}
+            </FloatingBox>
+          </CSSTransition>
         )}
-      </ReactCSSTransitionGroup>
+      </TransitionGroup>
+
     </div>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3703,21 +3703,6 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-addons-css-transition-group@^15.0.5":
-  version "15.0.5"
-  resolved "https://registry.yarnpkg.com/@types/react-addons-css-transition-group/-/react-addons-css-transition-group-15.0.5.tgz#73665af6b8efb47730ab583ead4bed5373dae686"
-  integrity sha512-UIJt5HQDOzRI7AOmnGnc2OZA0N3p7r6yMsxZ3T0+dyGPB3zWiKOPKrMkJr9tyuY3kHKPm26GyihcJKNJdMY8CQ==
-  dependencies:
-    "@types/react" "*"
-    "@types/react-addons-transition-group" "*"
-
-"@types/react-addons-transition-group@*":
-  version "15.0.4"
-  resolved "https://registry.yarnpkg.com/@types/react-addons-transition-group/-/react-addons-transition-group-15.0.4.tgz#5fb10a686e6f0899fecdc0efc63ea7166c24638e"
-  integrity sha512-0S2cKn9OLYr6N36oRH4ybzidkgQ0UGhuvrFvU3tdktJfrx3muu7MgfIWG434wKg7rcysBEfpmQaNpGteEtx6vw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-color@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/react-color/-/react-color-3.0.1.tgz#5433e2f503ea0e0831cbc6fd0c20f8157d93add0"
@@ -3762,7 +3747,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@*":
+"@types/react-transition-group@*", "@types/react-transition-group@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.2.3.tgz#4924133f7268694058e415bf7aea2d4c21131470"
   integrity sha512-Hk8jiuT7iLOHrcjKP/ZVSyCNXK73wJAUz60xm0mVhiRujrdiI++j4duLiL282VGxwAgxetHQFfqA29LgEeSkFA==
@@ -5761,6 +5746,30 @@ cacache@^12.0.0, cacache@^12.0.2, cacache@^12.0.3:
     unique-filename "^1.1.1"
     y18n "^4.0.0"
 
+cacache@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-13.0.1.tgz#a8000c21697089082f85287a1aec6e382024a71c"
+  integrity sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==
+  dependencies:
+    chownr "^1.1.2"
+    figgy-pudding "^3.5.1"
+    fs-minipass "^2.0.0"
+    glob "^7.1.4"
+    graceful-fs "^4.2.2"
+    infer-owner "^1.0.4"
+    lru-cache "^5.1.1"
+    minipass "^3.0.0"
+    minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.2"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    p-map "^3.0.0"
+    promise-inflight "^1.0.1"
+    rimraf "^2.7.1"
+    ssri "^7.0.0"
+    unique-filename "^1.1.1"
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -5967,11 +5976,6 @@ ccount@^1.0.0, ccount@^1.0.3:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.5.tgz#ac82a944905a65ce204eb03023157edf29425c17"
   integrity sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==
-
-chain-function@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.1.tgz#c63045e5b4b663fb86f1c6e186adaf1de402a1cc"
-  integrity sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg==
 
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
@@ -7304,7 +7308,7 @@ cssstyle@^2.0.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.2.0, csstype@^2.5.7:
+csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
   integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
@@ -7879,12 +7883,20 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.2.0, dom-helpers@^3.4.0:
+dom-helpers@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
   dependencies:
     "@babel/runtime" "^7.1.2"
+
+dom-helpers@^5.0.1:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.3.tgz#7233248eb3a2d1f74aafca31e52c5299cc8ce821"
+  integrity sha512-nZD1OtwfWGRBWlpANxacBEZrEuLa16o1nh7YopFWeoF68Zt8GGEmzHu6Xv4F3XaFIC+YXtTLrzgqKxFgLEe4jw==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+    csstype "^2.6.7"
 
 dom-serializer@0:
   version "0.2.2"
@@ -9350,7 +9362,7 @@ find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-cache-dir@^3.0.0:
+find-cache-dir@^3.0.0, find-cache-dir@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.2.0.tgz#e7fe44c1abc1299f516146e563108fd1006c1874"
   integrity sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==
@@ -10686,7 +10698,11 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
+<<<<<<< HEAD
 handlebars@^4.4.0, handlebars@^4.5.3:
+=======
+handlebars@^4.4.0:
+>>>>>>> Migrate to using react-transition-group
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.3.tgz#8ece2797826886cf8082d1726ff21d2a022550ee"
   integrity sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==
@@ -14050,7 +14066,7 @@ longest@^1.0.0:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
   integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -14696,6 +14712,27 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
+minipass-collect@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-1.0.2.tgz#22b813bf745dc6edba2576b940022ad6edc8c617"
+  integrity sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-flush@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373"
+  integrity sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-pipeline@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz#3dcb6bb4a546e32969c7ad710f2c79a86abba93a"
+  integrity sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==
+  dependencies:
+    minipass "^3.0.0"
+
 minipass@^2.3.5, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
@@ -14704,7 +14741,7 @@ minipass@^2.3.5, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minipass@^3.0.0:
+minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz#7607ce778472a185ad6d89082aa2070f79cedcd5"
   integrity sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==
@@ -15740,7 +15777,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0, p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
   integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
@@ -17347,7 +17384,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -17609,13 +17646,6 @@ rc@^1.2.7, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-addons-css-transition-group@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-css-transition-group/-/react-addons-css-transition-group-15.6.2.tgz#9e4376bcf40b5217d14ec68553081cee4b08a6d6"
-  integrity sha1-nkN2vPQLUhfRTsaFUwgc7ksIptY=
-  dependencies:
-    react-transition-group "^1.2.0"
 
 react-children-utilities@^1.3.3:
   version "1.3.3"
@@ -17952,17 +17982,6 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react-transition-group@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
-  integrity sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==
-  dependencies:
-    chain-function "^1.0.0"
-    dom-helpers "^3.2.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.5.6"
-    warning "^3.0.0"
-
 react-transition-group@^2.2.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
@@ -17972,6 +17991,16 @@ react-transition-group@^2.2.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-transition-group@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
+  integrity sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^16.12.0, react@^16.8.3:
   version "16.12.0"
@@ -18723,7 +18752,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -19687,6 +19716,14 @@ ssri@^6.0.0, ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
+ssri@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-7.1.0.tgz#92c241bf6de82365b5c7fb4bd76e975522e1294d"
+  integrity sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==
+  dependencies:
+    figgy-pudding "^3.5.1"
+    minipass "^3.1.1"
+
 stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
@@ -20498,6 +20535,7 @@ term-size@^2.1.0:
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.1.1.tgz#f81ec25854af91a480d2f9d0c77ffcb26594ed1a"
   integrity sha512-UqvQSch04R+69g4RDhrslmGvGL3ucDRX/U+snYW0Mab4uCAyKSndUksaoqlJ81QKSpRnIsuOYQCbC2ZWx2896A==
 
+<<<<<<< HEAD
 terminal-link@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
@@ -20507,6 +20545,9 @@ terminal-link@^2.0.0:
     supports-hyperlinks "^2.0.0"
 
 terser-webpack-plugin@^1.4.2, terser-webpack-plugin@^1.4.3, terser-webpack-plugin@^2.1.2:
+=======
+terser-webpack-plugin@^1.4.2, terser-webpack-plugin@^1.4.3:
+>>>>>>> Migrate to using react-transition-group
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz#5ecaf2dbdc5fb99745fd06791f46fc9ddb1c9a7c"
   integrity sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==
@@ -20521,7 +20562,22 @@ terser-webpack-plugin@^1.4.2, terser-webpack-plugin@^1.4.3, terser-webpack-plugi
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@^4.1.2, terser@^4.3.9:
+terser-webpack-plugin@^2.1.2:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-2.3.4.tgz#ac045703bd8da0936ce910d8fb6350d0e1dee5fe"
+  integrity sha512-Nv96Nws2R2nrFOpbzF6IxRDpIkkIfmhvOws+IqMvYdFLO7o6wAILWFKONFgaYy8+T4LVz77DQW0f7wOeDEAjrg==
+  dependencies:
+    cacache "^13.0.1"
+    find-cache-dir "^3.2.0"
+    jest-worker "^25.1.0"
+    p-limit "^2.2.2"
+    schema-utils "^2.6.4"
+    serialize-javascript "^2.1.2"
+    source-map "^0.6.1"
+    terser "^4.4.3"
+    webpack-sources "^1.4.3"
+
+terser@^4.1.2, terser@^4.3.9, terser@^4.4.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.3.tgz#e33aa42461ced5238d352d2df2a67f21921f8d87"
   integrity sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==
@@ -21788,7 +21844,7 @@ webpack-sources@^0.2.0:
     source-list-map "^1.1.1"
     source-map "~0.5.3"
 
-webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
+webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==


### PR DESCRIPTION
## Overview
Removes the use of `react-addons-css-transition-group` in favour of `react-transition-group`.

In addition, some of the `Masthead` state code was refactored to a custom hook and reusing `classNames`.

The `@hapi/hoek` security vulnerability needed to be fixed in this PR.

## Reason
The library is no longer supported.

## Work carried out
- [x] Remove old library
- [x] Refactor existing code
- [x] Fix security vulnerability

## Screenshot
No visual change.