### PR TITLE
feat(Progress Indicator): Add default component

### DIFF
--- a/packages/css-framework/index.scss
+++ b/packages/css-framework/index.scss
@@ -56,6 +56,7 @@
 @use "src/components/panel";
 @use "src/components/popover";
 @use "src/components/progress";
+@use "src/components/progress-indicator";
 @use "src/components/phase-banner";
 @use "src/components/radio";
 @use "src/components/range-slider";

--- a/packages/css-framework/src/components/_progress-indicator.scss
+++ b/packages/css-framework/src/components/_progress-indicator.scss
@@ -1,0 +1,16 @@
+@use "../abstracts/functions" as f;
+
+.rn-progress-indicator {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  text-align: center;
+  text-transform: uppercase;
+
+  span {
+    display: block;
+    margin-top: f.spacing("4");
+    font-size: f.font-size("s");
+    font-weight: 700;
+  }
+}

--- a/packages/docs-site/src/library/images/components/progress-indicator/anatomy.svg
+++ b/packages/docs-site/src/library/images/components/progress-indicator/anatomy.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 726 203">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#FFF" stroke="#B8C7D2" d="M.5.5h725v167H.5z"/>
+    <text fill="#3E5667" font-family="Lato-Medium, Lato" font-size="15" font-weight="400">
+      <tspan x="0" y="197">Anatomy of the Progress Indicator component.</tspan>
+    </text>
+    <text fill="#233745" font-family="Lato-Semibold, Lato" font-size="14" font-weight="500" transform="translate(440 93)">
+      <tspan x="26.27" y="14">Loading label</tspan>
+    </text>
+    <g transform="translate(440 93)">
+      <rect width="19.2" height="18.4" fill="#3E5667" rx="9.2"/>
+      <text fill="#FFF" font-family="Lato-Heavy, Lato" font-size="9.6" font-weight="600">
+        <tspan x="6.82" y="12.2">2</tspan>
+      </text>
+    </g>
+    <text fill="#233745" font-family="Lato-Semibold, Lato" font-size="14" font-weight="500" transform="translate(145 67)">
+      <tspan x=".48" y="14">Indicator Animation</tspan>
+    </text>
+    <g transform="translate(277 67)">
+      <rect width="19.2" height="18.4" fill="#3E5667" rx="9.2"/>
+      <text fill="#FFF" font-family="Lato-Heavy, Lato" font-size="9.6" font-weight="600">
+        <tspan x="6.82" y="12.2">1</tspan>
+      </text>
+    </g>
+    <path fill="#B8C7D2" d="M403 102h37v1h-37z"/>
+    <path fill="#B8C7D2" d="M296 76h37v1h-37z"/>
+    <circle cx="403" cy="102.5" r="3" fill="#3E5667"/>
+    <circle cx="336" cy="76.5" r="3" fill="#3E5667"/>
+    <g>
+      <text fill="#3E5667" font-family="Lato-Bold, Lato" font-size="10" font-weight="bold" transform="translate(338 96)">
+        <tspan x=".27" y="10">LOADING…</tspan>
+      </text>
+      <g transform="translate(350 64)">
+        <circle cx="12" cy="12" r="12"/>
+        <path fill="#B5C8D4" fill-rule="nonzero" d="M12 0a12 12 0 0112 12h-1.9A10.1 10.1 0 0012 1.9V0zM1.9 12A10.1 10.1 0 0012 22.1V24A12 12 0 010 12h1.9z"/>
+        <circle cx="12" cy="12" r="5.05" fill="#6F8A9B" fill-rule="nonzero"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/docs-site/src/library/images/components/progress-indicator/component.svg
+++ b/packages/docs-site/src/library/images/components/progress-indicator/component.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 726 213">
+  <g fill="none" fill-rule="evenodd">
+    <path fill="#FFF" stroke="#B8C7D2" d="M.5.5h725v177H.5z"/>
+    <text fill="#3E5667" font-family="Lato-Medium, Lato" font-size="15" font-weight="400">
+      <tspan x="0" y="207">The Progress Indicator component </tspan>
+    </text>
+    <text fill="#3E5667" font-family="Lato-Bold, Lato" font-size="10" font-weight="bold" transform="translate(337 101)">
+      <tspan x=".27" y="10">LOADING…</tspan>
+    </text>
+    <g transform="translate(349 69)">
+      <circle cx="12" cy="12" r="12"/>
+      <path fill="#B5C8D4" fill-rule="nonzero" d="M12 0a12 12 0 0112 12h-1.9A10.1 10.1 0 0012 1.9V0zM1.9 12A10.1 10.1 0 0012 22.1V24A12 12 0 010 12h1.9z"/>
+      <circle cx="12" cy="12" r="5.05" fill="#6F8A9B" fill-rule="nonzero"/>
+    </g>
+  </g>
+</svg>

