### PR TITLE
feat(breadcrumbs): Add ability for one breadcrumb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,12 @@ jobs:
       - *build_icon_library
       - run:
           name: Run visual regression tests
-          command: yarn --cwd packages/react-component-library chromatic --app-code=$CHROMATIC_APP_CODE
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              yarn --cwd packages/react-component-library chromatic --app-code=$CHROMATIC_APP_CODE --auto-accept-changes
+            else
+              yarn --cwd packages/react-component-library chromatic --app-code=$CHROMATIC_APP_CODE
+            fi
   publish_eslint-config-react:
     docker: *docker
     steps:

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -76,4 +76,19 @@ describe('Breadcrumbs', () => {
       )
     })
   })
+
+  describe('when there is only one breadcrumb', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Breadcrumbs>
+          <BreadcrumbsItem link={<Link href="#home">Home</Link>} />
+        </Breadcrumbs>
+      )
+    })
+
+    it('should render one breadcrumb', () => {
+      const linkElements = wrapper.queryAllByTestId('breadcrumb')
+      expect(linkElements).toHaveLength(1)
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -5,7 +5,7 @@ import { BreadcrumbsItem, BreadcrumbsItemProps } from '.'
 import { warnIfOverwriting } from '../../helpers'
 
 interface BreadcrumbsProps extends ComponentWithClass {
-  children: React.ReactElement<BreadcrumbsItemProps>[]
+  children: React.ReactElement<BreadcrumbsItemProps> | React.ReactElement<BreadcrumbsItemProps>[]
 }
 
 export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
@@ -23,7 +23,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
       return React.cloneElement(child, {
         ...child.props,
         isFirst: index === 0,
-        isLast: index === children.length - 1,
+        isLast: !Array.isArray(children) || index === children.length - 1,
       })
     }
   )

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -2,13 +2,10 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { BreadcrumbsItem, BreadcrumbsItemProps } from '.'
+import { Nav } from '../../types/Nav'
 import { warnIfOverwriting } from '../../helpers'
 
-interface BreadcrumbsProps extends ComponentWithClass {
-  children: React.ReactElement<BreadcrumbsItemProps> | React.ReactElement<BreadcrumbsItemProps>[]
-}
-
-export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
+export const Breadcrumbs: React.FC<Nav<BreadcrumbsItemProps>> = ({
   children,
   className,
 }) => {

--- a/packages/react-component-library/src/components/ScrollableNav/ScrollableNav.tsx
+++ b/packages/react-component-library/src/components/ScrollableNav/ScrollableNav.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import ScrollContainer from 'react-indiana-drag-scroll'
 
-import { Nav } from '../../types/Nav'
+import { Nav, NavItem } from '../../types/Nav'
 
-export const ScrollableNav: React.FC<Nav> = ({
+export const ScrollableNav: React.FC<Nav<NavItem>> = ({
   children,
   className,
 }) => (

--- a/packages/react-component-library/src/components/TabNav/TabNav.tsx
+++ b/packages/react-component-library/src/components/TabNav/TabNav.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
-import { Nav } from '../../types/Nav'
+import { Nav, NavItem } from '../../types/Nav'
 
-export const TabNav: React.FC<Nav> = ({ children, className }) => (
+export const TabNav: React.FC<Nav<NavItem>> = ({ children, className }) => (
   <nav className={`rn-tab-nav ${className}`}>
     <ol className="rn-tab-nav__tabs">{children}</ol>
   </nav>

--- a/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/Masthead.tsx
@@ -4,7 +4,7 @@ import { CSSTransition, TransitionGroup } from 'react-transition-group'
 
 import { Logo as DefaultLogo, Search as SearchIcon } from '../../icons'
 import { MastheadUserProps } from '.'
-import { Nav } from '../../types/Nav'
+import { Nav, NavItem } from '../../types/Nav'
 import {
   NOTIFICATION_PLACEMENT,
   NotificationPanel,
@@ -17,7 +17,7 @@ export interface MastheadProps {
   hasUnreadNotification?: boolean
   homeLink?: React.ReactElement<LinkTypes>
   Logo?: React.ComponentType
-  nav?: React.ReactElement<Nav>
+  nav?: React.ReactElement<Nav<NavItem>>
   notifications?: React.ReactElement<NotificationsProps>
   onSearch?: (term: string) => void
   searchPlaceholder?: string

--- a/packages/react-component-library/src/fragments/Masthead/MastheadNav.tsx
+++ b/packages/react-component-library/src/fragments/Masthead/MastheadNav.tsx
@@ -6,7 +6,7 @@ import {
   ScrollableNavItem,
 } from '../../components/ScrollableNav'
 
-export const MastheadNav: React.FC<Nav> = props => {
+export const MastheadNav: React.FC<Nav<NavItem>> = props => {
   return (
     <ScrollableNav {...props} className="rn-masthead__nav">
       {props.children}

--- a/packages/react-component-library/src/fragments/Sidebar/SidebarNav.tsx
+++ b/packages/react-component-library/src/fragments/Sidebar/SidebarNav.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
-import { Nav } from '../../types/Nav'
+import { Nav, NavItem } from '../../types/Nav'
 import { SidebarNavItem, SidebarNavItemProps } from '.'
 import { warnIfOverwriting } from '../../helpers'
 
-export interface SidebarNavProps extends Nav {
+export interface SidebarNavProps extends Nav<NavItem> {
   onBlur?: () => void
   onFocus?: () => void
   onItemClick?: () => void

--- a/packages/react-component-library/src/types/Nav.ts
+++ b/packages/react-component-library/src/types/Nav.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 
-export interface Nav extends ComponentWithClass {
-  children: React.ReactElement<NavItem> | React.ReactElement<NavItem>[]
+export interface Nav<T> extends ComponentWithClass {
+  children: React.ReactElement<T> | React.ReactElement<T>[]
 }
 
 export interface NavItem {


### PR DESCRIPTION
## Related issue
Closes #632 

## Overview
Currently multiple breadcrumbs need to be specified in order to use the `Breadcrumbs` component. A requirement is to present a single breadcrumb eg. `Home`

## Reason
This is a requirement from downstream dependents.

## Work carried out
- [x] Add ability for single breadcrumb
