### PR TITLE
fix(Select): Add ability to drill data-testid

### DIFF
--- a/packages/react-component-library/src/components/Select/Input.tsx
+++ b/packages/react-component-library/src/components/Select/Input.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { components } from 'react-select'
-import { InputProps } from 'react-select/src/components/Input'
+import get from 'lodash/get'
+import { components, InputProps } from 'react-select'
 
 export interface SelectInputProps extends InputProps {
   id?: string
 }
 
-export const Input: React.FC<SelectInputProps> = props => (
+export const Input: React.FC<SelectInputProps> = (props) => (
   <div className="rn-select__input-container">
     {props['aria-label'] !== undefined && (
       <label
@@ -17,6 +17,13 @@ export const Input: React.FC<SelectInputProps> = props => (
         {props['aria-label']}
       </label>
     )}
-    <components.Input data-testid="react-select-vendor-input" {...props} />
+    <components.Input
+      data-testid={get(
+        props,
+        'selectProps.data-testid',
+        'react-select-vendor-input'
+      )}
+      {...props}
+    />
   </div>
 )

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -1,8 +1,21 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import { render, RenderResult, fireEvent } from '@testing-library/react'
+import { fireEvent, render, RenderResult } from '@testing-library/react'
 
 import { Select } from '.'
+
+const options = [
+  {
+    badge: 'Badge 1',
+    label: 'Option 1',
+    value: '1',
+  },
+  {
+    badge: 'Badge 2',
+    label: 'Option 2',
+    value: '2',
+  },
+]
 
 describe('Select', () => {
   let wrapper: RenderResult
@@ -11,19 +24,6 @@ describe('Select', () => {
   describe('when provided with all props', () => {
     beforeEach(() => {
       onChangeSpy = jest.fn()
-
-      const options = [
-        {
-          badge: 'Badge 1',
-          label: 'Option 1',
-          value: '1',
-        },
-        {
-          badge: 'Badge 2',
-          label: 'Option 2',
-          value: '2',
-        },
-      ]
 
       wrapper = render(
         <Select
@@ -61,8 +61,9 @@ describe('Select', () => {
 
     describe('when the select is clicked', () => {
       beforeEach(() => {
-        fireEvent.focus(wrapper.container.querySelector('input'))
-        fireEvent.keyDown(wrapper.container.querySelector('input'), {
+        const input = wrapper.getByTestId('react-select-vendor-input')
+        fireEvent.focus(input)
+        fireEvent.keyDown(input, {
           key: 'ArrowDown',
           code: 40,
         })
@@ -84,6 +85,22 @@ describe('Select', () => {
           })
         })
       })
+    })
+  })
+
+  describe('when a downstream consumer provides a data-testid', () => {
+    beforeEach(() => {
+      wrapper = render(<Select options={options} data-testid="select-1" />)
+    })
+
+    it('should not find the input using the default `data-testid`', () => {
+      expect(
+        wrapper.queryAllByTestId('react-select-vendor-input')
+      ).toHaveLength(0)
+    })
+
+    it('should find the input using the new `data-testid`', () => {
+      expect(wrapper.getByTestId('select-1')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Related issue
Fixes #989 

## Overview
Consumer of the library requires the ability to pass in a custom `data-testid` which is particularly evident when there are multiple `Select` components on a page.

## Reason
Convenience for identifying `Select` components when writing tests.

## Work carried out
- [x] Drill `data-testid`