--- a/packages/docs-site/src/library/pages/components/progress-indicator.md
+++ b/packages/docs-site/src/library/pages/components/progress-indicator.md
@@ -1,0 +1,57 @@
+---
+title: Progress Indicator
+description: An animated indication that some form of network request or processing pending.
+header: true
+---
+
+import { ProgressIndicator, Tab, TabSet } from '@royalnavy/react-component-library'
+import CodeHighlighter from '../../../components/presenters/code-highlighter'
+import DataTable from '../../../components/presenters/data-table'
+
+import ProgressIndicatorComponent from '../../images/components/progress-indicator/Component'
+import ProgressIndicatorAnatomy from '../../images/components/progress-indicator/Anatomy'
+
+# Overview
+
+The Progress Indicator provides visual feedback to the user that an application is currently processing or retrieving data. Its purpose is to show that the application has not stalled - rather it is still running, however cannot update the UI with the newly requested or processed data.
+
+<ProgressIndicatorComponent />
+
+## Usage
+
+The Progress Indicator should be used when processing or retrieving data. It should be used to convey a delay in the loading of data, indicating a network request may be taking longer than usual to complete.
+
+<TabSet>
+<Tab title="Design">
+
+### Anatomy
+
+<ProgressIndicatorAnatomy />
+
+1. **Indicator Animation.** An SVG spinner that rotates to provide feedback to the user that the application is loading, rather than hung.
+2. **Loading Label.** Accompanies the Indicator Animation to provide written context to the spinner.
+
+### Hierarchy & Placement
+
+The Progress Indicator can either be used as a full screen overlay, or within an individual component. Use the indicator full screen when the application is on first load. Individual components should have the progress indicator displayed when they are retrieving data, yet don't have anything to display yet.
+
+</Tab>
+
+<Tab title="Develop">
+
+### Basic Usage
+<CodeHighlighter source={`<ProgressIndicator />`} language="javascript" />
+
+### Properties
+<DataTable data={[
+  {
+    Name: 'className',
+    Type: 'string',
+    Required: 'False',
+    Default: '',
+    Description: 'CSS modifier class to add to the component',
+  },
+]} />
+
+</Tab>
+</TabSet>

