### PR TITLE
fix(Timeline): Add missing `range` prop

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -426,3 +426,41 @@ stories.add('With custom day width', () => {
     </Timeline>
   )
 })
+
+stories.add('With custom range', () => {
+  return (
+    <Timeline
+      startDate={new Date(2020, 4, 0)}
+      today={new Date(2020, 3, 15)}
+      range={6}
+    >
+      <TimelineSide />
+      <TimelineTodayMarker />
+      <TimelineMonths />
+      <TimelineWeeks />
+      <TimelineDays />
+      <TimelineRows>
+        <TimelineRow name="Row 1">
+          <TimelineEvents>
+            <TimelineEvent
+              startDate={new Date(2020, 3, 25)}
+              endDate={new Date(2020, 3, 28)}
+            >
+              Event 2
+            </TimelineEvent>
+          </TimelineEvents>
+        </TimelineRow>
+        <TimelineRow name="Row 2">
+          <TimelineEvents>
+            <TimelineEvent
+              startDate={new Date(2020, 3, 22)}
+              endDate={new Date(2020, 3, 24)}
+            >
+              Event 4
+            </TimelineEvent>
+          </TimelineEvents>
+        </TimelineRow>
+      </TimelineRows>
+    </Timeline>
+  )
+})

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -48,6 +48,7 @@ export interface TimelineProps extends ComponentWithClass {
   dayWidth?: number
   startDate?: Date
   today?: Date
+  range?: number
 }
 
 function isComponentOf<T extends TimelineComponent>(
@@ -63,7 +64,7 @@ function extractChildrenOf<T>(
   children: timelineChildrenType | timelineChildrenType[],
   names: string[]
 ) {
-  return (children as []).filter(child => isComponentOf(child, names))
+  return (children as []).filter((child) => isComponentOf(child, names))
 }
 
 function extractRowData(
@@ -94,10 +95,11 @@ export const Timeline: React.FC<TimelineProps> = ({
   dayWidth = DEFAULTS.DAY_WIDTH,
   startDate,
   today,
+  range,
 }) => {
   const options: TimelineOptions = {
     dayWidth,
-    rangeInMonths: DEFAULTS.RANGE_IN_MONTHS,
+    rangeInMonths: range || DEFAULTS.RANGE_IN_MONTHS,
   }
 
   const bodyChildren = extractChildrenOf<TimelineBodyComponent>(children, [
@@ -113,7 +115,7 @@ export const Timeline: React.FC<TimelineProps> = ({
 
   const rootChildren = extractChildrenOf<TimelineRootComponent>(children, [
     TimelineSide.name,
-  ]).map(child => {
+  ]).map((child) => {
     if (isComponentOf(child, [TimelineSide.name])) {
       return React.cloneElement(child, {
         rowGroups: extractRowData(bodyChildren),

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -563,4 +563,37 @@ describe('Timeline', () => {
       ).toHaveLength(0)
     })
   })
+
+  describe('when custom range is provided', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Timeline
+          startDate={new Date(2020, 1, 1, 0, 0, 0)}
+          today={new Date(2020, 4, 1, 0, 0, 0)}
+          range={6}
+        >
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineWeeks />
+          <TimelineDays />
+          <TimelineRows>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={new Date(2020, 1, 1, 0, 0, 0)}
+                  endDate={new Date(2020, 1, 10, 0, 0, 0)}
+                >
+                  Event
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('renders the correct number of months', () => {
+      expect(wrapper.queryAllByTestId('timeline-month')).toHaveLength(6)
+    })
+  })
 })


### PR DESCRIPTION
## Related issue

Closes #1058

## Overview

Add missing range prop to Timeline so consumer can override default.

## Reason

There is currently no way for the end user to override the default Timeline range.

## Work carried out

- [x] Add range prop and short circuit against default
- [x] Add automated test