### PR TITLE
Add unit to NumberInput

### DIFF
--- a/packages/react-component-library/src/components/NumberInput/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInput/Input.tsx
@@ -11,7 +11,7 @@ interface InputProps {
   onInputBlur: (event: React.FormEvent<HTMLInputElement>) => void
   onInputFocus: () => void
   placeholder?: string
-  value?: number
+  value?: number | string
 }
 
 export const Input: React.FC<InputProps> = ({

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -87,6 +87,16 @@ examples.add('Unit', () => (
   />
 ))
 
+examples.add('Unit before', () => (
+  <NumberInput
+    name="number-input"
+    onChange={action('onChange')}
+    value={1000}
+    unit="&pound;"
+    unitPosition={UNIT_POSITION.BEFORE}
+  />
+))
+
 examples.add('Formik', () => {
   const NumberInputForm = () => {
     interface Data {

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -7,6 +7,7 @@ import { IconBrightnessHigh } from '@royalnavy/icon-library'
 import { Button } from '../Button'
 import { NumberInput } from './NumberInput'
 import { withFormik } from '../../enhancers/withFormik'
+import { UNIT_POSITION } from './constants'
 
 const stories = storiesOf('Number Input', module)
 const examples = storiesOf('Number Input/Examples', module)
@@ -75,6 +76,15 @@ examples.add('Start adornment text', () => (
 
 examples.add('Value', () => (
   <NumberInput name="number-input" onChange={action('onChange')} value={10} />
+))
+
+examples.add('Unit', () => (
+  <NumberInput
+    name="number-input"
+    onChange={action('onChange')}
+    value={1000}
+    unit="m&sup3;"
+  />
 ))
 
 examples.add('Formik', () => {

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
@@ -9,6 +9,27 @@ describe('NumberInput', () => {
   let wrapper: RenderResult
   let onChangeSpy: (event: any) => void
 
+  function assertInputValue(expected: string) {
+    it('should set the new value', () => {
+      const input = wrapper.getByTestId(
+        'number-input-input'
+      ) as HTMLInputElement
+      expect(input.value).toEqual(expected)
+    })
+  }
+
+  function assertOnChangeCall(expected: number, expectedNumberOfTimes = 1) {
+    it('should call the onChange callback with the new value', () => {
+      expect(onChangeSpy).toHaveBeenCalledTimes(expectedNumberOfTimes)
+      expect(onChangeSpy).toHaveBeenCalledWith({
+        target: {
+          name: 'number-input',
+          value: expected,
+        },
+      })
+    })
+  }
+
   beforeEach(() => {
     onChangeSpy = jest.fn()
   })
@@ -30,12 +51,7 @@ describe('NumberInput', () => {
       expect(wrapper.queryAllByTestId('number-input-label')).toHaveLength(0)
     })
 
-    it('should not display a value', () => {
-      const input = wrapper.getByTestId(
-        'number-input-input'
-      ) as HTMLInputElement
-      expect(input.value).toEqual('')
-    })
+    assertInputValue('')
 
     it('should set the name attribute', () => {
       expect(
@@ -52,66 +68,24 @@ describe('NumberInput', () => {
         wrapper.getByTestId('number-input-increase').click()
       })
 
-      it('should increase the value by 1', () => {
-        const input = wrapper.getByTestId(
-          'number-input-input'
-        ) as HTMLInputElement
-        expect(input.value).toEqual('1')
-      })
-
-      it('should call the onChange callback', () => {
-        expect(onChangeSpy).toHaveBeenCalledTimes(1)
-        expect(onChangeSpy).toHaveBeenCalledWith({
-          target: {
-            name: 'number-input',
-            value: 1,
-          },
-        })
-      })
+      assertInputValue('1')
+      assertOnChangeCall(1)
 
       describe('and the decrease button is clicked', () => {
         beforeEach(() => {
           wrapper.getByTestId('number-input-decrease').click()
         })
 
-        it('should decrease the value by 1', () => {
-          const input = wrapper.getByTestId(
-            'number-input-input'
-          ) as HTMLInputElement
-          expect(input.value).toEqual('0')
-        })
-
-        it('should call the onChange callback', () => {
-          expect(onChangeSpy).toHaveBeenCalledTimes(2)
-          expect(onChangeSpy).toHaveBeenCalledWith({
-            target: {
-              name: 'number-input',
-              value: 0,
-            },
-          })
-        })
+        assertInputValue('0')
+        assertOnChangeCall(0 ,2)
 
         describe('and the decrease button is clicked', () => {
           beforeEach(() => {
             wrapper.getByTestId('number-input-decrease').click()
           })
 
-          it('should decrease the value by 1', () => {
-            const input = wrapper.getByTestId(
-              'number-input-input'
-            ) as HTMLInputElement
-            expect(input.value).toEqual('-1')
-          })
-
-          it('should call the onChange callback', () => {
-            expect(onChangeSpy).toHaveBeenCalledTimes(3)
-            expect(onChangeSpy).toHaveBeenCalledWith({
-              target: {
-                name: 'number-input',
-                value: -1,
-              },
-            })
-          })
+          assertInputValue('-1')
+          assertOnChangeCall(-1, 3)
         })
       })
     })
@@ -173,12 +147,7 @@ describe('NumberInput', () => {
         increase.click()
       })
 
-      it('should increase the value to the max 3', () => {
-        const input = wrapper.getByTestId(
-          'number-input-input'
-        ) as HTMLInputElement
-        expect(input.value).toEqual('3')
-      })
+      assertInputValue('3')
 
       describe('and the decrease button is clicked four times', () => {
         beforeEach(() => {
@@ -189,12 +158,7 @@ describe('NumberInput', () => {
           decrease.click()
         })
 
-        it('should decrease the value to the min 0', () => {
-          const input = wrapper.getByTestId(
-            'number-input-input'
-          ) as HTMLInputElement
-          expect(input.value).toEqual('0')
-        })
+        assertInputValue('0')
       })
     })
 
@@ -215,12 +179,7 @@ describe('NumberInput', () => {
           })
         })
 
-        it('should not change the value', () => {
-          const input = wrapper.getByTestId(
-            'number-input-input'
-          ) as HTMLInputElement
-          expect(input.value).toEqual('1')
-        })
+        assertInputValue('1')
       })
 
       describe('and the user types a valid number', () => {
@@ -232,12 +191,7 @@ describe('NumberInput', () => {
           })
         })
 
-        it('should change the value', () => {
-          const input = wrapper.getByTestId(
-            'number-input-input'
-          ) as HTMLInputElement
-          expect(input.value).toEqual('3')
-        })
+        assertInputValue('3')
       })
 
       describe('and the user types an number outside the max min range', () => {
@@ -249,24 +203,14 @@ describe('NumberInput', () => {
           })
         })
 
-        it('should display the value', () => {
-          const input = wrapper.getByTestId(
-            'number-input-input'
-          ) as HTMLInputElement
-          expect(input.value).toEqual('4')
-        })
+        assertInputValue('4')
 
         describe('and the number input loses focus', () => {
           beforeEach(() => {
             wrapper.getByTestId('next-field').focus()
           })
 
-          it('should display the last valid value', () => {
-            const input = wrapper.getByTestId(
-              'number-input-input'
-            ) as HTMLInputElement
-            expect(input.value).toEqual('1')
-          })
+          assertInputValue('1')
         })
       })
     })
@@ -285,12 +229,7 @@ describe('NumberInput', () => {
         increase.click()
       })
 
-      it('should increase the value to 3', () => {
-        const input = wrapper.getByTestId(
-          'number-input-input'
-        ) as HTMLInputElement
-        expect(input.value).toEqual('3')
-      })
+      assertInputValue('3')
 
       describe('and the decrease button is clicked', () => {
         beforeEach(() => {
@@ -298,12 +237,7 @@ describe('NumberInput', () => {
           decrease.click()
         })
 
-        it('should decrease the value to 0', () => {
-          const input = wrapper.getByTestId(
-            'number-input-input'
-          ) as HTMLInputElement
-          expect(input.value).toEqual('0')
-        })
+        assertInputValue('0')
       })
     })
   })
@@ -431,57 +365,24 @@ describe('NumberInput', () => {
       )
     })
 
