### PR TITLE
Add accessibility attributes to `Tooltip`

### DIFF
--- a/packages/react-component-library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.test.tsx
@@ -22,6 +22,27 @@ describe('Tooltip', () => {
       expect(wrapper.getByTestId('tooltip')).not.toHaveAttribute('id')
     })
 
+    it('should render the tooltip with an `aria-describedby` attribute', () => {
+      const contentId = wrapper
+        .getByTestId('tooltip-content')
+        .getAttribute('id')
+
+      expect(wrapper.getByTestId('tooltip')).toHaveAttribute(
+        'aria-describedby',
+        contentId
+      )
+    })
+
+    it('should render the tooltip without an `aria-labelledby` attribute', () => {
+      expect(wrapper.getByTestId('tooltip')).not.toHaveAttribute(
+        'aria-labelledby'
+      )
+    })
+
+    it('should render the tooltip with a `role` attribute', () => {
+      expect(wrapper.getByTestId('tooltip')).toHaveAttribute('role', 'tooltip')
+    })
+
     it('should render the tooltip without extra style', () => {
       expect(wrapper.getByTestId('tooltip')).not.toHaveAttribute('style')
     })
@@ -57,6 +78,30 @@ describe('Tooltip', () => {
 
     it('should render the tooltip with an `id` attribute', () => {
       expect(wrapper.getByTestId('tooltip')).toHaveAttribute('id', '123')
+    })
+
+    it('should render the tooltip with an `aria-describedby` attribute', () => {
+      const contentId = wrapper
+        .getByTestId('tooltip-content')
+        .getAttribute('id')
+
+      expect(wrapper.getByTestId('tooltip')).toHaveAttribute(
+        'aria-describedby',
+        contentId
+      )
+    })
+
+    it('should render the tooltip with an `aria-labelledby` attribute', () => {
+      const titleId = wrapper.getByText('title').getAttribute('id')
+
+      expect(wrapper.getByTestId('tooltip')).toHaveAttribute(
+        'aria-labelledby',
+        titleId
+      )
+    })
+
+    it('should render the tooltip with a `role` attribute', () => {
+      expect(wrapper.getByTestId('tooltip')).toHaveAttribute('role', 'tooltip')
     })
 
     it('should render the tooltip with extra style', () => {

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.test.tsx
@@ -7,66 +7,71 @@ import { Tooltip, TOOLTIP_POSITION } from '.'
 describe('Tooltip', () => {
   let wrapper: RenderResult
 
-  describe('When no default position is provided', () => {
+  describe('minimal props', () => {
     beforeEach(() => {
-      wrapper = render(<Tooltip />)
+      wrapper = render(<Tooltip>Content</Tooltip>)
     })
 
-    it('should not include an id', () => {
-      expect(wrapper.getByTestId('tooltip')).toHaveAttribute('id', '')
-    })
-
-    it('should include the tooltip css class', () => {
-      expect(wrapper.getByTestId('tooltip')).toHaveClass('rn-tooltip')
-    })
-
-    it('should set a default position', () => {
-      expect(wrapper.getByTestId('tooltip')).toHaveClass('rn-tooltip--above')
-    })
-  })
-
-  describe('When a position relative to is provided', () => {
-    beforeEach(() => {
-      wrapper = render(<Tooltip position={TOOLTIP_POSITION.BELOW} />)
-    })
-
-    it('should set the position', () => {
-      expect(wrapper.getByTestId('tooltip')).toHaveClass('rn-tooltip--below')
-    })
-  })
-
-  describe('When an id is provided', () => {
-    beforeEach(() => {
-      wrapper = render(<Tooltip id="ID123" />)
-    })
-
-    it('should set the id', () => {
-      expect(wrapper.getByTestId('tooltip')).toHaveAttribute('id', 'ID123')
-    })
-  })
-
-  describe('When a title is provided', () => {
-    beforeEach(() => {
-      wrapper = render(<Tooltip title="Test Title" />)
-    })
-
-    it('should display a title', () => {
-      expect(wrapper.getByTestId('tooltip-title')).toBeInTheDocument()
-    })
-  })
-
-  describe('when a position it provided', () => {
-    beforeEach(() => {
-      wrapper = render(<Tooltip top={100} left={200} />)
-    })
-
-    it('should include the position', () => {
-      expect(wrapper.getByTestId('tooltip').getAttribute('style')).toContain(
-        'left: 200px'
+    it('should render the tooltip with the default position class', () => {
+      expect(wrapper.getByTestId('tooltip').classList).toContain(
+        'rn-tooltip--above'
       )
-      expect(wrapper.getByTestId('tooltip').getAttribute('style')).toContain(
-        'top: 100px'
+    })
+
+    it('should render the tooltip without an `id` attribute', () => {
+      expect(wrapper.getByTestId('tooltip')).not.toHaveAttribute('id')
+    })
+
+    it('should render the tooltip without extra style', () => {
+      expect(wrapper.getByTestId('tooltip')).not.toHaveAttribute('style')
+    })
+
+    it('should render the content', () => {
+      expect(wrapper.getByText('Content')).toBeInTheDocument()
+    })
+  })
+
+  describe('all props', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Tooltip
+          bottom={1}
+          id="123"
+          left={2}
+          position={TOOLTIP_POSITION.BELOW}
+          right={3}
+          title="title"
+          top={4}
+          width={100}
+        >
+          Content
+        </Tooltip>
       )
+    })
+
+    it('should render the tooltip with the position class', () => {
+      expect(wrapper.getByTestId('tooltip').classList).toContain(
+        'rn-tooltip--below'
+      )
+    })
+
+    it('should render the tooltip with an `id` attribute', () => {
+      expect(wrapper.getByTestId('tooltip')).toHaveAttribute('id', '123')
+    })
+
+    it('should render the tooltip with extra style', () => {
+      expect(wrapper.getByTestId('tooltip')).toHaveAttribute(
+        'style',
+        'bottom: 1px; left: 2px; right: 3px; top: 4px; width: 100px;'
+      )
+    })
+
+    it('should render the title', () => {
+      expect(wrapper.getByText('title')).toBeInTheDocument()
+    })
+
+    it('should render the content', () => {
+      expect(wrapper.getByText('Content')).toBeInTheDocument()
     })
   })
 })

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { TOOLTIP_POSITION } from '.'
 
 export interface TooltipProps extends PositionType {
+  children: React.ReactNode
   id?: string
   position?:
     | typeof TOOLTIP_POSITION.ABOVE
@@ -17,7 +18,7 @@ export interface TooltipProps extends PositionType {
 export const Tooltip: React.FC<TooltipProps> = ({
   bottom,
   children,
-  id = '',
+  id,
   left,
   position = TOOLTIP_POSITION.ABOVE,
   right,
@@ -33,25 +34,18 @@ export const Tooltip: React.FC<TooltipProps> = ({
     width,
   }
 
-  const tooltipClassNames = classNames([
-    'rn-tooltip',
-    `rn-tooltip--${position}`,
-  ])
+  const classes = classNames(['rn-tooltip', `rn-tooltip--${position}`])
 
   return (
     <div
-      className={tooltipClassNames}
+      className={classes}
       data-testid="tooltip"
       id={id}
       role="tooltip"
       style={style}
     >
       <div className="rn-tooltip__content">
-        {title && (
-          <div data-testid="tooltip-title" className="rn-tooltip__title">
-            {title}
-          </div>
-        )}
+        {title && <div className="rn-tooltip__title">{title}</div>}
         <div className="rn-tooltip__message">{children}</div>
       </div>
     </div>

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { TOOLTIP_POSITION } from '.'
+import { getId } from '../../helpers'
 
 export interface TooltipProps extends PositionType {
   children: React.ReactNode
@@ -36,8 +37,13 @@ export const Tooltip: React.FC<TooltipProps> = ({
 
   const classes = classNames(['rn-tooltip', `rn-tooltip--${position}`])
 
+  const contentId = getId('tooltip-content')
+  const titleId = title ? getId('tooltip-title') : null
+
   return (
     <div
+      aria-describedby={contentId}
+      aria-labelledby={titleId}
       className={classes}
       data-testid="tooltip"
       id={id}
@@ -45,8 +51,18 @@ export const Tooltip: React.FC<TooltipProps> = ({
       style={style}
     >
       <div className="rn-tooltip__content">
-        {title && <div className="rn-tooltip__title">{title}</div>}
-        <div className="rn-tooltip__message">{children}</div>
+        {title && (
+          <div className="rn-tooltip__title" id={titleId}>
+            {title}
+          </div>
+        )}
+        <div
+          className="rn-tooltip__message"
+          data-testid="tooltip-content"
+          id={contentId}
+        >
+          {children}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Related issue
Fixes #1079

## Overview
Adds attributes required for accessibility in the `Tooltip` component.

## Reason
Working our way towards agreed standard.

## Work carried out
- [x] Refactor existing code
- [x] Add attributes