### PR TITLE
fix(Timeline): Custom components not composable at top level

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -2,13 +2,7 @@ import React from 'react'
 import { differenceInDays } from 'date-fns'
 
 import { TimelineProvider, TimelineContext } from './context'
-
-import {
-  TimelineRootComponent,
-  TimelineHeadComponent,
-  TimelineBodyComponent,
-  TimelineComponent,
-} from './types'
+import { TimelineComponent } from './types'
 
 import {
   TimelineSide,
@@ -64,11 +58,14 @@ function isComponentOf<T extends TimelineComponent>(
   return names.includes(typeName)
 }
 
-function extractChildrenOf<T>(
+function extractChildren(
   children: timelineChildrenType | timelineChildrenType[],
-  names: string[]
+  names: string[],
+  inverse?: boolean
 ) {
-  return (children as []).filter((child) => isComponentOf(child, names))
+  return (children as []).filter((child) => {
+    return inverse ? !isComponentOf(child, names) : isComponentOf(child, names)
+  })
 }
 
 function extractRowData(
@@ -105,20 +102,26 @@ export const Timeline: React.FC<TimelineProps> = ({
     rangeInMonths: range || DEFAULTS.RANGE_IN_MONTHS,
   }
 
-  const bodyChildren = extractChildrenOf<TimelineBodyComponent>(children, [
-    TimelineRows.name,
-  ])
+  const bodyChildren = extractChildren(children, [TimelineRows.name])
 
-  const headChildren = extractChildrenOf<TimelineHeadComponent>(children, [
+  const headChildren = extractChildren(children, [
     TimelineDays.name,
     TimelineWeeks.name,
     TimelineMonths.name,
     TimelineTodayMarker.name,
   ])
 
-  const rootChildren = extractChildrenOf<TimelineRootComponent>(children, [
-    TimelineSide.name,
-  ]).map((child, index) => {
+  const rootChildren = extractChildren(
+    children,
+    [
+      TimelineRows.name,
+      TimelineDays.name,
+      TimelineWeeks.name,
+      TimelineMonths.name,
+      TimelineTodayMarker.name,
+    ],
+    true
+  ).map((child, index) => {
     if (isComponentOf(child, [TimelineSide.name])) {
       return React.cloneElement(child, {
         rowGroups: extractRowData(bodyChildren),

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -76,16 +76,13 @@ function extractRowData(
 ) {
   return (rowGroups as []).map(
     ({ props: { children } }: timelineBodyChildrenType) => {
-      let rows: any[] = []
-
-      if (children) {
-        const items = Array.isArray(children) ? children : [children]
-        rows = items.map(
+      const rows =
+        React.Children.map(
+          children,
           ({ props: { name } }: React.ReactElement<TimelineRowProps>) => ({
             name,
           })
-        )
-      }
+        ) || []
 
       return {
         // ref, // Create refs to original components? Drag + Drop etc?

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -692,4 +692,46 @@ describe('Timeline', () => {
       expect(wrapper.queryAllByTestId('timeline-day-title')).toHaveLength(15)
     })
   })
+
+  describe('when composed with a custom root child component', () => {
+    beforeEach(() => {
+      const CustomTimelineComponent = () => {
+        return (
+          <div data-testid="custom-timeline-component">
+            Custom Timeline Component
+          </div>
+        )
+      }
+
+      wrapper = render(
+        <Timeline
+          startDate={new Date(2020, 1, 1, 0, 0, 0)}
+          today={new Date(2020, 4, 1, 0, 0, 0)}
+        >
+          <CustomTimelineComponent />
+          <TimelineSide />
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineRows>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={new Date(2020, 1, 1, 0, 0, 0)}
+                  endDate={new Date(2020, 1, 10, 0, 0, 0)}
+                >
+                  Event
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('should render the custom component', () => {
+      expect(
+        wrapper.queryByTestId('custom-timeline-component')
+      ).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -628,6 +628,10 @@ describe('Timeline', () => {
       )
     })
 
+    it('renders the correct number of sidebar rows', () => {
+      expect(wrapper.queryAllByTestId('timeline-side-row')).toHaveLength(1)
+    })
+
     it('renders the sidebar month label', () => {
       expect(wrapper.queryByText('Months')).toBeInTheDocument()
     })
@@ -635,6 +639,27 @@ describe('Timeline', () => {
     it('does not render the sidebar weeks and days labels', () => {
       expect(wrapper.queryByText('Weeks')).not.toBeInTheDocument()
       expect(wrapper.queryByText('Days')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when TimelineSide is used with no row data', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Timeline
+          startDate={new Date(2020, 1, 1, 0, 0, 0)}
+          today={new Date(2020, 4, 1, 0, 0, 0)}
+          range={6}
+        >
+          <TimelineSide />
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineRows>{}</TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('renders the correct number of sidebar rows', () => {
+      expect(wrapper.queryAllByTestId('timeline-side-row')).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
## Related issue

Closes #1161

## Overview

Give the end user the ability to add custom Timeline components at the root of their composition.

## Reason

>Custom Timeline components don't render outside rows.

## Work carried out

- [x] Fix extraction of root Timeline children
- [x] Refactor `extractRowData` method
- [x] Add automated test