-    it('should set the value', () => {
-      const input = wrapper.getByTestId(
-        'number-input-input'
-      ) as HTMLInputElement
-      expect(input.value).toEqual('1000 m')
-    })
+    assertInputValue('1000 m')
 
     describe('and the increase button is clicked', () => {
       beforeEach(() => {
         wrapper.getByTestId('number-input-increase').click()
       })
 
-      it('should increase the value by 1', () => {
-        const input = wrapper.getByTestId(
-          'number-input-input'
-        ) as HTMLInputElement
-        expect(input.value).toEqual('1001 m')
+      assertInputValue('1001 m')
+      assertOnChangeCall(1001)
+    })
+
+    describe('and the decrease button is clicked', () => {
+      beforeEach(() => {
+        wrapper.getByTestId('number-input-decrease').click()
       })
 
-      it('should call the onChange callback', () => {
-        expect(onChangeSpy).toHaveBeenCalledTimes(1)
-        expect(onChangeSpy).toHaveBeenCalledWith({
-          target: {
-            name: 'number-input',
-            value: 1001,
-          },
-        })
-      })
-
-      describe('and the decrease button is clicked', () => {
-        beforeEach(() => {
-          wrapper.getByTestId('number-input-decrease').click()
-        })
-
-        it('should decrease the value by 1', () => {
-          const input = wrapper.getByTestId(
-            'number-input-input'
-          ) as HTMLInputElement
-          expect(input.value).toEqual('1000 m')
-        })
-
-        it('should call the onChange callback', () => {
-          expect(onChangeSpy).toHaveBeenCalledTimes(2)
-          expect(onChangeSpy).toHaveBeenCalledWith({
-            target: {
-              name: 'number-input',
-              value: 1000,
-            },
-          })
-        })
-      })
+      assertInputValue('999 m')
+      assertOnChangeCall(999)
     })
   })
 
