### PR TITLE
Create upnext.yml

### DIFF
--- a/.github/workflows/upnext.yml
+++ b/.github/workflows/upnext.yml
@@ -1,0 +1,14 @@
+on:
+  issues:
+    types: [labeled]
+jobs:
+  Move_Labeled_Issue_On_Project_Board:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+      with:
+        action-token: "${{ secrets.GHA_UPNEXT_TOKEN }}"
+        project-url: "https://github.com/orgs/Royal-Navy/projects/6"
+        column-name: "Ready"
+        label-name: "Status: Up next"
+        columns-to-ignore: "Doing,Needs Review,Done"


### PR DESCRIPTION


## Overview

Adding a GitHub action to automate movement of issues labelled 'Up next' into the ready column on the project board


