### PR TITLE
chore: Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+*       @elglup
+*       @hxltrhuxze
+*       @m7kvqbe1
+*       @thyhjwb6


### PR DESCRIPTION
## Related issue
Closes #761 

## Overview
To protect the release branches we need sign offs from code owners which effectively act as Release Managers. This change adds code owners to the repo.

## Reason
Protect release branches.

## Work carried out
- [x] Add code owners

## Screenshot
![Screenshot 2020-03-23 at 17 00 23](https://user-images.githubusercontent.com/56078793/77342236-cedd8e80-6d27-11ea-9a04-cf4ed7498717.png)