### PR TITLE
ci(Pipeline): Refactor publish_next

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,23 @@ jobs:
       - dependencies
       - attach_workspace:
           at: packages
+      - *authenticate_npm
+      - deploy: #deploy step is important to prevent triggering N builds
+          name: Publish next packages
+          command: >-
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/css-framework &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/eslint-config-react &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/fonts &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/icon-library &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/react-component-library &&
+            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/cra-template-royalnavy
+  commit_next:
+    docker: *docker
+    steps:
+      - checkout
+      - dependencies
+      - attach_workspace:
+          at: packages
       - run:
           name: Configure Git
           command: >-
@@ -171,19 +188,12 @@ jobs:
             git config user.name "${GH_NAME}" &&
             git remote set-url origin https://${GH_TOKEN}@github.com/Royal-Navy/design-system.git &&
             git checkout master
-      - *authenticate_npm
       - deploy: #deploy step is important to prevent triggering N builds
           name: Publish next packages
           command: >-
             yarn lerna:prerelease --yes --no-push &&
             git tag -d $(git describe --abbrev=0) &&
             git push origin master &&
-            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/css-framework &&
-            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/eslint-config-react &&
-            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/fonts &&
-            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/icon-library &&
-            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/react-component-library &&
-            node ./scripts/npm/publish.js https://$NPM_REGISTRY next packages/cra-template-royalnavy
   test_docs-site:
     docker: *docker
     steps:
@@ -273,6 +283,13 @@ workflows:
     jobs:
       - build_icon-library:
           filters:
+            branches:
+              only:
+                - master
+      - commit_next:
+         requires:
+            - build_icon-library
+         filters:
             branches:
               only:
                 - master


### PR DESCRIPTION
## Related issue

fixes #1168 

## Overview

Refactor publish_next CI job

## Reason

To help prevent merge bottlenecks whilst a publish is happening

## Work carried out

Edited circle config - split out the commit from the publish_next job so we can commit before the tests are run
                                 - added new job into build_test_deploy_next workflow


