### PR TITLE
fix(DatePicker): Prevent other fields losing focus

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import { withFormik } from '../../enhancers/withFormik'
 import { DatePicker, DATEPICKER_PLACEMENT } from '.'
 
+import { TextInput } from '../TextInput'
 import { Button } from '../Button'
 
 const stories = storiesOf('DatePicker', module)
@@ -56,15 +57,18 @@ examples.add('Range', () => {
 
 const DatePickerForm = () => {
   interface Data {
+    foo: string
     startDate: Date
     endDate: Date
   }
 
   const initialValues: Data = {
+    foo: '',
     startDate: new Date('01/01/2020'),
     endDate: new Date('01/05/2020'),
   }
 
+  const FormikTextInput = withFormik(TextInput)
   const FormikDatePicker = withFormik(DatePicker)
 
   return (
@@ -74,6 +78,7 @@ const DatePickerForm = () => {
       render={({ setFieldValue }) => {
         return (
           <Form>
+            <Field name="foo" label="Foo" component={FormikTextInput} />
             <Field
               name="date"
               label="Date"

--- a/packages/react-component-library/src/components/DatePicker/Day.tsx
+++ b/packages/react-component-library/src/components/DatePicker/Day.tsx
@@ -66,7 +66,7 @@ export const Day: React.FC<DayProps> = ({ dayLabel, date }) => {
       onMouseEnter={onMouseEnter}
       tabIndex={tabIndex}
       type="button"
-      ref={dayRef}
+      // ref={dayRef} https://github.com/tresko/react-datepicker/issues/91
       data-testid={`datepicker-day-${dayLabel}`}
     >
       {dayLabel}


### PR DESCRIPTION
## Related issue

Closes #985

## Overview

There appears to be a bug within the `@datepicker-react/hooks` library causing adjacent input fields to lose focus. I'm hotfixing our implementation by removing a rogue ref. 

Consequences are a temporary loss of keyboard control for the DatePicker component while we await a permanent fix upstream.

An issue exists with the library repository (https://github.com/tresko/react-datepicker/issues/91) - we'll be aiding with deeper investigation into underlying cause there.