### PR TITLE
feat(Modal): Respect primaryButton.icon if set

### DIFF
--- a/packages/react-component-library/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 
 import { Modal } from './index'
-import { ButtonProps } from '../Button'
+import { BUTTON_COLOR, ButtonProps } from '../Button'
 
 const stories = storiesOf('Modal', module)
 const examples = storiesOf('Modal/Examples', module)
@@ -55,6 +55,26 @@ examples.add('No header', () => {
 examples.add('No buttons', () => {
   return (
     <Modal title="Modal Header" onClose={action('onClose')} isOpen>
+      <pre style={{ padding: '1rem' }}>Arbitrary JSX content</pre>
+    </Modal>
+  )
+})
+
+examples.add('Danger primary button without icon', () => {
+  const primaryButtonWithoutIcon: ButtonProps = {
+    ...primaryButton,
+    color: BUTTON_COLOR.DANGER,
+    icon: undefined,
+  }
+
+  return (
+    <Modal
+      title="Modal Header"
+      primaryButton={primaryButtonWithoutIcon}
+      secondaryButton={secondaryButton}
+      onClose={action('onClose')}
+      isOpen
+    >
       <pre style={{ padding: '1rem' }}>Arbitrary JSX content</pre>
     </Modal>
   )

--- a/packages/react-component-library/src/components/Modal/Modal.test.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.test.tsx
@@ -188,6 +188,27 @@ describe('Modal', () => {
           )
         })
       })
+
+      describe('and no primary button icon is specified', () => {
+        beforeEach(() => {
+          wrapper = render(
+            <Modal
+              isOpen
+              title={title}
+              onClose={onClose}
+              primaryButton={{...primaryButton, icon: undefined}}
+            >
+              <span>Example child JSX</span>
+            </Modal>
+          )
+        })
+
+        it('does not render an icon for the primary button', () => {
+          expect(
+            wrapper.queryByTestId('modal-primary-confirm')
+          ).toBeNull()
+        })
+      })
     })
   })
 

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -43,8 +43,8 @@ export const Modal: React.FC<ModalProps> = ({
   )
 
   const primaryButtonWithIcon = primaryButton && {
-    ...primaryButton,
     icon: <IconForward data-testid="modal-primary-confirm" />,
+    ...primaryButton,
   }
 
   return (


### PR DESCRIPTION
## Related issue

#1336

## Overview

This changes `Modal` to respect `primaryButton.icon` if it's set, instead of always overriding it with a forward arrow.

## Reason

From #1336:

> Currently, `Modal` accepts an `icon` prop on `primaryButton` but always overrides it with the forward arrow icon.
>
> For a cancellation or deletion modal dialogue you may want to use a different or no icon, so it would be better if the forward arrow icon was only a default.

## Work carried out

- [x] Allow Modal primaryButton.icon to be overriden
- [x] Added unit test
- [x] Added story

## Screenshot

![image](https://user-images.githubusercontent.com/66470099/90017147-ffa46d00-dca2-11ea-868f-e858d90e5cb0.png)
