### PR TITLE
ci: Add commit message for lerna commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "lint-staged": "lerna run --parallel lint-staged",
     "test": "lerna run --parallel test",
     "storybook:static": "lerna run --parallel storybook:static",
-    "lerna:prerelease": "lerna version --force-publish=* --conventional-prerelease=* --tag-version-prefix='' --conventional-commits --no-changelog --amend",
-    "lerna:version": "yarn lerna:create-release && yarn lerna:fix-links",
-    "lerna:create-release": "lerna version --force-publish=* --tag-version-prefix='' --conventional-commits --conventional-graduate --create-release github",
+    "lerna:prerelease": "yarn lerna:run-version --conventional-prerelease=* --no-changelog -m \"chore(prerelease): %v [skip ci]\"",
+    "lerna:version": "yarn lerna:run-version --conventional-graduate --create-release github -m \"chore(release): %v\" && yarn lerna:fix-links",
+    "lerna:run-version": "lerna version --force-publish=* --conventional-commits --tag-version-prefix=''",
     "lerna:fix-links": "node ./scripts/release-notes/fix-links.js Royal-Navy standards-toolkit"
   },
   "husky": {


### PR DESCRIPTION
## Related issue
Closes #755 

## Overview
A recent change to add `--amend` implies that the local changes are not pushed so the version number is never updated. This change removes `--amend` and adds `[skip ci]` to the prerelease commit message. This also presented an opportunity to ensure commit messages follow the conventional format.

## Reason
Prereleases are not publishing.

## Work carried out
- [x] Update `lerna` commands