### PR TITLE
feat(RangeSlider): Set `aria-hidden` on icons

### DIFF
--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
@@ -174,8 +174,22 @@ describe('RangeSlider', () => {
       expect(wrapper.queryByTestId('rangeslider-icon-left')).not.toBeNull()
     })
 
+    it('should set the `aria-hidden` attribute to `true` for the left icon', () => {
+      expect(wrapper.queryByTestId('rangeslider-icon-left')).toHaveAttribute(
+        'aria-hidden',
+        'true'
+      )
+    })
+
     it('should render the Icon component right of the slider', () => {
       expect(wrapper.queryByTestId('rangeslider-icon-right')).not.toBeNull()
+    })
+
+    it('should set the `aria-hidden` attribute to `true` for the right icon', () => {
+      expect(wrapper.queryByTestId('rangeslider-icon-right')).toHaveAttribute(
+        'aria-hidden',
+        'true'
+      )
     })
   })
 

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -58,6 +58,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
     <div className={classes} data-testid="rangeslider">
       {IconLeft && (
         <IconLeft
+          aria-hidden
           className="rn-rangeslider__icon rn-rangeslider__icon--left"
           data-testid="rangeslider-icon-left"
         />
@@ -146,6 +147,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
       </Slider>
       {IconRight && (
         <IconRight
+          aria-hidden
           className="rn-rangeslider__icon rn-rangeslider__icon--right"
           data-testid="rangeslider-icon-right"
         />


### PR DESCRIPTION
## Related issue
Closes #1071 

## Overview
Sets the `aria-hidden` attribute to `true` on the `RangeSlider` icons.

## Reason
Screenreaders do not need to read out the icons for component.

## Work carried out
- [x] Add attributes

## Developer notes
Other aria attributes were already set on this component.
