### PR TITLE
fix(Timeline): Remove end date extension

### DIFF
--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
@@ -18,7 +18,7 @@ function getWidth (
   return differenceInCalendarDays(
     new Date(endDate),
     new Date(startDate)
-  ) + 1 // End day === full day
+  )
 }
 
 function getOffset (


### PR DESCRIPTION
## Related issue

Closes #1085

## Overview

Remove +1 from `useTimelinePosition` hook width generation.