### PR TITLE
fix(toast): add background colour to component. Fixes #783

### DIFF
--- a/packages/css-framework/src/components/_toast.scss
+++ b/packages/css-framework/src/components/_toast.scss
@@ -8,6 +8,7 @@
   border-radius: 4px;
   width: 340px;
   margin-bottom: f.spacing("6");
+  background-color: f.color("neutral", "white");
 
   div {
     display: flex;


### PR DESCRIPTION
## Related issue

#783 

## Overview

Adds a background colour to the toast component to prevent colour bleed from components situated beneath the toast.
