### PR TITLE
feat(Timeline): Add ability to bound by two dates

### DIFF
--- a/packages/docs-site/src/library/pages/timeline/index.md
+++ b/packages/docs-site/src/library/pages/timeline/index.md
@@ -104,6 +104,27 @@ yarn add @royalnavy/css-framework @royalnavy/react-component-library
 
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
+    <h1 className="rn-fw-api-title">
+      endDate
+    </h1>
+    <Badge color="supa" colorVariant="faded" size="small">Date</Badge>
+  </div>
+  <div className="rn-fw-api-body">
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Default Value</div>
+      <div className="rn-fw-api-value">
+        <code>-</code>
+      </div>
+    </div>
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Description</div>
+      <p className="rn-fw-api-value">Bound the timeline by the specified start and end dates.</p>
+    </div>
+  </div>
+</div>
+
+<div className="rn-fw-api">
+  <div className="rn-fw-api-header">
     <h1 className="rn-fw-api-title">today</h1>
     <Badge color="supa" colorVariant="faded" size="small">Date</Badge>
   </div>
@@ -526,6 +547,27 @@ Here you will find comprehensive API documentation for the Timeline Components.
     <div className="rn-fw-api-row">
       <div className="rn-fw-api-item">Description</div>
       <p className="rn-fw-api-value">A month will display either side of this start date.</p>
+    </div>
+  </div>
+</div>
+
+<div className="rn-fw-api">
+  <div className="rn-fw-api-header">
+    <h1 className="rn-fw-api-title">
+      endDate
+    </h1>
+    <Badge color="supa" colorVariant="faded" size="small">Date</Badge>
+  </div>
+  <div className="rn-fw-api-body">
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Default Value</div>
+      <div className="rn-fw-api-value">
+        <code>-</code>
+      </div>
+    </div>
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Description</div>
+      <p className="rn-fw-api-value">Bound the timeline by the specified start and end dates.</p>
     </div>
   </div>
 </div>

