### PR TITLE
fix(Timeline): Conditionally render TimelineSide headings

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -119,6 +119,7 @@ export const Timeline: React.FC<TimelineProps> = ({
     if (isComponentOf(child, [TimelineSide.name])) {
       return React.cloneElement(child, {
         rowGroups: extractRowData(bodyChildren),
+        headChildren,
       })
     }
 

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -75,7 +75,8 @@ function extractRowData(
       let rows: any[] = []
 
       if (children) {
-        rows = (children as []).map(
+        const items = Array.isArray(children) ? children : [children]
+        rows = items.map(
           ({ props: { name } }: React.ReactElement<TimelineRowProps>) => ({
             name,
           })

--- a/packages/react-component-library/src/components/Timeline/TimelineSide.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineSide.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { IconChevronRight, IconChevronLeft } from '@royalnavy/icon-library'
+import { startCase } from 'lodash'
 
 import { Button } from '../Button'
 import { getKey } from './helpers'
@@ -8,22 +9,28 @@ import { TIMELINE_ACTIONS } from './context/types'
 
 export interface TimelineSideProps extends ComponentWithClass {
   rowGroups?: any[]
+  headChildren?: any[]
 }
 
-const TimelineSideList: React.FC<TimelineSideProps> = ({ rowGroups }) => {
+const TimelineSideList: React.FC<TimelineSideProps> = ({
+  rowGroups,
+  headChildren,
+}) => {
   return (
     <ol className="timeline__side-list">
-      <li className="timeline__side-months">
-        <span className="timeline__side-title">Months</span>
-      </li>
-      <li className="timeline__side-weeks">
-        <span className="timeline__side-title">Weeks</span>
-      </li>
-      <li className="timeline__side-days">
-        <span className="timeline__side-title">Days</span>
-      </li>
+      {headChildren.map(({ type: { displayName } }) => {
+        const name = displayName.toLowerCase().substring('timeline'.length)
+
+        if (!['months', 'weeks', 'days'].includes(name)) return null
+
+        return (
+          <li className={`timeline__side-${name}`}>
+            <span className="timeline__side-title">{startCase(name)}</span>
+          </li>
+        )
+      })}
       {rowGroups
-        .flatMap(item => item.rows)
+        .flatMap((item) => item.rows)
         .map(({ name }, index) => {
           return (
             <li
@@ -39,7 +46,10 @@ const TimelineSideList: React.FC<TimelineSideProps> = ({ rowGroups }) => {
   )
 }
 
-export const TimelineSide: React.FC<TimelineSideProps> = ({ rowGroups }) => {
+export const TimelineSide: React.FC<TimelineSideProps> = ({
+  rowGroups,
+  headChildren,
+}) => {
   return (
     <TimelineContext.Consumer>
       {({ dispatch }) => {
@@ -49,17 +59,20 @@ export const TimelineSide: React.FC<TimelineSideProps> = ({ rowGroups }) => {
               <Button
                 variant="secondary"
                 icon={<IconChevronLeft />}
-                onClick={_ => dispatch({ type: TIMELINE_ACTIONS.GET_PREV })}
+                onClick={(_) => dispatch({ type: TIMELINE_ACTIONS.GET_PREV })}
                 data-testid="timeline-side-button-left"
               />
               <Button
                 variant="secondary"
                 icon={<IconChevronRight />}
-                onClick={_ => dispatch({ type: TIMELINE_ACTIONS.GET_NEXT })}
+                onClick={(_) => dispatch({ type: TIMELINE_ACTIONS.GET_NEXT })}
                 data-testid="timeline-side-button-right"
               />
             </div>
-            <TimelineSideList rowGroups={rowGroups} />
+            <TimelineSideList
+              rowGroups={rowGroups}
+              headChildren={headChildren}
+            />
           </aside>
         )
       }}

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -4,6 +4,7 @@ import { render, RenderResult } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
 import {
+  TimelineSide,
   TimelineTodayMarker,
   TimelineMonths,
   TimelineWeeks,
@@ -594,6 +595,43 @@ describe('Timeline', () => {
 
     it('renders the correct number of months', () => {
       expect(wrapper.queryAllByTestId('timeline-month')).toHaveLength(6)
+    })
+  })
+
+  describe('when TimelineSide is used with TimelineMonths', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Timeline
+          startDate={new Date(2020, 1, 1, 0, 0, 0)}
+          today={new Date(2020, 4, 1, 0, 0, 0)}
+          range={6}
+        >
+          <TimelineSide />
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineRows>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={new Date(2020, 1, 1, 0, 0, 0)}
+                  endDate={new Date(2020, 1, 10, 0, 0, 0)}
+                >
+                  Event
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('renders the sidebar month label', () => {
+      expect(wrapper.queryByText('Months')).toBeInTheDocument()
+    })
+
+    it('does not render the sidebar weeks and days labels', () => {
+      expect(wrapper.queryByText('Weeks')).not.toBeInTheDocument()
+      expect(wrapper.queryByText('Days')).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Related issue

Closes #1057

## Overview

Render TimelineSide headings based on the occurance of related subcomponents (TimelineMonths, TimelineWeeks, TimelineDays).

## Reason

When a consumer is using the provided TimelineSide component it always renders headings for the Months, Weeks and Days rows regardless of whether a Timeline has been composed with these sub components.

## Work carried out

- [x] Conditionally render headings based on consumer composition

## Developer notes

TimelineSide is in the roadmap for a complete rework - this fix is a short term solution.
