### PR TITLE
Add `render` to `TimelineEvent`

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -43,3 +43,50 @@ stories.add('With data', () => (
     </TimelineRows>
   </Timeline>
 ))
+
+stories.add('With custom event content', () => {
+  const render = (text: string) => {
+    return () => (
+      <div style={{ backgroundColor: '#e5ffd9' }}>
+        <span className="rn_text-s">{text}</span>
+      </div>
+    )
+  }
+
+  return (
+    <Timeline startDate={new Date(2020, 4, 0)} today={new Date(2020, 3, 15)}>
+      <TimelineRows>
+        <TimelineRow name="Row 1">
+          <TimelineEvents>
+            <TimelineEvent
+              startDate={new Date(2020, 3, 16)}
+              endDate={new Date(2020, 3, 20)}
+              render={render('Custom event 1')}
+            />
+            <TimelineEvent
+              startDate={new Date(2020, 3, 25)}
+              endDate={new Date(2020, 3, 28)}
+            >
+              Event 2
+            </TimelineEvent>
+          </TimelineEvents>
+        </TimelineRow>
+        <TimelineRow name="Row 2">
+          <TimelineEvents>
+            <TimelineEvent
+              startDate={new Date(2020, 3, 15)}
+              endDate={new Date(2020, 3, 19)}
+              render={render('Custom event 3')}
+            />
+            <TimelineEvent
+              startDate={new Date(2020, 3, 22)}
+              endDate={new Date(2020, 3, 24)}
+            >
+              Event 4
+            </TimelineEvent>
+          </TimelineEvents>
+        </TimelineRow>
+      </TimelineRows>
+    </Timeline>
+  )
+})

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -5,17 +5,49 @@ import { format } from 'date-fns'
 import { DAY_WIDTH } from './constants'
 import { useTimelinePosition } from './hooks/useTimelinePosition'
 
-export interface TimelineEventProps extends ComponentWithClass {
-  children?: string
+export interface TimelineEventWithRenderContentProps
+  extends ComponentWithClass {
+  children?: never
   endDate: Date
+  render: () => React.ReactNode
   startDate: Date
   status?: string
+}
+
+export interface TimelineEventWithChildrenProps extends ComponentWithClass {
+  children: string
+  endDate: Date
+  render?: never
+  startDate: Date
+  status?: string
+}
+
+export type TimelineEventProps =
+  | TimelineEventWithRenderContentProps
+  | TimelineEventWithChildrenProps
+
+function renderDefault(children: string, startDate: Date, width: number) {
+  return (
+    <>
+      <span
+        className="timeline__event-title"
+        data-testid="timeline-event-title"
+      >
+        {children || `Task ${format(new Date(startDate), 'dd/yyyy')}`}
+      </span>
+      <div
+        className="timeline__event-bar"
+        style={{ width: `${width * DAY_WIDTH}px` }}
+      />
+    </>
+  )
 }
 
 export const TimelineEvent: React.FC<TimelineEventProps> = ({
   children,
   className,
   endDate,
+  render,
   startDate,
   status = '',
 }) => {
@@ -37,13 +69,7 @@ export const TimelineEvent: React.FC<TimelineEventProps> = ({
       style={{ left: `${offset * DAY_WIDTH}px` }}
       data-testid="timeline-event-wrapper"
     >
-      <span className="timeline__event-title" data-testid="timeline-event-title">
-        {children || `Task ${format(new Date(startDate), 'dd/yyyy')}`}
-      </span>
-      <div
-        className="timeline__event-bar"
-        style={{ width: `${width * DAY_WIDTH}px` }}
-      />
+      {render ? render() : renderDefault(children, startDate, width)}
     </div>
   )
 }

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
+import { renderToStaticMarkup } from 'react-dom/server'
 
-import { TimelineEvent, TimelineEvents, TimelineRow, TimelineRows, Timeline } from '..'
+import {
+  TimelineEvent,
+  TimelineEvents,
+  TimelineRow,
+  TimelineRows,
+  Timeline,
+} from '..'
 
 const COMPLETED = 'COMPLETED'
 
@@ -129,11 +136,43 @@ describe('Timeline', () => {
           </TimelineRows>
         </Timeline>
       )
-
     })
 
     it('renders the correct number of events', () => {
       expect(wrapper.queryAllByTestId('timeline-event-wrapper')).toHaveLength(1)
+    })
+  })
+
+  describe('when an event has `render` specified', () => {
+    const CUSTOM_EVENT = <div>custom event</div>
+
+    beforeEach(() => {
+      const EventWithRender: React.FC = () => (
+        <TimelineEvent
+          startDate={new Date(2020, 1, 1, 0, 0, 0)}
+          endDate={new Date(2020, 1, 10, 0, 0, 0)}
+          status={COMPLETED}
+          render={() => CUSTOM_EVENT}
+        />
+      )
+
+      wrapper = render(
+        <Timeline startDate={new Date(2020, 1, 1, 0, 0, 0)}>
+          <TimelineRows>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <EventWithRender />
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('should render the event as specified', () => {
+      expect(wrapper.getByTestId('timeline-event-wrapper').innerHTML).toEqual(
+        renderToStaticMarkup(CUSTOM_EVENT)
+      )
     })
   })
 })

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -97,8 +97,6 @@ describe('Timeline', () => {
 
   describe('when an event is outside the range', () => {
     beforeEach(() => {
-      console.log('starting')
-
       const EventWithinRange: React.FC = () => (
         <TimelineEvent
           startDate={new Date(2020, 1, 1, 0, 0, 0)}


### PR DESCRIPTION
## Related issue
Closes #882 

## Overview
This change adds the ability to specify the `render` function when composing a `TimelineEvent`.

## Reason
Gives the consumer the flexibility to change what is rendered in the `TimelineEvent`.

## Work carried out
- [x] Add `render`

## Developer notes
I am going to split out the work to expose the components and subcomponents.