### PR TITLE
fix(Badge): Add ability to drill arbitrary props

### DIFF
--- a/packages/react-component-library/src/components/Badge/Badge.test.tsx
+++ b/packages/react-component-library/src/components/Badge/Badge.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, RenderResult } from '@testing-library/react'
+
+import {
+  BADGE_COLOR,
+  BADGE_COLOR_VARIANT,
+  BADGE_SIZE,
+  BADGE_VARIANT,
+  Badge,
+} from '.'
+
+describe('Badge', () => {
+  let wrapper: RenderResult
+
+  describe('when provided with additional custom props', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Badge
+          color={BADGE_COLOR.ACTION}
+          colorVariant={BADGE_COLOR_VARIANT.SOLID}
+          size={BADGE_SIZE.REGULAR}
+          variant={BADGE_VARIANT.PILL}
+          dummy-testid="example"
+        />
+      )
+    })
+
+    it('applies the props to the wrapper element', () => {
+      expect(wrapper.getByTestId('badge')).toHaveAttribute(
+        'dummy-testid',
+        'example'
+      )
+    })
+  })
+})

--- a/packages/react-component-library/src/components/Badge/Badge.tsx
+++ b/packages/react-component-library/src/components/Badge/Badge.tsx
@@ -38,6 +38,7 @@ export const Badge: React.FC<BadgeProps> = ({
   colorVariant = BADGE_COLOR_VARIANT.SOLID,
   size = BADGE_SIZE.REGULAR,
   variant,
+  ...rest
 }) => {
   const classes = classNames(
     'rn-badge',
@@ -49,7 +50,7 @@ export const Badge: React.FC<BadgeProps> = ({
   )
 
   return (
-    <span className={classes} data-testid="badge">
+    <span className={classes} data-testid="badge" {...rest}>
       {children}
     </span>
   )


### PR DESCRIPTION
## Related issue

Closes #1121

## Overview

Make Badge apply additional arbitrary props to component wrapper element.

## Reason

> Downstream consumers want to be able to apply their own test IDs to the components.

## Work carried out

- [x] Add ability to drill additional arbitrary props
- [x] Add automated test