@@ -498,57 +399,24 @@ describe('NumberInput', () => {
       )
     })
 
-    it('should set the value', () => {
-      const input = wrapper.getByTestId(
-        'number-input-input'
-      ) as HTMLInputElement
-      expect(input.value).toEqual('£ 1000')
-    })
+    assertInputValue('£ 1000')
 
     describe('and the increase button is clicked', () => {
       beforeEach(() => {
         wrapper.getByTestId('number-input-increase').click()
       })
 
-      it('should increase the value by 1', () => {
-        const input = wrapper.getByTestId(
-          'number-input-input'
-        ) as HTMLInputElement
-        expect(input.value).toEqual('£ 1001')
+      assertInputValue('£ 1001')
+      assertOnChangeCall(1001)
+    })
+
+    describe('and the decrease button is clicked', () => {
+      beforeEach(() => {
+        wrapper.getByTestId('number-input-decrease').click()
       })
 
-      it('should call the onChange callback', () => {
-        expect(onChangeSpy).toHaveBeenCalledTimes(1)
-        expect(onChangeSpy).toHaveBeenCalledWith({
-          target: {
-            name: 'number-input',
-            value: 1001,
-          },
-        })
-      })
-
-      describe('and the decrease button is clicked', () => {
-        beforeEach(() => {
-          wrapper.getByTestId('number-input-decrease').click()
-        })
-
-        it('should decrease the value by 1', () => {
-          const input = wrapper.getByTestId(
-            'number-input-input'
-          ) as HTMLInputElement
-          expect(input.value).toEqual('£ 1000')
-        })
-
-        it('should call the onChange callback', () => {
-          expect(onChangeSpy).toHaveBeenCalledTimes(2)
-          expect(onChangeSpy).toHaveBeenCalledWith({
-            target: {
-              name: 'number-input',
-              value: 1000,
-            },
-          })
-        })
-      })
+      assertInputValue('£ 999')
+      assertOnChangeCall(999)
     })
 
     describe('and the user focuses and then blurs the input', () => {
@@ -561,22 +429,8 @@ describe('NumberInput', () => {
         fireEvent.blur(input)
       })
 
-      it('should set the value to 1000', () => {
-        const input = wrapper.getByTestId(
-          'number-input-input'
-        ) as HTMLInputElement
-        expect(input.value).toEqual('£ 1000')
-      })
-
-      it('should call the onChange callback with 1000', () => {
-        expect(onChangeSpy).toHaveBeenCalledTimes(1)
-        expect(onChangeSpy).toHaveBeenCalledWith({
-          target: {
-            name: 'number-input',
-            value: 1000,
-          },
-        })
-      })
+      assertInputValue('£ 1000')
+      assertOnChangeCall(1000)
     })
   })
 })

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult, fireEvent } from '@testing-library/react'
 
 import { NumberInput } from './NumberInput'
