### PR TITLE
Fix extra ellipsis when moving between page numbers in pagination

### DIFF
--- a/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
@@ -1,176 +1,216 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import { render, fireEvent, RenderResult } from '@testing-library/react'
+import { render, RenderResult } from '@testing-library/react'
 
 import { Pagination } from '.'
 
-afterEach(() => jest.clearAllMocks())
-
 describe('Pagination', () => {
   let wrapper: RenderResult
-  let onChangeSpy: () => void
 
-  describe('when the Pagination is generated with only 2 records and pageSize is 10', () => {
-    onChangeSpy = jest.fn()
-
+  describe('when there is ten pages of data', () => {
     beforeEach(() => {
-      wrapper = render(
-        <Pagination onChange={onChangeSpy} pageSize={10} total={2} />
-      )
+      wrapper = render(<Pagination pageSize={10} total={95} />)
     })
 
-    it('should output a single page', () => {
-      expect(wrapper.queryAllByTestId('page')).toHaveLength(1)
+    it('should render pages', () => {
+      expect(wrapper.getAllByTestId('page')[0]).toHaveTextContent('1')
+      expect(wrapper.getAllByTestId('page')[1]).toHaveTextContent('2')
+      expect(wrapper.getAllByTestId('page')[2]).toHaveTextContent('3')
+      expect(wrapper.getAllByTestId('page')[3]).toHaveTextContent('4')
+      expect(wrapper.getAllByTestId('page')[4]).toHaveTextContent('5')
+      expect(wrapper.getAllByTestId('page')[5]).toHaveTextContent('...')
+      expect(wrapper.getAllByTestId('page')[6]).toHaveTextContent('10')
+      expect(wrapper.getAllByTestId('page')).toHaveLength(7)
     })
 
-    it('should disable both the left and right buttons', () => {
-      expect(
-        wrapper.getByTestId('button-previous').hasAttribute('disabled')
-      ).toBeTruthy()
-
-      expect(
-        wrapper.getByTestId('button-next').hasAttribute('disabled')
-      ).toBeTruthy()
-    })
-  })
-
-  describe('when the Pagination is generated with 20 records and pageSize is 10', () => {
-    onChangeSpy = jest.fn()
-
-    beforeEach(() => {
-      wrapper = render(
-        <Pagination onChange={onChangeSpy} pageSize={10} total={20} />
-      )
+    it('should apply the `is-active` class to the appropriate page', () => {
+      expect(wrapper.getByText('1').classList.contains('is-active')).toBe(true)
     })
 
-    it('should output the correct number of pages', () => {
-      expect(wrapper.queryAllByTestId('page')).toHaveLength(2)
-    })
-  })
-
-  describe('when the Pagination is generated with pageSize, total and onChange props', () => {
-    onChangeSpy = jest.fn()
-
-    beforeEach(() => {
-      wrapper = render(
-        <Pagination onChange={onChangeSpy} pageSize={10} total={1000} />
-      )
+    it('should disable the `Prev` button', () => {
+      expect(wrapper.getByText('Prev')).toHaveAttribute('disabled', '')
     })
 
-    it('should output the correct number of pages', () => {
-      expect(wrapper.queryAllByTestId('page')).toHaveLength(7)
+    it('should enable the `Next` button', () => {
+      expect(wrapper.getByText('Next')).not.toHaveAttribute('disabled')
     })
 
-    describe('handle: (1) ... {5 6} [7] {8 9} (10)', () => {
+    describe('and the current page is 5', () => {
       beforeEach(() => {
-        fireEvent(
-          wrapper.getByTestId('select-page-100'),
-          new MouseEvent('click', {
-            bubbles: true,
-            cancelable: true,
-          })
+        wrapper.getByText('5').click()
+      })
+
+      it('should apply the `is-active` class to the appropriate page', () => {
+        expect(wrapper.getByText('5').classList.contains('is-active')).toBe(
+          true
         )
       })
 
-      it('should render the three dots in the correct place', () => {
+      it('should render pages', () => {
+        expect(wrapper.getAllByTestId('page')[0]).toHaveTextContent('1')
         expect(wrapper.getAllByTestId('page')[1]).toHaveTextContent('...')
-        expect(wrapper.queryAllByText('...')).toHaveLength(1)
-      })
-    })
-
-    describe('handle: (1) ... {4 5} [6] {7 8} ... (10)', () => {
-      beforeEach(() => {
-        fireEvent(
-          wrapper.getByTestId('select-page-4'),
-          new MouseEvent('click', {
-            bubbles: true,
-            cancelable: true,
-          })
-        )
-      })
-
-      it('should render the three dots in the correct places', () => {
-        expect(wrapper.getAllByTestId('page')[1]).toHaveTextContent('...')
+        expect(wrapper.getAllByTestId('page')[2]).toHaveTextContent('4')
+        expect(wrapper.getAllByTestId('page')[3]).toHaveTextContent('5')
+        expect(wrapper.getAllByTestId('page')[4]).toHaveTextContent('6')
         expect(wrapper.getAllByTestId('page')[5]).toHaveTextContent('...')
-        expect(wrapper.queryAllByText('...')).toHaveLength(2)
+        expect(wrapper.getAllByTestId('page')[6]).toHaveTextContent('10')
+        expect(wrapper.getAllByTestId('page')).toHaveLength(7)
+      })
+
+      it('should enable the `Prev` and `Next` buttons', () => {
+        expect(wrapper.getByText('Prev')).not.toHaveAttribute('disabled')
+        expect(wrapper.getByText('Next')).not.toHaveAttribute('disabled')
+      })
+
+      describe('and the current page goes back to 1 and then 5 again', () => {
+        beforeEach(() => {
+          wrapper.getByText('1').click()
+          wrapper.getByText('5').click()
+        })
+
+        it('should render pages', () => {
+          expect(wrapper.getAllByTestId('page')[0]).toHaveTextContent('1')
+          expect(wrapper.getAllByTestId('page')[1]).toHaveTextContent('...')
+          expect(wrapper.getAllByTestId('page')[2]).toHaveTextContent('4')
+          expect(wrapper.getAllByTestId('page')[3]).toHaveTextContent('5')
+          expect(wrapper.getAllByTestId('page')[4]).toHaveTextContent('6')
+          expect(wrapper.getAllByTestId('page')[5]).toHaveTextContent('...')
+          expect(wrapper.getAllByTestId('page')[6]).toHaveTextContent('10')
+          expect(wrapper.getAllByTestId('page')).toHaveLength(7)
+        })
       })
     })
 
-    describe('when the user clicks on the right button then the left button', () => {
+    describe('and the current page is 10', () => {
       beforeEach(() => {
-        fireEvent(
-          wrapper.getByTestId('button-next'),
-          new MouseEvent('click', {
-            bubbles: true,
-            cancelable: true,
-          })
-        )
-
-        fireEvent(
-          wrapper.getByTestId('button-previous'),
-          new MouseEvent('click', {
-            bubbles: true,
-            cancelable: true,
-          })
-        )
+        wrapper.getByText('10').click()
       })
 
       it('should apply the `is-active` class to the appropriate page', () => {
-        expect(
-          wrapper.getByTestId('select-page-1').classList.contains('is-active')
-        ).toBe(true)
+        expect(wrapper.getByText('10').classList.contains('is-active')).toBe(
+          true
+        )
       })
 
-      it('should invoke the onChange function', () => {
-        expect(onChangeSpy).toHaveBeenCalledTimes(2)
-        expect(onChangeSpy).toHaveBeenCalledWith(1, 100)
+      it('should render pages', () => {
+        expect(wrapper.getAllByTestId('page')[0]).toHaveTextContent('1')
+        expect(wrapper.getAllByTestId('page')[1]).toHaveTextContent('...')
+        expect(wrapper.getAllByTestId('page')[2]).toHaveTextContent('6')
+        expect(wrapper.getAllByTestId('page')[3]).toHaveTextContent('7')
+        expect(wrapper.getAllByTestId('page')[4]).toHaveTextContent('8')
+        expect(wrapper.getAllByTestId('page')[5]).toHaveTextContent('9')
+        expect(wrapper.getAllByTestId('page')[6]).toHaveTextContent('10')
+        expect(wrapper.getAllByTestId('page')).toHaveLength(7)
+      })
+
+      it('should enable the `Prev` button', () => {
+        expect(wrapper.getByText('Prev')).not.toHaveAttribute('disabled')
+      })
+
+      it('should disable the `Next` button', () => {
+        expect(wrapper.getByText('Next')).toHaveAttribute('disabled', '')
       })
     })
+  })
 
-    describe('when the user clicks on the right button', () => {
-      beforeEach(() => {
-        fireEvent(
-          wrapper.getByTestId('button-next'),
-          new MouseEvent('click', {
-            bubbles: true,
-            cancelable: true,
-          })
-        )
-      })
-
-      it('should apply the `is-active` class to the appropriate page', () => {
-        expect(
-          wrapper.getByTestId('select-page-2').classList.contains('is-active')
-        ).toBe(true)
-      })
-
-      it('should invoke the onChange function', () => {
-        expect(onChangeSpy).toHaveBeenCalledTimes(1)
-        expect(onChangeSpy).toHaveBeenCalledWith(2, 100)
-      })
+  describe('when there is five pages of data', () => {
+    beforeEach(() => {
+      wrapper = render(<Pagination pageSize={10} total={45} />)
     })
 
-    describe('when the user clicks on a page', () => {
+    it('should render pages', () => {
+      expect(wrapper.getAllByTestId('page')[0]).toHaveTextContent('1')
+      expect(wrapper.getAllByTestId('page')[1]).toHaveTextContent('2')
+      expect(wrapper.getAllByTestId('page')[2]).toHaveTextContent('3')
+      expect(wrapper.getAllByTestId('page')[3]).toHaveTextContent('4')
+      expect(wrapper.getAllByTestId('page')[4]).toHaveTextContent('5')
+      expect(wrapper.getAllByTestId('page')).toHaveLength(5)
+    })
+
+    it('should apply the `is-active` class to the appropriate page', () => {
+      expect(wrapper.getByText('1').classList.contains('is-active')).toBe(true)
+    })
+
+    it('should disable the `Prev` button', () => {
+      expect(wrapper.getByText('Prev')).toHaveAttribute('disabled', '')
+    })
+
+    it('should enable the `Next` button', () => {
+      expect(wrapper.getByText('Next')).not.toHaveAttribute('disabled')
+    })
+
+    describe('and the current page is 5', () => {
       beforeEach(() => {
-        fireEvent(
-          wrapper.getByTestId('select-page-5'),
-          new MouseEvent('click', {
-            bubbles: true,
-            cancelable: true,
-          })
-        )
+        wrapper.getByText('5').click()
       })
 
       it('should apply the `is-active` class to the appropriate page', () => {
-        expect(
-          wrapper.getByTestId('select-page-5').classList.contains('is-active')
-        ).toBe(true)
+        expect(wrapper.getByText('5').classList.contains('is-active')).toBe(
+          true
+        )
       })
 
-      it('should invoke the onChange function', () => {
-        expect(onChangeSpy).toHaveBeenCalledTimes(1)
-        expect(onChangeSpy).toHaveBeenCalledWith(5, 100)
+      it('should render pages', () => {
+        expect(wrapper.getAllByTestId('page')[0]).toHaveTextContent('1')
+        expect(wrapper.getAllByTestId('page')[1]).toHaveTextContent('2')
+        expect(wrapper.getAllByTestId('page')[2]).toHaveTextContent('3')
+        expect(wrapper.getAllByTestId('page')[3]).toHaveTextContent('4')
+        expect(wrapper.getAllByTestId('page')[4]).toHaveTextContent('5')
+        expect(wrapper.getAllByTestId('page')).toHaveLength(5)
       })
+
+      it('should enable the `Prev` button', () => {
+        expect(wrapper.getByText('Prev')).not.toHaveAttribute('disabled')
+      })
+
+      it('should enable the `Next` button', () => {
+        expect(wrapper.getByText('Next')).toHaveAttribute('disabled', '')
+      })
+    })
+  })
+
+  describe('when there is one page of data and the current page is 1', () => {
+    beforeEach(() => {
+      wrapper = render(<Pagination pageSize={10} total={2} />)
+    })
+
+    it('should render pages', () => {
+      expect(wrapper.getAllByTestId('page')[0]).toHaveTextContent('1')
+      expect(wrapper.getAllByTestId('page')).toHaveLength(1)
+    })
+
+    it('should apply the `is-active` class to the appropriate page', () => {
+      expect(wrapper.getByText('1').classList.contains('is-active')).toBe(true)
+    })
+
+    it('should disable both the `Prev` and `Next` buttons', () => {
+      expect(wrapper.getByText('Prev')).toHaveAttribute('disabled', '')
+      expect(wrapper.getByText('Next')).toHaveAttribute('disabled', '')
+    })
+  })
+
+  describe('when there are three pages of data and the current page is 1', () => {
+    beforeEach(() => {
+      wrapper = render(<Pagination pageSize={10} total={25} />)
+    })
+
+    it('should render pages', () => {
+      expect(wrapper.getAllByTestId('page')[0]).toHaveTextContent('1')
+      expect(wrapper.getAllByTestId('page')[1]).toHaveTextContent('2')
+      expect(wrapper.getAllByTestId('page')[2]).toHaveTextContent('3')
+      expect(wrapper.getAllByTestId('page')).toHaveLength(3)
+    })
+
+    it('should apply the `is-active` class to the appropriate page', () => {
+      expect(wrapper.getByText('1').classList.contains('is-active')).toBe(true)
+    })
+
+    it('should enable the `Prev` button', () => {
+      expect(wrapper.getByText('Prev')).toHaveAttribute('disabled', '')
+    })
+
+    it('should enable the `Next` button', () => {
+      expect(wrapper.getByText('Next')).not.toHaveAttribute('disabled')
     })
   })
 })

--- a/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
@@ -8,8 +8,14 @@ describe('Pagination', () => {
   let wrapper: RenderResult
 
   describe('when there is ten pages of data', () => {
+    let onChangeSpy: (currentPage: number, totalPages: number) => void
+
     beforeEach(() => {
-      wrapper = render(<Pagination pageSize={10} total={95} />)
+      onChangeSpy = jest.fn()
+
+      wrapper = render(
+        <Pagination pageSize={10} total={95} onChange={onChangeSpy} />
+      )
     })
 
     it('should render pages', () => {
@@ -44,6 +50,11 @@ describe('Pagination', () => {
             cancelable: true,
           })
         )
+      })
+
+      it('should call the onChange callback', () => {
+        expect(onChangeSpy).toHaveBeenCalledWith(5, 10)
+        expect(onChangeSpy).toHaveBeenCalledTimes(1)
       })
 
       it('should apply the `is-active` class to the appropriate page', () => {
@@ -87,6 +98,13 @@ describe('Pagination', () => {
           )
         })
 
+        it('should call the onChange callback', () => {
+          expect(onChangeSpy).toHaveBeenCalledWith(5, 10)
+          expect(onChangeSpy).toHaveBeenCalledWith(1, 10)
+          expect(onChangeSpy).toHaveBeenCalledWith(5, 10)
+          expect(onChangeSpy).toHaveBeenCalledTimes(3)
+        })
+
         it('should render pages', () => {
           expect(wrapper.getAllByTestId('page')[0]).toHaveTextContent('1')
           expect(wrapper.getAllByTestId('page')[1]).toHaveTextContent('...')
@@ -109,6 +127,11 @@ describe('Pagination', () => {
             cancelable: true,
           })
         )
+      })
+
+      it('should call the onChange callback', () => {
+        expect(onChangeSpy).toHaveBeenCalledWith(10, 10)
+        expect(onChangeSpy).toHaveBeenCalledTimes(1)
       })
 
       it('should apply the `is-active` class to the appropriate page', () => {
@@ -148,8 +171,15 @@ describe('Pagination', () => {
         )
       })
 
+      it('should call the onChange callback', () => {
+        expect(onChangeSpy).toHaveBeenCalledWith(2, 10)
+        expect(onChangeSpy).toHaveBeenCalledTimes(1)
+      })
+
       it('should apply the `is-active` class to the appropriate page', () => {
-        expect(wrapper.getByText('2').classList.contains('is-active')).toBe(true)
+        expect(wrapper.getByText('2').classList.contains('is-active')).toBe(
+          true
+        )
       })
 
       describe('and the `Prev` button is clicked', () => {
@@ -163,8 +193,16 @@ describe('Pagination', () => {
           )
         })
 
+        it('should call the onChange callback', () => {
+          expect(onChangeSpy).toHaveBeenCalledWith(2, 10)
+          expect(onChangeSpy).toHaveBeenCalledWith(1, 10)
+          expect(onChangeSpy).toHaveBeenCalledTimes(2)
+        })
+
         it('should apply the `is-active` class to the appropriate page', () => {
-          expect(wrapper.getByText('1').classList.contains('is-active')).toBe(true)
+          expect(wrapper.getByText('1').classList.contains('is-active')).toBe(
+            true
+          )
         })
       })
     })

--- a/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import { render, RenderResult } from '@testing-library/react'
+import { render, RenderResult, fireEvent } from '@testing-library/react'
 
 import { Pagination } from '.'
 
@@ -37,7 +37,13 @@ describe('Pagination', () => {
 
     describe('and the current page is 5', () => {
       beforeEach(() => {
-        wrapper.getByText('5').click()
+        fireEvent(
+          wrapper.getByText('5'),
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+          })
+        )
       })
 
       it('should apply the `is-active` class to the appropriate page', () => {
@@ -64,8 +70,21 @@ describe('Pagination', () => {
 
       describe('and the current page goes back to 1 and then 5 again', () => {
         beforeEach(() => {
-          wrapper.getByText('1').click()
-          wrapper.getByText('5').click()
+          fireEvent(
+            wrapper.getByText('1'),
+            new MouseEvent('click', {
+              bubbles: true,
+              cancelable: true,
+            })
+          )
+
+          fireEvent(
+            wrapper.getByText('5'),
+            new MouseEvent('click', {
+              bubbles: true,
+              cancelable: true,
+            })
+          )
         })
 
         it('should render pages', () => {
@@ -83,7 +102,13 @@ describe('Pagination', () => {
 
     describe('and the current page is 10', () => {
       beforeEach(() => {
-        wrapper.getByText('10').click()
+        fireEvent(
+          wrapper.getByText('10'),
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+          })
+        )
       })
 
       it('should apply the `is-active` class to the appropriate page', () => {
@@ -109,6 +134,38 @@ describe('Pagination', () => {
 
       it('should disable the `Next` button', () => {
         expect(wrapper.getByText('Next')).toHaveAttribute('disabled', '')
+      })
+    })
+
+    describe('and the `Next` button is clicked', () => {
+      beforeEach(() => {
+        fireEvent(
+          wrapper.getByTestId('page-next'),
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      })
+
+      it('should apply the `is-active` class to the appropriate page', () => {
+        expect(wrapper.getByText('2').classList.contains('is-active')).toBe(true)
+      })
+
+      describe('and the `Prev` button is clicked', () => {
+        beforeEach(() => {
+          fireEvent(
+            wrapper.getByText('Prev'),
+            new MouseEvent('click', {
+              bubbles: true,
+              cancelable: true,
+            })
+          )
+        })
+
+        it('should apply the `is-active` class to the appropriate page', () => {
+          expect(wrapper.getByText('1').classList.contains('is-active')).toBe(true)
+        })
       })
     })
   })
@@ -141,7 +198,13 @@ describe('Pagination', () => {
 
     describe('and the current page is 5', () => {
       beforeEach(() => {
-        wrapper.getByText('5').click()
+        fireEvent(
+          wrapper.getByText('5'),
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+          })
+        )
       })
 
       it('should apply the `is-active` class to the appropriate page', () => {

--- a/packages/react-component-library/src/components/Pagination/Pagination.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.tsx
@@ -36,7 +36,7 @@ export const Pagination: React.FC<PaginationProps> = ({
             disabled={currentPage === 1}
             className="rn-pagination__button"
             onClick={() => {
-              changePage('previous')
+              changePage(currentPage - 1)
             }}
             data-testid="page-previous"
           >
@@ -85,7 +85,7 @@ export const Pagination: React.FC<PaginationProps> = ({
             disabled={currentPage === totalPages}
             className="rn-pagination__button"
             onClick={() => {
-              changePage('next')
+              changePage(currentPage + 1)
             }}
             data-testid="page-next"
           >

--- a/packages/react-component-library/src/components/Pagination/Pagination.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.tsx
@@ -3,7 +3,7 @@ import {
   IconKeyboardArrowLeft,
   IconKeyboardArrowRight,
 } from '@royalnavy/icon-library'
-import { usePageChange, BUMP_LEFT, BUMP_RIGHT } from './usePageChange'
+import { usePageChange, ELLIPSIS } from './usePageChange'
 import { getKey } from '../../helpers'
 
 interface PaginationProps {
@@ -19,7 +19,7 @@ export const Pagination: React.FC<PaginationProps> = ({
 }) => {
   const totalPages = Math.ceil(total / pageSize)
 
-  const [currentPage, changePage, pageNumbers] = usePageChange(
+  const { currentPage, changePage, pageNumbers } = usePageChange(
     1,
     totalPages,
     onChange
@@ -38,41 +38,41 @@ export const Pagination: React.FC<PaginationProps> = ({
             onClick={() => {
               changePage('previous')
             }}
-            data-testid="button-previous"
+            data-testid="page-previous"
           >
             <IconKeyboardArrowLeft />
             Prev
           </button>
         </li>
-        {pageNumbers().map((page: string | number) => {
-          if ([BUMP_LEFT, BUMP_RIGHT].includes(String(page))) {
+        {pageNumbers.map(({ key, value }) => {
+          if (value === ELLIPSIS) {
             return (
               <li
-                key={getKey('pagination-item', page)}
+                key={getKey('pagination-item', key)}
                 className="rn-pagination__item"
                 data-testid="page"
               >
-                {page}
+                {value}
               </li>
             )
           }
 
           return (
             <li
-              key={getKey('pagination-item', page)}
+              key={getKey('pagination-item', key)}
               className="rn-pagination__item"
               data-testid="page"
             >
               <button
                 className={`rn-pagination__button ${
-                  page === currentPage ? 'is-active' : ''
+                  value === currentPage ? 'is-active' : ''
                 }`}
                 onClick={() => {
-                  changePage(page)
+                  changePage(value)
                 }}
-                data-testid={`select-page-${page}`}
+                data-testid={`select-page-${value}`}
               >
-                {page}
+                {value}
               </button>
             </li>
           )
@@ -87,7 +87,7 @@ export const Pagination: React.FC<PaginationProps> = ({
             onClick={() => {
               changePage('next')
             }}
-            data-testid="button-next"
+            data-testid="page-next"
           >
             Next
             <IconKeyboardArrowRight />

--- a/packages/react-component-library/src/components/Pagination/usePageChange.tsx
+++ b/packages/react-component-library/src/components/Pagination/usePageChange.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import compact from 'lodash/compact'
 
 export const ELLIPSIS = '...'
@@ -78,15 +78,15 @@ export const usePageChange = (
   onChange?: (currentPage: number, totalPages: number) => void
 ) => {
   const [currentPage, setCurrentPage] = useState(initialPage)
-  const [pageNumbers, setPageNumbers] = useState(
-    getPageNumbers(initialPage, totalPages)
-  )
+  const [pageNumbers, setPageNumbers] = useState([])
 
   function changePage(page: string | number): void {
-    const newPageNumber = Number(page)
-    setCurrentPage(newPageNumber)
-    setPageNumbers(getPageNumbers(newPageNumber, totalPages))
+    setCurrentPage(Number(page))
   }
+
+  useEffect(() => {
+    setPageNumbers(getPageNumbers(currentPage, totalPages))
+  }, [currentPage])
 
   return {
     changePage,

--- a/packages/react-component-library/src/components/Pagination/usePageChange.tsx
+++ b/packages/react-component-library/src/components/Pagination/usePageChange.tsx
@@ -81,7 +81,12 @@ export const usePageChange = (
   const [pageNumbers, setPageNumbers] = useState([])
 
   function changePage(page: string | number): void {
-    setCurrentPage(Number(page))
+    const newPageNumber = Number(page)
+    setCurrentPage(newPageNumber)
+
+    if (onChange) {
+      onChange(newPageNumber, totalPages)
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Related issue
Fixes #947 

## Overview
Add fix so that extra ellipsis does not appear when scrolling between a set of page numbers that need the ellipsis vs those that don't. The issue is being cause by duplicate `key`.

## Reason
Confusing for the user.

## Work carried out
- [x] Fix
- [x] Refactor