### PR TITLE
fix(NumberInput): Call `onChange` callback

### DIFF
--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -67,7 +67,7 @@
     "@svgr/webpack": "^5.1.0",
     "@testing-library/jest-dom": "^5.0.2",
     "@testing-library/react": "^10.0.2",
-    "@testing-library/user-event": "^12.0.11",
+    "@testing-library/user-event": "^12.0.15",
     "@types/classnames": "^2.2.9",
     "@types/enzyme": "^3.10.4",
     "@types/enzyme-adapter-react-16": "^1.0.5",

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import { render, RenderResult, fireEvent } from '@testing-library/react'
+import { fireEvent, render, RenderResult } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { NumberInput } from './NumberInput'
 import { UNIT_POSITION } from './constants'
@@ -104,6 +105,20 @@ describe('NumberInput', () => {
           assertOnChangeCall(-1, 3)
         })
       })
+    })
+
+    describe('and the user types values', () => {
+      beforeEach(async () => {
+        const input = wrapper.getByTestId('number-input-input')
+
+        await userEvent.type(input, '1')
+        await userEvent.type(input, '2')
+        await userEvent.type(input, '3')
+      })
+
+      assertOnChangeCall(1, 3)
+      assertOnChangeCall(12, 3)
+      assertOnChangeCall(123, 3)
     })
   })
 

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -104,6 +104,12 @@ export const NumberInput: React.FC<NumberInputProps> = ({
     const newValue = getNewValue(event, unit)
     if (isFinite(newValue)) {
       setNextValue(newValue)
+      onChange({
+        target: {
+          name,
+          value: newValue,
+        },
+      })
     }
   }
 


### PR DESCRIPTION
## Related issue
Fixes #1256 

## Overview
A previous refactor of `NumberInput` removed the call of the `onChange` callback which was noticeable when a user would type in the field.

## Reason
Missed in a refactor. This is a regression.

## Work carried out
- [x] Add `onChange` call
