### PR TITLE
fix: Update labels in line with new scheme

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,5 +10,4 @@ update_configs:
       - "thyhjwb6"
 
     default_labels:
-      - "devops"
-      - "automation"
+      - "Type: Devops"


### PR DESCRIPTION
## Related issue

#745 

## Overview

Updated labels to reflect new

## Link to preview

[If you're on a project which auto-deploys branches, link to the branches preview link here]

## Reason

Current labels referenced no longer exist

## Work carried out

Updated dependabot config.yml


