### PR TITLE
ci: Add step to configure git before @next publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,13 @@ jobs:
       - checkout
       - dependencies
       - *build_icon_library
+      - run:
+          name: Configure Git
+          command: >-
+            git config user.email "${GH_EMAIL}" &&
+            git config user.name "${GH_NAME}" &&
+            git remote set-url origin https://${GH_TOKEN}@github.com/Royal-Navy/standards-toolkit.git &&
+            git checkout master
       - *authenticate_npm
       - deploy: #deploy step is important to prevent triggering N builds
           name: Publish next packages


### PR DESCRIPTION
## Related issue
Fixes #739 

## Overview
Configures Git within the Circle container before incrementing the prerelease version and pushing to `master`.

## Reason
Needed in order to run the command `yarn lerna:prerelease --yes` from CI.

## Work carried out
- [x] Configure Git in Circle config