### PR TITLE
fix(DatePicker): Datepicker Formik compatability

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,8 +1,12 @@
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
+import { Field, Formik, Form } from 'formik'
 import React from 'react'
 
+import { withFormik } from '../../enhancers/withFormik'
 import { DatePicker, DATEPICKER_PLACEMENT } from '.'
+
+import { Button } from '../Button'
 
 const stories = storiesOf('DatePicker', module)
 const examples = storiesOf('DatePicker/Examples', module)
@@ -48,4 +52,48 @@ examples.add('Range', () => {
       isRange
     />
   )
+})
+
+const DatePickerForm = () => {
+  interface Data {
+    startDate: Date
+    endDate: Date
+  }
+
+  const initialValues: Data = {
+    startDate: new Date('01/01/2020'),
+    endDate: new Date('01/05/2020'),
+  }
+
+  const FormikDatePicker = withFormik(DatePicker)
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      onSubmit={action('onSubmit')}
+      render={({ setFieldValue }) => {
+        return (
+          <Form>
+            <Field
+              name="date"
+              label="Date"
+              component={FormikDatePicker}
+              isRange
+              onChange={({ startDate, endDate }: any) => {
+                setFieldValue('startDate', startDate)
+                setFieldValue('endDate', endDate)
+              }}
+              startDate={initialValues.startDate}
+              endDate={initialValues.endDate}
+            />
+            <Button type="submit">Submit</Button>
+          </Form>
+        )
+      }}
+    />
+  )
+}
+
+examples.add('Formik', () => {
+  return <DatePickerForm />
 })

--- a/packages/react-component-library/src/components/DatePicker/Input.tsx
+++ b/packages/react-component-library/src/components/DatePicker/Input.tsx
@@ -14,7 +14,16 @@ export interface InputProps extends ComponentWithClass {
 }
 
 export const Input = forwardRef((props: InputProps, ref?: React.Ref<any>) => {
-  const { className, id, label, name, value, onBlur, onFocus, isDisabled } = props
+  const {
+    className,
+    id,
+    label,
+    name,
+    value,
+    onBlur,
+    onFocus,
+    isDisabled,
+  } = props
 
   return (
     <div className={className} ref={ref} data-testid="datepicker-input-wrapper">
@@ -37,6 +46,7 @@ export const Input = forwardRef((props: InputProps, ref?: React.Ref<any>) => {
             onFocus={onFocus}
             disabled={isDisabled}
             data-testid="datepicker-input"
+            readOnly
           />
         </div>
         <div className="rn-date-picker__end-adornment">


### PR DESCRIPTION
## Related issue

Closes #984

## Overview

Add Storybook usage example for Formik DatePicker and fix warning.

## Reason

Using custom form components with Formik requires the consumer to supply a custom onChange handler and utilise the Formik `setFieldValue` method.

## Work carried out

- [x] Add Formik usage example
- [x] Add missing `readOnly` attribute to input element to prevent console warning
