### PR TITLE
fix(masthead): Decrease font size of navigation link

### DIFF
--- a/packages/css-framework/src/components/_scrollable-nav.scss
+++ b/packages/css-framework/src/components/_scrollable-nav.scss
@@ -22,7 +22,7 @@ $btn-focus-width: 0.2rem;
   margin: 0 f.spacing("2");
   padding: 0 f.spacing("8");
   height: 58px;
-  font-size: font-size("base");
+  font-size: f.font-size("base");
   color: f.color("neutral", "300");
   text-align: center;
   text-decoration: none;


### PR DESCRIPTION
Adds the missing `f.` namespace to the `font-size` function, decreasing the font to its intended size.