### PR TITLE
Add accessibility attributes to `Timeline` (without `TimelineSide`)

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -304,6 +304,7 @@ stories.add('With custom event content', () => {
     endDate,
     widthPx,
     offsetPx,
+    ...rest
   }: {
     children: React.ReactNode
     startDate: Date
@@ -322,6 +323,7 @@ stories.add('With custom event content', () => {
           marginLeft: offsetPx,
           width: widthPx,
         }}
+        {...rest}
       >
         {children}
       </div>

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -138,13 +138,19 @@ export const Timeline: React.FC<TimelineProps> = ({
       today={today}
       options={options}
     >
-      <article className="timeline">
+      <div className="timeline" data-testid="timeline" role="grid">
         {rootChildren}
         <div className="timeline__inner" data-testid="timeline-inner">
-          <header className="timeline__header">{headChildren}</header>
+          <div
+            className="timeline__header"
+            data-testid="timeline-header"
+            role="rowgroup"
+          >
+            {headChildren}
+          </div>
           {bodyChildren}
         </div>
-      </article>
+      </div>
     </TimelineProvider>
   )
 }

--- a/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { format, isAfter } from 'date-fns'
 import classNames from 'classnames'
 
-import { withKey } from '../../helpers'
+import { getKey } from '../../helpers'
 import { TimelineContext } from './context'
 import { DATE_DAY_FORMAT } from './constants'
 
@@ -58,7 +58,7 @@ export const TimelineDays: React.FC<TimelineDaysProps> = ({ render }) => {
           options: { dayWidth },
         },
       }) => (
-        <div className={classes} data-testid="timeline-days">
+        <div className={classes} data-testid="timeline-days" role="row">
           {days &&
             days.map(({ date }, index) => {
               if (isAfter(date, timelineEndDate)) return null
@@ -67,7 +67,10 @@ export const TimelineDays: React.FC<TimelineDaysProps> = ({ render }) => {
                 ? render(index, dayWidth, date)
                 : renderDefault(index, dayWidth, date)
 
-              return withKey(child, 'timeline-day', date.toString())
+              return React.cloneElement(child, {
+                key: getKey('timeline-day', date.toString()),
+                role: 'columnheader',
+              })
             })}
         </div>
       )}

