### PR TITLE
fix(DatePicker): Dates under wrong days

### DIFF
--- a/packages/css-framework/src/components/_date-picker.scss
+++ b/packages/css-framework/src/components/_date-picker.scss
@@ -161,8 +161,6 @@
   width: 570px;
 
   div {
-    flex: 1;
-
     &:first-of-type {
       padding-right: f.spacing("6");
     }

--- a/packages/css-framework/src/components/_date-picker.scss
+++ b/packages/css-framework/src/components/_date-picker.scss
@@ -215,6 +215,7 @@
   font-size: f.font-size("base");
   color: f.color("neutral", "400");
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .rn-date-picker__day-label-grid {


### PR DESCRIPTION
## Related issue

Closes #1243 

## Overview

Fix styling issues with DatePicker.

## Reason

> DatePicker dates were appearing under the wrong days.

## Work carried out

- [x] Fix broken flexbox grid
- [x] Prevent month title text from wrapping

## Screenshot

<img width="611" alt="Screenshot 2020-07-23 at 09 41 16" src="https://user-images.githubusercontent.com/48086589/88267374-ac08ba00-ccc8-11ea-9aaa-29355f07db30.png">