### PR TITLE
fix(DatePicker): Fix some visual bugs with DatePicker

### DIFF
--- a/packages/css-framework/src/components/_date-picker.scss
+++ b/packages/css-framework/src/components/_date-picker.scss
@@ -162,7 +162,10 @@
 
   div {
     flex: 1;
-    margin-right: 10px;
+
+    &:first-of-type {
+      padding-right: f.spacing("6");
+    }
   }
 }
 

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -19,6 +19,7 @@ stories.add('Default', () => {
       onBlur={action('onBlur')}
       onChange={action('onChange')}
       placement={DATEPICKER_PLACEMENT.BELOW}
+      isOpen
     />
   )
 })
@@ -30,6 +31,7 @@ examples.add('Custom label', () => {
       onBlur={action('onBlur')}
       onChange={action('onChange')}
       label="Some other label"
+      isOpen
     />
   )
 })
@@ -51,6 +53,7 @@ examples.add('Range', () => {
       onBlur={action('onBlur')}
       onChange={action('onChange')}
       isRange
+      isOpen
     />
   )
 })

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -357,4 +357,20 @@ describe('DatePicker', () => {
       })
     })
   })
+
+  describe('when the isOpen prop is provided', () => {
+    beforeEach(() => {
+      wrapper = render(<DatePicker isOpen />)
+    })
+
+    it('displays the picker as open on initial render', () => {
+      expect(
+        wrapper.getByTestId('datepicker-input-wrapper').classList
+      ).toContain('is-open')
+
+      expect(wrapper.getByTestId('floating-box').classList).toContain(
+        'is-visible'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -47,6 +47,7 @@ export interface DatePickerProps extends ComponentWithClass {
     | typeof DATEPICKER_PLACEMENT.RIGHT
   startDate?: Date
   value?: string
+  isOpen?: boolean
 }
 
 function transformDates(startDate: Date, endDate: Date) {
@@ -74,6 +75,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   placement = DATEPICKER_PLACEMENT.BELOW,
   startDate,
   value,
+  isOpen,
 }) => {
   const [state, setState] = useState<StateObject>({
     startDate,
@@ -117,22 +119,22 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   })
 
   const componentRef = useRef(null)
-  const { isOpen, onFocus, onClose } = useOpenClose(componentRef)
+  const { openState, onFocus, onClose } = useOpenClose(componentRef, isOpen)
   const hasContent = (value && value.length) || state.startDate
   const PLACEMENTS = DATEPICKER_PLACEMENTS[placement]
 
   const classes = classNames('rn-date-picker', className, {
-    'is-open': isOpen,
+    'is-open': openState,
     'has-content': hasContent,
     'is-disabled': isDisabled,
   })
 
   const tetherClasses = classNames('rn-date-picker__tether', {
-    'is-visible': isOpen,
+    'is-visible': openState,
   })
 
   const floatingBoxClasses = classNames('rn-date-picker__container', {
-    'is-visible': isOpen,
+    'is-visible': openState,
   })
 
   const gridClasses = classNames('rn-date-picker__grid', {
@@ -179,7 +181,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
               onBlur={onBlur}
               onFocus={onFocus}
               isDisabled={isDisabled}
-              isOpen={isOpen}
+              isOpen={openState}
               onClose={onClose}
             />
           ),

--- a/packages/react-component-library/src/components/DatePicker/constants.ts
+++ b/packages/react-component-library/src/components/DatePicker/constants.ts
@@ -9,14 +9,14 @@ const DATEPICKER_PLACEMENT = {
 
 const DATEPICKER_PLACEMENTS = {
   [DATEPICKER_PLACEMENT.ABOVE]: {
-    OFFSET: '8px -75px',
-    ATTACHMENT: 'bottom right',
+    OFFSET: '8px 0px',
+    ATTACHMENT: 'bottom center',
     TARGET_ATTACHMENT: 'top center',
     ARROW_POSITION: FLOATING_BOX_ARROW_POSITION.BOTTOM_LEFT
   },
   [DATEPICKER_PLACEMENT.BELOW]: {
-    OFFSET: '-8px -75px',
-    ATTACHMENT: 'top right',
+    OFFSET: '-8px 0px',
+    ATTACHMENT: 'top center',
     TARGET_ATTACHMENT: 'bottom center',
     ARROW_POSITION: FLOATING_BOX_ARROW_POSITION.TOP_LEFT
   },

--- a/packages/react-component-library/src/components/DatePicker/useOpenClose.ts
+++ b/packages/react-component-library/src/components/DatePicker/useOpenClose.ts
@@ -11,27 +11,30 @@ function hasParentWithMatchingSelector(
   )
 }
 
-export function useOpenClose(ref: React.RefObject<undefined>) {
-  const [isOpen, setIsOpen] = useState<boolean>(false)
+export function useOpenClose(
+  ref: React.RefObject<undefined>,
+  isOpen?: boolean
+) {
+  const [openState, setOpenState] = useState<boolean>(isOpen)
 
   useDocumentClick(ref, (event: Event) => {
     const target = event.target as Node
 
     if (!hasParentWithMatchingSelector(target, '.rn-date-picker__container')) {
-      setIsOpen(false)
+      setOpenState(false)
     }
   })
 
   function onFocus() {
-    setIsOpen(true)
+    setOpenState(true)
   }
 
   function onClose() {
-    setIsOpen(false)
+    setOpenState(false)
   }
 
   return {
-    isOpen,
+    openState,
     onFocus,
     onClose
   }


### PR DESCRIPTION
## Related issue

Closes #1187 & #1186 

## Overview

Fix incorrect placement positionings.

## Reason

>Observe that the flyout is misaligned. This was tested in Chromium 83 and Firefox 78.

## Work carried out

- [x] Adjust placements
- [x] Add ability to set initial open state
- [x] Set Storybook stories to be open
- [x] Fix content overflow style bug

## Screenshot

<img width="864" alt="Screenshot 2020-07-09 at 11 29 14" src="https://user-images.githubusercontent.com/48086589/87029327-e3ab3880-c1d7-11ea-961c-ce61abcdd948.png">
<img width="850" alt="Screenshot 2020-07-09 at 11 29 21" src="https://user-images.githubusercontent.com/48086589/87029331-e574fc00-c1d7-11ea-953e-bc443931b978.png">
