### PR TITLE
feat(RangeSlider): Add threshold functionality

### DIFF
--- a/packages/css-framework/src/components/_range-slider.scss
+++ b/packages/css-framework/src/components/_range-slider.scss
@@ -1,10 +1,12 @@
 @use "../abstracts/functions" as f;
 @use "../abstracts/mixins" as m;
 
-
 $range-slider-bg-colour: f.color("neutral", "100");
 $range-slider-track-colour: f.color("action", "500");
 $range-slider-handle-colour: f.color("action", "500");
+$range-slider-track-below-first-threshold: f.color("danger", "500");
+$range-slider-track-between-thresholds: f.color("warning", "500");
+$range-slider-above-thresholds: f.color("action", "500");
 
 .rn-rangeslider {
   display: inline-flex;
@@ -107,6 +109,18 @@ $range-slider-handle-colour: f.color("action", "500");
   z-index: 1;
   background-color: $range-slider-track-colour;
   cursor: pointer;
+}
+
+.rn-rangeslider__track--below-first-threshold {
+  background-color: $range-slider-track-below-first-threshold;
+}
+
+.rn-rangeslider__track--between-thresholds {
+  background-color: $range-slider-track-between-thresholds;
+}
+
+.rn-rangeslider__track--above-thresholds {
+  background-color: $range-slider-above-thresholds;
 }
 
 .rn-rangeslider__ticks {

--- a/packages/docs-site/src/library/pages/components/range-slider.md
+++ b/packages/docs-site/src/library/pages/components/range-slider.md
@@ -71,6 +71,50 @@ Range Slider allows the user to move a 'handle' to select a single value or rang
   />
 </CodeHighlighter>
 
+### Single Threshold
+
+<CodeHighlighter source={`<RangeSlider
+  domain={[0, 40]}
+  mode={1}
+  values={[20]}
+  onChange={() => {}}
+  onUpdate={() => {}}
+  tracksLeft
+  thresholds={[25]}
+/>`} language="javascript">
+  <RangeSlider
+    domain={[0, 40]}
+    mode={1}
+    values={[20]}
+    onChange={() => {}}
+    onUpdate={() => {}}
+    tracksLeft
+    thresholds={[25]}
+  />
+</CodeHighlighter>
+
+### Double Threshold
+
+<CodeHighlighter source={`<RangeSlider
+  domain={[0, 40]}
+  mode={1}
+  values={[20]}
+  onChange={() => {}}
+  onUpdate={() => {}}
+  tracksLeft
+  thresholds={[25, 50]}
+/>`} language="javascript">
+  <RangeSlider
+    domain={[0, 40]}
+    mode={1}
+    values={[20]}
+    onChange={() => {}}
+    onUpdate={() => {}}
+    tracksLeft
+    thresholds={[25, 50]}
+  />
+</CodeHighlighter>
+
 ### Stepped
 
 <CodeHighlighter source={`<RangeSlider
@@ -172,6 +216,7 @@ Range Slider allows the user to move a 'handle' to select a single value or rang
 </CodeHighlighter>
 
 ### Reversed scale
+
 <CodeHighlighter source={`<RangeSlider
   domain={[0, 40]}
   step={10}
@@ -263,6 +308,13 @@ Additional details about props can be found [here](https://sghall.github.io/reac
     Required: 'True',
     Default: '',
     Description: 'An array of numbers. You can supply one for a value slider, two for a range slider or more to create n-handled sliders. The values should correspond to valid step values in the domain. The numbers will be forced into the domain if they are two small or large.',
+  },
+  {
+    Name: 'thresholds',
+    Type: 'number[]',
+    Required: 'False',
+    Default: '',
+    Description: 'An array of user defined thresholds. This is a percentage value. You can specify up to two distinct thresholds. The first value represents the lower threshold and second the upper.',
   },
   {
     Name: 'onChange',

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -32,6 +32,30 @@ examples.add('Stepped', () => (
   />
 ))
 
+examples.add('Single threshold', () => (
+  <RangeSlider
+    domain={[0, 40]}
+    mode={1}
+    values={[20]}
+    onChange={action('onChange')}
+    onUpdate={action('onUpdate')}
+    tracksLeft
+    thresholds={[40]}
+  />
+))
+
+examples.add('Double threshold', () => (
+  <RangeSlider
+    domain={[0, 40]}
+    mode={1}
+    values={[20]}
+    onChange={action('onChange')}
+    onUpdate={action('onUpdate')}
+    tracksLeft
+    thresholds={[40, 60]}
+  />
+))
+
 examples.add('Multiple handles', () => (
   <RangeSlider
     domain={[0, 40]}

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
@@ -73,6 +73,49 @@ describe('RangeSlider', () => {
     })
   })
 
+  describe('single threshold', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <RangeSlider
+          mode={mode}
+          domain={domain}
+          values={values}
+          tracksLeft
+          thresholds={[10]}
+        />
+      )
+    })
+
+    it('renders the correct track chunks', () => {
+      expect(
+        wrapper.queryByTestId('rangeslider-chunk-below-first-threshold')
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('double threshold', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <RangeSlider
+          mode={mode}
+          domain={domain}
+          values={values}
+          tracksLeft
+          thresholds={[10, 15]}
+        />
+      )
+    })
+
+    it('renders the correct track chunks', () => {
+      expect(
+        wrapper.queryByTestId('rangeslider-chunk-below-first-threshold')
+      ).toBeInTheDocument()
+      expect(
+        wrapper.queryByTestId('rangeslider-chunk-between-thresholds')
+      ).toBeInTheDocument()
+    })
+  })
+
   describe('disabled', () => {
     beforeEach(() => {
       wrapper = render(

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -10,9 +10,10 @@ import {
   Ticks,
 } from 'react-compound-slider'
 
-import { Handle, Track, Tick } from './index'
+import { Handle, Track, ThresholdTrack, Tick } from '.'
 
-interface RangeSliderProps extends Omit<SliderProps, 'children' | 'disabled' | 'reversed'> {
+interface RangeSliderProps
+  extends Omit<SliderProps, 'children' | 'disabled' | 'reversed'> {
   hasLabels?: boolean
   tracksLeft?: boolean
   tracksRight?: boolean
@@ -21,6 +22,7 @@ interface RangeSliderProps extends Omit<SliderProps, 'children' | 'disabled' | '
   IconRight?: React.ElementType
   isDisabled?: boolean
   isReversed?: boolean
+  thresholds?: number[]
 }
 
 export const RangeSlider: React.FC<RangeSliderProps> = ({
@@ -37,6 +39,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
   isDisabled,
   values,
   onUpdate,
+  thresholds,
   ...rest
 }) => {
   const [sliderValues, setSliderValues] = useState(values)
@@ -79,7 +82,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
         <Handles>
           {({ activeHandleID, handles, getHandleProps }) => (
             <div className="rn-rangeslider__handles">
-              {handles.map(handle => (
+              {handles.map((handle) => (
                 <Handle
                   key={handle.id}
                   handle={handle}
@@ -94,15 +97,30 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
         <Tracks left={tracksLeft} right={tracksRight}>
           {({ tracks, getTrackProps }) => (
             <div className="rn-rangeslider__tracks">
-              {tracks.map(({ id, source, target }) => (
-                <Track
-                  id={id}
-                  key={id}
-                  source={source}
-                  target={target}
-                  getTrackProps={getTrackProps}
-                />
-              ))}
+              {tracks.map(({ id, source, target }) => {
+                if (thresholds) {
+                  return (
+                    <ThresholdTrack
+                      id={id}
+                      key={id}
+                      source={source}
+                      target={target}
+                      getTrackProps={getTrackProps}
+                      thresholds={thresholds}
+                    />
+                  )
+                }
+
+                return (
+                  <Track
+                    id={id}
+                    key={id}
+                    source={source}
+                    target={target}
+                    getTrackProps={getTrackProps}
+                  />
+                )
+              })}
             </div>
           )}
         </Tracks>
@@ -110,7 +128,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
           <Ticks count={tickCount}>
             {({ ticks }) => (
               <div className="rn-rangeslider__ticks">
-                {ticks.map(tick => (
+                {ticks.map((tick) => (
                   <Tick
                     key={tick.id}
                     tick={tick}

--- a/packages/react-component-library/src/components/RangeSlider/ThresholdTrack.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/ThresholdTrack.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import classNames from 'classnames'
+import { TrackItem, GetTrackProps } from 'react-compound-slider'
+
+interface ThresholdTrackProps extends TrackItem {
+  getTrackProps: GetTrackProps
+  thresholds?: number[]
+}
+
+interface ChunkProps extends ComponentWithClass {
+  left: number
+  width: number
+  maxWidth: number
+  testId: string
+}
+
+export const ThresholdTrack: React.FC<ThresholdTrackProps> = ({
+  target,
+  getTrackProps,
+  thresholds,
+}) => {
+  const singleThreshold = thresholds?.length === 1
+  const doubleThreshold = thresholds?.length === 2
+
+  const Chunk: React.FC<ChunkProps> = ({
+    className,
+    left,
+    width,
+    maxWidth,
+    testId,
+  }) => {
+    const classes = classNames('rn-rangeslider__track', className)
+
+    return (
+      <div
+        className={classes}
+        style={{
+          left: `${left}%`,
+          width: `${width}%`,
+          maxWidth: `${maxWidth}%`,
+        }}
+        {...getTrackProps()}
+        data-testid={`rangeslider-chunk-${testId}`}
+      />
+    )
+  }
+
+  return (
+    <>
+      {(singleThreshold || doubleThreshold) && (
+        <Chunk
+          className="rn-rangeslider__track--below-first-threshold"
+          left={0}
+          width={target.percent}
+          maxWidth={thresholds[0]}
+          testId="below-first-threshold"
+        />
+      )}
+
+      {doubleThreshold && (
+        <Chunk
+          className="rn-rangeslider__track--between-thresholds"
+          left={thresholds[0]}
+          width={thresholds[1] - thresholds[0]}
+          maxWidth={Math.max(0, target.percent - thresholds[0])}
+          testId="between-thresholds"
+        />
+      )}
+
+      <Chunk
+        className="rn-rangeslider__track--above-thresholds"
+        left={thresholds[thresholds.length - 1]}
+        width={target.percent - thresholds[thresholds.length - 1]}
+        maxWidth={target.percent}
+        testId="above-thresholds"
+      />
+    </>
+  )
+}
+
+ThresholdTrack.displayName = 'ThresholdTrack'

--- a/packages/react-component-library/src/components/RangeSlider/index.ts
+++ b/packages/react-component-library/src/components/RangeSlider/index.ts
@@ -1,4 +1,5 @@
 export * from './Slider'
 export * from './Handle'
 export * from './Track'
+export * from './ThresholdTrack'
 export * from './Tick'


### PR DESCRIPTION
## Related issue

Closes #979

## Overview

Add threshold functionality to RangeSlider component.

## Reason

>We're implementing a "threshold" version of this component.
>
>The devs will be able to supply thresholds for the range selector, changing the colour appropriately. When the user then moves the range slider handle, the range slider will change colour based on its position of the handle. The range slider can have up to three colours - action, warning, and danger.
>
>The order of the colours are danger, then warning, and then the default action. danger and warning are both optional, and their limits are custom set via prop values.

## Work carried out

- [x] Implement Threshold feature
- [x] Add example stories to Storybook
- [x] Add automated tests
- [x] Update documentation

## Screenshot

![2020-06-16 12 24 05](https://user-images.githubusercontent.com/48086589/84768588-64f21f80-afcc-11ea-9518-e78ed72f8cf8.gif)

