### PR TITLE
Add `aria-hidden` to `Button`

### DIFF
--- a/packages/react-component-library/src/components/Button/Button.test.tsx
+++ b/packages/react-component-library/src/components/Button/Button.test.tsx
@@ -1,5 +1,5 @@
-import '@testing-library/jest-dom/extend-expect'
 import React, { FormEvent } from 'react'
+import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult, fireEvent } from '@testing-library/react'
 
 import { Button } from './index'
@@ -23,6 +23,10 @@ describe('Button', () => {
 
     it('should default the type to "button"', () => {
       expect(button).toHaveAttribute('type', 'button')
+    })
+
+    it('should not render an icon', () => {
+      expect(wrapper.queryByTestId('button-icon')).toBeNull()
     })
 
     describe('when the button is clicked', () => {

--- a/packages/react-component-library/src/components/Button/Button.test.tsx
+++ b/packages/react-component-library/src/components/Button/Button.test.tsx
@@ -1,5 +1,6 @@
 import React, { FormEvent } from 'react'
 import '@testing-library/jest-dom/extend-expect'
+import { IconBrightnessLow } from '@royalnavy/icon-library'
 import { render, RenderResult, fireEvent } from '@testing-library/react'
 
 import { Button } from './index'
@@ -83,6 +84,23 @@ describe('Button', () => {
       button = wrapper.getByText('Click me').parentElement
 
       expect(button).toHaveAttribute('type', expected)
+    })
+  })
+
+  describe('when an icon is specified', () => {
+    beforeEach(() => {
+      wrapper = render(<Button icon={<IconBrightnessLow />}>Click me</Button>)
+    })
+
+    it('should render an icon', () => {
+      expect(wrapper.getByTestId('button-icon')).toBeInTheDocument()
+    })
+
+    it('should render the icon with an `aria-hidden` attribute', () => {
+      expect(wrapper.queryByTestId('button-icon')).toHaveAttribute(
+        'aria-hidden',
+        'true'
+      )
     })
   })
 })

--- a/packages/react-component-library/src/components/Button/Button.tsx
+++ b/packages/react-component-library/src/components/Button/Button.tsx
@@ -37,7 +37,7 @@ export interface ButtonProps extends ComponentWithClass {
 
 export const Button: React.FC<ButtonProps> = ({
   children,
-  className = '',
+  className,
   color,
   isDisabled,
   icon,
@@ -59,10 +59,10 @@ export const Button: React.FC<ButtonProps> = ({
   return (
     <button
       className={classes}
+      data-testid="button"
       disabled={isDisabled}
-      data-testid="rn-button"
       type={type}
-      onClick={e => {
+      onClick={(e) => {
         e.currentTarget.blur()
 
         if (onClick) {
@@ -72,7 +72,11 @@ export const Button: React.FC<ButtonProps> = ({
       {...rest}
     >
       <span className="rn-btn__text">{children}</span>
-      {icon && <span className="rn-btn__icon">{icon}</span>}
+      {icon && (
+        <span className="rn-btn__icon" data-testid="button-icon">
+          {icon}
+        </span>
+      )}
     </button>
   )
 }

--- a/packages/react-component-library/src/components/Button/Button.tsx
+++ b/packages/react-component-library/src/components/Button/Button.tsx
@@ -73,7 +73,7 @@ export const Button: React.FC<ButtonProps> = ({
     >
       <span className="rn-btn__text">{children}</span>
       {icon && (
-        <span className="rn-btn__icon" data-testid="button-icon">
+        <span aria-hidden className="rn-btn__icon" data-testid="button-icon">
           {icon}
         </span>
       )}

--- a/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.test.tsx
@@ -37,27 +37,27 @@ describe('ButtonGroup', () => {
     })
 
     it('should render a button group wrapper', () => {
-      expect(wrapper.getByTestId('rn-buttongroup')).toBeInTheDocument()
+      expect(wrapper.getByTestId('buttongroup')).toBeInTheDocument()
     })
 
     it('should render 3 buttons', () => {
-      expect(wrapper.getAllByTestId('rn-button')).toHaveLength(3)
+      expect(wrapper.getAllByTestId('button')).toHaveLength(3)
     })
 
     it('should style the buttons as secondary buttons', () => {
-      const buttons = wrapper.getAllByTestId('rn-button')
+      const buttons = wrapper.getAllByTestId('button')
       buttons.forEach((button) =>
         expect(button).toHaveClass('rn-btn--secondary')
       )
     })
 
     it('should set the default size', () => {
-      const buttons = wrapper.getAllByTestId('rn-button')
+      const buttons = wrapper.getAllByTestId('button')
       buttons.forEach((button) => expect(button).toHaveClass('rn-btn--regular'))
     })
 
     it('should default the type to "button"', () => {
-      const buttons = wrapper.getAllByTestId('rn-button')
+      const buttons = wrapper.getAllByTestId('button')
       buttons.forEach((button) =>
         expect(button).toHaveAttribute('type', 'button')
       )
@@ -67,7 +67,7 @@ describe('ButtonGroup', () => {
       let buttons
 
       beforeEach(() => {
-        buttons = wrapper.getAllByTestId('rn-button')
+        buttons = wrapper.getAllByTestId('button')
 
         fireEvent(
           buttons[1],
@@ -100,7 +100,7 @@ describe('ButtonGroup', () => {
     })
 
     it('should render a button group wrapper', () => {
-      expect(wrapper.getByTestId('rn-buttongroup')).toHaveClass('Scooby')
+      expect(wrapper.getByTestId('buttongroup')).toHaveClass('Scooby')
     })
   })
 
@@ -133,7 +133,7 @@ describe('ButtonGroup', () => {
     })
 
     it('should set the button size to the same as the size specified by the parent', () => {
-      const buttons = wrapper.getAllByTestId('rn-button')
+      const buttons = wrapper.getAllByTestId('button')
       buttons.forEach((button) => expect(button).toHaveClass('rn-btn--regular'))
     })
   })

--- a/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.tsx
@@ -24,7 +24,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = ({
   })
 
   return (
-    <div className={classes} data-testid="rn-buttongroup">
+    <div className={classes} data-testid="buttongroup">
       {React.Children.map(
         children,
         (child: React.ReactElement<ButtonGroupItemProps>) => {


### PR DESCRIPTION
## Related issue
Closes #1061 

## Overview
Adds the `aria-hidden` to the button icon if specified.

## Reason
Required for screenreaders to be efficient.

## Work carried out
- [x] Tidy existing code
- [x] Add attribute