--- a/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
@@ -32,6 +32,7 @@ function renderDefault(index: number, dayWidth: number, date: Date) {
   return (
     <div
       className={wrapperClasses}
+      data-testid="timeline-day"
       style={{
         width: `${dayWidth}px`,
       }}

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -4,6 +4,7 @@ import { format } from 'date-fns'
 
 import { useTimelinePosition } from './hooks/useTimelinePosition'
 import { getKey } from '../../helpers'
+import { ACCESSIBLE_DATE_FORMAT } from './constants'
 
 export interface TimelineEventWithRenderContentProps
   extends ComponentWithClass {
@@ -57,6 +58,15 @@ function renderDefault(
   )
 }
 
+function getTitle(children: string, startDate: Date, endDate: Date) {
+  const start = children ? `${children} begins` : `Begins`
+
+  return `${start} on ${format(
+    startDate,
+    ACCESSIBLE_DATE_FORMAT
+  )} and ends on ${format(endDate, ACCESSIBLE_DATE_FORMAT)}`
+}
+
 export const TimelineEvent: React.FC<TimelineEventProps> = ({
   children,
   endDate,
@@ -76,9 +86,13 @@ export const TimelineEvent: React.FC<TimelineEventProps> = ({
     ? render(startDate, endDate, widthPx, offsetPx)
     : renderDefault(children, offsetPx, startDate, widthPx)
 
+  const title = getTitle(children, startDate, endDate)
+
   return (
     <div data-testid="timeline-event-wrapper">
       {React.cloneElement(event as React.ReactElement, {
+        title,
+        'aria-label': title,
         role: 'cell',
       })}
     </div>

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { format } from 'date-fns'
 
 import { useTimelinePosition } from './hooks/useTimelinePosition'
+import { getKey } from '../../helpers'
 
 export interface TimelineEventWithRenderContentProps
   extends ComponentWithClass {
@@ -71,11 +72,15 @@ export const TimelineEvent: React.FC<TimelineEventProps> = ({
 
   if (isBeforeStart || isAfterEnd) return null
 
+  const event = render
+    ? render(startDate, endDate, widthPx, offsetPx)
+    : renderDefault(children, offsetPx, startDate, widthPx)
+
   return (
     <div data-testid="timeline-event-wrapper">
-      {render
-        ? render(startDate, endDate, widthPx, offsetPx)
-        : renderDefault(children, offsetPx, startDate, widthPx)}
+      {React.cloneElement(event as React.ReactElement, {
+        role: 'cell',
+      })}
     </div>
   )
 }

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -3,7 +3,7 @@ import { format, endOfMonth, differenceInDays, min, max } from 'date-fns'
 import classNames from 'classnames'
 
 import { formatPx } from './helpers'
-import { withKey } from '../../helpers'
+import { getKey } from '../../helpers'
 import { TimelineContext } from './context'
 import { DATE_MONTH_FORMAT } from './constants'
 
@@ -67,7 +67,7 @@ export const TimelineMonths: React.FC<TimelineMonthsProps> = ({ render }) => {
         },
       }) => {
         return (
-          <div className="timeline__months" data-testid="timeline-months">
+          <div className="timeline__months" data-testid="timeline-months" role="row">
             {months &&
               months.map(({ startDate }, index) => {
                 const firstDateDisplayed = max([startDate, days[0].date])
@@ -82,7 +82,10 @@ export const TimelineMonths: React.FC<TimelineMonthsProps> = ({ render }) => {
                   ? render(index, dayWidth, daysTotal, startDate)
                   : renderDefault(index, dayWidth, daysTotal, startDate)
 
-                return withKey(child, 'timeline-month', startDate.toString())
+                return React.cloneElement(child, {
+                  key: getKey('timeline-month', startDate.toString()),
+                  role: 'columnheader',
+                })
               })}
           </div>
         )

--- a/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
@@ -17,7 +17,7 @@ export const TimelineRow: React.FC<TimelineRowProps> = ({
   const classes = classNames('timeline__row', className)
 
   return (
-    <div className={classes} data-testid="timeline-row">
+    <div className={classes} data-testid="timeline-row" role="row">
       {children}
     </div>
   )

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -79,7 +79,7 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
   })
 
   return (
-    <main className={mainClasses}>
+    <div className={mainClasses} data-testid="timeline-rows" role="rowgroup">
       {hasChildren && (
         <TimelineContext.Consumer>
           {({
@@ -93,6 +93,7 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
               <div
                 className={rowClasses}
                 data-testid="timeline-columns"
+                role="presentation"
               >
                 {weeks.map(({ startDate }, index) => {
                   const lastDateDisplayed = min([
@@ -133,7 +134,7 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
       )}
 
       {hasChildren ? children : noData}
-    </main>
+    </div>
   )
 }
 

--- a/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
@@ -39,7 +39,7 @@ export const TimelineTodayMarker: React.FC<TimelineTodayMarkerProps> = ({
   if (isBeforeStart || isAfterEnd) return null
 
   return (
-    <div data-testid="timeline-today-marker-wrapper">
+    <div data-testid="timeline-today-marker-wrapper" role="presentation">
       {render ? render(today, offset) : renderDefault(offset)}
     </div>
   )

--- a/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
@@ -106,8 +106,11 @@ export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({ render }) => {
 
               // @ts-ignore
               const child = render ? render(...args) : renderDefault(...args)
+              const title = `Week beginning ${format(startDate, 'do MMMM y')}`
 
               return React.cloneElement(child, {
+                title,
+                'aria-label': title,
                 key: getKey('timeline-week', startDate.toString()),
                 role: 'columnheader',
               })

--- a/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import classNames from 'classnames'
 import { format, differenceInDays, endOfWeek, max, min } from 'date-fns'
 
-import { DATE_WEEK_FORMAT, WEEK_START } from './constants'
+import {
+  ACCESSIBLE_DATE_FORMAT,
+  DATE_WEEK_FORMAT,
+  WEEK_START,
+} from './constants'
 import { formatPx, isOdd } from './helpers'
 import { getKey } from '../../helpers'
 import { TimelineContext } from './context'
@@ -77,7 +81,11 @@ export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({ render }) => {
         },
       }) => {
         return (
-          <div className="timeline__weeks" data-testid="timeline-weeks" role="row">
+          <div
+            className="timeline__weeks"
+            data-testid="timeline-weeks"
+            role="row"
+          >
             {weeks.map(({ startDate }, index) => {
               const lastDateDisplayed = min([
                 endOfWeek(startDate, { weekStartsOn: WEEK_START }),
@@ -106,7 +114,10 @@ export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({ render }) => {
 
               // @ts-ignore
               const child = render ? render(...args) : renderDefault(...args)
-              const title = `Week beginning ${format(startDate, 'do MMMM y')}`
+              const title = `Week beginning ${format(
+                startDate,
+                ACCESSIBLE_DATE_FORMAT
+              )}`
 
               return React.cloneElement(child, {
                 title,

--- a/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
@@ -4,7 +4,7 @@ import { format, differenceInDays, endOfWeek, max, min } from 'date-fns'
 
 import { DATE_WEEK_FORMAT, WEEK_START } from './constants'
 import { formatPx, isOdd } from './helpers'
-import { withKey } from '../../helpers'
+import { getKey } from '../../helpers'
 import { TimelineContext } from './context'
 
 export interface TimelineWeeksWithRenderContentProps
@@ -77,7 +77,7 @@ export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({ render }) => {
         },
       }) => {
         return (
-          <div className="timeline__weeks" data-testid="timeline-weeks">
+          <div className="timeline__weeks" data-testid="timeline-weeks" role="row">
             {weeks.map(({ startDate }, index) => {
               const lastDateDisplayed = min([
                 endOfWeek(startDate, { weekStartsOn: WEEK_START }),
@@ -107,7 +107,10 @@ export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({ render }) => {
               // @ts-ignore
               const child = render ? render(...args) : renderDefault(...args)
 
-              return withKey(child, 'timeline-week', startDate.toString())
+              return React.cloneElement(child, {
+                key: getKey('timeline-week', startDate.toString()),
+                role: 'columnheader',
+              })
             })}
           </div>
         )

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -20,10 +20,13 @@ import {
 describe('Timeline', () => {
   let wrapper: RenderResult
 
-  describe('no data is provided', () => {
+  describe('when no data is provided', () => {
     beforeEach(() => {
       wrapper = render(
-        <Timeline>
+        <Timeline
+          startDate={new Date(2020, 3, 1)}
+          today={new Date(2020, 3, 15)}
+        >
           <TimelineTodayMarker />
           <TimelineMonths />
           <TimelineWeeks />
@@ -37,6 +40,26 @@ describe('Timeline', () => {
       expect(
         wrapper.queryByTestId('timeline-today-marker-wrapper')
       ).toBeInTheDocument()
+    })
+
+    it('renders the correct number of months', () => {
+      expect(wrapper.queryAllByTestId('timeline-month')).toHaveLength(3)
+    })
+
+    it('renders the month title in correct format', () => {
+      const months = wrapper.queryAllByTestId('timeline-month')
+
+      expect(months[0]).toHaveTextContent('April 2020')
+      expect(months[1]).toHaveTextContent('May 2020')
+      expect(months[2]).toHaveTextContent('June 2020')
+    })
+
+    it('renders the correct number of weeks', () => {
+      expect(wrapper.queryAllByTestId('timeline-week')).toHaveLength(14)
+    })
+
+    it('renders the correct number of days', () => {
+      expect(wrapper.queryAllByTestId('timeline-day')).toHaveLength(91)
     })
 
     it('should display the no data message', () => {
@@ -94,35 +117,6 @@ describe('Timeline', () => {
             </TimelineRow>
           </TimelineRows>
         </Timeline>
-      )
-    })
-
-    it('should display the today marker', () => {
-      expect(
-        wrapper.queryByTestId('timeline-today-marker-wrapper')
-      ).toBeInTheDocument()
-    })
-
-    it('renders the correct number of months', () => {
-      expect(wrapper.queryAllByTestId('timeline-month')).toHaveLength(3)
-    })
-
-    it('renders the month title in correct format', () => {
-      expect(
-        wrapper.getByTestId('timeline-months').firstChild.textContent
-      ).toContain('April 2020')
-    })
-
-    it('renders the correct number of weeks', () => {
-      expect(wrapper.queryAllByTestId('timeline-week')).toHaveLength(14)
-    })
-
-    it('applies the --alt modifier class to odd weeks', () => {
-      expect(wrapper.getAllByTestId('timeline-week')[1].classList).toContain(
-        'timeline__week--alt'
-      )
-      expect(wrapper.getAllByTestId('timeline-week')[3].classList).toContain(
-        'timeline__week--alt'
       )
     })
 

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -97,6 +97,18 @@ describe('Timeline', () => {
       expect(wrapper.queryAllByTestId('timeline-week')).toHaveLength(14)
     })
 
+    it('should set the `aria-label` on each week', () => {
+      const week = wrapper.getAllByTestId('timeline-week')[0]
+
+      expect(week).toHaveAttribute('aria-label', 'Week beginning 30th March 2020')
+    })
+
+    it('should set the `title` on each week', () => {
+      const week = wrapper.getAllByTestId('timeline-week')[0]
+
+      expect(week).toHaveAttribute('title', 'Week beginning 30th March 2020')
+    })
+
     it('should set the `role` attribute to `columnheader` on each week', () => {
       const weeks = wrapper.getAllByTestId('timeline-week')
 

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -100,7 +100,10 @@ describe('Timeline', () => {
     it('should set the `aria-label` on each week', () => {
       const week = wrapper.getAllByTestId('timeline-week')[0]
 
-      expect(week).toHaveAttribute('aria-label', 'Week beginning 30th March 2020')
+      expect(week).toHaveAttribute(
+        'aria-label',
+        'Week beginning 30th March 2020'
+      )
     })
 
     it('should set the `title` on each week', () => {
@@ -242,6 +245,24 @@ describe('Timeline', () => {
       expect(wrapper.getByText('Event 2')).toBeInTheDocument()
       expect(wrapper.getByText('Event 3')).toBeInTheDocument()
       expect(wrapper.getByText('Event 4')).toBeInTheDocument()
+    })
+
+    it('should set the `aria-label` on each event', () => {
+      const week = wrapper.getAllByTestId('timeline-event')[0]
+
+      expect(week).toHaveAttribute(
+        'aria-label',
+        'Event 1 begins on 13th April 2020 and ends on 18th April 2020'
+      )
+    })
+
+    it('should set the `title` on each week', () => {
+      const week = wrapper.getAllByTestId('timeline-event')[0]
+
+      expect(week).toHaveAttribute(
+        'title',
+        'Event 1 begins on 13th April 2020 and ends on 18th April 2020'
+      )
     })
   })
 
@@ -528,6 +549,7 @@ describe('Timeline', () => {
       children,
       offsetPx,
       widthPx,
+      ...rest
     }: {
       children: React.ReactNode
       offsetPx: string
@@ -535,6 +557,7 @@ describe('Timeline', () => {
     }) => {
       return (
         <div
+          data-testid="timeline-custom-event"
           style={{
             position: 'absolute',
             top: '50%',
@@ -542,6 +565,7 @@ describe('Timeline', () => {
             left: offsetPx,
             width: widthPx,
           }}
+          {...rest}
         >
           {children}
         </div>
@@ -587,6 +611,24 @@ describe('Timeline', () => {
 
     it('should render the event as specified', () => {
       expect(wrapper.queryByText('Custom Event')).toBeInTheDocument()
+    })
+
+    it('should set the `aria-label` on each event', () => {
+      const week = wrapper.getAllByTestId('timeline-custom-event')[0]
+
+      expect(week).toHaveAttribute(
+        'aria-label',
+        'Begins on 16th April 2020 and ends on 20th April 2020'
+      )
+    })
+
+    it('should set the `title` on each week', () => {
+      const week = wrapper.getAllByTestId('timeline-custom-event')[0]
+
+      expect(week).toHaveAttribute(
+        'title',
+        'Begins on 16th April 2020 and ends on 20th April 2020'
+      )
     })
   })
 

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -36,17 +36,49 @@ describe('Timeline', () => {
       )
     })
 
+    it('should set the `role` attribute to `grid` on the timeline', () => {
+      expect(wrapper.getByTestId('timeline')).toHaveAttribute('role', 'grid')
+    })
+
+    it('should set the `role` attribute to `rowgroup` on the header', () => {
+      expect(wrapper.queryByTestId('timeline-header')).toHaveAttribute(
+        'role',
+        'rowgroup'
+      )
+    })
+
     it('should display the today marker', () => {
       expect(
         wrapper.queryByTestId('timeline-today-marker-wrapper')
       ).toBeInTheDocument()
     })
 
+    it('should set the `role` attribute to `presentation` on the today marker', () => {
+      expect(
+        wrapper.queryByTestId('timeline-today-marker-wrapper')
+      ).toHaveAttribute('role', 'presentation')
+    })
+
+    it('should set the `role` attribute to `row` on the months', () => {
+      expect(wrapper.queryByTestId('timeline-months')).toHaveAttribute(
+        'role',
+        'row'
+      )
+    })
+
     it('renders the correct number of months', () => {
       expect(wrapper.queryAllByTestId('timeline-month')).toHaveLength(3)
     })
 
-    it('renders the month title in correct format', () => {
+    it('should set the `role` attribute to `columnheader` on each month', () => {
+      const months = wrapper.getAllByTestId('timeline-month')
+
+      months.forEach((month) =>
+        expect(month).toHaveAttribute('role', 'columnheader')
+      )
+    })
+
+    it('renders the month text in correct format', () => {
       const months = wrapper.queryAllByTestId('timeline-month')
 
       expect(months[0]).toHaveTextContent('April 2020')
@@ -54,12 +86,44 @@ describe('Timeline', () => {
       expect(months[2]).toHaveTextContent('June 2020')
     })
 
+    it('should set the `role` attribute to `row` on the weeks', () => {
+      expect(wrapper.queryByTestId('timeline-weeks')).toHaveAttribute(
+        'role',
+        'row'
+      )
+    })
+
     it('renders the correct number of weeks', () => {
       expect(wrapper.queryAllByTestId('timeline-week')).toHaveLength(14)
     })
 
+    it('should set the `role` attribute to `columnheader` on each week', () => {
+      const weeks = wrapper.getAllByTestId('timeline-week')
+
+      weeks.forEach((week) =>
+        expect(week).toHaveAttribute('role', 'columnheader')
+      )
+    })
+
+    it('should set the `role` attribute to `row` on the days', () => {
+      expect(wrapper.queryByTestId('timeline-days')).toHaveAttribute(
+        'role',
+        'row'
+      )
+    })
+
     it('renders the correct number of days', () => {
       expect(wrapper.queryAllByTestId('timeline-day')).toHaveLength(91)
+    })
+
+    it('should set the `role` attribute to `columnheader` on each day', () => {
+      const days = wrapper.getAllByTestId('timeline-day')
+
+      days.forEach((day) => expect(day).toHaveAttribute('role', 'columnheader'))
+    })
+
+    it('should not display the timeline columns', () => {
+      expect(wrapper.queryAllByTestId('timeline-columns')).toHaveLength(0)
     })
 
     it('should display the no data message', () => {
@@ -120,14 +184,44 @@ describe('Timeline', () => {
       )
     })
 
+    it('should display the timeline columns', () => {
+      expect(wrapper.getByTestId('timeline-columns')).toBeInTheDocument()
+    })
+
+    it('should set the `role` attribute to `presentation` on the timeline columns', () => {
+      expect(wrapper.getByTestId('timeline-columns')).toHaveAttribute(
+        'role',
+        'presentation'
+      )
+    })
+
     it('does not display the no data message', () => {
       expect(wrapper.queryByTestId('timeline-no-data')).not.toBeInTheDocument()
+    })
+
+    it('should set the `role` attribute to `rowgroup` on the rows group', () => {
+      expect(wrapper.queryByTestId('timeline-rows')).toHaveAttribute(
+        'role',
+        'rowgroup'
+      )
+    })
+
+    it('should set the `role` attribute to `row` on the rows', () => {
+      const rows = wrapper.queryAllByTestId('timeline-row')
+
+      rows.forEach((row) => expect(row).toHaveAttribute('role', 'row'))
     })
 
     it('should display 2 rows', () => {
       expect(wrapper.queryAllByTestId('timeline-row')).toHaveLength(2)
       // expect(wrapper.getByText('Row 1')).toBeInTheDocument()
       // expect(wrapper.getByText('Row 2')).toBeInTheDocument()
+    })
+
+    it('should set the `role` attribute to `cell` on the events', () => {
+      const events = wrapper.queryAllByTestId('timeline-event')
+
+      events.forEach((row) => expect(row).toHaveAttribute('role', 'cell'))
     })
 
     it('should display 4 events', () => {

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -229,8 +229,6 @@ describe('Timeline', () => {
 
     it('should display 2 rows', () => {
       expect(wrapper.queryAllByTestId('timeline-row')).toHaveLength(2)
-      // expect(wrapper.getByText('Row 1')).toBeInTheDocument()
-      // expect(wrapper.getByText('Row 2')).toBeInTheDocument()
     })
 
     it('should set the `role` attribute to `cell` on the events', () => {

--- a/packages/react-component-library/src/components/Timeline/constants.ts
+++ b/packages/react-component-library/src/components/Timeline/constants.ts
@@ -1,3 +1,5 @@
+const ACCESSIBLE_DATE_FORMAT = 'do MMMM y'
+
 const DATE_DAY_FORMAT = 'dd'
 const DATE_MONTH_FORMAT = 'MMMM yyyy'
 const DATE_WEEK_FORMAT = 'dd/MM'
@@ -12,6 +14,7 @@ const NO_DATA_MESSAGE = 'No data available'
 const WEEK_START = 1 // Monday
 
 export {
+  ACCESSIBLE_DATE_FORMAT,
   DATE_DAY_FORMAT,
   DATE_MONTH_FORMAT,
   DATE_WEEK_FORMAT,


### PR DESCRIPTION
## Related issue
Closes #1077 

## Overview
Adds the attributes.

## Reason
A11Y compliance.

## Work carried out
- [x] Add attributes