--- a/packages/icon-library/src/assets/standards/loader.svg
+++ b/packages/icon-library/src/assets/standards/loader.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40px" height="40px" viewBox="0 0 38 38">
+    <style>
+        @keyframes rotating {
+            0% {
+                transform: rotate(0deg);
+            }
+            100% {
+                transform: rotate(720deg);
+            }
+        }
+        @keyframes fade {
+            0% {
+                opacity: 1;
+            }
+            50% {
+                opacity: 0.3;
+            }
+            100% {
+                opacity: 1;
+            }
+        }
+        .loader {
+            transform-origin: 50% 50%;
+            animation: rotating 1s infinite cubic-bezier(.61,-0.11,.32,1.13);
+        }
+        .dot {
+            opacity: 1;
+            animation: fade 1s infinite;
+        }
+    </style>
+    <g fill="none" fill-rule="evenodd">
+        <circle fill="none" cx="19" cy="19" r="19"/>
+        <path class="loader" d="M19 0c10.4934102 0 19 8.50658975 19 19h-3c0-8.836556-7.163444-16-16-16V0zM3 19c0 8.836556 7.163444 16 16 16v3C8.50658975 38 0 29.4934102 0 19h3z" fill="#b5c8d4"/>
+        <circle class="dot" fill="#6f8a9b" cx="19" cy="19" r="8"/>
+    </g>
+</svg>

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import { ProgressIndicator } from './index'
+
+const stories = storiesOf('ProgressIndicator', module)
+
+stories.add('Default', () => <ProgressIndicator />)

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, RenderResult } from '@testing-library/react'
+
+import { ProgressIndicator } from '.'
+
+describe('ProgressIndicator', () => {
+  let wrapper: RenderResult
+
+  describe('default props', () => {
+    beforeEach(() => {
+      wrapper = render(<ProgressIndicator />)
+    })
+
+    it('should show the loader', () => {
+      expect(wrapper.getByTestId('loader')).toBeInTheDocument()
+    })
+
+    it('should show the "Loading..." text', () => {
+      expect(wrapper.getByText('Loading...')).toBeInTheDocument()
+    })
+  })
+
+  describe('with CSS modifier', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <ProgressIndicator className="rn-progress-indicator--custom" />
+      )
+    })
+
+    it('should add the modifier', () => {
+      expect(wrapper.getByTestId('progress-indicator').classList).toContain(
+        'rn-progress-indicator--custom'
+      )
+    })
+  })
+})

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import classNames from 'classnames'
+import { IconLoader } from '@royalnavy/icon-library'
+
+export const ProgressIndicator: React.FC<ComponentWithClass> = ({
+  className,
+}) => {
+  const classes = classNames('rn-progress-indicator', className)
+
+  return (
+    <div className={classes} data-testid="progress-indicator">
+      <IconLoader data-testid="loader" />
+      <span>Loading...</span>
+    </div>
+  )
+}
+
+ProgressIndicator.displayName = 'ProgressIndicator'

--- a/packages/react-component-library/src/components/ProgressIndicator/index.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/index.tsx
@@ -1,0 +1,1 @@
+export * from './ProgressIndicator'

--- a/packages/react-component-library/src/components/index.ts
+++ b/packages/react-component-library/src/components/index.ts
@@ -24,6 +24,7 @@ import { NumberInput } from './NumberInput'
 import Pagination from './Pagination'
 import PhaseBanner from './PhaseBanner'
 import { Popover, POPOVER_PLACEMENT } from './Popover'
+import { ProgressIndicator } from './ProgressIndicator'
 import Radio from './Radio'
 import { ScrollableNav, ScrollableNavItem } from './ScrollableNav'
 import { Searchbar } from './Searchbar'
@@ -72,6 +73,7 @@ export {
   PhaseBanner,
   Popover,
   POPOVER_PLACEMENT,
+  ProgressIndicator,
   Radio,
   ScrollableNav,
   ScrollableNavItem,

--- a/packages/react-component-library/src/index.ts
+++ b/packages/react-component-library/src/index.ts
@@ -28,6 +28,7 @@ import { NumberInput } from './components/NumberInput'
 import Pagination from './components/Pagination'
 import PhaseBanner from './components/PhaseBanner'
 import { Popover, POPOVER_PLACEMENT } from './components/Popover'
+import { ProgressIndicator } from './components/ProgressIndicator'
 import { Select } from './components/Select'
 import Switch from './components/Switch/Switch'
 import { RangeSlider } from './components/RangeSlider'
@@ -102,6 +103,7 @@ export {
   PhaseBanner,
   Popover,
   POPOVER_PLACEMENT,
+  ProgressIndicator,
   Switch,
   RangeSlider,
   ResponsiveSwitch,


### PR DESCRIPTION
## Related issue
Closes #347 

## Overview
Add `ProgressIndicator` component to toolkit.

## Reason
> An animated indication that some form of network request or processing pending.

## Work carried out
- [x] Add component
- [x] Add docs

## Screenshot
![Screenshot 2020-03-26 at 09 57 55](https://user-images.githubusercontent.com/56078793/77634069-4ab62180-6f48-11ea-8f95-eb6ed8eaaab9.png)