+import { UNIT_POSITION } from './constants'
 
 describe('NumberInput', () => {
   let wrapper: RenderResult
@@ -479,6 +480,101 @@ describe('NumberInput', () => {
               value: 1000,
             },
           })
+        })
+      })
+    })
+  })
+
+  describe('when there is a unit before', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <NumberInput
+          name="number-input"
+          onChange={onChangeSpy}
+          value={1000}
+          unit="&pound;"
+          unitPosition={UNIT_POSITION.BEFORE}
+        />
+      )
+    })
+
+    it('should set the value', () => {
+      const input = wrapper.getByTestId(
+        'number-input-input'
+      ) as HTMLInputElement
+      expect(input.value).toEqual('£ 1000')
+    })
+
+    describe('and the increase button is clicked', () => {
+      beforeEach(() => {
+        wrapper.getByTestId('number-input-increase').click()
+      })
+
+      it('should increase the value by 1', () => {
+        const input = wrapper.getByTestId(
+          'number-input-input'
+        ) as HTMLInputElement
+        expect(input.value).toEqual('£ 1001')
+      })
+
+      it('should call the onChange callback', () => {
+        expect(onChangeSpy).toHaveBeenCalledTimes(1)
+        expect(onChangeSpy).toHaveBeenCalledWith({
+          target: {
+            name: 'number-input',
+            value: 1001,
+          },
+        })
+      })
+
+      describe('and the decrease button is clicked', () => {
+        beforeEach(() => {
+          wrapper.getByTestId('number-input-decrease').click()
+        })
+
+        it('should decrease the value by 1', () => {
+          const input = wrapper.getByTestId(
+            'number-input-input'
+          ) as HTMLInputElement
+          expect(input.value).toEqual('£ 1000')
+        })
+
+        it('should call the onChange callback', () => {
+          expect(onChangeSpy).toHaveBeenCalledTimes(2)
+          expect(onChangeSpy).toHaveBeenCalledWith({
+            target: {
+              name: 'number-input',
+              value: 1000,
+            },
+          })
+        })
+      })
+    })
+
+    describe('and the user focuses and then blurs the input', () => {
+      beforeEach(() => {
+        const input = wrapper.getByTestId(
+          'number-input-input'
+        ) as HTMLInputElement
+
+        fireEvent.focus(input)
+        fireEvent.blur(input)
+      })
+
+      it('should set the value to 1000', () => {
+        const input = wrapper.getByTestId(
+          'number-input-input'
+        ) as HTMLInputElement
+        expect(input.value).toEqual('£ 1000')
+      })
+
+      it('should call the onChange callback with 1000', () => {
+        expect(onChangeSpy).toHaveBeenCalledTimes(1)
+        expect(onChangeSpy).toHaveBeenCalledWith({
+          target: {
+            name: 'number-input',
+            value: 1000,
+          },
         })
       })
     })

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
@@ -417,4 +417,70 @@ describe('NumberInput', () => {
       })
     })
   })
