### PR TITLE
Wrap Formik error with component

### DIFF
--- a/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
@@ -33,14 +33,16 @@ stories.add('Formik', () => {
   const TextInputForm = () => {
     interface Data {
       colour: string
+      city: string
     }
 
     const initialValues: Data = {
       colour: 'Green',
+      city: '',
     }
 
     const validationSchema = yup.object().shape({
-      city: yup.string().required('Hey, enter a city!'),
+      city: yup.string().required('Something went wrong!'),
     })
 
     const FormikTextInput = withFormik(TextInput)
@@ -48,8 +50,10 @@ stories.add('Formik', () => {
     return (
       <Formik
         initialValues={initialValues}
-        onSubmit={action('Submitted')}
+        initialErrors={{ city: 'Something went wrong!' }}
+        initialTouched={{ city: true }}
         validationSchema={validationSchema}
+        onSubmit={action('Submit')}
       >
         <Form>
           <Field

--- a/packages/react-component-library/src/enhancers/withFormik.tsx
+++ b/packages/react-component-library/src/enhancers/withFormik.tsx
@@ -17,12 +17,18 @@ const withFormik = (FormComponent: React.FC<any>) => ({
   ...props
 }: FormikProps) => {
   const hasError = touched[field.name] && errors[field.name]
+
+  const formikWrapperClassNames = classNames(
+    'formik-form-component',
+    `formik-form-component--${FormComponent.displayName}`
+  )
+
   const formComponentClassNames = classNames(className, {
     'is-invalid': hasError,
   })
 
   return (
-    <>
+    <div className={formikWrapperClassNames}>
       <FormComponent
         {...field}
         {...props}
@@ -33,7 +39,7 @@ const withFormik = (FormComponent: React.FC<any>) => ({
           {errors[field.name]}
         </div>
       )}
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Related issue

https://github.com/Royal-Navy/standards-toolkit/issues/608

## Overview

Wrap the error in with the enhanced Formik component instead of returning a fragment.

## Reason

>If a field has an error the withFormik function puts the error message below the field, but does not do this within the component.

## Work carried out

- [x] Wrap error in with enhanced component
- [x] Test in dummy application
- [x] Display Storybook validation error on mount (for visual regression test)
