### PR TITLE
fix(TabSet): Explicitly set tab background

### DIFF
--- a/packages/css-framework/src/components/_tab-set.scss
+++ b/packages/css-framework/src/components/_tab-set.scss
@@ -103,6 +103,7 @@ $active-border-color: f.color("action", "600");
   font-size: f.font-size("base");
   font-weight: 600;
   color: f.color("neutral", "300");
+  background-color: f.color("neutral", "white");
 
   // default
   border: none;


### PR DESCRIPTION
## Related issue

Closes #246 

## Overview

Add explicit background colour to tabs. Was displaying as grey in Windows and on new Chrome.