### PR TITLE
ci: Set flag to not add git tag for prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint-staged": "lerna run --parallel lint-staged",
     "test": "lerna run --parallel test",
     "storybook:static": "lerna run --parallel storybook:static",
-    "lerna:prerelease": "yarn lerna:run-version --conventional-prerelease=* --no-changelog -m \"chore(prerelease): %v [skip ci]\"",
+    "lerna:prerelease": "yarn lerna:run-version --conventional-prerelease=* --no-changelog --no-git-tag-version -m \"chore(prerelease): %v [skip ci]\"",
     "lerna:version": "yarn lerna:run-version --conventional-graduate --create-release github -m \"chore(release): %v\" && yarn lerna:fix-links",
     "lerna:run-version": "lerna version --force-publish=* --conventional-commits --tag-version-prefix=''",
     "lerna:fix-links": "node ./scripts/release-notes/fix-links.js Royal-Navy standards-toolkit"


### PR DESCRIPTION
Do not set the Git tag when prereleasing.