### PR TITLE
feat(Table): Add ability to display caption

### DIFF
--- a/packages/docs-site/src/library/pages/components/table.md
+++ b/packages/docs-site/src/library/pages/components/table.md
@@ -147,6 +147,13 @@ Whilst there is no restriction on the number of Table instances that can be used
     Default: '',
     Description: 'Order the column will be sorted in `asc` or `desc`',
   },
+  {
+    Name: 'caption',
+    Type: 'string',
+    Required: 'False',
+    Default: '',
+    Description: 'An optional string to render as the table caption',
+  },
 ]} />
 
 </Tab>

--- a/packages/react-component-library/src/components/Table/Table.stories.tsx
+++ b/packages/react-component-library/src/components/Table/Table.stories.tsx
@@ -111,3 +111,28 @@ examples.add('Sortable', () => {
     </Table>
   )
 })
+
+examples.add('With caption', () => {
+  const tableDataMock = [
+    {
+      id: 'a',
+      first: 'Row 1 cell 1',
+      second: 'Row 1 cell 2',
+      third: 'Row 1 cell 3',
+    },
+    {
+      id: 'b',
+      first: 'Row 2 cell 1',
+      second: 'Row 2 cell 2',
+      third: 'Row 2 cell 3',
+    },
+  ]
+
+  return (
+    <Table data={tableDataMock} caption="Example caption">
+      <TableColumn field="first">First column</TableColumn>
+      <TableColumn field="second">Second column</TableColumn>
+      <TableColumn field="third">Third column</TableColumn>
+    </Table>
+  )
+})

--- a/packages/react-component-library/src/components/Table/Table.test.tsx
+++ b/packages/react-component-library/src/components/Table/Table.test.tsx
@@ -44,6 +44,10 @@ describe('Table', () => {
       )
     })
 
+    it('should not display the caption', () => {
+      expect(wrapper.queryByTestId('table-caption')).not.toBeInTheDocument()
+    })
+
     it('should set the `role` attribute to `grid`', () => {
       expect(wrapper.getByTestId('table')).toHaveAttribute('role', 'grid')
     })
@@ -301,6 +305,46 @@ describe('Table', () => {
     it('should update the table data', () => {
       const rows = wrapper.queryAllByTestId('table-row')
       expect(rows).toHaveLength(2)
+    })
+  })
+
+  describe('when caption is provided', () => {
+    beforeEach(() => {
+      const tableDataMock = [
+        {
+          id: 'a',
+          first: 'a1',
+          second: 'a2',
+          third: 'a3',
+        },
+        {
+          id: 'b',
+          first: 'b1',
+          second: 'b2',
+          third: 'b3',
+        },
+        {
+          id: 'c',
+          first: 'c1',
+          second: 'c2',
+          third: 'c3',
+        },
+      ]
+
+      wrapper = render(
+        <Table data={tableDataMock} caption="Hello, World!">
+          <TableColumn field="first">First</TableColumn>
+          <TableColumn field="second">Second</TableColumn>
+          <TableColumn field="third">Third</TableColumn>
+        </Table>
+      )
+    })
+
+    it('should display the caption', () => {
+      expect(wrapper.queryByTestId('table-caption')).toBeInTheDocument()
+      expect(wrapper.getByTestId('table-caption').innerHTML).toEqual(
+        'Hello, World!'
+      )
     })
   })
 })

--- a/packages/react-component-library/src/components/Table/Table.tsx
+++ b/packages/react-component-library/src/components/Table/Table.tsx
@@ -10,13 +10,14 @@ export interface RowProps {
 interface TableProps {
   data: RowProps[]
   children: React.ReactElement<TableColumnProps>[]
+  caption?: string
 }
 
 function getKey(prefix: string, id: string) {
   return `${prefix}_${id}`
 }
 
-export const Table: React.FC<TableProps> = ({ data, children }) => {
+export const Table: React.FC<TableProps> = ({ data, children, caption }) => {
   const { tableData, sortTableData, sortField, sortOrder } = useTableData(data)
 
   const childrenWithSort = React.Children.map(
@@ -32,6 +33,7 @@ export const Table: React.FC<TableProps> = ({ data, children }) => {
   return (
     <div className="rn-table__wrapper" data-testid="table-wrapper">
       <table className="rn-table" data-testid="table" role="grid">
+        {caption && <caption data-testid="table-caption">{caption}</caption>}
         <thead>
           <tr>{childrenWithSort}</tr>
         </thead>


### PR DESCRIPTION
## Related issue

Closes #1264

## Overview

Add ability to display caption alongside table.

## Reason

> Caption display should be included for accessibility reasons.

## Work carried out

- [x] Add ability to display caption
- [x] Update automated tests

## Screenshot

<img width="816" alt="Screenshot 2020-08-10 at 10 42 48" src="https://user-images.githubusercontent.com/48086589/89770149-3f7a2180-daf6-11ea-9320-59d292e182c6.png">
