### PR TITLE
fix: Remove SVGR generated icon-library exports (#723)

### DIFF
--- a/packages/icon-library/package.json
+++ b/packages/icon-library/package.json
@@ -17,7 +17,7 @@
     "build": "run-s svgr exports build:es build:cjs types",
     "build:es": "NODE_ENV=es babel src --out-dir \"dist/es\" --extensions \".ts,.tsx\"",
     "build:cjs": "NODE_ENV=cjs webpack -p --config=webpack/prod.js",
-    "svgr": "rm -rf src/icons; svgr --ext tsx -d src/icons src/assets/**/",
+    "svgr": "rm -rf src/icons; svgr --ext tsx -d src/icons src/assets/**/; rm src/icons/index.tsx",
     "exports": "./generate-exports.sh",
     "types": "tsc --emitDeclarationOnly --declarationMap --declaration --noEmit false --isolatedMOdules false --allowJs false --outDir dist/types",
     "prepare": "yarn build"


### PR DESCRIPTION
This file never used to be generated by SVGR and it breaks the build. 

The file also doesn't appear to be generated properly (possibly :some kind of race condition).