### PR TITLE
ci(prerelease): Delete tag before push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,9 @@ jobs:
       - deploy: #deploy step is important to prevent triggering N builds
           name: Publish next packages
           command: >-
-            yarn lerna:prerelease --yes &&
+            yarn lerna:prerelease --yes --no-push &&
+            git tag -d $(git describe --abbrev=0) &&
+            git push origin master &&
             node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/css-framework &&
             node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/eslint-config-react &&
             node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/fonts &&

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint-staged": "lerna run --parallel lint-staged",
     "test": "lerna run --parallel test",
     "storybook:static": "lerna run --parallel storybook:static",
-    "lerna:prerelease": "yarn lerna:run-version --conventional-prerelease=* --no-changelog --no-git-tag-version -m \"chore(prerelease): %v [skip ci]\"",
+    "lerna:prerelease": "yarn lerna:run-version --conventional-prerelease=* --no-changelog -m \"chore(prerelease): %v [skip ci]\"",
     "lerna:version": "yarn lerna:run-version --conventional-graduate --create-release github -m \"chore(release): %v\" && yarn lerna:fix-links",
     "lerna:run-version": "lerna version --force-publish=* --conventional-commits --tag-version-prefix=''",
     "lerna:fix-links": "node ./scripts/release-notes/fix-links.js Royal-Navy standards-toolkit"


### PR DESCRIPTION
## Related issue
Fixes #780

## Overview
Change addresses issue with prereleases not publishing:
- `--no-git-tag-version` implies no commit so we need to remove this
- from CI we need to pass in `--no-push` to prevent tag being pushed
- then we need to `delete` the `tag`
- then we need to `push` to the remote

## Reason
Prereleases are not publishing

## Work carried out
- [x] Add fix