### PR TITLE
fix(timeline): Generate correct number of calendar weeks

### DIFF
--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -112,7 +112,7 @@ describe('Timeline', () => {
     })
 
     it('renders the correct number of weeks', () => {
-      expect(wrapper.queryAllByTestId('timeline-week')).toHaveLength(13)
+      expect(wrapper.queryAllByTestId('timeline-week')).toHaveLength(14)
     })
 
     it('applies the --alt modifier class to odd weeks', () => {
@@ -419,7 +419,7 @@ describe('Timeline', () => {
 
     it('should render the correct number of columns', () => {
       expect(wrapper.getByTestId('timeline-columns').childNodes).toHaveLength(
-        13
+        14
       )
     })
 

--- a/packages/react-component-library/src/components/Timeline/constants.ts
+++ b/packages/react-component-library/src/components/Timeline/constants.ts
@@ -9,10 +9,13 @@ const DEFAULTS = {
 
 const NO_DATA_MESSAGE = 'No data available'
 
+const WEEK_START = 1 // Monday
+
 export {
   DATE_DAY_FORMAT,
   DATE_MONTH_FORMAT,
   DATE_WEEK_FORMAT,
   DEFAULTS,
   NO_DATA_MESSAGE,
+  WEEK_START
 }

--- a/packages/react-component-library/src/components/Timeline/context/__tests__/reducer.test.ts
+++ b/packages/react-component-library/src/components/Timeline/context/__tests__/reducer.test.ts
@@ -49,7 +49,7 @@ describe('TimelineContext reducer', () => {
     })
 
     it('returns the correct number of weeks', () => {
-      expect(weeks.length).toBe(13)
+      expect(weeks.length).toBe(14)
     })
 
     it('returns the correct week start dates', () => {

--- a/packages/react-component-library/src/components/Timeline/context/reducer.ts
+++ b/packages/react-component-library/src/components/Timeline/context/reducer.ts
@@ -4,7 +4,7 @@ import {
   setMonth,
   startOfMonth,
   endOfMonth,
-  differenceInWeeks,
+  differenceInCalendarWeeks,
   addWeeks,
   startOfWeek,
   getDaysInMonth,
@@ -20,6 +20,10 @@ import {
   TimelineWeek,
   TimelineDay,
 } from './types'
+
+import {
+  WEEK_START
+} from '../constants'
 
 export function getMonths(
   date: Date,
@@ -56,13 +60,13 @@ export function getWeeks(
   const startDate = months[0].startDate
   const endDate = endOfMonth(months[months.length - 1].startDate)
 
-  const diffInWeeks = differenceInWeeks(endDate, startDate)
+  const diffInWeeks = differenceInCalendarWeeks(endDate, startDate)
 
   const weeks = Array.from({ length: diffInWeeks + 1 })
     .map((_, weekIndex) => {
       const weekStart = startOfWeek(
         addWeeks(startDate, weekIndex),
-        { weekStartsOn: 1 }
+        { weekStartsOn: WEEK_START }
       )
 
       return {


### PR DESCRIPTION
## Related issue

Closes #931 

## Overview

Fix incorrect number of weeks being generated for month range.