### PR TITLE
Add condensed variation of NumberInput

### DIFF
--- a/packages/css-framework/src/components/_numberinput.scss
+++ b/packages/css-framework/src/components/_numberinput.scss
@@ -17,33 +17,27 @@
   background-color: f.color("neutral", "white");
   border: 1px solid f.color("neutral", "200");
   border-radius: 4px;
-  transition:
-    border-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
+  transition: border-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
     box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
 .rn-numberinput.has-focus .rn-numberinput__input-wrapper {
   border-radius: 4px;
-  box-shadow:
-    2px 2px 0 0 f.color("action", "600"),
+  box-shadow: 2px 2px 0 0 f.color("action", "600"),
     -2px -2px 0 0 f.color("action", "600"),
-    2px -2px 0 0 f.color("action", "600"),
-    -2px 2px 0 0 f.color("action", "600");
+    2px -2px 0 0 f.color("action", "600"), -2px 2px 0 0 f.color("action", "600");
 }
 
 .rn-numberinput.is-invalid .rn-numberinput__input-wrapper {
   border-radius: 4px;
-  box-shadow:
-    2px 2px 0 0 f.color("danger", "600"),
+  box-shadow: 2px 2px 0 0 f.color("danger", "600"),
     -2px -2px 0 0 f.color("danger", "600"),
-    2px -2px 0 0 f.color("danger", "600"),
-    -2px 2px 0 0 f.color("danger", "600");
+    2px -2px 0 0 f.color("danger", "600"), -2px 2px 0 0 f.color("danger", "600");
 }
 
 .rn-numberinput.is-valid .rn-numberinput__input-wrapper {
   border-radius: 4px;
-  box-shadow:
-    2px 2px 0 0 f.color("success", "700"),
+  box-shadow: 2px 2px 0 0 f.color("success", "700"),
     -2px -2px 0 0 f.color("success", "700"),
     2px -2px 0 0 f.color("success", "700"),
     -2px 2px 0 0 f.color("success", "700");
@@ -62,8 +56,7 @@
   left: 0;
   transform-origin: top left;
   transform: translate(f.spacing("6"), f.spacing("6")) scale(1);
-  transition:
-    color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
+  transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
     transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
   pointer-events: none;
   color: f.color("neutral", "300");
@@ -115,7 +108,6 @@
   width: 42px;
   align-items: center;
 
-
   background: transparent;
   margin: 0;
   padding: 0;
@@ -126,8 +118,7 @@
 
   &:focus {
     border-radius: 4px;
-    box-shadow:
-      2px 2px 0 0 f.color("action", "600"),
+    box-shadow: 2px 2px 0 0 f.color("action", "600"),
       -2px -2px 0 0 f.color("action", "600"),
       2px -2px 0 0 f.color("action", "600"),
       -2px 2px 0 0 f.color("action", "600");

--- a/packages/css-framework/src/components/_numberinput.scss
+++ b/packages/css-framework/src/components/_numberinput.scss
@@ -87,16 +87,16 @@
   font-size: f.font-size("base");
 }
 
+.rn-numberinput__input--condensed {
+  padding: f.spacing("3");
+}
+
 .rn-numberinput__label + .rn-numberinput__input {
   padding: f.spacing("10") f.spacing("6") f.spacing("2");
 }
 
 .rn-numberinput__input:focus {
   outline: 0;
-}
-
-.rn-numberinput__increase > svg {
-  transform: rotate(180deg);
 }
 
 .rn-numberinput__controls {
@@ -134,11 +134,31 @@
   }
 }
 
+.rn-numberinput__increase > svg {
+  transform: rotate(180deg);
+}
+
+.rn-numberinput__increase--condensed {
+  width: 36px;
+
+  & > svg {
+    transform: rotate(180deg) scale(0.7);
+  }
+}
+
 .rn-numberinput__decrease {
   border-top: 1px solid f.color("neutral", "100");
 
   &:focus {
     border-color: transparent;
+  }
+}
+
+.rn-numberinput__decrease--condensed {
+  width: 36px;
+
+  & > svg {
+    transform: scale(0.7);
   }
 }
 

