### PR TITLE
refactor(component library): Remove UUID React key usage

### DIFF
--- a/packages/react-component-library/src/components/Nav/index.tsx
+++ b/packages/react-component-library/src/components/Nav/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { v4 as uuidv4 } from 'uuid'
+import { getKey } from '../../helpers'
 
 import { Link } from '../index'
 import NavItem from './NavItem'
@@ -26,7 +26,7 @@ function renderMenu(LinkComponent: any, navItems: any[]) {
         }
 
         return (
-          <NavItem key={uuidv4()} hasChildren={hasChildren}>
+          <NavItem key={getKey('nav-item', label)} hasChildren={hasChildren}>
             <LinkComponent
               className={`rn-nav__item ${active ? 'is-active' : ''}`}
               {...item}

--- a/packages/react-component-library/src/components/Pagination/index.tsx
+++ b/packages/react-component-library/src/components/Pagination/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { v4 as uuidv4 } from 'uuid'
 import { usePageChange, BUMP_LEFT, BUMP_RIGHT } from './usePageChange'
+import { getKey } from '../../helpers'
 
 interface PaginationProps {
   onChange?: (currentPage: number, totalPages: number) => void
@@ -24,7 +24,10 @@ const Pagination: React.FC<PaginationProps> = ({
   return (
     <div className="rn-pagination">
       <ol className="rn-pagination__list">
-        <li key={uuidv4()} className="rn-pagination__item">
+        <li
+          key={getKey('pagination-item', 'previous')}
+          className="rn-pagination__item"
+        >
           <button
             disabled={currentPage === 1}
             className="rn-pagination__button"
@@ -39,14 +42,21 @@ const Pagination: React.FC<PaginationProps> = ({
         {pageNumbers().map((page: string | number) => {
           if ([BUMP_LEFT, BUMP_RIGHT].includes(String(page))) {
             return (
-              <li key={uuidv4()} className="rn-pagination__item">
+              <li
+                key={getKey('pagination-item', page)}
+                className="rn-pagination__item"
+              >
                 {page}
               </li>
             )
           }
 
           return (
-            <li key={uuidv4()} className="rn-pagination__item" data-testid="page">
+            <li
+              key={getKey('pagination-item', page)}
+              className="rn-pagination__item"
+              data-testid="page"
+            >
               <button
                 className={`rn-pagination__button ${
                   page === currentPage ? 'is-active' : ''
@@ -61,7 +71,10 @@ const Pagination: React.FC<PaginationProps> = ({
             </li>
           )
         })}
-        <li key={uuidv4()} className="rn-pagination__item">
+        <li
+          key={getKey('pagination-item', 'next')}
+          className="rn-pagination__item"
+        >
           <button
             disabled={currentPage === totalPages}
             className="rn-pagination__button"

--- a/packages/react-component-library/src/components/ScrollableNav/ScrollableNavItem.tsx
+++ b/packages/react-component-library/src/components/ScrollableNav/ScrollableNavItem.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { v4 as uuidv4 } from 'uuid'
+import { getKey } from '../../helpers'
 import { NavItem } from '../../types/Nav'
 
 export const ScrollableNavItem: React.FC<NavItem> = ({ isActive, link }) => (
   <li
-    key={uuidv4()}
+    key={getKey('scrollable-nav-item', link.toString())}
     className={`rn-scrollable-nav__item ${isActive ? 'is-active' : ''}`}
     data-testid={isActive ? 'tab-active' : 'tab'}
   >

--- a/packages/react-component-library/src/components/Switch/Switch.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
+import { getKey } from '../../helpers'
 
 import { SwitchType, OptionType } from '../../types/Switch'
 
@@ -32,7 +33,7 @@ const Switch: React.FC<SwitchType> = ({
       <div className="rn-switch__container">
         {options.map(({ label: optionLabel, value: optionValue }) => (
           <label
-            key={uuidv4()}
+            key={getKey('switch-option', label)}
             className={`rn-switch__option ${
               active === optionLabel ? 'is-active' : ''
             }`}

--- a/packages/react-component-library/src/components/TabNav/TabNavItem.tsx
+++ b/packages/react-component-library/src/components/TabNav/TabNavItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { v4 as uuidv4 } from 'uuid'
 import classNames from 'classnames'
+import { getKey } from '../../helpers'
 
 import { NavItem } from '../../types/Nav'
 
@@ -9,7 +9,7 @@ export const TabNavItem: React.FC<NavItem> = ({ isActive, link }) => {
 
   return (
     <li
-      key={uuidv4()}
+      key={getKey('tab-nav-item', link.toString())}
       className={classes}
       data-testid={isActive ? 'tab-active' : 'tab'}
     >

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -1,3 +1,7 @@
+function getKey(prefix: string, index: string | number): string {
+  return `${prefix}-${index}`.replace(/\s/g,'')
+}
+
 function warnIfOverwriting<P>(props: P, propertyName: string, componentName: string) {
   if (props[propertyName]) {
     console.warn(
@@ -6,4 +10,4 @@ function warnIfOverwriting<P>(props: P, propertyName: string, componentName: str
   }
 }
 
-export { warnIfOverwriting }
+export { getKey, warnIfOverwriting }


### PR DESCRIPTION
## Related issue

Closes #771 

## Overview

Stop using UUID for generating React keys.

## Reason

>It's an anti-pattern which will be causing performance issues.

## Work carried out

- [x] Add getKey function to helpers
- [x] Refactor where UUID is used
