### PR TITLE
feat(Popover): Add accessibility attributes

### DIFF
--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -36,6 +36,17 @@ describe('Popover', () => {
       )
     })
 
+    it('should set the `aria-describedby` attribute to the ID of the content', () => {
+      const contentId = wrapper
+        .getByTestId('floating-box-content')
+        .getAttribute('id')
+
+      expect(wrapper.getByTestId('floating-box')).toHaveAttribute(
+        'aria-describedby',
+        contentId
+      )
+    })
+
     describe('and the user hovers on the target element', () => {
       beforeEach(() => {
         fireEvent.mouseEnter(wrapper.getByText(HOVER_ON_ME))

--- a/packages/react-component-library/src/components/Popover/Popover.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.tsx
@@ -14,6 +14,8 @@ import {
   FLOATING_BOX_SCHEME,
 } from '../../primitives/FloatingBox'
 
+import { getId } from '../../helpers'
+
 interface PopoverProps
   extends Omit<FloatingBoxProps, 'onMouseEnter' | 'onMouseLeave'> {
   children: React.ReactElement
@@ -67,6 +69,8 @@ export const Popover: React.FC<PopoverProps> = ({
     )[0]
   }
 
+  const contentId = getId('popover-content')
+
   /**
    * Type error in upstream Tether package. Fix submitted.
    * Using createElement allows us to avoid the type error.
@@ -91,6 +95,8 @@ export const Popover: React.FC<PopoverProps> = ({
             onMouseLeave={handleOnMouseLeave}
             position={PLACEMENTS.ARROW_POSITION}
             scheme={scheme}
+            aria-describedby={contentId}
+            contentId={contentId}
             {...rest}
           >
             {content}

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.test.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.test.tsx
@@ -42,6 +42,13 @@ describe('FloatingBox', () => {
       )
     })
 
+    it('applies the `role` attribute', () => {
+      expect(wrapper.getByTestId('floating-box')).toHaveAttribute(
+        'role',
+        'dialog'
+      )
+    })
+
     it('renders the box', () => {
       expect(wrapper.queryByTestId('floating-box')).toBeInTheDocument()
     })

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -2,9 +2,11 @@ import React, { forwardRef } from 'react'
 import classNames from 'classnames'
 
 import { FLOATING_BOX_SCHEME, FLOATING_BOX_ARROW_POSITION } from './constants'
+import { getId } from '../../helpers'
 
 export interface FloatingBoxProps extends PositionType, ComponentWithClass {
   role?: string
+  contentId?: string
   width?: number
   height?: number
   top?: number
@@ -29,6 +31,7 @@ export interface FloatingBoxProps extends PositionType, ComponentWithClass {
 export const FloatingBox = forwardRef(
   (props: FloatingBoxProps, ref?: React.Ref<any>) => {
     const {
+      contentId = getId('floating-box'),
       className,
       width,
       height,
@@ -72,6 +75,7 @@ export const FloatingBox = forwardRef(
       >
         <div
           className="rn-floating-box__content"
+          id={contentId}
           data-testid="floating-box-content"
         >
           {children}

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -70,6 +70,7 @@ export const FloatingBox = forwardRef(
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         style={style}
+        role="dialog"
         data-testid="floating-box"
         {...rest}
       >


### PR DESCRIPTION
## Related issue

Closes #1069 

## Overview

Add accessibility related attributes to Popover and FloatingBox components.

## Reason

>Make all existing components accessible.

## Work carried out

- [x] Add accessibility related attributes
- [x] Add automated tests