### PR TITLE
chore(Lint): Make subject a warning

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,7 @@ module.exports = {
     'header-max-length': [2, 'always', 72],
     'scope-case': [2, 'always', 'sentence-case'],
     'scope-empty': [2, 'never'],
-    'subject-case': [2, 'always', 'sentence-case'],
+    'subject-case': [1, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],
     'type-case': [2, 'always', 'lower-case'],


### PR DESCRIPTION
Dependabot commits with `bump` as the subject which we have no control over. This makes the rule a warning as it is still preferred for our own commits messages because of downstream impact on release notes.