### PR TITLE
feat(Table): Apply `aria-hidden` to sort icons

### DIFF
--- a/packages/react-component-library/src/components/Table/Table.test.tsx
+++ b/packages/react-component-library/src/components/Table/Table.test.tsx
@@ -153,6 +153,16 @@ describe('Table', () => {
         expect(wrapper.queryAllByTestId('ascending').length).toEqual(0)
       })
 
+      it('should apply `aria-hidden` to sort icons', () => {
+        expect(wrapper.queryAllByTestId('unsorted')[0]).toHaveAttribute(
+          'aria-hidden'
+        )
+
+        expect(wrapper.queryAllByTestId('descending')[0]).toHaveAttribute(
+          'aria-hidden'
+        )
+      })
+
       it('should set the `aria-sort` attribute on the table header cells', () => {
         const tableHeaderCells = wrapper.queryAllByTestId('table-header')
 
@@ -177,6 +187,16 @@ describe('Table', () => {
           expect(wrapper.queryAllByTestId('unsorted').length).toEqual(1)
           expect(wrapper.queryAllByTestId('descending').length).toEqual(0)
           expect(wrapper.queryAllByTestId('ascending').length).toEqual(1)
+        })
+
+        it('should apply `aria-hidden` to sort icons', () => {
+          expect(wrapper.queryAllByTestId('unsorted')[0]).toHaveAttribute(
+            'aria-hidden'
+          )
+
+          expect(wrapper.queryAllByTestId('ascending')[0]).toHaveAttribute(
+            'aria-hidden'
+          )
         })
 
         it('should set the `aria-sort` attribute on the table header cells', () => {

--- a/packages/react-component-library/src/components/Table/TableColumn.tsx
+++ b/packages/react-component-library/src/components/Table/TableColumn.tsx
@@ -24,9 +24,11 @@ export interface TableColumnProps {
 }
 
 const SORT_ORDER_ICONS_MAP = {
-  [TABLE_SORT_ORDER.ASCENDING]: <IconSortAscending data-testid="ascending" />,
+  [TABLE_SORT_ORDER.ASCENDING]: (
+    <IconSortAscending aria-hidden data-testid="ascending" />
+  ),
   [TABLE_SORT_ORDER.DESCENDING]: (
-    <IconSortDescending data-testid="descending" />
+    <IconSortDescending aria-hidden data-testid="descending" />
   ),
 }
 
@@ -42,7 +44,7 @@ function getIcon(sortable: boolean, sortOrder: string) {
 
   return (
     get(SORT_ORDER_ICONS_MAP, sortOrder) || (
-      <IconSortUnsorted data-testid="unsorted" />
+      <IconSortUnsorted aria-hidden data-testid="unsorted" />
     )
   )
 }


### PR DESCRIPTION
## Related issue

Closes #1261 

## Overview

Apply `aria-hidden` to sort icons.

## Reason

>Make components comply with accessibility guidelines.

## Work carried out

- [x] Add `aria-hidden` attributes
- [x] Update automated tests