### PR TITLE
ci: Add fixup check to CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,12 @@ jobs:
       - checkout
       - dependencies
       - run: node ./scripts/commitlint $CIRCLE_PULL_REQUEST
+  check_fixup_commits:
+    docker: *docker
+    steps:
+      - checkout
+      - dependencies
+      - run: node ./scripts/check-fixup $CIRCLE_PULL_REQUEST
   lint_css-framework:
     docker: *docker
     steps:
@@ -248,6 +254,10 @@ workflows:
       - test_visual_regression:
           requires:
             - test_react-component-library
+      - check_fixup_commits:
+          requires:
+            - code_climate
+            - test_visual_regression
   build_test_and_deploy_next:
     jobs:
       - test_react-component-library:
@@ -272,6 +282,11 @@ workflows:
               only:
                 - latest
       - lint_commits:
+          filters:
+            branches:
+              only:
+                - latest
+      - check_fixup_commits:
           filters:
             branches:
               only:

--- a/scripts/check-fixup/index.js
+++ b/scripts/check-fixup/index.js
@@ -11,7 +11,9 @@ function getPrOptions(prUrl) {
 }
 
 function getCommitsByPr(options) {
-  const github = new Octokit()
+  const github = new Octokit({
+    auth: process.env.GH_TOKEN,
+  })
   return github.pulls.listCommits(options)
 }
 

--- a/scripts/check-fixup/index.js
+++ b/scripts/check-fixup/index.js
@@ -1,0 +1,52 @@
+const { Octokit } = require('@octokit/rest')
+
+function getPrOptions(prUrl) {
+  const prUrlParts = prUrl.split('/')
+
+  return {
+    owner: prUrlParts[prUrlParts.length - 4],
+    repo: prUrlParts[prUrlParts.length - 3],
+    pull_number: prUrlParts[prUrlParts.length - 1],
+  }
+}
+
+function getCommitsByPr(options) {
+  const github = new Octokit()
+  return github.pulls.listCommits(options)
+}
+
+function checkFixups(commits) {
+  return commits.data.map(({ commit: { message } }) => {
+    return {
+      message,
+      valid: message.indexOf('fixup!') === -1
+    }
+  })
+}
+
+(async function runCheckFixups() {
+  try {
+    if (process.argv[2]) {
+      const prOptions = getPrOptions(process.argv[2])
+      const prCommits = await getCommitsByPr(prOptions)
+
+      const fixupResults = await checkFixups(prCommits)
+
+      const errors = fixupResults.filter(result => !result.valid)
+      errors.forEach(({ message }) => {
+        console.error(
+          `Commit message \`${message}\` is a fixup`
+        )
+      })
+
+      if (errors.length) {
+        process.exit(1)
+      }
+    }
+
+    process.exit(0)
+  } catch (e) {
+    console.error('Error running check fixups', e)
+    process.exit(1)
+  }
+})()

--- a/scripts/commitlint/index.js
+++ b/scripts/commitlint/index.js
@@ -14,7 +14,9 @@ function getPrOptions(prUrl) {
 }
 
 function getCommitsByPr(options) {
-  const github = new Octokit()
+  const github = new Octokit({
+    auth: process.env.GH_TOKEN,
+  })
   return github.pulls.listCommits(options)
 }
 


### PR DESCRIPTION
## Related issue
Closes #901 

## Overview
Change introduces a new check so that `fixup` commits cannot be merged into `master`.

Also authenticating against GH to increase rate limit.

## Reason
We do not want `fixup` commits in `master`.

## Work carried out
- [x] Add script
- [x] Integate script
- [x] Add auth

## Screenshot
### Circle
![Screenshot 2020-05-11 at 11 33 41](https://user-images.githubusercontent.com/56078793/81553697-7452cd00-937d-11ea-8e2e-b180c0e88159.png)

### GH checks
![Screenshot 2020-05-11 at 11 33 28](https://user-images.githubusercontent.com/56078793/81553719-7c127180-937d-11ea-8e60-51c6ab3acaaf.png)