### PR TITLE
feat(Masthead): Add ability to have no service logo

### DIFF
--- a/packages/css-framework/src/fragments/_masthead.scss
+++ b/packages/css-framework/src/fragments/_masthead.scss
@@ -34,7 +34,7 @@ $masthead-main-height: 58px;
     box-shadow: 0 0 0 0.2rem rgba(f.color("action", "700") , 0.5);
   }
 
-  .rn-masthead__title {
+  &.rn-masthead__service--has-logo .rn-masthead__title {
     margin-left: f.spacing("4");
   }
 }

--- a/packages/docs-site/src/library/pages/components/masthead.md
+++ b/packages/docs-site/src/library/pages/components/masthead.md
@@ -130,6 +130,13 @@ Aside from the active page links (an example of these states is shown in the [Ta
 ### Properties
 <DataTable caption="MastHead" data={[
   {
+    Name: 'hasDefaultLogo',
+    Type: 'boolean',
+    Required: 'False',
+    Default: 'True',
+    Description: 'If `true`, a default logo is used when `Logo` is not passed. If `false`, no logo is displayed when `Logo` is not passed.',
+  },
+  {
     Name: 'hasUnreadNotification',
     Type: 'boolean',
     Required: 'False',
@@ -140,48 +147,56 @@ Aside from the active page links (an example of these states is shown in the [Ta
     Name: 'homeLink',
     Type: 'React.ReactElement<LinkTypes>',
     Required: 'False',
+    Default: '',
     Description: 'A `Link` which will contain the `href` for sending the user back to home.',
   },
   {
     Name: 'Logo',
     Type: 'React. ComponentType',
     Required: 'False',
-    Description: 'A 21x19 logo or if none is provided a default is used.',
+    Default: '',
+    Description: 'A 21x19 logo. If no value is passed, the behaviour depends on the value of `hasDefaultLogo`.',
   },
   {
     Name: 'nav',
     Type: 'React.ReactElement<ScrollableNavProps>',
     Required: 'False',
+    Default: '',
     Description: 'Navigation for the MastHead.',
   },
   {
     Name: 'notifications',
     Type: 'React.ReactElement<NotificationsProps>',
     Required: 'False',
+    Default: '',
     Description: 'This property contains the content for the Notifications Popover. These are recent notifications, including read status, and a link to read them.',
   },
   {
     Name: 'onSearch',
     Type: '(term: string) => void',
     Required: 'False',
+    Default: '',
     Description: 'If a search function is provided the searchbox is shown and the function called on submission.',
   },
   {
     Name: 'searchPlaceholder',
     Type: 'String',
     Required: 'False',
+    Default: '',
     Description: 'Provide a placeholder attribute for the search text input if desired.',
   },
   {
     Name: 'title',
     Type: 'String',
     Required: 'True',
+    Default: '',
     Description: 'A service name that will be displayed next to the logo',
   },
   {
     Name: 'user',
     Type: 'React.ReactElement<MastheadUserProps>',
     Required: 'False',
+    Default: '',
     Description: 'If your application has a User Profile page, specify a `MastheadUser` to add their initials to the Avatar sub-component. This Avatar provides a link to the User’s profile.',
   },
 ]} />

--- a/packages/react-component-library/src/components/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/Masthead/Masthead.stories.tsx
@@ -87,6 +87,28 @@ stories.add('Without search', () => <Masthead title="Test" />)
 
 stories.add('Custom logo', () => <Masthead title="Test" Logo={CustomLogo} />)
 
+stories.add('Without logo', () => (
+  <Masthead title="Test" hasDefaultLogo={false} />
+))
+
+stories.add('Without logo, with navigation', () => (
+  <Masthead
+    title="Test"
+    hasDefaultLogo={false}
+    nav={(
+      <MastheadNav>
+        <MastheadNavItem
+          link={<Link href="/home">Get started</Link>}
+          isActive
+        />
+        <MastheadNavItem link={<Link href="/styles">Styles</Link>} />
+        <MastheadNavItem link={<Link href="/components">Components</Link>} />
+        <MastheadNavItem link={<Link href="/about">About</Link>} />
+      </MastheadNav>
+    )}
+  />
+))
+
 stories.add('all but navigation', () => (
   <Masthead
     homeLink={<Link href="/" />}

--- a/packages/react-component-library/src/components/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/components/Masthead/Masthead.test.tsx
@@ -18,7 +18,7 @@ describe('Masthead', () => {
   let wrapper: RenderResult
   let props: MastheadProps
 
-  describe('When the title it provided', () => {
+  describe('When the title is provided', () => {
     beforeEach(() => {
       props = {
         title: 'Test masthead',
@@ -59,6 +59,18 @@ describe('Masthead', () => {
 
       it('should not render a user link', () => {
         expect(wrapper.queryByTestId('userlink')).toBeNull()
+      })
+    })
+
+    describe('and hasDefaultLogo is false', () => {
+      beforeEach(() => {
+        props.hasDefaultLogo = false
+
+        wrapper = render(<Masthead {...props} />)
+      })
+
+      it("doesn't render a logo", () => {
+        expect(wrapper.queryByTestId('logo')).toBeNull()
       })
     })
 

--- a/packages/react-component-library/src/components/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/components/Masthead/Masthead.tsx
@@ -14,6 +14,7 @@ import { Searchbar } from '../Searchbar'
 import { useMastheadSearch } from './useMastheadSearch'
 
 export interface MastheadProps {
+  hasDefaultLogo?: boolean
   hasUnreadNotification?: boolean
   homeLink?: React.ReactElement<LinkTypes>
   Logo?: React.ComponentType
@@ -36,20 +37,23 @@ function getServiceName(
     ...link.props,
     children: (
       <>
-        <Logo />
+        {Logo && <Logo />}
         <span className="rn-masthead__title" data-testid="masthead-servicename">
           {title}
         </span>
       </>
     ),
-    className: 'rn-masthead__service-name',
+    className: classNames('rn-masthead__service-name', {
+      'rn-masthead__service--has-logo': Logo,
+    }),
   })
 }
 
 export const Masthead: React.FC<MastheadProps> = ({
+  hasDefaultLogo = true,
   hasUnreadNotification,
   homeLink,
-  Logo = DefaultLogo,
+  Logo,
   nav,
   notifications,
   onSearch,
@@ -67,6 +71,8 @@ export const Masthead: React.FC<MastheadProps> = ({
     showSearch,
     toggleSearch,
   } = useMastheadSearch()
+
+  const DisplayLogo = Logo ?? (hasDefaultLogo ? DefaultLogo : null)
 
   const classes = classNames('rn-masthead', {
     'rn-masthead--show-search': showSearch,
@@ -90,7 +96,7 @@ export const Masthead: React.FC<MastheadProps> = ({
   return (
     <div className={classes} data-testid="masthead" ref={mastheadContainerRef}>
       <div className="rn-masthead__main">
-        {getServiceName(homeLink, Logo, title)}
+        {getServiceName(homeLink, DisplayLogo, title)}
 
         <div className="rn-masthead__options">
           {onSearch && (


### PR DESCRIPTION
## Related issue

Closes #1106 

## Overview

This adds a new `hasDefaultLogo` prop to `Masthead` to control whether a default logo is used when no logo is specified. By setting this to `false` and not passing a value for `Logo`, there's now a way to show no logo in the `Masthead`.

## Reason

Not all services have a logo. Before, you could chose between a default logo or a custom logo, but there was no way to display no logo which some services will want to do.

## Work carried out

- [x] Add new `hasDefaultLogo` prop to Masthead
- [x] Update unit tests
- [x] Update docs

## Screenshot

### No logo

![image](https://user-images.githubusercontent.com/66470099/86019453-89171d00-ba1e-11ea-9574-205cddb16684.png)

### With logo (and some other bits)

![image](https://user-images.githubusercontent.com/66470099/86019513-9c29ed00-ba1e-11ea-9276-4c8466621dcd.png)

(This one should be as it was before.)

## Developer notes

- A new prop was used to avoid introducing a breaking change.
- The CSS changes are because the padding between the logo and service name needs to be removed when a logo isn't shown.
- There was a problem with the props table in the docs where some of the descriptions were in the wrong column. I fixed this by following what was done in the docs for other components and setting Default for all rows.