### PR TITLE
fix(date picker): centres calendar previous and next arrows. Fixes #654

### DIFF
--- a/packages/css-framework/src/components/_date-picker.scss
+++ b/packages/css-framework/src/components/_date-picker.scss
@@ -184,6 +184,7 @@
   top: f.spacing("8");
   display: inline-flex;
   justify-content: center;
+  align-items: center;
   width: 1.5rem;
   height: 1.5rem;
   padding: 0;


### PR DESCRIPTION
## Related issue

#654 

## Overview

Realigns the previous and next arrows in the date picker dropdown