+
+  describe('when there is a unit', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <NumberInput
+          name="number-input"
+          onChange={onChangeSpy}
+          value={1000}
+          unit="m"
+        />
+      )
+    })
+
+    it('should set the value', () => {
+      const input = wrapper.getByTestId(
+        'number-input-input'
+      ) as HTMLInputElement
+      expect(input.value).toEqual('1000 m')
+    })
+
+    describe('and the increase button is clicked', () => {
+      beforeEach(() => {
+        wrapper.getByTestId('number-input-increase').click()
+      })
+
+      it('should increase the value by 1', () => {
+        const input = wrapper.getByTestId(
+          'number-input-input'
+        ) as HTMLInputElement
+        expect(input.value).toEqual('1001 m')
+      })
+
+      it('should call the onChange callback', () => {
+        expect(onChangeSpy).toHaveBeenCalledTimes(1)
+        expect(onChangeSpy).toHaveBeenCalledWith({
+          target: {
+            name: 'number-input',
+            value: 1001,
+          },
+        })
+      })
+
+      describe('and the decrease button is clicked', () => {
+        beforeEach(() => {
+          wrapper.getByTestId('number-input-decrease').click()
+        })
+
+        it('should decrease the value by 1', () => {
+          const input = wrapper.getByTestId(
+            'number-input-input'
+          ) as HTMLInputElement
+          expect(input.value).toEqual('1000 m')
+        })
+
+        it('should call the onChange callback', () => {
+          expect(onChangeSpy).toHaveBeenCalledTimes(2)
+          expect(onChangeSpy).toHaveBeenCalledWith({
+            target: {
+              name: 'number-input',
+              value: 1000,
+            },
+          })
+        })
+      })
+    })
+  })
 })

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -1,7 +1,6 @@
 import React, { FormEvent } from 'react'
 import classNames from 'classnames'
-import isFinite from 'lodash/isFinite'
-import isNil from 'lodash/isNil'
+import { isFinite, isNil, without } from 'lodash'
 import { v4 as uuidv4 } from 'uuid'
 
 import { EndAdornment } from './EndAdornment'
@@ -12,7 +11,7 @@ import { useFocus } from './useFocus'
 import { useValue } from './useValue'
 import { UNIT_POSITION } from './constants'
 
