### PR TITLE
Add ability to automate publishing of @next packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,22 @@ jobs:
             node ./scripts/npm/publish.js https://$NPM_REGISTRY latest packages/fonts &&
             node ./scripts/npm/publish.js https://$NPM_REGISTRY latest packages/icon-library &&
             node ./scripts/npm/publish.js https://$NPM_REGISTRY latest packages/react-component-library
+  publish_next:
+    docker: *docker
+    steps:
+      - checkout
+      - dependencies
+      - *build_icon_library
+      - *authenticate_npm
+      - deploy: #deploy step is important to prevent triggering N builds
+          name: Publish next packages
+          command: >-
+            yarn lerna:prerelease --yes &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/css-framework &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/eslint-config-react &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/fonts &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/icon-library &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/react-component-library
   test_docs-site:
     docker: *docker
     steps:
@@ -225,6 +241,22 @@ workflows:
       - test_visual_regression:
           requires:
             - test_react-component-library
+  build_test_and_deploy_next:
+    jobs:
+      - test_react-component-library:
+          filters:
+            branches:
+              only:
+                - master
+      - test_visual_regression:
+          filters:
+            branches:
+              only:
+                - master
+      - publish_next:
+          requires:
+            - test_react-component-library
+            - test_visual_regression
   build_test_and_deploy_latest:
     jobs:
       - test_react-component-library:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,20 +26,6 @@ commands:
           paths:
             - ~/.cache/yarn
           key: yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
-  publish_package:
-    description: 'Publish an NPM package to a registry'
-    parameters:
-      working_directory:
-          type: string
-          description: 'Directory of package'
-      tag:
-          type: string
-          default: latest
-          description: 'The NPM dist-tag associated with the release'
-    steps:
-      - run:
-          name: Publish package
-          command: node ./scripts/npm/publish.js https://$NPM_REGISTRY << parameters.tag >> << parameters.working_directory >>
 
 jobs:
   security_audit:
@@ -146,52 +132,21 @@ jobs:
             else
               yarn --cwd packages/react-component-library chromatic --app-code=$CHROMATIC_APP_CODE
             fi
-  publish_latest_eslint-config-react:
-    docker: *docker
-    steps:
-      - checkout
-      - dependencies
-      - *authenticate_npm
-      - publish_package:
-          working_directory: packages/eslint-config-react
-          tag: latest
-  publish_latest_css-framework:
-    docker: *docker
-    steps:
-      - checkout
-      - dependencies
-      - *authenticate_npm
-      - publish_package:
-          working_directory: packages/css-framework
-          tag: latest
-  publish_latest_react-component-library:
+  publish_latest:
     docker: *docker
     steps:
       - checkout
       - dependencies
       - *build_icon_library
       - *authenticate_npm
-      - publish_package:
-          working_directory: packages/react-component-library
-          tag: latest
-  publish_latest_icon-library:
-    docker: *docker
-    steps:
-      - checkout
-      - dependencies
-      - *authenticate_npm
-      - publish_package:
-          working_directory: packages/icon-library
-          tag: latest
-  publish_latest_fonts:
-    docker: *docker
-    steps:
-      - checkout
-      - dependencies
-      - *authenticate_npm
-      - publish_package:
-          working_directory: packages/fonts
-          tag: latest
+      - deploy: #deploy step is important to prevent triggering N builds
+          name: Publish latest packages
+          command: >-
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY latest packages/css-framework &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY latest packages/eslint-config-react &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY latest packages/fonts &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY latest packages/icon-library &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY latest packages/react-component-library
   test_docs-site:
     docker: *docker
     steps:
@@ -227,30 +182,35 @@ workflows:
           filters:
             branches:
               ignore:
+                - latest
                 - master
                 - /^\d\.\d\.\d-hotfix/
       - lint_commits:
           filters:
             branches:
               ignore:
+                - latest
                 - master
                 - /^\d\.\d\.\d-hotfix/
       - lint_css-framework:
           filters:
             branches:
               ignore:
+                - latest
                 - master
                 - /^\d\.\d\.\d-hotfix/
       - lint_react-component-library:
           filters:
             branches:
               ignore:
+                - latest
                 - master
                 - /^\d\.\d\.\d-hotfix/
       - lint_docs_site:
           filters:
             branches:
               ignore:
+                - latest
                 - master
                 - /^\d\.\d\.\d-hotfix/
       - test_docs-site:
@@ -265,40 +225,21 @@ workflows:
       - test_visual_regression:
           requires:
             - test_react-component-library
-  build_test_and_deploy:
+  build_test_and_deploy_latest:
     jobs:
       - test_react-component-library:
           filters:
             branches:
               only:
-                - master
+                - latest
                 - /^\d\.\d\.\d-hotfix/
       - test_visual_regression:
           filters:
             branches:
               only:
-                - master
+                - latest
                 - /^\d\.\d\.\d-hotfix/
-      - publish_latest_eslint-config-react:
+      - publish_latest:
           requires:
             - test_react-component-library
             - test_visual_regression
-      - publish_latest_icon-library:
-          requires:
-            - test_react-component-library
-            - test_visual_regression
-      - publish_latest_fonts:
-          requires:
-            - test_react-component-library
-            - test_visual_regression
-      - publish_latest_css-framework:
-          requires:
-            - test_react-component-library
-            - test_visual_regression
-      - publish_latest_react-component-library:
-          requires:
-            - test_react-component-library
-            - test_visual_regression
-            - publish_latest_css-framework
-            - publish_latest_fonts
-            - publish_latest_icon-library

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lint-staged": "lerna run --parallel lint-staged",
     "test": "lerna run --parallel test",
     "storybook:static": "lerna run --parallel storybook:static",
+    "lerna:prerelease": "lerna version --force-publish=* --conventional-prerelease=* --tag-version-prefix='' --conventional-commits",
     "lerna:version": "yarn lerna:create-release && yarn lerna:fix-links",
     "lerna:create-release": "lerna version --force-publish=* --tag-version-prefix='' --conventional-commits --create-release github",
     "lerna:fix-links": "node ./scripts/release-notes/fix-links.js Royal-Navy standards-toolkit"


### PR DESCRIPTION
## Related issue
Closes #660 

## Overview
This change adds the ability to publish `@next` for each `merge` to `master`.

It was noticed previously that by automating the release notes from `master` and waiting for a release PR to be signed off, it is possible that other PRs are merged into `master` and therefore the release notes are out of date. This change also includes changing to use a `latest` branch for releasing.

## Reason
Prereleases have been required before and this change automates the process.

Other issues such as automated release notes out of sync and concurrency have been solved with this change.

## Work carried out
- [x] Add prerelease script
- [x] Update `latest` deployments
- [x] Add `next` deployments

## Developer notes
Note that it is possible that multiple containers could be running and therefore previously publishing of packages would have issues with concurrency. Within this change, the `deploy` job is introduced which handles this concurrency problem across containers.