### PR TITLE
Add ability to hide label for NumberInput

### DIFF
--- a/packages/css-framework/src/components/_numberinput.scss
+++ b/packages/css-framework/src/components/_numberinput.scss
@@ -80,15 +80,15 @@
   box-sizing: border-box;
   width: 100%;
   margin: 0;
-  padding: f.spacing("10") f.spacing("6") f.spacing("2");
+  padding: f.spacing("6");
   border: 0;
   background: none;
   -webkit-tap-highlight-color: transparent;
   font-size: f.font-size("base");
 }
 
-.rn-numberinput--no-label .rn-numberinput__input {
-  padding: f.spacing("6");
+.rn-numberinput__label + .rn-numberinput__input {
+  padding: f.spacing("10") f.spacing("6") f.spacing("2");
 }
 
 .rn-numberinput__input:focus {

--- a/packages/react-component-library/src/components/NumberInput/EndAdornment.tsx
+++ b/packages/react-component-library/src/components/NumberInput/EndAdornment.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+
+import { EndAdornmentButton } from './EndAdornmentButton'
+import { END_ADORNMENT_DIRECTION } from './constants'
+
+interface EndAdornmentProps {
+  max?: number
+  min?: number
+  name: string
+  onChange: (event: any) => void
+  step?: number
+  value?: number
+}
+
+export const EndAdornment: React.FC<EndAdornmentProps> = ({
+  max,
+  min,
+  name,
+  onChange,
+  step,
+  value,
+}) => {
+  function onButtonClick(
+    getNextValue: () => number,
+    canRaiseOnChange: (newValue: number) => boolean
+  ) {
+    return (event: React.MouseEvent<HTMLButtonElement>) => {
+      const target = event.currentTarget
+      target.blur()
+
+      const newValue = getNextValue()
+      if (canRaiseOnChange(newValue)) {
+        onChange({
+          target: {
+            name,
+            value: newValue,
+          },
+        })
+      }
+    }
+  }
+
+  return (
+    <div className="rn-numberinput__controls">
+      <EndAdornmentButton
+        onClick={onButtonClick(
+          () => (value ? value + step : step),
+          newValue => !max || newValue <= max
+        )}
+        type={END_ADORNMENT_DIRECTION.INCREASE}
+      />
+      <EndAdornmentButton
+        onClick={onButtonClick(
+          () => (value ? value - step : step),
+          newValue => !min || newValue >= min
+        )}
+        type={END_ADORNMENT_DIRECTION.DECREASE}
+      />
+    </div>
+  )
+}
+
+EndAdornment.displayName = 'EndAdornment'

--- a/packages/react-component-library/src/components/NumberInput/EndAdornmentButton.tsx
+++ b/packages/react-component-library/src/components/NumberInput/EndAdornmentButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import { END_ADORNMENT_DIRECTION } from './constants'
+
+interface EndAdornmentButtonProps {
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
+  type:
+    | typeof END_ADORNMENT_DIRECTION.DECREASE
+    | typeof END_ADORNMENT_DIRECTION.INCREASE
+}
+
+export const EndAdornmentButton: React.FC<EndAdornmentButtonProps> = ({
+  onClick,
+  type,
+}) => (
+  <button
+    data-testid={`number-input-${type}`}
+    type="button"
+    className={`rn-numberinput__${type}`}
+    onClick={onClick}
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" width="11" height="7">
+      <path
+        fill="#6F798A"
+        fillRule="evenodd"
+        d="M5.66 4.49L9.19.95a1 1 0 1 1 1.42 1.41L6.36 6.61a1 1 0 0 1-1.41 0L.71 2.36A1 1 0 1 1 2.12.95l3.54 3.54z"
+      />
+    </svg>
+  </button>
+)
+
+EndAdornmentButton.displayName = 'EndAdornmentButton'

--- a/packages/react-component-library/src/components/NumberInput/Footnote.tsx
+++ b/packages/react-component-library/src/components/NumberInput/Footnote.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+interface FootnoteProps {
+  children?: string
+}
+
+export const Footnote: React.FC<FootnoteProps> = ({ children }) => {
+  return children ? (
+    <small
+      className="rn-numberinput__footnote"
+      data-testid="number-input-footnote"
+    >
+      {children}
+    </small>
+  ) : null
+}
+
+Footnote.displayName = 'Footnote'

--- a/packages/react-component-library/src/components/NumberInput/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInput/Input.tsx
@@ -1,0 +1,89 @@
+import React, { FormEvent, useRef } from 'react'
+
+import { calculateNewValue } from './NumberInput'
+
+interface InputProps {
+  isDisabled?: boolean
+  id?: string
+  label?: string
+  max?: number
+  min?: number
+  name: string
+  onChange: (event: any) => void
+  onInputBlur: (event: FormEvent) => void
+  onInputFocus: () => void
+  placeholder?: string
+  value?: number
+}
+
+export const Input: React.FC<InputProps> = ({
+  isDisabled = false,
+  id,
+  label,
+  max,
+  min,
+  name,
+  onChange,
+  onInputBlur,
+  onInputFocus,
+  placeholder = '',
+  value,
+  ...rest
+}) => {
+  const hasLabel = label && label.length
+  const inputRef = useRef(null)
+  const displayValue =
+    value === null || value === undefined || Number.isNaN(value) ? '' : value
+
+  const onInputChange = (event: React.SyntheticEvent) => {
+    event.preventDefault()
+    const target = event.currentTarget as HTMLInputElement
+    const newValue = calculateNewValue({
+      currentValue: value,
+      newInputValue: target.value,
+      min,
+      max,
+    })
+
+    onChange({
+      target: {
+        name,
+        value: newValue,
+      },
+    })
+  }
+
+  return (
+    <div
+      className="rn-numberinput__input-wrapper"
+      data-testid="number-input-wrapper"
+    >
+      {hasLabel && (
+        <label
+          className="rn-numberinput__label"
+          data-testid="number-input-label"
+          htmlFor={id}
+        >
+          {label}
+        </label>
+      )}
+      <input
+        className="rn-numberinput__input"
+        data-testid="number-input-input"
+        disabled={isDisabled}
+        id={id}
+        name={name}
+        onBlur={onInputBlur}
+        onChange={onInputChange}
+        onFocus={onInputFocus}
+        placeholder={placeholder}
+        ref={inputRef}
+        type="text"
+        value={displayValue}
+        {...rest}
+      />
+    </div>
+  )
+}
+
+Input.displayName = 'Input'

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -63,3 +63,11 @@ stories.add('With start adornment text', () => (
     startAdornment="Kts"
   />
 ))
+
+stories.add('With hidden label', () => (
+  <NumberInput
+    name="example-number-input"
+    value={1}
+    onChange={action('onChange')}
+  />
+))

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -163,7 +163,6 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   const classes = classNames('rn-numberinput', className, {
     'has-focus': focus,
     'has-content': hasContent,
-    'no-label': !hasLabel,
   })
 
   const displayValue =

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react'
 import uuid from 'uuid'
 import classNames from 'classnames'
 
+import { StartAdornment } from './StartAdornment'
 import { useFocus } from './useFocus'
 
 export interface NumberInputProps {
@@ -160,14 +161,8 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   return (
     <div className={classes} data-testid="number-input-container">
       <div className="rn-numberinput__outer-wrapper">
-        {startAdornment && (
-          <div
-            className="rn-numberinput__start-adornment"
-            data-testid="number-input-start-adornment"
-          >
-            {startAdornment}
-          </div>
-        )}
+        <StartAdornment>{startAdornment}</StartAdornment>
+
         <div
           className="rn-numberinput__input-wrapper"
           data-testid="number-input-wrapper"

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import uuid from 'uuid'
 import classNames from 'classnames'
 
+import { EndAdornment } from './EndAdornment'
 import { Input } from './Input'
 import { StartAdornment } from './StartAdornment'
 import { useFocus } from './useFocus'
@@ -69,66 +70,6 @@ export const NumberInput: React.FC<NumberInputProps> = ({
 }) => {
   const { hasFocus, onInputBlur, onInputFocus } = useFocus(onBlur)
 
-  const mutateValue = (newValue: number) => {
-    onChange({
-      target: {
-        name,
-        value: newValue,
-      },
-    })
-  }
-
-  const clickIncrease = (event: React.MouseEvent<HTMLButtonElement>) => {
-    const target = event.currentTarget
-    target.blur()
-
-    const newValue = value ? value + step : step
-    if (!max || newValue <= max) {
-      mutateValue(newValue)
-    }
-  }
-
-  const clickDecrease = (event: React.MouseEvent<HTMLButtonElement>) => {
-    const target = event.currentTarget
-    target.blur()
-
-    const newValue = value ? value - step : -step
-    if (!min || newValue >= min) mutateValue(newValue)
-  }
-
-  const EndAdornment = (
-    <div className="rn-numberinput__controls">
-      <button
-        data-testid="number-input-increase"
-        type="button"
-        className="rn-numberinput__increase"
-        onClick={clickIncrease}
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" width="11" height="7">
-          <path
-            fill="#6F798A"
-            fillRule="evenodd"
-            d="M5.66 4.49L9.19.95a1 1 0 1 1 1.42 1.41L6.36 6.61a1 1 0 0 1-1.41 0L.71 2.36A1 1 0 1 1 2.12.95l3.54 3.54z"
-          />
-        </svg>
-      </button>
-      <button
-        data-testid="number-input-decrease"
-        type="button"
-        className="rn-numberinput__decrease"
-        onClick={clickDecrease}
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" width="11" height="7">
-          <path
-            fill="#6F798A"
-            fillRule="evenodd"
-            d="M5.66 4.49L9.19.95a1 1 0 1 1 1.42 1.41L6.36 6.61a1 1 0 0 1-1.41 0L.71 2.36A1 1 0 1 1 2.12.95l3.54 3.54z"
-          />
-        </svg>
-      </button>
-    </div>
-  )
-
   const hasContent = value !== null && value !== undefined
 
   const classes = classNames('rn-numberinput', className, {
@@ -156,7 +97,14 @@ export const NumberInput: React.FC<NumberInputProps> = ({
           {...rest}
         />
 
-        {EndAdornment}
+        <EndAdornment
+          max={max}
+          min={min}
+          name={name}
+          onChange={onChange}
+          step={step}
+          value={value}
+        />
       </div>
       {footnote && (
         <small

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -6,6 +6,7 @@ import { EndAdornment } from './EndAdornment'
 import { Input } from './Input'
 import { StartAdornment } from './StartAdornment'
 import { useFocus } from './useFocus'
+import { Footnote } from './Footnote'
 
 export interface NumberInputProps {
   autoFocus?: boolean
@@ -106,14 +107,8 @@ export const NumberInput: React.FC<NumberInputProps> = ({
           value={value}
         />
       </div>
-      {footnote && (
-        <small
-          className="rn-numberinput__footnote"
-          data-testid="number-input-footnote"
-        >
-          {footnote}
-        </small>
-      )}
+
+      <Footnote>{footnote}</Footnote>
     </div>
   )
 }

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -1,7 +1,8 @@
-import React, { useRef } from 'react'
+import React from 'react'
 import uuid from 'uuid'
 import classNames from 'classnames'
 
+import { Input } from './Input'
 import { StartAdornment } from './StartAdornment'
 import { useFocus } from './useFocus'
 
@@ -66,28 +67,9 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   startAdornment,
   ...rest
 }) => {
-  const inputRef = useRef(null)
   const { hasFocus, onInputBlur, onInputFocus } = useFocus(onBlur)
 
   const mutateValue = (newValue: number) => {
-    onChange({
-      target: {
-        name,
-        value: newValue,
-      },
-    })
-  }
-
-  const inputChange = (event: React.SyntheticEvent) => {
-    event.preventDefault()
-    const target = event.currentTarget as HTMLInputElement
-    const newValue = calculateNewValue({
-      currentValue: value,
-      newInputValue: target.value,
-      min,
-      max,
-    })
-
     onChange({
       target: {
         name,
@@ -148,50 +130,32 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   )
 
   const hasContent = value !== null && value !== undefined
-  const hasLabel = label && label.length
 
   const classes = classNames('rn-numberinput', className, {
     'has-focus': hasFocus,
     'has-content': hasContent,
   })
 
-  const displayValue =
-    value === null || value === undefined || Number.isNaN(value) ? '' : value
-
   return (
     <div className={classes} data-testid="number-input-container">
       <div className="rn-numberinput__outer-wrapper">
         <StartAdornment>{startAdornment}</StartAdornment>
 
-        <div
-          className="rn-numberinput__input-wrapper"
-          data-testid="number-input-wrapper"
-        >
-          {hasLabel && (
-            <label
-              className="rn-numberinput__label"
-              data-testid="number-input-label"
-              htmlFor={id}
-            >
-              {label}
-            </label>
-          )}
-          <input
-            className="rn-numberinput__input"
-            data-testid="number-input-input"
-            disabled={isDisabled}
-            id={id}
-            name={name}
-            onBlur={onInputBlur}
-            onChange={inputChange}
-            onFocus={onInputFocus}
-            placeholder={placeholder}
-            ref={inputRef}
-            type="text"
-            value={displayValue}
-            {...rest}
-          />
-        </div>
+        <Input
+          isDisabled={isDisabled}
+          id={id}
+          label={label}
+          max={max}
+          min={min}
+          name={name}
+          onChange={onChange}
+          onInputBlur={onInputBlur}
+          onInputFocus={onInputFocus}
+          placeholder={placeholder}
+          value={value}
+          {...rest}
+        />
+
         {EndAdornment}
       </div>
       {footnote && (

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -1,6 +1,8 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef } from 'react'
 import uuid from 'uuid'
 import classNames from 'classnames'
+
+import { useFocus } from './useFocus'
 
 export interface NumberInputProps {
   autoFocus?: boolean
@@ -64,12 +66,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   ...rest
 }) => {
   const inputRef = useRef(null)
-
-  const [focus, setFocus] = useState(false)
-
-  const onFocus = () => {
-    setFocus(true)
-  }
+  const { hasFocus, onInputBlur, onInputFocus } = useFocus(onBlur)
 
   const mutateValue = (newValue: number) => {
     onChange({
@@ -116,14 +113,6 @@ export const NumberInput: React.FC<NumberInputProps> = ({
     if (!min || newValue >= min) mutateValue(newValue)
   }
 
-  const onLocalBlur = (event: React.FormEvent) => {
-    setFocus(false)
-
-    if (onBlur) {
-      onBlur(event)
-    }
-  }
-
   const EndAdornment = (
     <div className="rn-numberinput__controls">
       <button
@@ -161,7 +150,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   const hasLabel = label && label.length
 
   const classes = classNames('rn-numberinput', className, {
-    'has-focus': focus,
+    'has-focus': hasFocus,
     'has-content': hasContent,
   })
 
@@ -198,9 +187,9 @@ export const NumberInput: React.FC<NumberInputProps> = ({
             disabled={isDisabled}
             id={id}
             name={name}
-            onBlur={onLocalBlur}
+            onBlur={onInputBlur}
             onChange={inputChange}
-            onFocus={onFocus}
+            onFocus={onInputFocus}
             placeholder={placeholder}
             ref={inputRef}
             type="text"

--- a/packages/react-component-library/src/components/NumberInput/StartAdornment.tsx
+++ b/packages/react-component-library/src/components/NumberInput/StartAdornment.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+interface StartAdornmentProps {
+  children: React.ReactNode | string
+}
+
+export const StartAdornment: React.FC<StartAdornmentProps> = ({ children }) => {
+  return children ? (
+    <div
+      className="rn-numberinput__start-adornment"
+      data-testid="number-input-start-adornment"
+    >
+      {children}
+    </div>
+  ) : null
+}
+
+StartAdornment.displayName = 'StartAdornment'

--- a/packages/react-component-library/src/components/NumberInput/constants.ts
+++ b/packages/react-component-library/src/components/NumberInput/constants.ts
@@ -1,0 +1,6 @@
+const END_ADORNMENT_DIRECTION = {
+  DECREASE: 'decrease',
+  INCREASE: 'increase',
+} as const
+
+export { END_ADORNMENT_DIRECTION }

--- a/packages/react-component-library/src/components/NumberInput/useFocus.ts
+++ b/packages/react-component-library/src/components/NumberInput/useFocus.ts
@@ -1,0 +1,23 @@
+import { FormEvent, useState } from 'react'
+
+export function useFocus(onBlur: (event: FormEvent) => void) {
+  const [hasFocus, setHasFocus] = useState(false)
+
+  const onInputBlur = (event: FormEvent) => {
+    setHasFocus(false)
+
+    if (onBlur) {
+      onBlur(event)
+    }
+  }
+
+  const onInputFocus = () => {
+    setHasFocus(true)
+  }
+
+  return {
+    hasFocus,
+    onInputBlur,
+    onInputFocus,
+  }
+}


### PR DESCRIPTION
## Related issue
#471 

## Overview
Adds ability to hide `label` in `NumberInput`. This was already possible but not correctly styled.

In addition the component has been refactored.

## Reason
`NumberInput` might be in a table so therefore column header effectively replaces the `label`.

## Work carried out
- [x] Hide label with style
- [x] Refactor

## Screenshot
![Screenshot 2020-02-14 at 14 21 07](https://user-images.githubusercontent.com/56078793/74539066-49e7a400-4f35-11ea-8cb2-1bd8f5a48c6c.png)

## Developer notes
There will be another PR to refactor the tests and increase coverage.