### PR TITLE
Tweak prereleases and update docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,37 +205,32 @@ workflows:
           filters:
             branches:
               ignore:
-                - latest
                 - master
-                - /^\d\.\d\.\d-hotfix/
+                - /^\d\.\d-latest/
       - lint_commits:
           filters:
             branches:
               ignore:
-                - latest
                 - master
-                - /^\d\.\d\.\d-hotfix/
+                - /^\d\.\d-latest/
       - lint_css-framework:
           filters:
             branches:
               ignore:
-                - latest
                 - master
-                - /^\d\.\d\.\d-hotfix/
+                - /^\d\.\d-latest/
       - lint_react-component-library:
           filters:
             branches:
               ignore:
-                - latest
                 - master
-                - /^\d\.\d\.\d-hotfix/
+                - /^\d\.\d-latest/
       - lint_docs_site:
           filters:
             branches:
               ignore:
-                - latest
                 - master
-                - /^\d\.\d\.\d-hotfix/
+                - /^\d\.\d-latest/
       - test_docs-site:
           requires:
             - lint_docs_site
@@ -270,14 +265,12 @@ workflows:
           filters:
             branches:
               only:
-                - latest
-                - /^\d\.\d\.\d-hotfix/
+                - /^\d\.\d-latest/
       - test_visual_regression:
           filters:
             branches:
               only:
-                - latest
-                - /^\d\.\d\.\d-hotfix/
+                - /^\d\.\d-latest/
       - publish_latest:
           requires:
             - test_react-component-library

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,13 +10,13 @@
     - [Pull requests](#pull-requests)
         - [Fixups](#fixups)
         - [Squashing](#squashing)
+- [Prereleases](#prereleases)
 - [Hot fixing](#hot-fixing)
     - [Apply the fix to master in the first instance](#apply-the-fix-to-master-in-the-first-instance)
     - [Add the fix to the release](#add-the-fix-to-the-release)
-        - [Create the release branch](#create-the-release-branch)
         - [Cherry pick the fix](#cherry-pick-the-fix)
-    - [Release the fix](#release-the-fix)
-    - [Finally](#finally)
+        - [Release the fix](#release-the-fix)
+        - [Finally](#finally)
 
 ## Branching strategy
 The Standards Toolkit repository is using a trunk-based development branching strategy. All changes are merged directly into `master`. To have control over publishing of packages, `npm publish` is triggered only when a new version tag is merged into `master`. Branches are still used for the peer review process. When required, separate branches are maintained for fixes.
@@ -103,6 +103,9 @@ git checkout feature/<name>
 git rebase -i --autosquash origin/master
 ```
 
+### Prereleases
+Each `merge` to `master` publishes a prerelease to NPM. 
+
 ## Hot fixing
 If there is an issue (never happens :sunglasses:) then `master` is always fixed first as it is possible that another release from `master` could happen once the hot fix is live.
 
@@ -123,37 +126,30 @@ Make changes to the fix branch, `commit` and `push` to the remote repository. Op
 ### Add the fix to the release
 Once the fix is merged into `master` you are ready to add the fix to the release.
 
-#### Create the release branch
-The release branch needs to be created from the current live tag.
-```
-// checkout at live tag
-git checkout tags/<version-in-prod>
-
-// create a branch
-git checkout -b <version-in-prod>-hotfix
-
-// push the branch
-git push origin <version-in-prod>-hotfix
-```
-
 #### Cherry pick the fix
-The bug has been fixed on `master` and needs to be added to the release branch.
+The release branch will already exist from the previous `latest` release. This step is to apply the fix from `master` to the release branch.
 ```
-// work with the hotfix branch
-git checkout <version-in-prod>-hotfix
+// work with the release
+git checkout <major>.<minor>-latest
 
-// get the fix commit on master
+// apply the fix commit from master
 git cherry-pick <commit-hash>
 ```
 
-### Release the fix
+#### Release the fix
+The package numbers will need updating to trigger publishing of the packages.
 ```
-// work with the hotfix branch
-git checkout <version-in-prod>-hotfix
+// work with the release
+git checkout <major>.<minor>-latest
+
+// create a branch to increment version numbers
+git checkout <name-of-hot-fix>
 
 // create a version
 yarn lerna:version
 ```
 
-### Finally
+A PR will need to be opened to `merge` the package updates into the release branch which will then trigger the publishing of packages.
+
+#### Finally
 Once deployed successfully, open a PR to `merge` the `CHANGELOG` and `package.json` changes back into `master`.

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -2,13 +2,14 @@
 
 NOTE: Fix problems by moving forward (roll a new release with a fix).
 
-- [ ] Check and update dependencies
-- [ ] Create and push new release branch from `develop`, using the convention `release/*.*.*` ([Semver](https://semver.org/))
+- [ ] Clean up redundant `*.*-latest` branches
+- [ ] Create and push new release branch from `master`, using the convention `*.*-latest` ([Semver](https://semver.org/))
+- [ ] Create and push a branch from `*.*-latest`
 - [ ] Update [docs-site Versions page](update_versions_page.md)
 - [ ] Run `yarn lerna:version` (updates package version, linked dependency versions, tags and pushes to remote)
-- [ ] Add draft release notes to GitHub and link to tag
-- [ ] Merge release branch to `master` (Pull Request should include release notes) [2x peer approval]
+- [ ] Merge branch to `*.*-latest` (Pull Request should include release notes) [2x peer approval]
 - [ ] [Deploy documentation at tag](deploy_documentation.md)
-- [ ] Merge `master` back into `develop`
+- [ ] Merge `*.*-latest` back into `master`
 - [ ] Check published packages on the [NPM public registry](https://www.npmjs.com/search?q=royalnavy) and the `docs-site` [production deployment](https://docs.royalnavy.io)
-- [ ] Publish GitHub release
+
+Do not delete the `*.*-latest` branch as it may be required for hot fixes.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "storybook:static": "lerna run --parallel storybook:static",
     "lerna:prerelease": "lerna version --force-publish=* --conventional-prerelease=* --tag-version-prefix='' --conventional-commits --no-changelog",
     "lerna:version": "yarn lerna:create-release && yarn lerna:fix-links",
-    "lerna:create-release": "lerna version --force-publish=* --tag-version-prefix='' --conventional-commits --create-release github",
+    "lerna:create-release": "lerna version --force-publish=* --tag-version-prefix='' --conventional-commits --conventional-graduate --create-release github",
     "lerna:fix-links": "node ./scripts/release-notes/fix-links.js Royal-Navy standards-toolkit"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint-staged": "lerna run --parallel lint-staged",
     "test": "lerna run --parallel test",
     "storybook:static": "lerna run --parallel storybook:static",
-    "lerna:prerelease": "lerna version --force-publish=* --conventional-prerelease=* --tag-version-prefix='' --conventional-commits --no-changelog",
+    "lerna:prerelease": "lerna version --force-publish=* --conventional-prerelease=* --tag-version-prefix='' --conventional-commits --no-changelog --amend",
     "lerna:version": "yarn lerna:create-release && yarn lerna:fix-links",
     "lerna:create-release": "lerna version --force-publish=* --tag-version-prefix='' --conventional-commits --conventional-graduate --create-release github",
     "lerna:fix-links": "node ./scripts/release-notes/fix-links.js Royal-Navy standards-toolkit"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint-staged": "lerna run --parallel lint-staged",
     "test": "lerna run --parallel test",
     "storybook:static": "lerna run --parallel storybook:static",
-    "lerna:prerelease": "lerna version --force-publish=* --conventional-prerelease=* --tag-version-prefix='' --conventional-commits",
+    "lerna:prerelease": "lerna version --force-publish=* --conventional-prerelease=* --tag-version-prefix='' --conventional-commits --no-changelog",
     "lerna:version": "yarn lerna:create-release && yarn lerna:fix-links",
     "lerna:create-release": "lerna version --force-publish=* --tag-version-prefix='' --conventional-commits --create-release github",
     "lerna:fix-links": "node ./scripts/release-notes/fix-links.js Royal-Navy standards-toolkit"


### PR DESCRIPTION
## Related issue
#746 

## Overview
This change is several small tweaks to address issues:
- changelog should not be added for prerelease as we want to use the changelog for the next `latest` release
- when creating the `latest` release we need to graduate the prereleases that have been created in order to use the correct version number
- `--amend` needs to be used on `master` as without it new commits are added which triggers Circle builds and Netlify deployments so there are infinite publishes/deployments to NPM/Netlify (CD ✌️ )
- Circle config has been updated as we are using `*.*-latest` release branches. This becomes more obvious when considering hot fixes. It's easy to isolate the hot fix for the first fix but then there would be issues for subsequent hot fixes in order to isolate the change. A release branch that does not get deleted until the next minor release resolves this issue
- documentation updates for all of the above ☝️ 

## Reason
Changes have been implemented after observations during releases of `next` and `latest`.

## Work carried out
- [x] Update configs
- [x] Update docs
