### PR TITLE
fix(DatePicker): Add explicit button type

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -20,6 +20,7 @@ describe('DatePicker', () => {
   let onBlur: (e: React.FormEvent) => void
   let dateSpy: jest.SpyInstance
   let days: string[]
+  let onSubmitSpy: (e: React.FormEvent) => void
 
   beforeAll(() => {
     dateSpy = jest
@@ -461,6 +462,27 @@ describe('DatePicker', () => {
       expect(wrapper.getByTestId('floating-box').classList).toContain(
         'is-visible'
       )
+    })
+  })
+
+  describe('when the DatePicker is nested within a form', () => {
+    beforeEach(() => {
+      onSubmitSpy = jest.fn()
+      wrapper = render(
+        <form onSubmit={onSubmitSpy}>
+          <DatePicker />
+        </form>
+      )
+    })
+
+    describe('and the open/close button is clicked', () => {
+      beforeEach(() => {
+        wrapper.getByTestId('datepicker-input-button').click()
+      })
+
+      it('does not submit the form', () => {
+        expect(onSubmitSpy).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/packages/react-component-library/src/components/DatePicker/DatePickerInput.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePickerInput.tsx
@@ -60,6 +60,7 @@ export const DatePickerInput = forwardRef(
             />
           </div>
           <button
+            type="button"
             className="rn-date-picker__end-adornment"
             onClick={isOpen ? onClose : onFocus}
             data-testid="datepicker-input-button"


### PR DESCRIPTION
## Related issue

Closes #1260 

## Overview

Prevents submission of parent form - default button type is `submit`.

## Reason

>Opening and closing the picker using the arrow button when nested within a form would submit the form.

## Work carried out

- [x] Add explicit button type attribute