### PR TITLE
feat(TabSet): Define `aria-label` for tab

### DIFF
--- a/packages/react-component-library/src/components/TabSet/TabItem.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabItem.tsx
@@ -30,6 +30,7 @@ export const TabItem = forwardRef<HTMLLIElement, TabItemProps>(
         aria-selected={!!isActive}
         tabIndex={!isActive ? -1 : 0}
         data-testid="tab-set-tab"
+        aria-label={children.toString()}
       >
         <button className={tabClasses} onClick={handleClick}>
           <div>{children}</div>

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -39,6 +39,13 @@ describe('TabSet', () => {
         )
       })
 
+      it('should apply the `aria-label` attribute to the tab', () => {
+        expect(wrapper.getAllByTestId('tab-set-tab')[0]).toHaveAttribute(
+          'aria-label',
+          'Title 1'
+        )
+      })
+
       it('should apply the correct roles', () => {
         expect(wrapper.getByTestId('tab-set-list')).toHaveAttribute(
           'role',


### PR DESCRIPTION
## Related issue

Closes #1103

## Overview

Define `aria-label` for TabSet tab.

## Reason

>Make all existing components accessible.

## Work carried out

- [x] Add missing ARIA attribute
- [x] Update automated tests