### PR TITLE
fix(Timeline): Export TIMELINE_ACTIONS

### DIFF
--- a/packages/react-component-library/src/components/Timeline/context/types.ts
+++ b/packages/react-component-library/src/components/Timeline/context/types.ts
@@ -29,14 +29,14 @@ export type TimelineState = {
   options: TimelineOptions
 }
 
-export enum TIMELINE_ACTIONS {
-  GET_NEXT,
-  GET_PREV
-}
+export const TIMELINE_ACTIONS = {
+  GET_NEXT: 'GET_NEXT',
+  GET_PREV: 'GET_PREV'
+} as const
 
 export type TimelineAction =
-  | { type: TIMELINE_ACTIONS.GET_NEXT }
-  | { type: TIMELINE_ACTIONS.GET_PREV }
+  | { type: typeof TIMELINE_ACTIONS.GET_NEXT }
+  | { type: typeof TIMELINE_ACTIONS.GET_PREV }
 
 export interface TimelineContextDefault {
   state: TimelineState

--- a/packages/react-component-library/src/components/Timeline/index.ts
+++ b/packages/react-component-library/src/components/Timeline/index.ts
@@ -1,4 +1,5 @@
 export * from './context'
+export * from './context/types'
 export * from './hooks'
 export * from './TimelineEvent'
 export * from './TimelineEvents'


### PR DESCRIPTION
## Related issue

Closes #1003

## Overview

Expose the TIMELINE_ACTIONS enum.

## Reason

> Currently there is no way for a consumer to use the TIMELINE_ACTIONS enum.
