### PR TITLE
fix(List): Correct type of ListItem children

### DIFF
--- a/packages/docs-site/src/library/pages/components/list.md
+++ b/packages/docs-site/src/library/pages/components/list.md
@@ -82,7 +82,7 @@ todo
 <DataTable data={[
   {
     Name: 'children',
-    Type: 'string',
+    Type: 'string | string[]',
     Required: 'True',
     Default: '',
     Description: 'Text content of the item',

--- a/packages/react-component-library/src/components/List/List.test.tsx
+++ b/packages/react-component-library/src/components/List/List.test.tsx
@@ -207,4 +207,23 @@ describe('List', () => {
       )
     })
   })
+
+  describe('when a list item has multiple children ', () => {
+    beforeEach(() => {
+      const extraItemText = 'extra text'
+      wrapper = render(
+        <List>
+          <ListItem onClick={jest.fn()} title="List item">
+            Main text: {extraItemText}
+          </ListItem>
+        </List>
+      )
+    })
+
+    it("renders the item's text", () => {
+      expect(wrapper.getAllByTestId('list-item')[0]).toHaveTextContent(
+        'Main text: extra text'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/List/ListItem.tsx
+++ b/packages/react-component-library/src/components/List/ListItem.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { IconChevronRight } from '@royalnavy/icon-library'
 
 export interface ListItemProps extends ComponentWithClass {
-  children: string
+  children: string | string[]
   isActive?: boolean
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
   onMouseEnter?: (event: React.MouseEvent<HTMLButtonElement>) => void


### PR DESCRIPTION
## Related issue

n/a

## Overview

This changes the type of the `children` prop of `ListItem` from `string` to `string | string[]` to allow embedded expressions to be used within a `ListItem`.

## Reason

When using an embedded expression within a `ListItem`, the type of `children` ends up being `string[]` instead of `string`.

For example:

```jsx
const text = 'Ha'

...

<List>
  <ListItem title="Title" onClick={() => {}}>
    Description {text}
  </ListItem>
</List>
```

was resulting in the following error:

```
TypeScript error in ...:
Type '{ children: string[]; title: string; onClick: () => void; }' is not assignable to type 'ListItemProps'.
  Types of property 'children' are incompatible.
    Type 'string[]' is not assignable to type 'string'.  TS2322
```

## Work carried out

- [x] Change type of `ListItemProps.children`
- [x] Add unit test for this case
- [x] Update docs
