### PR TITLE
fix(Types): Rename and export ComponentWithClass

### DIFF
--- a/packages/react-component-library/src/components/Badge/Badge.tsx
+++ b/packages/react-component-library/src/components/Badge/Badge.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 import {
   BADGE_COLOR,
   BADGE_COLOR_VARIANT,
@@ -22,7 +23,7 @@ export type BadgeSizeType =
   | typeof BADGE_SIZE.LARGE
   | typeof BADGE_SIZE.XLARGE
 
-interface BadgeProps extends ComponentWithClass {
+interface BadgeProps extends PropsWithClassName {
   color?: BadgeColorType
   colorVariant?:
     | typeof BADGE_COLOR_VARIANT.FADED

--- a/packages/react-component-library/src/components/Button/Button.tsx
+++ b/packages/react-component-library/src/components/Button/Button.tsx
@@ -7,6 +7,7 @@ import {
   BUTTON_VARIANT,
   BUTTON_ICON_POSITION,
 } from './constants'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
 export type ButtonSizeType =
   | typeof BUTTON_SIZE.SMALL
@@ -23,7 +24,7 @@ export type ButtonIconPositionType =
   | typeof BUTTON_ICON_POSITION.LEFT
   | typeof BUTTON_ICON_POSITION.RIGHT
 
-export interface ButtonProps extends ComponentWithClass {
+export interface ButtonProps extends PropsWithClassName {
   children?: string
   color?: typeof BUTTON_COLOR.DANGER
   isDisabled?: boolean

--- a/packages/react-component-library/src/components/CardFrame/CardFrame.tsx
+++ b/packages/react-component-library/src/components/CardFrame/CardFrame.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import classNames from 'classnames'
 
-export const CardFrame: React.FC<ComponentWithClass> = ({
+import { PropsWithClassName } from '../../types/PropsWithClassName'
+
+export const CardFrame: React.FC<PropsWithClassName> = ({
   children,
   className,
 }) => {

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
@@ -2,7 +2,9 @@ import React, { forwardRef } from 'react'
 import classNames from 'classnames'
 import { v4 as uuidv4 } from 'uuid'
 
-export interface CheckboxProps extends ComponentWithClass {
+import { PropsWithClassName } from '../../types/PropsWithClassName'
+
+export interface CheckboxProps extends PropsWithClassName {
   id?: string
   isChecked?: boolean
   isDisabled?: boolean

--- a/packages/react-component-library/src/components/DataList/DataList.tsx
+++ b/packages/react-component-library/src/components/DataList/DataList.tsx
@@ -3,10 +3,11 @@ import classNames from 'classnames'
 import { IconKeyboardArrowDown } from '@royalnavy/icon-library'
 
 import { Badge } from '../Badge'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 import { DataListItemProps } from '.'
 import { getId } from '../../helpers'
 
-export interface DataListProps extends ComponentWithClass {
+export interface DataListProps extends PropsWithClassName {
   children:
     | React.ReactElement<DataListItemProps>
     | React.ReactElement<DataListItemProps>[]

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -24,6 +24,7 @@ import { NavButton } from './NavButton'
 import { useOpenClose } from './useOpenClose'
 import { DATEPICKER_PLACEMENT, DATEPICKER_PLACEMENTS } from '.'
 import { FloatingBox, FLOATING_BOX_SCHEME } from '../../primitives/FloatingBox'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
 export interface StateObject {
   endDate?: Date
@@ -31,7 +32,7 @@ export interface StateObject {
   startDate?: Date
 }
 
-export interface DatePickerProps extends ComponentWithClass {
+export interface DatePickerProps extends PropsWithClassName {
   endDate?: Date
   id?: string
   isDisabled?: boolean

--- a/packages/react-component-library/src/components/DatePicker/Day.tsx
+++ b/packages/react-component-library/src/components/DatePicker/Day.tsx
@@ -2,9 +2,10 @@ import React, { useContext } from 'react'
 import classNames from 'classnames'
 import { useDay } from '@datepicker-react/hooks'
 
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 import DatepickerContext from './datepickerContext'
 
-export interface DayProps extends ComponentWithClass {
+export interface DayProps extends PropsWithClassName {
   dayLabel?: string
   date: Date
 }

--- a/packages/react-component-library/src/components/DatePicker/Input.tsx
+++ b/packages/react-component-library/src/components/DatePicker/Input.tsx
@@ -1,8 +1,9 @@
 import React, { forwardRef } from 'react'
 
 import { TriangleDown } from '../../icons'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-export interface InputProps extends ComponentWithClass {
+export interface InputProps extends PropsWithClassName {
   ref: React.Ref<any>
   id?: string
   label?: string

--- a/packages/react-component-library/src/components/DatePicker/Month.tsx
+++ b/packages/react-component-library/src/components/DatePicker/Month.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 import { useMonth, FirstDayOfWeek } from '@datepicker-react/hooks'
 
 import { Day } from './Day'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-export interface MonthProps extends ComponentWithClass {
+export interface MonthProps extends PropsWithClassName {
   year: number
   month: number
   firstDayOfWeek: FirstDayOfWeek

--- a/packages/react-component-library/src/components/DatePicker/NavButton.tsx
+++ b/packages/react-component-library/src/components/DatePicker/NavButton.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
-export interface NavButtonProps extends ComponentWithClass {
+import { PropsWithClassName } from '../../types/PropsWithClassName'
+
+export interface NavButtonProps extends PropsWithClassName {
   children: React.ReactElement | string
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
 }

--- a/packages/react-component-library/src/components/Dialog/Dialog.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.tsx
@@ -4,8 +4,9 @@ import classNames from 'classnames'
 import { Modal } from '../Modal'
 import { ButtonProps } from '../Button'
 import { getId } from '../../helpers'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-export interface DialogProps extends ComponentWithClass {
+export interface DialogProps extends PropsWithClassName {
   description?: string
   isDanger?: boolean
   isOpen?: boolean

--- a/packages/react-component-library/src/components/DismissibleBanner/DismissableBanner.tsx
+++ b/packages/react-component-library/src/components/DismissibleBanner/DismissableBanner.tsx
@@ -3,8 +3,9 @@ import classNames from 'classnames'
 
 import { Button, BUTTON_SIZE, BUTTON_VARIANT } from '../Button'
 import { Checkbox } from '../Checkbox'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-interface DismissibleBannerWithTitleProps extends ComponentWithClass {
+interface DismissibleBannerWithTitleProps extends PropsWithClassName {
   hasCheckbox?: boolean
   children: string
   onDismiss: (
@@ -15,7 +16,7 @@ interface DismissibleBannerWithTitleProps extends ComponentWithClass {
 }
 
 interface DismissibleBannerWithArbitraryContentProps
-  extends ComponentWithClass {
+  extends PropsWithClassName {
   hasCheckbox?: boolean
   children: React.ReactElement
   onDismiss: (

--- a/packages/react-component-library/src/components/Drawer/Drawer.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 import classNames from 'classnames'
 import { IconClose } from '@royalnavy/icon-library'
 import { useOpenClose } from '../../hooks/useOpenClose'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-interface DrawerProps extends ComponentWithClass {
+interface DrawerProps extends PropsWithClassName {
   children?: React.ReactNode
   isOpen?: boolean
   onClose?: (event: React.FormEvent<HTMLButtonElement>) => void

--- a/packages/react-component-library/src/components/FormikGroup/FormikGroup.tsx
+++ b/packages/react-component-library/src/components/FormikGroup/FormikGroup.tsx
@@ -6,8 +6,9 @@ import {
   getError,
   transformErrorToAriaAttributes,
 } from '../../enhancers'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-interface FormikGroupProps extends ComponentWithClass {
+interface FormikGroupProps extends PropsWithClassName {
   children: React.ReactElement[]
   label?: string
 }

--- a/packages/react-component-library/src/components/List/List.tsx
+++ b/packages/react-component-library/src/components/List/List.tsx
@@ -4,8 +4,9 @@ import classNames from 'classnames'
 import { ListItem, ListItemProps } from './ListItem'
 import { useListItem } from './useListItem'
 import { warnIfOverwriting } from '../../helpers'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-interface ListProps extends ComponentWithClass {
+interface ListProps extends PropsWithClassName {
   children:
     | React.ReactElement<ListItemProps>
     | React.ReactElement<ListItemProps>[]

--- a/packages/react-component-library/src/components/List/ListItem.tsx
+++ b/packages/react-component-library/src/components/List/ListItem.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { IconChevronRight } from '@royalnavy/icon-library'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-export interface ListItemProps extends ComponentWithClass {
+export interface ListItemProps extends PropsWithClassName {
   children: string | string[]
   isActive?: boolean
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -7,8 +7,9 @@ import { Header } from './Header'
 import { Footer } from './Footer'
 import { useOpenClose } from '../../hooks/useOpenClose'
 import { getId } from '../../helpers'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-export interface ModalProps extends ComponentWithClass {
+export interface ModalProps extends PropsWithClassName {
   children?: React.ReactNode
   descriptionId?: string
   isOpen?: boolean

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import classNames from 'classnames'
 import { IconLoader } from '@royalnavy/icon-library'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-export const ProgressIndicator: React.FC<ComponentWithClass> = ({
+export const ProgressIndicator: React.FC<PropsWithClassName> = ({
   className,
 }) => {
   const classes = classNames('rn-progress-indicator', className)

--- a/packages/react-component-library/src/components/Radio/Radio.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.tsx
@@ -1,7 +1,9 @@
 import React, { forwardRef } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
-export interface RadioProps extends ComponentWithClass {
+import { PropsWithClassName } from '../../types/PropsWithClassName'
+
+export interface RadioProps extends PropsWithClassName {
   id?: string
   isChecked?: boolean
   isDisabled?: boolean

--- a/packages/react-component-library/src/components/RangeSlider/ThresholdTrack.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/ThresholdTrack.tsx
@@ -2,12 +2,14 @@ import React from 'react'
 import classNames from 'classnames'
 import { TrackItem, GetTrackProps } from 'react-compound-slider'
 
+import { PropsWithClassName } from '../../types/PropsWithClassName'
+
 interface ThresholdTrackProps extends TrackItem {
   getTrackProps: GetTrackProps
   thresholds?: number[]
 }
 
-interface ChunkProps extends ComponentWithClass {
+interface ChunkProps extends PropsWithClassName {
   left: number
   width: number
   maxWidth: number

--- a/packages/react-component-library/src/components/TextArea/TextArea.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.tsx
@@ -3,10 +3,11 @@ import { v4 as uuidv4 } from 'uuid'
 import classNames from 'classnames'
 
 import { useFocus } from '../../hooks/useFocus'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
 export interface TextAreaInputProps
   extends TextareaHTMLAttributes<HTMLTextAreaElement>,
-    ComponentWithClass {
+    PropsWithClassName {
   isDisabled?: boolean
   footnote?: string
   label?: string

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -24,6 +24,7 @@ import { TimelineOptions } from './context/types'
 import { DEFAULTS } from './constants'
 import { getKey } from '../../helpers'
 import { formatPx } from './helpers'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
 type timelineRootChildrenType = React.ReactElement<TimelineSideProps>
 
@@ -40,7 +41,7 @@ type timelineChildrenType =
   | timelineHeadChildrenType
   | timelineBodyChildrenType
 
-export interface TimelineProps extends ComponentWithClass {
+export interface TimelineProps extends PropsWithClassName {
   children: timelineChildrenType | timelineChildrenType[]
   dayWidth?: number
   startDate?: Date

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -3,9 +3,10 @@ import classNames from 'classnames'
 import { format } from 'date-fns'
 
 import { useTimelinePosition } from './hooks/useTimelinePosition'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
 export interface TimelineEventWithRenderContentProps
-  extends ComponentWithClass {
+  extends PropsWithClassName {
   children?: never
   endDate: Date
   render: (
@@ -17,7 +18,7 @@ export interface TimelineEventWithRenderContentProps
   startDate: Date
 }
 
-export interface TimelineEventWithChildrenProps extends ComponentWithClass {
+export interface TimelineEventWithChildrenProps extends PropsWithClassName {
   children: string
   endDate: Date
   render?: never

--- a/packages/react-component-library/src/components/Timeline/TimelineEvents.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvents.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 import { TimelineEventProps } from '.'
 
-export interface TimelineEventsProps extends ComponentWithClass {
+export interface TimelineEventsProps extends PropsWithClassName {
   children:
     | React.ReactElement<TimelineEventProps>
     | React.ReactElement<TimelineEventProps>[]

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -4,11 +4,12 @@ import classNames from 'classnames'
 
 import { formatPx } from './helpers'
 import { withKey } from '../../helpers'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 import { TimelineContext } from './context'
 import { DATE_MONTH_FORMAT } from './constants'
 
 export interface TimelineMonthsWithRenderContentProps
-  extends ComponentWithClass {
+  extends PropsWithClassName {
   render: (
     index: number,
     dayWidth: number,
@@ -17,7 +18,7 @@ export interface TimelineMonthsWithRenderContentProps
   ) => React.ReactElement
 }
 
-export interface TimelineMonthsWithChildrenProps extends ComponentWithClass {
+export interface TimelineMonthsWithChildrenProps extends PropsWithClassName {
   render?: never
 }
 

--- a/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import classNames from 'classnames'
 
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 import { TimelineEventsProps } from '.'
 
-export interface TimelineRowProps extends ComponentWithClass {
+export interface TimelineRowProps extends PropsWithClassName {
   children:
     | React.ReactElement<TimelineEventsProps>
     | React.ReactElement<TimelineEventsProps>[]

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -7,8 +7,9 @@ import { TimelineContext } from './context'
 import { withKey } from '../../helpers'
 import { formatPx, isOdd } from './helpers'
 import { NO_DATA_MESSAGE } from './constants'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-export interface TimelineRowsProps extends ComponentWithClass {
+export interface TimelineRowsProps extends PropsWithClassName {
   children:
     | React.ReactElement<TimelineRowProps>
     | React.ReactElement<TimelineRowProps>[]

--- a/packages/react-component-library/src/components/Timeline/TimelineSide.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineSide.tsx
@@ -6,8 +6,9 @@ import { Button } from '../Button'
 import { getKey } from '../../helpers'
 import { TimelineContext } from './context'
 import { TIMELINE_ACTIONS } from './context/types'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-export interface TimelineSideProps extends ComponentWithClass {
+export interface TimelineSideProps extends PropsWithClassName {
   rowGroups?: any[]
   headChildren?: any[]
 }

--- a/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
@@ -3,14 +3,15 @@ import classNames from 'classnames'
 
 import { TimelineContext } from './context'
 import { useTimelinePosition } from './hooks/useTimelinePosition'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
 export interface TimelineTodayMarkerWithRenderContentProps
-  extends ComponentWithClass {
+  extends PropsWithClassName {
   render: (today: Date, offset: string) => React.ReactNode
 }
 
 export interface TimelineTodayMarkerWithChildrenProps
-  extends ComponentWithClass {
+  extends PropsWithClassName {
   render?: never
 }
 

--- a/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
@@ -6,9 +6,10 @@ import { DATE_WEEK_FORMAT } from './constants'
 import { formatPx, isOdd } from './helpers'
 import { withKey } from '../../helpers'
 import { TimelineContext } from './context'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
 export interface TimelineWeeksWithRenderContentProps
-  extends ComponentWithClass {
+  extends PropsWithClassName {
   render: (
     index: number,
     isOddNumber: boolean,
@@ -20,7 +21,7 @@ export interface TimelineWeeksWithRenderContentProps
   ) => React.ReactElement
 }
 
-export interface TimelineWeeksWithChildrenProps extends ComponentWithClass {
+export interface TimelineWeeksWithChildrenProps extends PropsWithClassName {
   render?: never
 }
 

--- a/packages/react-component-library/src/components/Toast/Toast.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.tsx
@@ -14,8 +14,9 @@ import {
 } from '@royalnavy/icon-library'
 
 import { getId } from '../../helpers'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
-export interface ToastProps extends BaseToastProps, ComponentWithClass {
+export interface ToastProps extends BaseToastProps, PropsWithClassName {
   label?: string
   dateTime?: Date
 }

--- a/packages/react-component-library/src/components/Toast/ToastProvider.tsx
+++ b/packages/react-component-library/src/components/Toast/ToastProvider.tsx
@@ -6,10 +6,11 @@ import {
 } from 'react-toast-notifications'
 
 import { Toast } from '.'
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 
 export interface ToastProviderProps
   extends BaseToastProviderProps,
-    ComponentWithClass {
+    PropsWithClassName {
   //
 }
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
@@ -4,6 +4,7 @@ import React, { ReactElement } from 'react'
 import { Avatar, AVATAR_VARIANT } from '../../Avatar'
 import { MastheadUserItemProps } from './MastheadUserItem'
 import { Nav } from '../../../types/Nav'
+import { PropsWithClassName } from '../../../types/PropsWithClassName'
 import { Sheet } from '../Sheet/Sheet'
 import { SheetButton } from '../Sheet/SheetButton'
 import { SHEET_PLACEMENT } from '../Sheet/constants'
@@ -15,7 +16,7 @@ export interface MastheadUserWithItemsProps extends Nav<MastheadUserItemProps> {
   link?: never
 }
 
-export interface MastheadUserWithLinkProps extends ComponentWithClass {
+export interface MastheadUserWithLinkProps extends PropsWithClassName {
   children?: never
   initials: string
   link: React.ReactElement<LinkTypes>

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
@@ -7,11 +7,12 @@ import {
 } from './constants'
 
 import { FloatingBox } from '../../../primitives/FloatingBox'
+import { PropsWithClassName } from '../../../types/PropsWithClassName'
 import { SheetButtonProps } from './SheetButton'
 import { useSheet } from './useSheet'
 import { getId } from '../../../helpers'
 
-export interface SheetProps extends ComponentWithClass {
+export interface SheetProps extends PropsWithClassName {
   button: React.ReactElement<SheetButtonProps>
   children: React.ReactElement
   placement?: typeof SHEET_PLACEMENT.RIGHT | typeof SHEET_PLACEMENT.BELOW

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sheet/SheetButton.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sheet/SheetButton.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import classNames from 'classnames'
 
-export interface SheetButtonProps extends ComponentWithClass {
+import { PropsWithClassName } from '../../../types/PropsWithClassName'
+
+export interface SheetButtonProps extends PropsWithClassName {
   children?: React.ReactElement
   icon: React.ReactElement
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
@@ -2,8 +2,9 @@ import React, { ReactElement } from 'react'
 import classNames from 'classnames'
 
 import { Avatar } from '../../Avatar'
+import { PropsWithClassName } from '../../../types/PropsWithClassName'
 
-export interface SidebarUserProps extends ComponentWithClass {
+export interface SidebarUserProps extends PropsWithClassName {
   initials: string
   link: React.ReactElement<LinkTypes>
 }

--- a/packages/react-component-library/src/icons/Bell.tsx
+++ b/packages/react-component-library/src/icons/Bell.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
-export const Bell: React.FC<ComponentWithClass> = ({ className = '' }) => (
+import { PropsWithClassName } from '../types/PropsWithClassName'
+
+export const Bell: React.FC<PropsWithClassName> = ({ className = '' }) => (
   <svg
     className={className}
     width="16px"

--- a/packages/react-component-library/src/icons/Logo.tsx
+++ b/packages/react-component-library/src/icons/Logo.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 
-export const Logo: React.FC<ComponentWithClass> = ({ className = '', ...rest }) => (
+import { PropsWithClassName } from '../types/PropsWithClassName'
+
+export const Logo: React.FC<PropsWithClassName> = ({ className = '', ...rest }) => (
   <svg
     className={className}
     width="21"

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -1,9 +1,10 @@
 import React, { forwardRef } from 'react'
 import classNames from 'classnames'
 
+import { PropsWithClassName } from '../../types/PropsWithClassName'
 import { FLOATING_BOX_SCHEME, FLOATING_BOX_ARROW_POSITION } from './constants'
 
-export interface FloatingBoxProps extends PositionType, ComponentWithClass {
+export interface FloatingBoxProps extends PositionType, PropsWithClassName {
   width?: number
   height?: number
   top?: number

--- a/packages/react-component-library/src/types/ComponentWithClass.d.ts
+++ b/packages/react-component-library/src/types/ComponentWithClass.d.ts
@@ -1,3 +1,0 @@
-interface ComponentWithClass extends React.ComponentType {
-  className?: string
-}

--- a/packages/react-component-library/src/types/Link.d.ts
+++ b/packages/react-component-library/src/types/Link.d.ts
@@ -1,8 +1,15 @@
-interface AnchorType extends ComponentWithClass {
+// LinkTypes is currently not exported, but to start exporting it would
+// introduce a breaking change.
+// PropsWithClassName is defined here to avoid needing to export LinkTypes.
+interface PropsWithClassName {
+  className?: string
+}
+
+interface AnchorType extends PropsWithClassName {
   href: string
 }
 
-interface LinkType extends ComponentWithClass {
+interface LinkType extends PropsWithClassName {
   to: string
 }
 

--- a/packages/react-component-library/src/types/Link.d.ts
+++ b/packages/react-component-library/src/types/Link.d.ts
@@ -1,15 +1,15 @@
 // LinkTypes is currently not exported, but to start exporting it would
 // introduce a breaking change.
-// PropsWithClassName is defined here to avoid needing to export LinkTypes.
-interface PropsWithClassName {
-  className?: string
-}
+// AnchorType and LinkType should be using PropsWithClassName, but importing it
+// means LinkTypes needs to be exported.
 
-interface AnchorType extends PropsWithClassName {
+interface AnchorType {
+  className?: string
   href: string
 }
 
-interface LinkType extends PropsWithClassName {
+interface LinkType {
+  className?: string
   to: string
 }
 

--- a/packages/react-component-library/src/types/Nav.ts
+++ b/packages/react-component-library/src/types/Nav.ts
@@ -1,6 +1,8 @@
 import React from 'react'
 
-export interface Nav<T> extends ComponentWithClass {
+import { PropsWithClassName } from './PropsWithClassName'
+
+export interface Nav<T> extends PropsWithClassName {
   children: React.ReactElement<T> | React.ReactElement<T>[]
 }
 

--- a/packages/react-component-library/src/types/PropsWithClassName.ts
+++ b/packages/react-component-library/src/types/PropsWithClassName.ts
@@ -1,0 +1,3 @@
+export interface PropsWithClassName {
+  className?: string
+}


### PR DESCRIPTION
## Related issue

n/a

## Overview

This renames `ComponentWithClass` to `PropsWithClassName` and starts exporting it.

## Reason

Previously the `ComponentWithClass` interface was not exported. This meant that it wasn't included in the distributed types (in `packages/react-component-library/dist/types`) and users of the component library could not set the `className` prop (for supported components e.g. `Modal`).

Additionally, the name of `ComponentWithClass` was misleading as it's used for props rather than components.

For example, the following no longer returns a type error when using the distributed version of the component library:

```
      <List className="test" >
        <ListItem title="Title" onClick={() => {}}>
          Description
        </ListItem>
      </List>
```

An example of the error that you would've previously received:
```
TypeScript error in ...:
Type '{ children: Element; className: string; }' is not assignable to type 'IntrinsicAttributes & ListProps & { children?: ReactNode; }'.
  Property 'className' does not exist on type 'IntrinsicAttributes & ListProps & { children?: ReactNode; }'.  TS2322
```


## Work carried out

- [x] Rename `ComponentWithClass` to `PropsWithClassName`
- [x] Remove incorrect inheritance from `React.ComponentType`
- [x] Export `PropsWithClassName`
- [x] Import `PropsWithClassName` where needed

## Screenshot

n/a

## Developer notes

Note there seems to be a similar problem for `LinkTypes` and possibly others. Those aren't fixed here as we also need to be careful to not introduce a breaking change by adding non-optional props. (A small workaround for `LinkTypes` was added to avoid needing to export it.)