### PR TITLE
Streamline CircleCI jobs within workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,6 +248,9 @@ workflows:
               ignore:
                 - master
                 - /^\d\.\d\.\d-hotfix/
+      - test_docs-site:
+          requires:
+            - lint_docs_site
       - test_react-component-library:
           requires:
             - lint_react-component-library
@@ -257,65 +260,40 @@ workflows:
       - test_visual_regression:
           requires:
             - test_react-component-library
-  build_and_test_master:
+  build_test_and_deploy:
     jobs:
-      - security_audit:
-          filters:
-            branches:
-              only:
-                - master
-                - /^\d\.\d\.\d-hotfix/
-      - lint_commits:
-          filters:
-            branches:
-              only:
-                - master
-                - /^\d\.\d\.\d-hotfix/
-      - lint_css-framework:
-          filters:
-            branches:
-              only:
-                - master
-                - /^\d\.\d\.\d-hotfix/
-      - lint_react-component-library:
-          filters:
-            branches:
-              only:
-                - master
-                - /^\d\.\d\.\d-hotfix/
-      - lint_docs_site:
-          filters:
-            branches:
-              only:
-                - master
-                - /^\d\.\d\.\d-hotfix/
       - test_react-component-library:
-          requires:
-            - lint_react-component-library
-      - code_climate:
-          requires:
-            - test_react-component-library
+          filters:
+            branches:
+              only:
+                - master
+                - /^\d\.\d\.\d-hotfix/
       - test_visual_regression:
-          requires:
-            - test_react-component-library
+          filters:
+            branches:
+              only:
+                - master
+                - /^\d\.\d\.\d-hotfix/
       - publish_stable_eslint-config-react:
           requires:
-            - lint_commits
+            - test_react-component-library
+            - test_visual_regression
       - publish_stable_icon-library:
           requires:
-            - lint_commits
+            - test_react-component-library
+            - test_visual_regression
       - publish_stable_fonts:
           requires:
-            - lint_commits
+            - test_react-component-library
+            - test_visual_regression
       - publish_stable_css-framework:
           requires:
-            - lint_commits
-            - lint_css-framework
+            - test_react-component-library
+            - test_visual_regression
       - publish_stable_react-component-library:
           requires:
             - test_react-component-library
+            - test_visual_regression
             - publish_stable_css-framework
+            - publish_stable_fonts
             - publish_stable_icon-library
-      - test_docs-site:
-          requires:
-            - test_react-component-library

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
       - run:
           name: Run visual regression tests
           command: yarn --cwd packages/react-component-library chromatic --app-code=$CHROMATIC_APP_CODE
-  publish_stable_eslint-config-react:
+  publish_latest_eslint-config-react:
     docker: *docker
     steps:
       - checkout
@@ -150,7 +150,7 @@ jobs:
       - publish_package:
           working_directory: packages/eslint-config-react
           tag: latest
-  publish_stable_css-framework:
+  publish_latest_css-framework:
     docker: *docker
     steps:
       - checkout
@@ -159,7 +159,7 @@ jobs:
       - publish_package:
           working_directory: packages/css-framework
           tag: latest
-  publish_stable_react-component-library:
+  publish_latest_react-component-library:
     docker: *docker
     steps:
       - checkout
@@ -169,7 +169,7 @@ jobs:
       - publish_package:
           working_directory: packages/react-component-library
           tag: latest
-  publish_stable_icon-library:
+  publish_latest_icon-library:
     docker: *docker
     steps:
       - checkout
@@ -178,7 +178,7 @@ jobs:
       - publish_package:
           working_directory: packages/icon-library
           tag: latest
-  publish_stable_fonts:
+  publish_latest_fonts:
     docker: *docker
     steps:
       - checkout
@@ -274,26 +274,26 @@ workflows:
               only:
                 - master
                 - /^\d\.\d\.\d-hotfix/
-      - publish_stable_eslint-config-react:
+      - publish_latest_eslint-config-react:
           requires:
             - test_react-component-library
             - test_visual_regression
-      - publish_stable_icon-library:
+      - publish_latest_icon-library:
           requires:
             - test_react-component-library
             - test_visual_regression
-      - publish_stable_fonts:
+      - publish_latest_fonts:
           requires:
             - test_react-component-library
             - test_visual_regression
-      - publish_stable_css-framework:
+      - publish_latest_css-framework:
           requires:
             - test_react-component-library
             - test_visual_regression
-      - publish_stable_react-component-library:
+      - publish_latest_react-component-library:
           requires:
             - test_react-component-library
             - test_visual_regression
-            - publish_stable_css-framework
-            - publish_stable_fonts
-            - publish_stable_icon-library
+            - publish_latest_css-framework
+            - publish_latest_fonts
+            - publish_latest_icon-library


### PR DESCRIPTION
## Related issue
Closes #705 

## Overview
This change streamlines the existing jobs within workflows. Some jobs are not required as it is safe to assume that they ran as part of the branching and PR process. It was also noted that testing of the docs site can happen at the same time as testing the component library.

## Reason
Performance

## Work carried out
- [x] Streamline jobs
- [x] Rename `stable` to `latest`

## Developer notes
There is an opportunity to use parallelisation.
