### PR TITLE
fix(Timeline): Improve behaviour when bounding by start and end date

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { differenceInDays } from 'date-fns'
 
-import { TimelineProvider, TimelineContext } from './context'
+import { TimelineProvider } from './context'
 import { TimelineComponent } from './types'
 
 import {
@@ -23,7 +22,6 @@ import {
 import { TimelineOptions } from './context/types'
 import { DEFAULTS } from './constants'
 import { getKey } from '../../helpers'
-import { formatPx } from './helpers'
 
 type timelineRootChildrenType = React.ReactElement<TimelineSideProps>
 
@@ -140,32 +138,13 @@ export const Timeline: React.FC<TimelineProps> = ({
       today={today}
       options={options}
     >
-      <TimelineContext.Consumer>
-        {({ state: { months } }) => {
-          const offset = endDate
-            ? formatPx(
-                dayWidth,
-                differenceInDays(months[0].startDate, startDate)
-              )
-            : null
-
-          return (
-            <article className="timeline">
-              {rootChildren}
-              <div
-                className="timeline__inner"
-                style={{
-                  marginLeft: offset,
-                }}
-                data-testid="timeline-inner"
-              >
-                <header className="timeline__header">{headChildren}</header>
-                {bodyChildren}
-              </div>
-            </article>
-          )
-        }}
-      </TimelineContext.Consumer>
+      <article className="timeline">
+        {rootChildren}
+        <div className="timeline__inner" data-testid="timeline-inner">
+          <header className="timeline__header">{headChildren}</header>
+          {bodyChildren}
+        </div>
+      </article>
     </TimelineProvider>
   )
 }

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -40,7 +40,11 @@ function renderDefault(
   )
 
   return (
-    <div className={classes} style={{ left: offsetPx }}>
+    <div
+      className={classes}
+      style={{ left: offsetPx }}
+      data-testid="timeline-event"
+    >
       <span
         className="timeline__event-title"
         data-testid="timeline-event-title"

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { format, getDaysInMonth, differenceInDays } from 'date-fns'
+import { format, endOfMonth, differenceInDays, min, max } from 'date-fns'
 import classNames from 'classnames'
 
 import { formatPx } from './helpers'
@@ -61,30 +61,22 @@ export const TimelineMonths: React.FC<TimelineMonthsProps> = ({ render }) => {
     <TimelineContext.Consumer>
       {({
         state: {
+          days,
           months,
-          endDate: timelineEndDate,
           options: { dayWidth },
         },
       }) => {
-        const wrapperStyles = timelineEndDate
-          ? {
-              width: formatPx(
-                dayWidth,
-                differenceInDays(timelineEndDate, months[0].startDate) + 1
-              ),
-              overflow: 'hidden',
-            }
-          : null
-
         return (
-          <div
-            className="timeline__months"
-            data-testid="timeline-months"
-            style={wrapperStyles}
-          >
+          <div className="timeline__months" data-testid="timeline-months">
             {months &&
               months.map(({ startDate }, index) => {
-                const daysTotal = getDaysInMonth(startDate)
+                const firstDateDisplayed = max([startDate, days[0].date])
+                const lastDateDisplayed = min([
+                  endOfMonth(startDate),
+                  days[days.length - 1].date,
+                ])
+                const daysTotal =
+                  differenceInDays(lastDateDisplayed, firstDateDisplayed) + 1
 
                 const child = render
                   ? render(index, dayWidth, daysTotal, startDate)

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import classNames from 'classnames'
-import { differenceInDays } from 'date-fns'
+import { differenceInDays, endOfWeek, max, min } from 'date-fns'
 
 import { TimelineRowProps } from '.'
 import { TimelineContext } from './context'
 import { withKey } from '../../helpers'
 import { formatPx, isOdd } from './helpers'
-import { NO_DATA_MESSAGE } from './constants'
+import { NO_DATA_MESSAGE, WEEK_START } from './constants'
 
 export interface TimelineRowsProps extends ComponentWithClass {
   children:
@@ -84,40 +84,30 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
         <TimelineContext.Consumer>
           {({
             state: {
-              months,
               weeks,
-              endDate: timelineEndDate,
+              days,
               options: { dayWidth },
             },
           }) => {
-            const wrapperStyles = timelineEndDate
-              ? {
-                  width: formatPx(
-                    dayWidth,
-                    differenceInDays(timelineEndDate, months[0].startDate) + 1
-                  ),
-                  overflow: 'hidden',
-                }
-              : null
-
             return (
               <div
                 className={rowClasses}
-                style={wrapperStyles}
                 data-testid="timeline-columns"
               >
                 {weeks.map(({ startDate }, index) => {
-                  const diff = differenceInDays(
-                    new Date(startDate),
-                    new Date(months[0].startDate)
+                  const lastDateDisplayed = min([
+                    endOfWeek(startDate, { weekStartsOn: WEEK_START }),
+                    days[days.length - 1].date,
+                  ])
+                  const offsetInDays = differenceInDays(
+                    startDate,
+                    max([startDate, days[0].date])
                   )
-
-                  const offsetPx = formatPx(
+                  const offsetPx = formatPx(dayWidth, offsetInDays)
+                  const widthPx = formatPx(
                     dayWidth,
-                    diff < 0 ? -Math.abs(diff) : 0
+                    differenceInDays(lastDateDisplayed, startDate) + 1
                   )
-
-                  const widthPx = formatPx(dayWidth, 7)
 
                   const isOddNumber = isOdd(index)
 

--- a/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import classNames from 'classnames'
-import { format, differenceInDays, isAfter } from 'date-fns'
+import { format, differenceInDays, endOfWeek, max, min } from 'date-fns'
 
-import { DATE_WEEK_FORMAT } from './constants'
+import { DATE_WEEK_FORMAT, WEEK_START } from './constants'
 import { formatPx, isOdd } from './helpers'
 import { withKey } from '../../helpers'
 import { TimelineContext } from './context'
@@ -71,41 +71,26 @@ export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({ render }) => {
     <TimelineContext.Consumer>
       {({
         state: {
-          months,
+          days,
           weeks,
-          endDate: timelineEndDate,
           options: { dayWidth },
         },
       }) => {
-        const wrapperStyles = timelineEndDate
-          ? {
-              width: formatPx(
-                dayWidth,
-                differenceInDays(timelineEndDate, months[0].startDate) + 1
-              ),
-              overflow: 'hidden',
-            }
-          : null
-
         return (
-          <div
-            className="timeline__weeks"
-            data-testid="timeline-weeks"
-            style={wrapperStyles}
-          >
+          <div className="timeline__weeks" data-testid="timeline-weeks">
             {weeks.map(({ startDate }, index) => {
-              if (isAfter(startDate, timelineEndDate)) return null
-
-              const diff = differenceInDays(
-                new Date(startDate),
-                new Date(months[0].startDate)
+              const lastDateDisplayed = min([
+                endOfWeek(startDate, { weekStartsOn: WEEK_START }),
+                days[days.length - 1].date,
+              ])
+              const daysTotal =
+                differenceInDays(lastDateDisplayed, startDate) + 1
+              const offsetInDays = differenceInDays(
+                startDate,
+                max([startDate, days[0].date])
               )
-
-              const offsetPx = formatPx(
-                dayWidth,
-                diff < 0 ? -Math.abs(diff) : 0
-              )
-              const widthPx = formatPx(dayWidth, 7)
+              const offsetPx = formatPx(dayWidth, offsetInDays)
+              const widthPx = formatPx(dayWidth, daysTotal)
 
               const isOddNumber = isOdd(index)
 
@@ -115,7 +100,7 @@ export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({ render }) => {
                 offsetPx,
                 widthPx,
                 dayWidth,
-                7,
+                daysTotal,
                 startDate,
               ]
 

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
+import { DEFAULTS } from '../constants'
 import {
   TimelineSide,
   TimelineTodayMarker,
@@ -667,8 +668,8 @@ describe('Timeline', () => {
     beforeEach(() => {
       wrapper = render(
         <Timeline
-          startDate={new Date(2020, 1, 1, 0, 0, 0)}
-          endDate={new Date(2020, 1, 15, 0, 0, 0)}
+          startDate={new Date(2020, 1, 6, 0, 0, 0)}
+          endDate={new Date(2020, 1, 22, 0, 0, 0)}
           today={new Date(2020, 4, 1, 0, 0, 0)}
         >
           <TimelineSide />
@@ -680,7 +681,7 @@ describe('Timeline', () => {
             <TimelineRow name="Row 1">
               <TimelineEvents>
                 <TimelineEvent
-                  startDate={new Date(2020, 1, 1, 0, 0, 0)}
+                  startDate={new Date(2020, 1, 7, 0, 0, 0)}
                   endDate={new Date(2020, 1, 10, 0, 0, 0)}
                 >
                   Event
@@ -692,29 +693,22 @@ describe('Timeline', () => {
       )
     })
 
-    it('applies the dynamic styles to the appropriate wrappers', () => {
-      expect(wrapper.getByTestId('timeline-inner')).toHaveStyle({
-        marginLeft: '0px',
-      })
+    it('renders the correct number of months', () => {
+      expect(wrapper.queryAllByTestId('timeline-month')).toHaveLength(1)
+    })
 
-      expect(wrapper.getByTestId('timeline-columns')).toHaveStyle({
-        width: '450px',
-        overflow: 'hidden',
-      })
-
-      expect(wrapper.getByTestId('timeline-months')).toHaveStyle({
-        width: '450px',
-        overflow: 'hidden',
-      })
-
-      expect(wrapper.getByTestId('timeline-weeks')).toHaveStyle({
-        width: '450px',
-        overflow: 'hidden',
-      })
+    it('renders the correct number of weeks', () => {
+      expect(wrapper.queryAllByTestId('timeline-week')).toHaveLength(3)
     })
 
     it('renders the correct number of days', () => {
-      expect(wrapper.queryAllByTestId('timeline-day-title')).toHaveLength(15)
+      expect(wrapper.queryAllByTestId('timeline-day-title')).toHaveLength(17)
+    })
+
+    it('positions the event correctly', () => {
+      expect(wrapper.getByTestId('timeline-event')).toHaveStyle({
+        left: `${DEFAULTS.DAY_WIDTH}px`,
+      })
     })
   })
 

--- a/packages/react-component-library/src/components/Timeline/context/__tests__/reducer.test.ts
+++ b/packages/react-component-library/src/components/Timeline/context/__tests__/reducer.test.ts
@@ -10,17 +10,16 @@ describe('TimelineContext reducer', () => {
 
   describe('getMonths', () => {
     let months: TimelineMonth[]
-    const rangeInMonths = 3
 
     beforeEach(() => {
       months = getMonths(
         new Date(2020, 3, 1, 0, 0, 0),
-        rangeInMonths,
+        new Date(2020, 5, 30, 0, 0, 0),
       )
     })
 
     it('returns the correct number of months', () => {
-      expect(months.length).toBe(rangeInMonths)
+      expect(months.length).toBe(3)
     })
 
     it('returns the correct month start dates', () => {
@@ -37,12 +36,11 @@ describe('TimelineContext reducer', () => {
 
   describe('getWeeks', () => {
     let weeks: TimelineWeek[]
-    const rangeInMonths = 3
 
     beforeEach(() => {
       weeks = getWeeks(
         new Date(2020, 3, 1, 0, 0, 0),
-        rangeInMonths,
+        new Date(2020, 5, 30, 0, 0, 0),
       )
     })
 
@@ -70,12 +68,11 @@ describe('TimelineContext reducer', () => {
 
   describe('getDays', () => {
     let days: TimelineDay[]
-    const rangeInMonths = 1
 
     beforeEach(() => {
       days = getDays(
         new Date(2020, 3, 1, 0, 0, 0),
-        rangeInMonths,
+        new Date(2020, 3, 30, 0, 0, 0),
       )
     })
 

--- a/packages/react-component-library/src/components/Timeline/context/state.ts
+++ b/packages/react-component-library/src/components/Timeline/context/state.ts
@@ -1,4 +1,6 @@
-import { getDays, getMonths, getWeeks, calcRange } from './reducer'
+import { addMonths, endOfMonth, startOfMonth } from 'date-fns'
+
+import { buildCalendar } from './reducer'
 import { TimelineOptions, TimelineState } from './types'
 
 const initialState: TimelineState = {
@@ -25,15 +27,14 @@ function initialiseState(
     options: { ...initialState.options, ...options },
   }
 
-  const range = endDate
-    ? calcRange(startDate, endDate)
-    : state.options.rangeInMonths
+  const firstDateDisplayed = endDate ? startDate : startOfMonth(startDate)
+  const lastDateDisplayed =
+    endDate ??
+    endOfMonth(addMonths(firstDateDisplayed, state.options.rangeInMonths - 1))
 
   return {
     ...state,
-    months: getMonths(startDate, range),
-    weeks: getWeeks(startDate, range),
-    days: getDays(startDate, range),
+    ...buildCalendar(firstDateDisplayed, lastDateDisplayed),
   }
 }
 

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
@@ -2,9 +2,8 @@ import { useContext } from 'react'
 
 import {
   differenceInCalendarDays,
-  endOfMonth,
   isBefore,
-  isAfter
+  isAfter,
 } from 'date-fns'
 
 import { TimelineContext } from '../context'
@@ -34,31 +33,34 @@ export function useTimelinePosition(
   startDate: Date,
   endDate: Date
 ): {
-  width: string,
-  offset: string,
-  isBeforeStart: boolean,
+  width: string
+  offset: string
+  isBeforeStart: boolean
   isAfterEnd: boolean
 } {
   const {
     state: {
-      months,
-      options
-    }
+      days,
+      options,
+    },
   } = useContext(TimelineContext)
 
-  const timelineStart = new Date(months[0].startDate)
-  const timelineEnd = new Date(endOfMonth(months[months.length - 1].startDate))
+  const firstDateDisplayed = days[0].date
+  const lastDateDisplayed = days[days.length - 1].date
 
-  const isBeforeStart = isBefore(new Date(startDate), timelineStart)
-  const isAfterEnd = isAfter(new Date(startDate), timelineEnd)
+  const isBeforeStart = isBefore(new Date(startDate), firstDateDisplayed)
+  const isAfterEnd = isAfter(new Date(startDate), lastDateDisplayed)
 
   const width = formatPx(options.dayWidth, getWidth(startDate, endDate))
-  const offset = formatPx(options.dayWidth, getOffset(startDate, timelineStart))
+  const offset = formatPx(
+    options.dayWidth,
+    getOffset(startDate, firstDateDisplayed)
+  )
 
   return {
     width,
     offset,
     isBeforeStart,
-    isAfterEnd
+    isAfterEnd,
   }
 }


### PR DESCRIPTION
## Related issue

#1231

## Overview

This changes how the feature to bound a timeline by a start and end date works so that it behaves better and is compatible with custom layouts.

## Reason

- The previous implementation wasn't compatible with custom layouts in the style of [fp-grey-box](https://github.com/m7kvqbe1/fp-grey-box)
- The title of the first month was hidden if the start date wasn't the first of the month, which wasn't desirable
- There were some other artefacts like the 'No data available' message not being centred

The changes also fixed this artefact when not bound by two dates:

<img src="https://user-images.githubusercontent.com/66470099/87662717-87599300-c75a-11ea-9631-a3f3020a73d8.png" width="371" height="302">

## Work carried out

- [x] Refactor how the Timeline state is constructed so it's built from a start and end date rather than a date and a number of months
- [x] Change `days` in the Timeline state when the Timeline is bound by two dates so that it only contains the dates between the two dates
- [x] Change how the Timeline is rendered when it is bound by two dates, so instead of hiding dates outside the date range, it doesn't display them and sizes things appropriately
- [x] Made sure the first month label is always displayed
- [x] Updated tests for when the Timeline is bound by two dates

## Screenshot

This is the example from #1231 after these changes:

![image](https://user-images.githubusercontent.com/66470099/87568291-537c6000-c6bd-11ea-846d-86290545eeae.png)

## Developer notes

- Chromatic picked up one change for the timeline that is an improvement (the 'No data available' message now being positioned correctly when the timeline is bound by two dates)
- The existing values of `dayIndex`, `weekIndex` etc. in the state should be preserved (though I'm not sure how they're intended to be used)
- The reducer is missing some test coverage, this is unchanged in this PR at the moment
- I've had a look through and everything not related to the bounded by two dates case should be the same (apart from that empty week problem mentioned above), but please have a play in Storybook etc. to double-check