### PR TITLE
Update CI to use correct latest branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,31 +208,31 @@ workflows:
             branches:
               ignore:
                 - master
-                - /^\d\.\d-latest/
+                - latest
       - lint_commits:
           filters:
             branches:
               ignore:
                 - master
-                - /^\d\.\d-latest/
+                - latest
       - lint_css-framework:
           filters:
             branches:
               ignore:
                 - master
-                - /^\d\.\d-latest/
+                - latest
       - lint_react-component-library:
           filters:
             branches:
               ignore:
                 - master
-                - /^\d\.\d-latest/
+                - latest
       - lint_docs_site:
           filters:
             branches:
               ignore:
                 - master
-                - /^\d\.\d-latest/
+                - latest
       - test_docs-site:
           requires:
             - lint_docs_site
@@ -267,12 +267,12 @@ workflows:
           filters:
             branches:
               only:
-                - /^\d\.\d-latest/
+                - latest
       - test_visual_regression:
           filters:
             branches:
               only:
-                - /^\d\.\d-latest/
+                - latest
       - publish_latest:
           requires:
             - test_react-component-library

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -2,14 +2,11 @@
 
 NOTE: Fix problems by moving forward (roll a new release with a fix).
 
-- [ ] Clean up redundant `*.*-latest` branches
-- [ ] Create and push new release branch from `master`, using the convention `*.*-latest` ([Semver](https://semver.org/))
-- [ ] Create and push a branch from `*.*-latest`
+- [ ] Delete the `latest` branch and recreate from `master`
+- [ ] Create and push a branch from `latest`
 - [ ] Update [docs-site Versions page](update_versions_page.md)
 - [ ] Run `yarn lerna:version` (updates package version, linked dependency versions, tags and pushes to remote)
-- [ ] Merge branch to `*.*-latest` (Pull Request should include release notes) [2x peer approval]
+- [ ] Merge branch to `latest` (Pull Request should include release notes) [2x peer approval]
 - [ ] [Deploy documentation at tag](deploy_documentation.md)
-- [ ] Merge `*.*-latest` back into `master`
+- [ ] Merge `latest` back into `master`
 - [ ] Check published packages on the [NPM public registry](https://www.npmjs.com/search?q=royalnavy) and the `docs-site` [production deployment](https://docs.royalnavy.io)
-
-Do not delete the `*.*-latest` branch as it may be required for hot fixes.


### PR DESCRIPTION
## Overview
Change:
- Updates CI to use `latest` rather than `*.*-latest`
- Update release docs

## Reason
Simplifies configuration and for Netlify configuration.