### PR TITLE
fix: add ability to inject custom CardFrame className

### DIFF
--- a/packages/react-component-library/src/components/CardFrame/CardFrame.test.tsx
+++ b/packages/react-component-library/src/components/CardFrame/CardFrame.test.tsx
@@ -7,12 +7,16 @@ describe('CardFrame', () => {
   let wrapper: RenderResult
 
   beforeEach(() => {
-    wrapper = render(
-      <CardFrame>Content</CardFrame>
-    )
+    wrapper = render(<CardFrame className="example-class">Content</CardFrame>)
   })
 
   it('should render the content', () => {
     expect(wrapper.getByText('Content')).toBeTruthy()
+  })
+
+  it('shoulder apply the injected custom class', () => {
+    expect(wrapper.getByTestId('cardframe-wrapper').classList).toContain(
+      'example-class'
+    )
   })
 })

--- a/packages/react-component-library/src/components/CardFrame/CardFrame.tsx
+++ b/packages/react-component-library/src/components/CardFrame/CardFrame.tsx
@@ -1,5 +1,15 @@
 import React from 'react'
+import classNames from 'classnames'
 
-export const CardFrame: React.FC = ({ children }) => {
-  return <div className="rn-card-frame">{children}</div>
+export const CardFrame: React.FC<ComponentWithClass> = ({
+  children,
+  className,
+}) => {
+  const classes = classNames('rn-card-frame', className)
+
+  return (
+    <div className={classes} data-testid="cardframe-wrapper">
+      {children}
+    </div>
+  )
 }


### PR DESCRIPTION
## Related issue

Closes #633

## Overview

Add ability to inject custom CardFrame className.

## Reason

>Would like to include additional styling to the Card Frame component such as positioning.

## Work carried out

- [x] Apply class from className prop
- [x] Add automated test