### PR TITLE
Fix collapsible DataList expand in legacy browsers

### DIFF
--- a/packages/css-framework/index.scss
+++ b/packages/css-framework/index.scss
@@ -28,7 +28,6 @@
 @use "src/base/normalize";
 @use "src/base/box-sizing";
 @use "src/base/fonts";
-@use "src/base/dev";
 
 
 // Components

--- a/packages/css-framework/src/base/_dev.scss
+++ b/packages/css-framework/src/base/_dev.scss
@@ -1,8 +1,0 @@
-@use "../config";
-
-@if config.$dev-mode == true {
-  // Adds padding to the storybook wrapper
-  .sb-show-main {
-    padding: 40px;
-  }
-}

--- a/packages/css-framework/src/components/_btn.scss
+++ b/packages/css-framework/src/components/_btn.scss
@@ -172,7 +172,7 @@ $btn-focus-width: 0.2rem;
   flex-direction: row-reverse;
 
   .rn-btn__icon {
-    margin-left: unset;
+    margin-left: 0;
     margin-right: f.spacing("3");
   }
 }

--- a/packages/css-framework/src/components/_data-list.scss
+++ b/packages/css-framework/src/components/_data-list.scss
@@ -59,7 +59,7 @@
       }
       .rn-data-list__sheet {
         transform: scale(1, 1);
-        height: unset;
+        height: auto;
         overflow: hidden;
       }
     }

--- a/packages/css-framework/src/components/_timeline.scss
+++ b/packages/css-framework/src/components/_timeline.scss
@@ -4,10 +4,6 @@ $timeline-border-color: f.color("neutral", "100");
 $timeline-bg-color: f.color("neutral", "000");
 $timeline-alt-bg-color: f.color("neutral", "white");
 
-.sb-show-main {
-  padding: unset;
-}
-
 .timeline {
   position: relative;
   display: flex;

--- a/packages/css-framework/src/objects/_floating-box.scss
+++ b/packages/css-framework/src/objects/_floating-box.scss
@@ -206,7 +206,7 @@ a.rn-floating-box__footer-link {
   .rn-floating-box--left_bottom .rn-floating-box__content:after,
   .rn-floating-box--right_bottom .rn-floating-box__content:before,
   .rn-floating-box--right_bottom .rn-floating-box__content:after {
-    top: unset;
+    top: auto;
     bottom: 15px;
   }
 
@@ -226,7 +226,7 @@ a.rn-floating-box__footer-link {
   .rn-floating-box--top_right .rn-floating-box__content:after,
   .rn-floating-box--bottom_right .rn-floating-box__content:before,
   .rn-floating-box--bottom_right .rn-floating-box__content:after {
-    left: unset;
+    left: auto;
     right: 15px;
   }
 }


### PR DESCRIPTION
## Related issue
Fixes #1002 

## Overview
The collapsible `DataList` was not expanding as expected in legacy browsers. The issue is that we are using `unset`.

## Reason
All components need to function in legacy browsers.

## Work carried out
- [x] Fix `DataList`
- [x] Replace other uses of `unset`

## Screenshot
![datalist](https://user-images.githubusercontent.com/56078793/84874411-73980f80-b07c-11ea-9ad5-3cfb15a12de3.gif)