### PR TITLE
feat(component library): Icon placement left of button text

### DIFF
--- a/packages/css-framework/src/components/_btn.scss
+++ b/packages/css-framework/src/components/_btn.scss
@@ -46,153 +46,149 @@ $btn-focus-width: 0.2rem;
     border: 1px solid f.color("danger", "500");
     box-shadow: 0 0 0 $btn-focus-width rgba(f.color("danger", "500"), 0.3);
   }
+}
 
-  &__text {
-    position: relative;
-    z-index: 2;
+.rn-btn__text {
+  position: relative;
+  z-index: 2;
+}
+
+// States
+.rn-btn--primary {
+
+  background: linear-gradient(to bottom, f.color("action", "400"), f.color("action", "500"));
+  color: f.color("neutral", "white");
+  position: relative;
+  &::before {
+    content: "";
+    position: absolute;
+    top: -1px;
+    right: -1px;
+    bottom: -1px;
+    left: -1px;
+    border-radius: $btn-border-radius;
+    background-color: rgba(255, 255, 255, 0);
+    z-index: 1;
+    transition: all config.$animation-timing ease-out;
   }
 
-  // States
-  &--primary {
-
-    background: linear-gradient(to bottom, f.color("action", "400"), f.color("action", "500"));
-    color: f.color("neutral", "white");
-    position: relative;
+  &:hover {
+    box-shadow: 0 1px 3px 0 rgba(0,0,0,0.04), 0 4px 8px 0 rgba(0,0,0,0.14);
     &::before {
-      content: "";
-      position: absolute;
-      top: -1px;
-      right: -1px;
-      bottom: -1px;
-      left: -1px;
-      border-radius: $btn-border-radius;
-      background-color: rgba(255, 255, 255, 0);
-      z-index: 1;
-      transition: all config.$animation-timing ease-out;
+      background-color: rgba(0, 0, 0, 0.15);
     }
+  }
+
+  &.rn-btn--danger {
+    background: linear-gradient(to bottom, f.color("danger", "500"), f.color("danger", "600"));
+    color: f.color("neutral", "white");
 
     &:hover {
       box-shadow: 0 1px 3px 0 rgba(0,0,0,0.04), 0 4px 8px 0 rgba(0,0,0,0.14);
-      &::before {
-        background-color: rgba(0, 0, 0, 0.15);
-      }
     }
 
-    &.rn-btn--danger {
-      background: linear-gradient(to bottom, f.color("danger", "500"), f.color("danger", "600"));
-      color: f.color("neutral", "white");
-
-      &:hover {
-        box-shadow: 0 1px 3px 0 rgba(0,0,0,0.04), 0 4px 8px 0 rgba(0,0,0,0.14);
-      }
-
-      &:focus {
-        box-shadow: 0 0 0 $btn-focus-width rgba(f.color("danger", "800"), 0.5);
-      }
-    }
-
-  }
-
-  &--secondary {
-    border: 1px solid f.color("neutral", "200");
-    color: f.color("neutral", "400");
-    background-color: f.color("neutral", "white");
-    background-image: none;
-
-    &.rn-btn--danger {
-      color: f.color("danger", "600");
-      &:hover {
-        color: f.color("danger", "600");
-      }
-
-      &:focus {
-        box-shadow: 0 0 0 $btn-focus-width rgba(f.color("danger", "800"), 0.5);
-      }
-    }
-    &:hover {
-      background-color: f.color("neutral", "100");
-      color: f.color("neutral", "600");
+    &:focus {
+      box-shadow: 0 0 0 $btn-focus-width rgba(f.color("danger", "800"), 0.5);
     }
   }
-
-  &--tertiary {
-    border: 1px solid transparent;
-    color: f.color("neutral", "400");
-    background-color: transparent;
-    background-image: none;
-    &.rn-btn--danger {
-      color: f.color("danger", "600");
-      .rn-btn__text {
-        &::after {
-          background: f.color("danger", "300");
-        }
-      }
-    }
-    &:hover {
-      transform: none;
-      box-shadow: none;
-      border: 1px solid f.color("neutral", "200");
-      .rn-btn__text::after {
-        transform: scale(0, 1);
-      }
-    }
-    .rn-btn__text {
-      position: relative;
-      z-index: 0;
-      &::after {
-        transition: transform config.$animation-timing;
-        transform-origin: 0 0;
-        bottom: 2px;
-        left: 0;
-        right: 0;
-        height: 2px;
-        background: f.color("neutral", "200");
-        content: "";
-        position: absolute;
-        border-radius: 5px;
-        z-index: -1;
-      }
-    }
-  }
-
-  // Icon
-  &__icon {
-    display: inline-flex;
-    align-items: center;
-    margin-left: f.spacing("4");
-    position: relative;
-    z-index: 2;
-  }
-
-  // Sizes
-  &--small {
-    padding: f.spacing("3") f.spacing("5");
-    border-radius: $btn-border-radius--small;
-    font-size: f.font-size("base");
-  }
-
-  &--large {
-    padding: f.spacing("6") f.spacing("9");
-    font-size: f.font-size("l");
-    line-height: 1.45;
-    .rn-btn__text {
-      transform: translateY(-1px);
-    }
-  }
-
-  &--xlarge {
-    font-size: f.font-size("l");
-    padding: f.spacing("6") f.spacing("10");
-    .rn-btn__icon svg {
-      width: 20px;
-      height: 20px;
-    }
-  }
-
 
 }
 
+.rn-btn--secondary {
+  border: 1px solid f.color("neutral", "200");
+  color: f.color("neutral", "400");
+  background-color: f.color("neutral", "white");
+  background-image: none;
 
+  &.rn-btn--danger {
+    color: f.color("danger", "600");
+    &:hover {
+      color: f.color("danger", "600");
+    }
+
+    &:focus {
+      box-shadow: 0 0 0 $btn-focus-width rgba(f.color("danger", "800"), 0.5);
+    }
+  }
+  &:hover {
+    background-color: f.color("neutral", "100");
+    color: f.color("neutral", "600");
+  }
+}
+
+.rn-btn--tertiary {
+  border: 1px solid transparent;
+  color: f.color("neutral", "400");
+  background-color: transparent;
+  background-image: none;
+  &.rn-btn--danger {
+    color: f.color("danger", "600");
+    .rn-btn__text {
+      &::after {
+        background: f.color("danger", "300");
+      }
+    }
+  }
+  &:hover {
+    transform: none;
+    box-shadow: none;
+    border: 1px solid f.color("neutral", "200");
+    .rn-btn__text::after {
+      transform: scale(0, 1);
+    }
+  }
+  .rn-btn__text {
+    position: relative;
+    z-index: 0;
+    &::after {
+      transition: transform config.$animation-timing;
+      transform-origin: 0 0;
+      bottom: 2px;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: f.color("neutral", "200");
+      content: "";
+      position: absolute;
+      border-radius: 5px;
+      z-index: -1;
+    }
+  }
+}
+
+// Icon
+.rn-btn__icon {
+  display: inline-flex;
+  align-items: center;
+  margin-left: f.spacing("4");
+  position: relative;
+  z-index: 2;
+}
+
+// Sizes
+.rn-btn--small {
+  padding: f.spacing("3") f.spacing("5");
+  border-radius: $btn-border-radius--small;
+  font-size: f.font-size("base");
+}
+
+.rn-btn--large {
+  padding: f.spacing("6") f.spacing("9");
+  font-size: f.font-size("l");
+  line-height: 1.45;
+  .rn-btn__text {
+    transform: translateY(-1px);
+  }
+}
+
+.rn-btn--xlarge {
+  font-size: f.font-size("l");
+  padding: f.spacing("6") f.spacing("10");
+  .rn-btn__icon svg {
+    width: 20px;
+    height: 20px;
+  }
+}
 
 fieldset:disabled a.rn-btn,
 .rn-btn.rn-btn--disabled,

--- a/packages/css-framework/src/components/_btn.scss
+++ b/packages/css-framework/src/components/_btn.scss
@@ -190,6 +190,15 @@ $btn-focus-width: 0.2rem;
   }
 }
 
+.rn-btn--icon-left {
+  flex-direction: row-reverse;
+
+  .rn-btn__icon {
+    margin-left: unset;
+    margin-right: f.spacing("4");
+  }
+}
+
 fieldset:disabled a.rn-btn,
 .rn-btn.rn-btn--disabled,
 .rn-btn[disabled],

--- a/packages/docs-site/src/library/pages/components/button.md
+++ b/packages/docs-site/src/library/pages/components/button.md
@@ -204,6 +204,13 @@ source={`<Button onClick={action} icon={<TriangleDown />}>Closed</Button>
     Description: 'Icon to display to the right of text in the button. Accepts any Node but ideally would be an image or svg tag',
   },
   {
+    Name: 'iconPlacement',
+    Type: 'string (left/right)',
+    Required: 'False',
+    Default: 'right',
+    Description: 'This specifies which side of the button text the icon should be rendered',
+  },
+  {
     Name: 'onClick',
     Type: '(event: React.SyntheticEvent):void',
     Required: 'False',

--- a/packages/react-component-library/src/components/Button/Button.stories.tsx
+++ b/packages/react-component-library/src/components/Button/Button.stories.tsx
@@ -9,6 +9,7 @@ import { BUTTON_COLOR, BUTTON_SIZE, BUTTON_VARIANT } from './constants'
 
 const stories = storiesOf('Button', module)
 const examples = storiesOf('Button/Examples', module)
+const iconExamples = storiesOf('Button/Examples/Icon', module)
 const variantExamples = storiesOf('Button/Examples/Variants', module)
 const dangerExamples = storiesOf('Button/Examples/Danger', module)
 const defaultSizeExamples = storiesOf('Button/Examples/Sizes/Default', module)
@@ -83,12 +84,26 @@ dangerExamples.add('Tertiary', () => (
   </Button>
 ))
 
-examples.add('Icons', () => (
+iconExamples.add('Left', () => (
   <>
     <Button
       variant="primary"
       onClick={action('Decreasing brightness')}
       icon={<IconBrightnessLow />}
+      iconPosition="left"
+    >
+      Button
+    </Button>
+  </>
+))
+
+iconExamples.add('Right', () => (
+  <>
+    <Button
+      variant="primary"
+      onClick={action('Decreasing brightness')}
+      icon={<IconBrightnessLow />}
+      iconPosition="right"
     >
       Button
     </Button>

--- a/packages/react-component-library/src/components/Button/Button.tsx
+++ b/packages/react-component-library/src/components/Button/Button.tsx
@@ -1,7 +1,12 @@
 import React, { FormEvent } from 'react'
 import classNames from 'classnames'
 
-import { BUTTON_COLOR, BUTTON_SIZE, BUTTON_VARIANT } from './constants'
+import {
+  BUTTON_COLOR,
+  BUTTON_SIZE,
+  BUTTON_VARIANT,
+  BUTTON_ICON_POSITION,
+} from './constants'
 
 export type ButtonSizeType =
   | typeof BUTTON_SIZE.SMALL
@@ -14,11 +19,16 @@ export type ButtonVariantType =
   | typeof BUTTON_VARIANT.SECONDARY
   | typeof BUTTON_VARIANT.TERTIARY
 
+export type ButtonIconPositionType =
+  | typeof BUTTON_ICON_POSITION.LEFT
+  | typeof BUTTON_ICON_POSITION.RIGHT
+
 export interface ButtonProps extends ComponentWithClass {
   children?: string
   color?: typeof BUTTON_COLOR.DANGER
   isDisabled?: boolean
   icon?: React.ReactNode
+  iconPosition?: ButtonIconPositionType
   onClick?: (event: FormEvent<HTMLButtonElement>) => void
   size?: ButtonSizeType
   type?: 'button' | 'submit'
@@ -31,6 +41,7 @@ export const Button: React.FC<ButtonProps> = ({
   color,
   isDisabled,
   icon,
+  iconPosition = BUTTON_ICON_POSITION.RIGHT,
   onClick,
   size = BUTTON_SIZE.REGULAR,
   type = 'button',
@@ -39,6 +50,7 @@ export const Button: React.FC<ButtonProps> = ({
 }) => {
   const classes = classNames('rn-btn', className, {
     'rn-btn--disabled': isDisabled,
+    [`rn-btn--icon-${iconPosition}`]: icon,
     [`rn-btn--${variant}`]: variant,
     [`rn-btn--${color}`]: color,
     [`rn-btn--${size}`]: size,

--- a/packages/react-component-library/src/components/Button/constants.ts
+++ b/packages/react-component-library/src/components/Button/constants.ts
@@ -13,6 +13,11 @@ const BUTTON_VARIANT = {
 
 const BUTTON_COLOR = {
   DANGER: 'danger',
-}
+} as const
 
-export { BUTTON_SIZE, BUTTON_VARIANT, BUTTON_COLOR }
+const BUTTON_ICON_POSITION = {
+  LEFT: 'left',
+  RIGHT: 'right'
+} as const
+
+export { BUTTON_SIZE, BUTTON_VARIANT, BUTTON_COLOR, BUTTON_ICON_POSITION }


### PR DESCRIPTION
## Related issue

Closes #333 

## Overview

Add the ability to place an icon to the left of the text within the Button component.

## Reason

>You can’t place icons to the left of the button text without overriding styles.
>
>This appears to be a pattern based on the Coffee app mocks.

## Work carried out

- [x] Refactor the button styles to avoid nesting
- [x] Add ability to place icon to the left of Button
- [x] Update docs-site documentation

## Screenshot

<img width="1582" alt="Screenshot 2020-03-30 at 10 56 10" src="https://user-images.githubusercontent.com/48086589/77899868-19ee2900-7275-11ea-82d9-f596087c538a.png">
