### PR TITLE
Add accessibility attributes to `Alert`

### DIFF
--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -69,75 +69,21 @@ describe('Alert', () => {
     })
   })
 
-  describe('when the variant is specified', () => {
-    describe('when the variant is `INFO`', () => {
-      beforeEach(() => {
-        wrapper = render(
-          <Alert title="Title" variant={ALERT_VARIANT.INFO}>
-            Description
-          </Alert>
-        )
-      })
+  describe('when composing with different variants', () => {
+    it.each`
+      variant
+      ${ALERT_VARIANT.DANGER}
+      ${ALERT_VARIANT.INFO}
+      ${ALERT_VARIANT.SUCCESS}
+      ${ALERT_VARIANT.WARNING}
+    `('should render the $variant icon', ({ variant }) => {
+      wrapper = render(
+        <Alert title="Title" variant={variant}>
+          Description
+        </Alert>
+      )
 
-      it('should render the info icon', () => {
-        expect(wrapper.getByTestId('icon-info')).toBeInTheDocument()
-      })
-    })
-
-    describe('when the variant is `DANGER`', () => {
-      describe('when the title is specified', () => {
-        beforeEach(() => {
-          wrapper = render(
-            <Alert title="Title" variant={ALERT_VARIANT.DANGER}>
-              Description
-            </Alert>
-          )
-        })
-
-        it('should render the danger icon', () => {
-          expect(wrapper.getByTestId('icon-danger')).toBeInTheDocument()
-        })
-      })
-
-      describe('when the title is not specified', () => {
-        beforeEach(() => {
-          wrapper = render(
-            <Alert variant={ALERT_VARIANT.DANGER}>Description</Alert>
-          )
-        })
-
-        it('should render the danger icon', () => {
-          expect(wrapper.getByTestId('icon-danger')).toBeInTheDocument()
-        })
-      })
-    })
-
-    describe('when the variant is `SUCCESS`', () => {
-      beforeEach(() => {
-        wrapper = render(
-          <Alert title="Title" variant={ALERT_VARIANT.SUCCESS}>
-            Description
-          </Alert>
-        )
-      })
-
-      it('should render the success icon', () => {
-        expect(wrapper.getByTestId('icon-success')).toBeInTheDocument()
-      })
-    })
-
-    describe('when the variant is `WARNING`', () => {
-      beforeEach(() => {
-        wrapper = render(
-          <Alert title="Title" variant={ALERT_VARIANT.WARNING}>
-            Description
-          </Alert>
-        )
-      })
-
-      it('should render the warning icon', () => {
-        expect(wrapper.getByTestId('icon-warning')).toBeInTheDocument()
-      })
+      expect(wrapper.getByTestId(`icon-${variant}`)).toBeInTheDocument()
     })
   })
 

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -12,6 +12,10 @@ describe('Alert', () => {
       wrapper = render(<Alert>Description</Alert>)
     })
 
+    it('should set the `role` attribute to `alert`', () => {
+      expect(wrapper.getByTestId('alert')).toHaveAttribute('role', 'alert')
+    })
+
     it('should render the close button', () => {
       expect(wrapper.getByTestId('close')).toBeInTheDocument()
     })
@@ -50,8 +54,35 @@ describe('Alert', () => {
       wrapper = render(<Alert title="Title">Description</Alert>)
     })
 
+    it('should set the `aria-labelledby` attribute to the ID of the title', () => {
+      const titleId = wrapper.getByTestId('content-title').getAttribute('id')
+
+      expect(wrapper.getByTestId('alert')).toHaveAttribute(
+        'aria-labelledby',
+        titleId
+      )
+    })
+
+    it('should set the `aria-describedby` attribute to the ID of the content', () => {
+      const contentId = wrapper
+        .getByTestId('content-description')
+        .getAttribute('id')
+
+      expect(wrapper.getByTestId('alert')).toHaveAttribute(
+        'aria-describedby',
+        contentId
+      )
+    })
+
     it('should render the state icon', () => {
       expect(wrapper.getByTestId('state-icon')).toBeInTheDocument()
+    })
+
+    it('should set the `aria-hidden` attribute on the state icon', () => {
+      expect(wrapper.getByTestId('state-icon')).toHaveAttribute(
+        'aria-hidden',
+        'true'
+      )
     })
 
     it('should render the default info icon', () => {

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -8,6 +8,7 @@ import {
 import classNames from 'classnames'
 
 import { ALERT_VARIANT } from './constants'
+import { getId } from '../../helpers'
 
 const VARIANT_ICON_MAP = {
   [ALERT_VARIANT.DANGER]: (
@@ -60,19 +61,40 @@ export const Alert: React.FC<AlertProps> = ({
     `rn-alert__description--${variant}`
   )
 
+  const titleId = getId('alert-title')
+  const descriptionId = getId('alert-description')
+
   return (
     !closed && (
-      <div className={classes} data-testid="alert">
-        <div className={iconClasses} data-testid="state-icon">
+      <div
+        aria-describedby={descriptionId}
+        aria-labelledby={titleId}
+        className={classes}
+        data-testid="alert"
+        role="alert"
+      >
+        <div
+          aria-hidden="true"
+          className={iconClasses}
+          data-testid="state-icon"
+        >
           {VARIANT_ICON_MAP[variant]}
         </div>
         <div className="rn-alert__content" data-testid="content">
           {title && (
-            <h2 className="rn-alert__title" data-testid="content-title">
+            <h2
+              className="rn-alert__title"
+              data-testid="content-title"
+              id={titleId}
+            >
               {title}
             </h2>
           )}
-          <p className={descriptionClasses} data-testid="content-description">
+          <p
+            className={descriptionClasses}
+            data-testid="content-description"
+            id={descriptionId}
+          >
             {children}
           </p>
           <div className="rn-alert__footer">

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -1,7 +1,12 @@
 import React from 'react'
+import { v4 as uuidv4 } from 'uuid'
 
 function getKey(prefix: string, suffix: string | number): string {
   return `${prefix}-${suffix}`.replace(/\s/g, '')
+}
+
+function getId(prefix: string): string {
+  return getKey(prefix, uuidv4())
 }
 
 function warnIfOverwriting<P>(
@@ -30,4 +35,4 @@ function withKey(
   return null
 }
 
-export { getKey, warnIfOverwriting, withKey }
+export { getId, getKey, warnIfOverwriting, withKey }


### PR DESCRIPTION
## Related issue
Closes #1059 

## Overview
Adds the `role`, `aria-labelledby` and `aria-describedby` attributes to the `Alert` component.

## Reason
Required for accessibility.

## Work carried out
- Refactor existing tests
- Add `getId` helper
- Add attributes
