### PR TITLE
feat(IconLibrary): Add ability to set explicit size

### DIFF
--- a/packages/icon-library/.babelrc
+++ b/packages/icon-library/.babelrc
@@ -22,5 +22,26 @@
       ]
     }
   },
-  "plugins": []
+  "plugins": [
+    [
+      "@svgr/babel-plugin-add-jsx-attribute",
+      {
+        "elements": ["svg"],
+        "attributes": [
+          {
+            "name": "width",
+            "value": "size",
+            "spread": false,
+            "literal": true
+          },
+          {
+            "name": "height",
+            "value": "size",
+            "spread": false,
+            "literal": true
+          }
+        ]
+      }
+    ]
+  ]
 }

--- a/packages/icon-library/.svgrrc.js
+++ b/packages/icon-library/.svgrrc.js
@@ -7,7 +7,11 @@ module.exports = {
     const typeScriptTpl = template.smart({ plugins: ['typescript'] })
     return typeScriptTpl.ast`
     import React, { SVGProps } from 'react';
-    const ${componentName} = (props: SVGProps<SVGSVGElement>) => ${jsx};
+    interface SVGIconProps extends SVGProps<SVGSVGElement> {
+      size?: number
+      className?: string
+    }
+    const ${componentName} = ({ size = 16, ...props }: SVGIconProps) => ${jsx};
     export default ${componentName};
   `
   },

--- a/packages/icon-library/README.md
+++ b/packages/icon-library/README.md
@@ -18,8 +18,10 @@ If you want to install the prerelease then use the `@next` distribution tag.
 ```javascript
 import { IconHome } from '@royalnavy/icon-library'
 
-// <IconHome />
+// <IconHome size={16} />
 ```
+### Sizing
+The `size` prop sets the `width` and `height` attribute values of the wrapped SVG.
 
 ## Questions
 The Icon Library is maintained by a team at the Royal Navy. If you want to know more, please email the [Design System team](mailto:design-system@royalnavy.io).

--- a/packages/icon-library/package.json
+++ b/packages/icon-library/package.json
@@ -31,6 +31,7 @@
     "@babel/preset-env": "^7.8.3",
     "@babel/preset-react": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",
+    "@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
     "@svgr/cli": "^5.1.0",
     "babel-loader": "^8.0.6",
     "clean-webpack-plugin": "^3.0.0",

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -9,7 +9,7 @@ export const ProgressIndicator: React.FC<ComponentWithClass> = ({
 
   return (
     <div className={classes} data-testid="progress-indicator">
-      <IconLoader data-testid="loader" />
+      <IconLoader size={40} data-testid="loader" />
       <span>Loading...</span>
     </div>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -11521,7 +11521,7 @@ http-proxy-middleware@0.19.1:
     lodash "^4.17.11"
     micromatch "^3.1.10"
 
-http-proxy@^1.17.0, http-proxy@^1.18.1:
+http-proxy@^1.17.0:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
@@ -22717,7 +22717,38 @@ yaml@^1.7.2, yaml@^1.8.3:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
-yargs-parser@^10.0.0, yargs-parser@^11.1.1, yargs-parser@^13.1.0, yargs-parser@^13.1.2, yargs-parser@^15.0.1, yargs-parser@^18.1.1, yargs-parser@^18.1.3:
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^13.1.0, yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
+  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^18.1.1, yargs-parser@^18.1.3:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==


### PR DESCRIPTION
## Related issue

Closes #679 

## Overview

Add ability for end user to supply `size` prop that sets SVG element `width` and `height` attributes.

## Reason

>Currently the SVGs are at a fixed size of 16px x 16px. We need the ability to pass in an arbitrary size so that we can match the Sketch toolkit.
>
>To keep proportions, we should create a size prop that accepts a single value.

## Work carried out

- [x] Use Babel transform plugin and custom AST template to apply sizing attribute values

## Developer notes

See compiled output from build step here for an Icon ESM:

```javascript
function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }

function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }

function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }

import React from 'react';

var SvgAccessAlarm = function SvgAccessAlarm(_ref) {
  var _ref$size = _ref.size,
      size = _ref$size === void 0 ? 16 : _ref$size,
      props = _objectWithoutProperties(_ref, ["size"]);

  return /*#__PURE__*/React.createElement("svg", _extends({
    width: size,
    height: size,
    viewBox: "0 0 16 16"
  }, props), /*#__PURE__*/React.createElement("defs", null, /*#__PURE__*/React.createElement("path", {
    id: "access-alarm_svg__a",
    d: "M14.667 3.813L11.6 1.24l-.86 1.02 3.067 2.573.86-1.02zM5.253 2.26L4.4 1.24 1.333 3.807l.86 1.02 3.06-2.567zm3.08 3.073h-1v4l3.167 1.9.5-.82-2.667-1.58v-3.5zM8 2.667a6 6 0 10.001 12 6 6 0 00-.001-12zm0 10.666a4.663 4.663 0 01-4.667-4.666A4.663 4.663 0 018 4a4.663 4.663 0 014.667 4.667A4.663 4.663 0 018 13.333z"
  })), /*#__PURE__*/React.createElement("g", {
    fill: "none",
    fillRule: "evenodd"
  }, /*#__PURE__*/React.createElement("mask", {
    id: "access-alarm_svg__b",
    fill: "#fff"
  }, /*#__PURE__*/React.createElement("use", {
    xlinkHref: "#access-alarm_svg__a"
  })), /*#__PURE__*/React.createElement("g", {
    fill: "CurrentColor",
    mask: "url(#access-alarm_svg__b)"
  }, /*#__PURE__*/React.createElement("path", {
    d: "M0 0h16v16H0z"
  }))));
};

export default SvgAccessAlarm;
```
