### PR TITLE
Fix Timeline keys

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -27,6 +27,7 @@ import {
 
 import { TimelineOptions } from './context/types'
 import { DEFAULTS } from './constants'
+import { getKey } from '../../helpers'
 
 type timelineRootChildrenType = React.ReactElement<TimelineSideProps>
 
@@ -116,11 +117,12 @@ export const Timeline: React.FC<TimelineProps> = ({
 
   const rootChildren = extractChildrenOf<TimelineRootComponent>(children, [
     TimelineSide.name,
-  ]).map((child) => {
+  ]).map((child, index) => {
     if (isComponentOf(child, [TimelineSide.name])) {
       return React.cloneElement(child, {
         rowGroups: extractRowData(bodyChildren),
         headChildren,
+        key: getKey('root-component', index),
       })
     }
 

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -133,7 +133,7 @@ export const Timeline: React.FC<TimelineProps> = ({
         {rootChildren}
         <div className="timeline__inner">
           <header className="timeline__header">{headChildren}</header>
-          <main className="timeline__main">{bodyChildren}</main>
+          {bodyChildren}
         </div>
       </article>
     </TimelineProvider>

--- a/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
@@ -2,12 +2,12 @@ import React from 'react'
 import { format } from 'date-fns'
 import classNames from 'classnames'
 
-import { getKey } from './helpers'
+import { withKey } from '../../helpers'
 import { TimelineContext } from './context'
 import { DATE_DAY_FORMAT } from './constants'
 
 export interface TimelineDaysWithRenderContentProps {
-  render: (index: number, dayWidth: number, date: Date) => React.ReactNode
+  render: (index: number, dayWidth: number, date: Date) => React.ReactElement
 }
 
 export interface TimelineDaysWithChildrenProps {
@@ -32,7 +32,6 @@ function renderDefault(index: number, dayWidth: number, date: Date) {
   return (
     <div
       className={wrapperClasses}
-      key={getKey('timeline-day', index)}
       style={{
         width: `${dayWidth}px`,
       }}
@@ -60,9 +59,11 @@ export const TimelineDays: React.FC<TimelineDaysProps> = ({ render }) => {
         <div className={classes} data-testid="timeline-days">
           {days &&
             days.map(({ date }, index) => {
-              return render
+              const child = render
                 ? render(index, dayWidth, date)
                 : renderDefault(index, dayWidth, date)
+
+              return withKey(child, 'timeline-day', date.toString())
             })}
         </div>
       )}

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { format, getDaysInMonth } from 'date-fns'
 import classNames from 'classnames'
 
-import { formatPx, getKey } from './helpers'
+import { formatPx } from './helpers'
+import { withKey } from '../../helpers'
 import { TimelineContext } from './context'
 import { DATE_MONTH_FORMAT } from './constants'
 
@@ -13,7 +14,7 @@ export interface TimelineMonthsWithRenderContentProps
     dayWidth: number,
     daysTotal: number,
     startDate: Date
-  ) => React.ReactNode
+  ) => React.ReactElement
 }
 
 export interface TimelineMonthsWithChildrenProps extends ComponentWithClass {
@@ -29,7 +30,7 @@ function renderDefault(
   dayWidth: number,
   daysTotal: number,
   startDate: Date
-) {
+): React.ReactElement {
   const wrapperClasses = classNames(
     'timeline__month',
     'timeline__month--renderDefault'
@@ -43,7 +44,6 @@ function renderDefault(
   return (
     <div
       className={wrapperClasses}
-      key={getKey('timeline-month', index)}
       style={{
         width: formatPx(dayWidth, daysTotal),
       }}
@@ -70,9 +70,11 @@ export const TimelineMonths: React.FC<TimelineMonthsProps> = ({ render }) => {
             months.map(({ startDate }, index) => {
               const daysTotal = getDaysInMonth(startDate)
 
-              return render
+              const child = render
                 ? render(index, dayWidth, daysTotal, startDate)
                 : renderDefault(index, dayWidth, daysTotal, startDate)
+
+              return withKey(child, 'timeline-month', startDate.toString())
             })}
         </div>
       )}

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -116,4 +116,4 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
   )
 }
 
-TimelineRows.displayName = 'Rows'
+TimelineRows.displayName = 'TimelineRows'

--- a/packages/react-component-library/src/components/Timeline/TimelineSide.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineSide.tsx
@@ -3,7 +3,7 @@ import { IconChevronRight, IconChevronLeft } from '@royalnavy/icon-library'
 import { startCase } from 'lodash'
 
 import { Button } from '../Button'
-import { getKey } from './helpers'
+import { getKey } from '../../helpers'
 import { TimelineContext } from './context'
 import { TIMELINE_ACTIONS } from './context/types'
 
@@ -18,13 +18,14 @@ const TimelineSideList: React.FC<TimelineSideProps> = ({
 }) => {
   return (
     <ol className="timeline__side-list">
-      {headChildren.map(({ type: { displayName } }) => {
+      {headChildren.map(({ type: { displayName } }, index) => {
         const name = displayName.toLowerCase().substring('timeline'.length)
 
         if (!['months', 'weeks', 'days'].includes(name)) return null
 
+        const className = `timeline__side-${name}`
         return (
-          <li className={`timeline__side-${name}`}>
+          <li className={className} key={getKey(className, index)}>
             <span className="timeline__side-title">{startCase(name)}</span>
           </li>
         )

--- a/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
@@ -3,7 +3,8 @@ import classNames from 'classnames'
 import { format, differenceInDays } from 'date-fns'
 
 import { DATE_WEEK_FORMAT } from './constants'
-import { formatPx, getKey, isOdd } from './helpers'
+import { formatPx, isOdd } from './helpers'
+import { withKey } from '../../helpers'
 import { TimelineContext } from './context'
 
 export interface TimelineWeeksWithRenderContentProps
@@ -16,7 +17,7 @@ export interface TimelineWeeksWithRenderContentProps
     dayWidth: number,
     daysTotal: number,
     startDate: Date
-  ) => React.ReactNode
+  ) => React.ReactElement
 }
 
 export interface TimelineWeeksWithChildrenProps extends ComponentWithClass {
@@ -52,7 +53,6 @@ function renderDefault(
   return (
     <div
       className={wrapperClasses}
-      key={getKey('timeline-week', index)}
       style={{
         marginLeft: offsetPx,
         width: widthPx,
@@ -99,7 +99,9 @@ export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({ render }) => {
             ]
 
             // @ts-ignore
-            return render ? render(...args) : renderDefault(...args)
+            const child = render ? render(...args) : renderDefault(...args)
+
+            return withKey(child, 'timeline-week', startDate.toString())
           })
         }}
       </TimelineContext.Consumer>

--- a/packages/react-component-library/src/components/Timeline/helpers/getKey.ts
+++ b/packages/react-component-library/src/components/Timeline/helpers/getKey.ts
@@ -1,6 +1,0 @@
-export function getKey(
-  prefix: string,
-  index: number | string
-): string {
-  return `${prefix}-${index}`
-}

--- a/packages/react-component-library/src/components/Timeline/helpers/index.ts
+++ b/packages/react-component-library/src/components/Timeline/helpers/index.ts
@@ -1,3 +1,2 @@
 export * from './formatPx'
-export * from './getKey'
 export * from './isOdd'

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -1,3 +1,5 @@
+import React from 'react'
+
 function getKey(prefix: string, suffix: string | number): string {
   return `${prefix}-${suffix}`.replace(/\s/g, '')
 }
@@ -14,4 +16,18 @@ function warnIfOverwriting<P>(
   }
 }
 
-export { getKey, warnIfOverwriting }
+function withKey(
+  element: React.ReactElement,
+  prefix: string,
+  suffix: string | number
+) {
+  if (element) {
+    return React.cloneElement(element, {
+      key: getKey(prefix, suffix),
+    })
+  }
+
+  return null
+}
+
+export { getKey, warnIfOverwriting, withKey }

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -1,8 +1,12 @@
 function getKey(prefix: string, index: string | number): string {
-  return `${prefix}-${index}`.replace(/\s/g,'')
+  return `${prefix}-${index}`.replace(/\s/g, '')
 }
 
-function warnIfOverwriting<P>(props: P, propertyName: string, componentName: string) {
+function warnIfOverwriting<P>(
+  props: P,
+  propertyName: string,
+  componentName: string
+) {
   if (props[propertyName]) {
     console.warn(
       `Prop \`${propertyName}\` on \`${componentName}\` will be overwritten`

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -1,5 +1,5 @@
-function getKey(prefix: string, index: string | number): string {
-  return `${prefix}-${index}`.replace(/\s/g, '')
+function getKey(prefix: string, suffix: string | number): string {
+  return `${prefix}-${suffix}`.replace(/\s/g, '')
 }
 
 function warnIfOverwriting<P>(


### PR DESCRIPTION
## Related issue
Fixes #1153 

## Overview
#1153 was raised because there was duplicate rows when building for production. Investigation found that there was keys missing.

## Work carried out
- [x] Tweaks to `Timeline`
- [x] Fix `key` issue

## Screenshot
View #1153 for a screenshot of the original issue.
### Example of error in Storybook
<img width="1014" alt="Screenshot 2020-07-03 at 09 24 10" src="https://user-images.githubusercontent.com/56078793/86448675-02f52200-bd0f-11ea-9572-76628f56a325.png">

## Developer notes
`TimelineSide` is still using `index` to create a `key`. More work will be done on `TimelineSide` with the anticipation that we can fully remove the use of `index` for `key` generation.
