### PR TITLE
fix(breadcrumbs): match hover state to link hover state

### DIFF
--- a/packages/css-framework/src/components/_breadcrumbs.scss
+++ b/packages/css-framework/src/components/_breadcrumbs.scss
@@ -1,4 +1,5 @@
 @use "../abstracts/functions" as f;
+@use "../config" as config;
 
 .rn-breadcrumbs {
   display: block;
@@ -11,11 +12,19 @@
 .rn-breadcrumbs__breadcrumb {
   display: inline-block;
   vertical-align: top;
+  transition: all config.$animation-timing;
 
   > a {
     color: f.color("neutral", "400");
     font-weight: 400;
     text-decoration: none;
+    &:hover {
+      color: f.color("action", "500");
+    }
+  }
+
+  svg {
+    margin: 0 f.spacing("2");
   }
 
   span, a {
@@ -23,9 +32,6 @@
   }
 }
 
-.rn-breadcrumbs__link:hover {
-  color: f.color("action", "500");
-}
 
 .rn-breadcrumbs__breadcrumb:hover ~ .rn-breadcrumbs__breadcrumb {
   opacity: 0.2;
@@ -38,4 +44,6 @@
 
 .rn-breadcrumbs__separator {
   display: inline-block;
+  transform: translateY(1px);
+  color: f.color("neutral", "200");
 }


### PR DESCRIPTION
## Related issue

#390 

## Work carried out

- [x] Matches the breadcrumb hover state to that of the link for consistency.