-type UnitPosition = typeof UNIT_POSITION.AFTER
+type UnitPosition = typeof UNIT_POSITION.AFTER | typeof UNIT_POSITION.BEFORE
 
 export interface NumberInputProps {
   autoFocus?: boolean
@@ -45,14 +44,20 @@ function formatValue(
   }
 
   if (unit) {
-    return `${displayValue} ${unit}`
+    return unitPosition === UNIT_POSITION.AFTER
+      ? `${displayValue} ${unit}`
+      : `${unit} ${displayValue}`
   }
 
   return displayValue
 }
 
 function getNewValue(event: React.FormEvent<HTMLInputElement>, unit: string) {
-  return parseInt(event.currentTarget.value, 10)
+  const { value } = event.currentTarget
+  const valueParts = value.split(' ')
+  const valueWithoutUnit = without(valueParts, unit).join()
+
+  return parseInt(valueWithoutUnit, 10)
 }
 
 export const NumberInput: React.FC<NumberInputProps> = ({

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -14,10 +14,10 @@ import { Footnote } from './Footnote'
 export interface NumberInputProps {
   autoFocus?: boolean
   className?: string
-  isDisabled?: boolean
   footnote?: string
   id?: string
-  isCondensed?: boolean,
+  isCondensed?: boolean
+  isDisabled?: boolean
   label?: string
   max?: number
   min?: number
@@ -25,17 +25,17 @@ export interface NumberInputProps {
   onBlur?: (event: React.FormEvent) => void
   onChange: (event: any) => void
   placeholder?: string
+  startAdornment?: React.ReactNode | string
   step?: number
   value?: number
-  startAdornment?: React.ReactNode | string
 }
 
 export const NumberInput: React.FC<NumberInputProps> = ({
   className,
-  isDisabled = false,
   footnote,
   id = uuidv4(),
   isCondensed,
+  isDisabled = false,
   label,
   max,
   min,
@@ -43,9 +43,9 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   onBlur,
   onChange,
   placeholder = '',
+  startAdornment,
   step = 1,
   value,
-  startAdornment,
   ...rest
 }) => {
   const { hasFocus, onInputBlur, onInputFocus } = useFocus(onBlur)

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -5,11 +5,14 @@ import isNil from 'lodash/isNil'
 import { v4 as uuidv4 } from 'uuid'
 
 import { EndAdornment } from './EndAdornment'
+import { Footnote } from './Footnote'
 import { Input } from './Input'
 import { StartAdornment } from './StartAdornment'
 import { useFocus } from './useFocus'
 import { useValue } from './useValue'
-import { Footnote } from './Footnote'
+import { UNIT_POSITION } from './constants'
+
+type UnitPosition = typeof UNIT_POSITION.AFTER
 
 export interface NumberInputProps {
   autoFocus?: boolean
@@ -27,7 +30,29 @@ export interface NumberInputProps {
   placeholder?: string
   startAdornment?: React.ReactNode | string
   step?: number
+  unit?: string
+  unitPosition?: UnitPosition
   value?: number
+}
+
+function formatValue(
+  displayValue: number,
+  unit: string,
+  unitPosition: UnitPosition
+) {
+  if (isNil(displayValue)) {
+    return null
+  }
+
+  if (unit) {
+    return `${displayValue} ${unit}`
+  }
+
+  return displayValue
+}
+
+function getNewValue(event: React.FormEvent<HTMLInputElement>, unit: string) {
+  return parseInt(event.currentTarget.value, 10)
 }
 
 export const NumberInput: React.FC<NumberInputProps> = ({
@@ -45,6 +70,8 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   placeholder = '',
   startAdornment,
   step = 1,
+  unit,
+  unitPosition = UNIT_POSITION.AFTER,
   value,
   ...rest
 }) => {
@@ -62,14 +89,14 @@ export const NumberInput: React.FC<NumberInputProps> = ({
 
   function onInputBlurSetCommittedValue(event: FormEvent<HTMLInputElement>) {
     setNextValue(null)
-    const newValue = parseInt(event.currentTarget.value, 10)
+    const newValue = getNewValue(event, unit)
 
     setCommittedValueIfWithinRange(max, min, name, onChange)(event, newValue)
     onInputBlur(event)
   }
 
   function onInputChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const newValue = parseInt(event.currentTarget.value, 10)
+    const newValue = getNewValue(event, unit)
     if (isFinite(newValue)) {
       setNextValue(newValue)
     }
@@ -90,7 +117,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
           onInputBlur={onInputBlurSetCommittedValue}
           onInputFocus={onInputFocus}
           placeholder={placeholder}
-          value={displayValue}
+          value={formatValue(displayValue, unit, unitPosition)}
           {...rest}
         />
 

--- a/packages/react-component-library/src/components/NumberInput/constants.ts
+++ b/packages/react-component-library/src/components/NumberInput/constants.ts
@@ -3,4 +3,9 @@ const END_ADORNMENT_TYPE = {
   INCREASE: 'increase',
 } as const
 
-export { END_ADORNMENT_TYPE }
+const UNIT_POSITION = {
+  AFTER: 'after',
+  BEFORE: 'before',
+} as const
+
+export { END_ADORNMENT_TYPE, UNIT_POSITION }

--- a/packages/react-component-library/src/components/NumberInput/index.ts
+++ b/packages/react-component-library/src/components/NumberInput/index.ts
@@ -1,1 +1,2 @@
+export * from './constants'
 export * from './NumberInput'


### PR DESCRIPTION
## Related issue
Closes #978 

## Overview
Adds the ability to specify a unit before or after the actual number valiue.

## Reason
Required for an exemplar and it's useful for other consumers.

## Work carried out
- [x] Add unit after
- [x] Add unit before
- [x] Refactor code

## Screenshot
### Unit after
![after](https://user-images.githubusercontent.com/56078793/84636859-fb4f1400-aeec-11ea-85eb-051cc3460bed.gif)

### Unit before
![before](https://user-images.githubusercontent.com/56078793/84636869-fee29b00-aeec-11ea-873e-9c52b7daedab.gif)

## Developer notes
A request was made to set the unit as neutral 400 but this is not possible without significant rework.