### PR TITLE
feat(button group): use z-index stacking for hover states

### DIFF
--- a/packages/css-framework/index.scss
+++ b/packages/css-framework/index.scss
@@ -37,8 +37,8 @@
 @use "src/components/autosuggest";
 @use "src/components/badge";
 @use "src/components/breadcrumbs";
+@use "src/components/btn";
 @use "src/components/btn-group";
-@use "src/components/button";
 @use "src/components/card-frame";
 @use "src/components/checkbox";
 @use "src/components/container";

--- a/packages/css-framework/src/components/_btn-group.scss
+++ b/packages/css-framework/src/components/_btn-group.scss
@@ -1,47 +1,36 @@
 @use "../abstracts/functions" as f;
 
 .rn-btn-group {
+  position: relative;
+  z-index: 0;
+  display: inline-block;
   .rn-btn {
     border-radius: 0;
-    border: 1px solid f.color("neutral", "100");
-    border-right: none;
+    border: 1px solid f.color("neutral", "200");
+    margin-right: -1px;
+    position: relative;
+    z-index: 1;
 
     &:first-child {
-      border-radius: 3px 0 0 3px;
+      border-radius: 4px 0 0 4px;
     }
 
     &:last-child {
-      border-radius: 0 3px 3px 0;
-      border-right: 1px solid f.color("neutral", "100");
+      border-radius: 0 4px 4px 0;
+      margin-right: 0;
     }
 
     &:hover,
     &:focus {
-      background: f.color("action", "600");
-      color: f.color("neutral", "white");
-      border-color: f.color("action", "500");
-      box-shadow: none;
+      background-color: f.color("neutral", "100");
+      color: f.color("neutral", "600");
+      box-shadow: f.shadow("1");
+      z-index: 2;
     }
 
-    &:hover + .rn-btn,
-    &:focus + .rn-btn {
-      border-left: 1px solid f.color("action", "500");
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
+    &.rn-btn--disabled,
+    &[disabled] {
+      z-index: 0;
     }
-
-    &.rn-btn--disabled:hover,
-    &.rn-btn--disabled:focus {
-      border-color: f.color("neutral", "100");
-    }
-
-    &.rn-btn--disabled:hover + .rn-btn,
-    &.rn-btn--disabled:focus + .rn-btn {
-      border-left: 1px solid f.color("neutral", "100");
-    }
-  }
-
-  .rn-btn + .rn-btn {
-    margin-left: 0;
   }
 }

--- a/packages/css-framework/src/components/_btn.scss
+++ b/packages/css-framework/src/components/_btn.scss
@@ -3,6 +3,7 @@
 @use "../abstracts/functions" as f;
 
 $btn-border-radius: 4px;
+$btn-border-radius--small: 3px;
 $btn-disabled-opacity: 0.4;
 $btn-block-spacing-y: 1rem;
 $btn-focus-width: 0.2rem;
@@ -166,6 +167,8 @@ $btn-focus-width: 0.2rem;
   // Sizes
   &--small {
     padding: f.spacing("3") f.spacing("5");
+    border-radius: $btn-border-radius--small;
+    font-size: f.font-size("base");
   }
 
   &--large {


### PR DESCRIPTION
## Related issue

#390 

## Overview

Updates the Button Group component to ensure parity with the Sketch file.

## Work carried out

- [x] Swaps out the removal of borders in favour of z-index stacking for hovered/active items. This ensures we can have a border on every side of the hovered button.
- [x] Renames `_button.scss` to `_btn.scss` to keep consistency with the button group and the underlying class names.