### PR TITLE
feat(Breadcrumb): Add aria attributes

### DIFF
--- a/packages/css-framework/src/components/_breadcrumbs.scss
+++ b/packages/css-framework/src/components/_breadcrumbs.scss
@@ -1,7 +1,7 @@
 @use "../abstracts/functions" as f;
 @use "../config" as config;
 
-.rn-breadcrumbs {
+.rn-breadcrumbs__list {
   display: block;
   font-size: f.font-size("base");
   margin: 0;

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -21,13 +21,33 @@ describe('Breadcrumbs', () => {
       )
     })
 
+    it('should set the `aria-label` attribute to `breadcrumb`', () => {
+      expect(wrapper.getByTestId('breadcrumb-wrapper')).toHaveAttribute(
+        'aria-label',
+        'Breadcrumb'
+      )
+    })
+
+    it('should apply the `aria-hidden` attribute to seperators', () => {
+      expect(wrapper.getAllByTestId('breadcrumb-separator')[0]).toHaveAttribute(
+        'aria-hidden'
+      )
+    })
+
+    it('should apply the `aria-current` attribute to the last crumb', () => {
+      expect(wrapper.getByTestId('breadcrumb-end-title')).toHaveAttribute(
+        'aria-current',
+        'page'
+      )
+    })
+
     it('should render a list of breadcrumbs', () => {
       const linkElements = wrapper.queryAllByTestId('breadcrumb')
       expect(linkElements).toHaveLength(5)
     })
 
     it('should render four separators', () => {
-      const linkElements = wrapper.queryAllByTestId('separator')
+      const linkElements = wrapper.queryAllByTestId('breadcrumb-separator')
       expect(linkElements).toHaveLength(4)
     })
 
@@ -37,7 +57,7 @@ describe('Breadcrumbs', () => {
     })
 
     it('should render the last link as a title', () => {
-      const endTitle = wrapper.getByTestId('end-title')
+      const endTitle = wrapper.getByTestId('breadcrumb-end-title')
       expect(endTitle).toBeInTheDocument()
     })
 

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -25,7 +25,15 @@ export const Breadcrumbs: React.FC<Nav<BreadcrumbsItemProps>> = ({
     }
   )
 
-  return <ul className={classes}>{mapped}</ul>
+  return (
+    <nav
+      className={classes}
+      aria-label="Breadcrumb"
+      data-testid="breadcrumb-wrapper"
+    >
+      <ol className="rn-breadcrumbs__list">{mapped}</ol>
+    </nav>
+  )
 }
 
 Breadcrumbs.displayName = 'Breadcrumbs'

--- a/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -19,8 +19,9 @@ export const BreadcrumbsItem: React.FC<BreadcrumbsItemProps> = ({
     <li data-testid="breadcrumb" className="rn-breadcrumbs__breadcrumb">
       {!isFirst && (
         <IconChevronRight
-          data-testid="separator"
           className="rn-breadcrumbs__separator"
+          aria-hidden
+          data-testid="breadcrumb-separator"
         />
       )}
       {isLast ? (

--- a/packages/react-component-library/src/components/Breadcrumbs/EndTitle.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/EndTitle.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 
 export const EndTitle: React.FC = ({ children }) => (
-  <span className="rn-breadcrumbs__title" data-testid="end-title">
+  <span
+    className="rn-breadcrumbs__title"
+    aria-current="page"
+    data-testid="breadcrumb-end-title"
+  >
     {children}
   </span>
 )


### PR DESCRIPTION
## Related issue

Closes #1060

## Overview

Add aria attributes to Breadcrumb component.

## Reason

> We want to meet accessibility guidelines for all existing components.

## Work carried out

- [x] Add aria attributes
- [x] Minor refactor
- [x] Add automated tests

## Developer notes

https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html