### PR TITLE
fix: Add chore prefix for automated dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,8 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "weekly"
+    commit_message:
+      prefix: "chore"
     default_reviewers:
       - "m7kvqbe1"
       - "thyhjwb6"


### PR DESCRIPTION
## Related issue

Fixes #676 

## Overview
The commit messages in the dependabot PRs do not have the correct structure. This change will prefix the commit message with `chore`

## Reason
Commit messages need to be correctly structure for CI automation.

## Work carried out
- [x] Add prefix