--- a/packages/react-component-library/src/components/NumberInput/EndAdornment.tsx
+++ b/packages/react-component-library/src/components/NumberInput/EndAdornment.tsx
@@ -4,6 +4,7 @@ import { EndAdornmentButton } from './EndAdornmentButton'
 import { END_ADORNMENT_TYPE } from './constants'
 
 interface EndAdornmentProps {
+  isCondensed: boolean
   isDisabled: boolean
   max?: number
   min?: number
@@ -14,6 +15,7 @@ interface EndAdornmentProps {
 }
 
 export const EndAdornment: React.FC<EndAdornmentProps> = ({
+  isCondensed,
   isDisabled,
   onClick,
   step,
@@ -32,11 +34,13 @@ export const EndAdornment: React.FC<EndAdornmentProps> = ({
   return (
     <div className="rn-numberinput__controls">
       <EndAdornmentButton
+        isCondensed={isCondensed}
         isDisabled={isDisabled}
         onClick={onButtonClick(() => (value || 0) + step)}
         type={END_ADORNMENT_TYPE.INCREASE}
       />
       <EndAdornmentButton
+        isCondensed={isCondensed}
         isDisabled={isDisabled}
         onClick={onButtonClick(() => (value || 0) - step)}
         type={END_ADORNMENT_TYPE.DECREASE}

--- a/packages/react-component-library/src/components/NumberInput/EndAdornmentButton.tsx
+++ b/packages/react-component-library/src/components/NumberInput/EndAdornmentButton.tsx
@@ -1,23 +1,30 @@
 import React from 'react'
+import classNames from 'classnames'
 
 import { END_ADORNMENT_TYPE } from './constants'
 
 interface EndAdornmentButtonProps {
+  isCondensed: boolean,
   isDisabled: boolean
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
   type: typeof END_ADORNMENT_TYPE.DECREASE | typeof END_ADORNMENT_TYPE.INCREASE
 }
 
 export const EndAdornmentButton: React.FC<EndAdornmentButtonProps> = ({
+  isCondensed,
   isDisabled,
   onClick,
   type,
 }) => {
+  const classes = classNames(`rn-numberinput__${type}`, {
+    [`rn-numberinput__${type}--condensed`]: isCondensed,
+  })
+
   return (
     <button
       data-testid={`number-input-${type}`}
       type="button"
-      className={`rn-numberinput__${type}`}
+      className={classes}
       disabled={isDisabled}
       onClick={onClick}
     >

--- a/packages/react-component-library/src/components/NumberInput/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInput/Input.tsx
@@ -1,8 +1,10 @@
 import React, { useRef } from 'react'
+import classNames from 'classnames'
 
 interface InputProps {
   isDisabled?: boolean
   id?: string
+  isCondensed: boolean
   label?: string
   name: string
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
@@ -15,6 +17,7 @@ interface InputProps {
 export const Input: React.FC<InputProps> = ({
   isDisabled = false,
   id,
+  isCondensed,
   label,
   name,
   onChange,
@@ -28,6 +31,10 @@ export const Input: React.FC<InputProps> = ({
   const inputRef = useRef(null)
   const displayValue =
     value === null || value === undefined || Number.isNaN(value) ? '' : value
+
+  const inputClasses = classNames('rn-numberinput__input', {
+    'rn-numberinput__input--condensed': isCondensed,
+  })
 
   return (
     <div
@@ -44,7 +51,7 @@ export const Input: React.FC<InputProps> = ({
         </label>
       )}
       <input
-        className="rn-numberinput__input"
+        className={inputClasses}
         data-testid="number-input-input"
         disabled={isDisabled}
         id={id}

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -15,6 +15,10 @@ stories.add('Default', () => (
   <NumberInput name="number-input" onChange={action('onChange')} />
 ))
 
+examples.add('Condensed', () => (
+  <NumberInput isCondensed name="number-input" onChange={action('onChange')} />
+))
+
 examples.add('Disabled', () => (
   <NumberInput isDisabled name="number-input" onChange={action('onChange')} />
 ))

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -17,6 +17,7 @@ export interface NumberInputProps {
   isDisabled?: boolean
   footnote?: string
   id?: string
+  isCondensed?: boolean,
   label?: string
   max?: number
   min?: number
@@ -34,6 +35,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   isDisabled = false,
   footnote,
   id = uuidv4(),
+  isCondensed,
   label,
   max,
   min,
@@ -81,6 +83,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
         <Input
           id={id}
           isDisabled={isDisabled}
+          isCondensed={isCondensed}
           label={label}
           name={name}
           onChange={onInputChange}
@@ -92,6 +95,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
         />
 
         <EndAdornment
+          isCondensed={isCondensed}
           isDisabled={isDisabled}
           max={max}
           min={min}


### PR DESCRIPTION
## Related issue
Closes #981 

## Overview
Add `isCondensed` prop to condense the `NumberInput` component.

## Reason
Required for when presenting `NumberInput` in a `table`.

## Work carried out
- [x] Add prop