--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -18,7 +18,21 @@ import {
 const stories = storiesOf('Timeline', module)
 
 stories.add('No data', () => (
-  <Timeline startDate={new Date(2020, 4, 0)} today={new Date(2020, 3, 15)}>
+  <Timeline startDate={new Date(2020, 0, 1)} today={new Date(2020, 0, 15)}>
+    <TimelineTodayMarker />
+    <TimelineMonths />
+    <TimelineWeeks />
+    <TimelineDays />
+    <TimelineRows>{}</TimelineRows>
+  </Timeline>
+))
+
+stories.add('Bound by fixed dates', () => (
+  <Timeline
+    startDate={new Date(2020, 0, 13)}
+    endDate={new Date(2020, 1, 15)}
+    today={new Date(2020, 0, 15)}
+  >
     <TimelineTodayMarker />
     <TimelineMonths />
     <TimelineWeeks />
@@ -28,7 +42,7 @@ stories.add('No data', () => (
 ))
 
 stories.add('With data', () => (
-  <Timeline startDate={new Date(2020, 4, 0)} today={new Date(2020, 3, 15)}>
+  <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15)}>
     <TimelineTodayMarker />
     <TimelineMonths />
     <TimelineWeeks />
@@ -59,7 +73,7 @@ stories.add('With data', () => (
 ))
 
 stories.add('With sidebar', () => (
-  <Timeline startDate={new Date(2020, 4, 0)} today={new Date(2020, 3, 15)}>
+  <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15)}>
     <TimelineSide />
     <TimelineTodayMarker />
     <TimelineMonths />
@@ -115,7 +129,7 @@ stories.add('With custom months', () => {
   }
 
   return (
-    <Timeline startDate={new Date(2020, 4, 0)} today={new Date(2020, 3, 15)}>
+    <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15)}>
       <TimelineSide />
       <TimelineTodayMarker />
       <TimelineMonths render={CustomTimelineMonth} />
@@ -156,7 +170,7 @@ stories.add('With custom weeks', () => {
   }
 
   return (
-    <Timeline startDate={new Date(2020, 4, 0)} today={new Date(2020, 3, 15)}>
+    <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15)}>
       <TimelineSide />
       <TimelineTodayMarker />
       <TimelineMonths />
@@ -185,7 +199,7 @@ stories.add('With custom days', () => {
   }
 
   return (
-    <Timeline startDate={new Date(2020, 4, 0)} today={new Date(2020, 3, 15)}>
+    <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15)}>
       <TimelineSide />
       <TimelineTodayMarker />
       <TimelineMonths />
@@ -219,7 +233,7 @@ stories.add('With custom today marker', () => {
   }
 
   return (
-    <Timeline startDate={new Date(2020, 4, 0)} today={new Date(2020, 3, 15)}>
+    <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15)}>
       <TimelineSide />
       <TimelineTodayMarker render={CustomTodayMarker} />
       <TimelineMonths />
@@ -251,7 +265,7 @@ stories.add('With custom columns', () => {
   }
 
   return (
-    <Timeline startDate={new Date(2020, 4, 0)} today={new Date(2020, 3, 15)}>
+    <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15)}>
       <TimelineSide />
       <TimelineTodayMarker />
       <TimelineMonths />
@@ -315,7 +329,7 @@ stories.add('With custom event content', () => {
   }
 
   return (
-    <Timeline startDate={new Date(2020, 4, 0)} today={new Date(2020, 3, 15)}>
+    <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15)}>
       <TimelineSide />
       <TimelineTodayMarker />
       <TimelineMonths />
@@ -392,7 +406,7 @@ stories.add('With custom event content', () => {
 stories.add('With custom day width', () => {
   return (
     <Timeline
-      startDate={new Date(2020, 4, 0)}
+      startDate={new Date(2020, 3, 1)}
       today={new Date(2020, 3, 15)}
       dayWidth={75}
     >
@@ -430,7 +444,7 @@ stories.add('With custom day width', () => {
 stories.add('With custom range', () => {
   return (
     <Timeline
-      startDate={new Date(2020, 4, 0)}
+      startDate={new Date(2020, 3, 1)}
       today={new Date(2020, 3, 15)}
       range={6}
     >

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
+import { differenceInDays } from 'date-fns'
 
-import { TimelineProvider } from './context'
+import { TimelineProvider, TimelineContext } from './context'
 
 import {
   TimelineRootComponent,
@@ -28,6 +29,7 @@ import {
 import { TimelineOptions } from './context/types'
 import { DEFAULTS } from './constants'
 import { getKey } from '../../helpers'
+import { formatPx } from './helpers'
 
 type timelineRootChildrenType = React.ReactElement<TimelineSideProps>
 
@@ -48,6 +50,7 @@ export interface TimelineProps extends ComponentWithClass {
   children: timelineChildrenType | timelineChildrenType[]
   dayWidth?: number
   startDate?: Date
+  endDate?: Date
   today?: Date
   range?: number
 }
@@ -96,6 +99,7 @@ export const Timeline: React.FC<TimelineProps> = ({
   children,
   dayWidth = DEFAULTS.DAY_WIDTH,
   startDate,
+  endDate,
   today,
   range,
 }) => {
@@ -130,14 +134,38 @@ export const Timeline: React.FC<TimelineProps> = ({
   })
 
   return (
-    <TimelineProvider startDate={startDate} today={today} options={options}>
-      <article className="timeline">
-        {rootChildren}
-        <div className="timeline__inner">
-          <header className="timeline__header">{headChildren}</header>
-          {bodyChildren}
-        </div>
-      </article>
+    <TimelineProvider
+      startDate={startDate}
+      endDate={endDate}
+      today={today}
+      options={options}
+    >
+      <TimelineContext.Consumer>
+        {({ state: { months } }) => {
+          const offset = endDate
+            ? formatPx(
+                dayWidth,
+                differenceInDays(months[0].startDate, startDate)
+              )
+            : null
+
+          return (
+            <article className="timeline">
+              {rootChildren}
+              <div
+                className="timeline__inner"
+                style={{
+                  marginLeft: offset,
+                }}
+                data-testid="timeline-inner"
+              >
+                <header className="timeline__header">{headChildren}</header>
+                {bodyChildren}
+              </div>
+            </article>
+          )
+        }}
+      </TimelineContext.Consumer>
     </TimelineProvider>
   )
 }

--- a/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { format } from 'date-fns'
+import { format, isAfter } from 'date-fns'
 import classNames from 'classnames'
 
 import { withKey } from '../../helpers'
@@ -53,12 +53,15 @@ export const TimelineDays: React.FC<TimelineDaysProps> = ({ render }) => {
       {({
         state: {
           days,
+          endDate: timelineEndDate,
           options: { dayWidth },
         },
       }) => (
         <div className={classes} data-testid="timeline-days">
           {days &&
             days.map(({ date }, index) => {
+              if (isAfter(date, timelineEndDate)) return null
+
               const child = render
                 ? render(index, dayWidth, date)
                 : renderDefault(index, dayWidth, date)

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { format, getDaysInMonth } from 'date-fns'
+import { format, getDaysInMonth, differenceInDays } from 'date-fns'
 import classNames from 'classnames'
 
 import { formatPx } from './helpers'
@@ -62,22 +62,39 @@ export const TimelineMonths: React.FC<TimelineMonthsProps> = ({ render }) => {
       {({
         state: {
           months,
+          endDate: timelineEndDate,
           options: { dayWidth },
         },
-      }) => (
-        <div className="timeline__months" data-testid="timeline-months">
-          {months &&
-            months.map(({ startDate }, index) => {
-              const daysTotal = getDaysInMonth(startDate)
+      }) => {
+        const wrapperStyles = timelineEndDate
+          ? {
+              width: formatPx(
+                dayWidth,
+                differenceInDays(timelineEndDate, months[0].startDate) + 1
+              ),
+              overflow: 'hidden',
+            }
+          : null
 
-              const child = render
-                ? render(index, dayWidth, daysTotal, startDate)
-                : renderDefault(index, dayWidth, daysTotal, startDate)
+        return (
+          <div
+            className="timeline__months"
+            data-testid="timeline-months"
+            style={wrapperStyles}
+          >
+            {months &&
+              months.map(({ startDate }, index) => {
+                const daysTotal = getDaysInMonth(startDate)
 
-              return withKey(child, 'timeline-month', startDate.toString())
-            })}
-        </div>
-      )}
+                const child = render
+                  ? render(index, dayWidth, daysTotal, startDate)
+                  : renderDefault(index, dayWidth, daysTotal, startDate)
+
+                return withKey(child, 'timeline-month', startDate.toString())
+              })}
+          </div>
+        )
+      }}
     </TimelineContext.Consumer>
   )
 }

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -81,39 +81,65 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
   return (
     <main className={mainClasses}>
       {hasChildren && (
-        <div className={rowClasses} data-testid="timeline-columns">
-          <TimelineContext.Consumer>
-            {({
-              state: {
-                months,
-                weeks,
-                options: { dayWidth },
-              },
-            }) => {
-              return weeks.map(({ startDate }, index) => {
-                const diff = differenceInDays(
-                  new Date(startDate),
-                  new Date(months[0].startDate)
-                )
+        <TimelineContext.Consumer>
+          {({
+            state: {
+              months,
+              weeks,
+              endDate: timelineEndDate,
+              options: { dayWidth },
+            },
+          }) => {
+            const wrapperStyles = timelineEndDate
+              ? {
+                  width: formatPx(
+                    dayWidth,
+                    differenceInDays(timelineEndDate, months[0].startDate) + 1
+                  ),
+                  overflow: 'hidden',
+                }
+              : null
 
-                const offsetPx = formatPx(
-                  dayWidth,
-                  diff < 0 ? -Math.abs(diff) : 0
-                )
+            return (
+              <div
+                className={rowClasses}
+                style={wrapperStyles}
+                data-testid="timeline-columns"
+              >
+                {weeks.map(({ startDate }, index) => {
+                  const diff = differenceInDays(
+                    new Date(startDate),
+                    new Date(months[0].startDate)
+                  )
 
-                const widthPx = formatPx(dayWidth, 7)
+                  const offsetPx = formatPx(
+                    dayWidth,
+                    diff < 0 ? -Math.abs(diff) : 0
+                  )
 
-                const isOddNumber = isOdd(index)
+                  const widthPx = formatPx(dayWidth, 7)
 
-                const column = renderColumns
-                  ? renderColumns(index, isOddNumber, offsetPx, widthPx)
-                  : renderDefaultColumns(index, isOddNumber, offsetPx, widthPx)
+                  const isOddNumber = isOdd(index)
 
-                return withKey(column, 'timeline-column', startDate.toString())
-              })
-            }}
-          </TimelineContext.Consumer>
-        </div>
+                  const column = renderColumns
+                    ? renderColumns(index, isOddNumber, offsetPx, widthPx)
+                    : renderDefaultColumns(
+                        index,
+                        isOddNumber,
+                        offsetPx,
+                        widthPx
+                      )
+
+                  return withKey(
+                    column,
+                    'timeline-column',
+                    startDate.toString()
+                  )
+                })}
+              </div>
+            )
+          }}
+        </TimelineContext.Consumer>
       )}
 
       {hasChildren ? children : noData}

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -637,4 +637,59 @@ describe('Timeline', () => {
       expect(wrapper.queryByText('Days')).not.toBeInTheDocument()
     })
   })
+
+  describe('when Timeline is initialized with a fixed endDate', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Timeline
+          startDate={new Date(2020, 1, 1, 0, 0, 0)}
+          endDate={new Date(2020, 1, 15, 0, 0, 0)}
+          today={new Date(2020, 4, 1, 0, 0, 0)}
+        >
+          <TimelineSide />
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineWeeks />
+          <TimelineDays />
+          <TimelineRows>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={new Date(2020, 1, 1, 0, 0, 0)}
+                  endDate={new Date(2020, 1, 10, 0, 0, 0)}
+                >
+                  Event
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('applies the dynamic styles to the appropriate wrappers', () => {
+      expect(wrapper.getByTestId('timeline-inner')).toHaveStyle({
+        marginLeft: '0px',
+      })
+
+      expect(wrapper.getByTestId('timeline-columns')).toHaveStyle({
+        width: '450px',
+        overflow: 'hidden',
+      })
+
+      expect(wrapper.getByTestId('timeline-months')).toHaveStyle({
+        width: '450px',
+        overflow: 'hidden',
+      })
+
+      expect(wrapper.getByTestId('timeline-weeks')).toHaveStyle({
+        width: '450px',
+        overflow: 'hidden',
+      })
+    })
+
+    it('renders the correct number of days', () => {
+      expect(wrapper.queryAllByTestId('timeline-day-title')).toHaveLength(15)
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Timeline/context/__mocks__/index.tsx
+++ b/packages/react-component-library/src/components/Timeline/context/__mocks__/index.tsx
@@ -3,6 +3,7 @@ import { TimelineState } from '../types'
 const state: TimelineState = {
   today: new Date(),
   startDate: new Date(),
+  endDate: null,
   months: [],
   weeks: [],
   days: [],

--- a/packages/react-component-library/src/components/Timeline/context/__tests__/reducer.test.ts
+++ b/packages/react-component-library/src/components/Timeline/context/__tests__/reducer.test.ts
@@ -9,30 +9,28 @@ describe('TimelineContext reducer', () => {
   })
 
   describe('getMonths', () => {
-    let dates: {
-      months: TimelineMonth[]
-    }
+    let months: TimelineMonth[]
     const rangeInMonths = 3
 
     beforeEach(() => {
-      dates = getMonths(
+      months = getMonths(
         new Date(2020, 3, 1, 0, 0, 0),
         rangeInMonths,
       )
     })
 
     it('returns the correct number of months', () => {
-      expect(dates.months.length).toBe(rangeInMonths)
+      expect(months.length).toBe(rangeInMonths)
     })
 
     it('returns the correct month start dates', () => {
-      expect(dates.months[0].startDate)
+      expect(months[0].startDate)
         .toEqual(new Date('2020-04-01T00:00:00.000Z'))
 
-      expect(dates.months[1].startDate)
+      expect(months[1].startDate)
         .toEqual(new Date('2020-05-01T00:00:00.000Z'))
 
-      expect(dates.months[2].startDate)
+      expect(months[2].startDate)
         .toEqual(new Date('2020-06-01T00:00:00.000Z'))
     })
   })

--- a/packages/react-component-library/src/components/Timeline/context/index.tsx
+++ b/packages/react-component-library/src/components/Timeline/context/index.tsx
@@ -14,11 +14,12 @@ export const TimelineContext = createContext(timelineContextDefaults)
 export const TimelineProvider: React.FC<TimelineProviderProps> = ({
   children,
   startDate,
+  endDate,
   today,
   options,
 }) => {
   const [state, dispatch] = useReducer(reducer, initialState, () =>
-    initialiseState(startDate, today, options)
+    initialiseState(startDate, endDate, today, options)
   )
 
   return (

--- a/packages/react-component-library/src/components/Timeline/context/state.ts
+++ b/packages/react-component-library/src/components/Timeline/context/state.ts
@@ -1,4 +1,4 @@
-import { getDays, getMonths, getWeeks } from './reducer'
+import { getDays, getMonths, getWeeks, calcRange } from './reducer'
 import { TimelineOptions, TimelineState } from './types'
 
 const initialState: TimelineState = {
@@ -6,12 +6,14 @@ const initialState: TimelineState = {
   months: [],
   options: null,
   startDate: null,
+  endDate: null,
   today: new Date(),
   weeks: [],
 }
 
 function initialiseState(
   startDate: Date = new Date(),
+  endDate: Date,
   today: Date = new Date(),
   options: TimelineOptions
 ) {
@@ -19,14 +21,19 @@ function initialiseState(
     ...initialState,
     today,
     startDate,
+    endDate,
     options: { ...initialState.options, ...options },
   }
 
+  const range = endDate
+    ? calcRange(startDate, endDate)
+    : state.options.rangeInMonths
+
   return {
     ...state,
-    ...getMonths(startDate, state.options.rangeInMonths),
-    days: getDays(startDate, state.options.rangeInMonths),
-    weeks: getWeeks(startDate, state.options.rangeInMonths),
+    months: getMonths(startDate, range),
+    weeks: getWeeks(startDate, range),
+    days: getDays(startDate, range),
   }
 }
 

--- a/packages/react-component-library/src/components/Timeline/context/state.ts
+++ b/packages/react-component-library/src/components/Timeline/context/state.ts
@@ -16,7 +16,7 @@ function initialiseState(
   endDate: Date,
   today: Date = new Date(),
   options: TimelineOptions
-) {
+): TimelineState {
   const state = {
     ...initialState,
     today,

--- a/packages/react-component-library/src/components/Timeline/context/types.ts
+++ b/packages/react-component-library/src/components/Timeline/context/types.ts
@@ -23,6 +23,7 @@ export type TimelineMonth = {
 export type TimelineState = {
   today: Date
   startDate: null | Date
+  endDate: null | Date
   months: TimelineMonth[]
   weeks: TimelineWeek[]
   days: TimelineDay[]
@@ -46,6 +47,7 @@ export interface TimelineContextDefault {
 export interface TimelineProviderProps {
   children?: React.ReactNode
   startDate?: Date
+  endDate?: Date
   today?: Date
   options?: TimelineOptions
 }

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
@@ -8,7 +8,6 @@ import {
 } from 'date-fns'
 
 import { TimelineContext } from '../context'
-
 import { formatPx } from '../helpers'
 
 function getWidth (
@@ -34,11 +33,14 @@ function getOffset (
 export function useTimelinePosition(
   startDate: Date,
   endDate: Date
-) {
+): {
+  width: string,
+  offset: string,
+  isBeforeStart: boolean,
+  isAfterEnd: boolean
+} {
   const {
     state: {
-      startDate: timelineStartDate,
-      endDate: timelineEndDate,
       months,
       options
     }

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
@@ -35,7 +35,14 @@ export function useTimelinePosition(
   startDate: Date,
   endDate: Date
 ) {
-  const { state: { months, options } } = useContext(TimelineContext)
+  const {
+    state: {
+      startDate: timelineStartDate,
+      endDate: timelineEndDate,
+      months,
+      options
+    }
+  } = useContext(TimelineContext)
 
   const timelineStart = new Date(months[0].startDate)
   const timelineEnd = new Date(endOfMonth(months[months.length - 1].startDate))


### PR DESCRIPTION
## Related issue

Closes #1160

## Overview

Add the ability to bound a Timeline by two explicit dates.

## Reason

>In our exemplar project, there's a requirement to bound the timeline by two dates, and be able to scroll horizontally within that date range.
>
>At the moment the Timeline component supports startDate and range arguments. These (as I understand) let you control the start and end month, but don't let you specify the bounds at a day level.

## Work carried out

- [x] Add ability to bound a Timeline by two dates

## Screenshot

<img width="1027" alt="Screenshot 2020-07-06 at 10 41 28" src="https://user-images.githubusercontent.com/48086589/86579453-44870680-bf75-11ea-8ddc-32c4308e452f.png">

## Developer Notes

I could add a test that checks for the exact values of the dynamic styles but felt like the storybook story does a better job of covering this?

