### PR TITLE
fix(Dropdown): Resolve arrow visual glitch

### DIFF
--- a/packages/css-framework/src/components/_dropdown.scss
+++ b/packages/css-framework/src/components/_dropdown.scss
@@ -49,9 +49,8 @@ $offset: $outer + $border-thick;
     border-color: f.color("action", "600") transparent;
     position: absolute;
     top: -7px;
-    left: 95%;
+    right: 0.9rem;
     width: 0;
-    margin-left: -7px;
     z-index: 0;
     content: "";
   }
@@ -63,11 +62,11 @@ $offset: $outer + $border-thick;
     border-color: f.color("neutral", "white") transparent;
     position: absolute;
     top: -4px;
-    left: 95%;
+    right: 0.9rem;
     width: 0;
-    margin-left: -6px;
     z-index: 1;
     content: "";
+    transform: translateX(-1px);
   }
 
   .rn-dropdown__option,


### PR DESCRIPTION
## Related issue

Closes #1317

## Overview

Resolve clipping with expanded menu arrow.

## Reason

>Expanded menu arrow in top right would clip border at low widths.

## Work carried out

- [x] Adjust styles to resolve clipping

## Screenshot

<img width="240" alt="Screenshot 2020-08-20 at 11 06 10" src="https://user-images.githubusercontent.com/48086589/90757214-4282c800-e2d5-11ea-8606-40c82c2b553b.png">
