### PR TITLE
Fix declaration files copying after compilation

### DIFF
--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -42,7 +42,7 @@
     "storybook": "start-storybook -p 6006",
     "test:watch": "NODE_ENV=test jest --watch",
     "test": "NODE_ENV=test jest",
-    "types": "tsc",
+    "types": "tsc"
   },
   "lint-staged": {
     "*.@(js|jsx|ts|tsx)": "eslint"

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -42,7 +42,7 @@
     "storybook": "start-storybook -p 6006",
     "test:watch": "NODE_ENV=test jest --watch",
     "test": "NODE_ENV=test jest",
-    "types": "tsc --emitDeclarationOnly --declarationMap --declaration --noEmit false --allowJs false --outDir dist/types"
+    "types": "tsc",
   },
   "lint-staged": {
     "*.@(js|jsx|ts|tsx)": "eslint"

--- a/packages/react-component-library/src/common/ComponentWithClass.ts
+++ b/packages/react-component-library/src/common/ComponentWithClass.ts
@@ -1,0 +1,3 @@
+export interface ComponentWithClass {
+  className?: string
+}

--- a/packages/react-component-library/src/common/FieldProps.ts
+++ b/packages/react-component-library/src/common/FieldProps.ts
@@ -1,4 +1,4 @@
-export default interface FieldProps {
+export interface FieldProps {
   name: string
   value: string
   onChange: (e: React.SyntheticEvent) => void

--- a/packages/react-component-library/src/common/FormProps.ts
+++ b/packages/react-component-library/src/common/FormProps.ts
@@ -1,0 +1,4 @@
+export interface FormProps {
+  errors: any
+  touched: any
+}

--- a/packages/react-component-library/src/common/Link.ts
+++ b/packages/react-component-library/src/common/Link.ts
@@ -1,0 +1,11 @@
+import { ComponentWithClass } from './ComponentWithClass'
+
+export interface AnchorType extends ComponentWithClass {
+  href: string
+}
+
+export interface LinkType extends ComponentWithClass {
+  to: string
+}
+
+export type LinkTypes = AnchorType | LinkType

--- a/packages/react-component-library/src/common/Nav.ts
+++ b/packages/react-component-library/src/common/Nav.ts
@@ -1,5 +1,8 @@
 import React from 'react'
 
+import { ComponentWithClass } from './ComponentWithClass'
+import { LinkTypes } from './Link'
+
 export interface Nav<T> extends ComponentWithClass {
   children: React.ReactElement<T> | React.ReactElement<T>[]
 }

--- a/packages/react-component-library/src/common/Position.ts
+++ b/packages/react-component-library/src/common/Position.ts
@@ -1,4 +1,4 @@
-interface PositionType {
+export interface PositionType {
   left?: number
   right?: number
   bottom?: number

--- a/packages/react-component-library/src/common/User.ts
+++ b/packages/react-component-library/src/common/User.ts
@@ -1,0 +1,3 @@
+export interface UserType {
+  initials: string
+}

--- a/packages/react-component-library/src/components/Badge/Badge.tsx
+++ b/packages/react-component-library/src/components/Badge/Badge.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import classNames from 'classnames'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+
 import {
   BADGE_COLOR,
   BADGE_COLOR_VARIANT,

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { BreadcrumbsItem, BreadcrumbsItemProps } from '.'
-import { Nav } from '../../types/Nav'
+import { Nav } from '../../common/Nav'
 import { warnIfOverwriting } from '../../helpers'
 
 export const Breadcrumbs: React.FC<Nav<BreadcrumbsItemProps>> = ({

--- a/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from 'react'
 import { IconChevronRight } from '@royalnavy/icon-library'
 
 import { EndTitle } from '.'
+import { LinkTypes } from '../../common/Link'
 
 export interface BreadcrumbsItemProps {
   isFirst?: boolean

--- a/packages/react-component-library/src/components/Button/Button.tsx
+++ b/packages/react-component-library/src/components/Button/Button.tsx
@@ -7,6 +7,7 @@ import {
   BUTTON_VARIANT,
   BUTTON_ICON_POSITION,
 } from './constants'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 
 export type ButtonSizeType =
   | typeof BUTTON_SIZE.SMALL

--- a/packages/react-component-library/src/components/CardFrame/CardFrame.tsx
+++ b/packages/react-component-library/src/components/CardFrame/CardFrame.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import classNames from 'classnames'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+
 export const CardFrame: React.FC<ComponentWithClass> = ({
   children,
   className,

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.test.tsx
@@ -3,9 +3,9 @@ import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
 
 import { Checkbox } from '.'
+import { FieldProps } from '../../common/FieldProps'
+import { FormProps } from '../../common/FormProps'
 import { withFormik } from '../../enhancers/withFormik'
-import FieldProps from '../../types/FieldProps'
-import FormProps from '../../types/FormProps'
 
 describe('Checkbox', () => {
   let field: FieldProps

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
@@ -2,6 +2,8 @@ import React, { forwardRef } from 'react'
 import classNames from 'classnames'
 import { v4 as uuidv4 } from 'uuid'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+
 export interface CheckboxProps extends ComponentWithClass {
   id?: string
   isChecked?: boolean

--- a/packages/react-component-library/src/components/CheckboxEnhanced/CheckboxEnhanced.test.tsx
+++ b/packages/react-component-library/src/components/CheckboxEnhanced/CheckboxEnhanced.test.tsx
@@ -4,9 +4,9 @@ import { render, RenderResult, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { CheckboxEnhanced } from '.'
+import { FieldProps } from '../../common/FieldProps'
+import { FormProps } from '../../common/FormProps'
 import { withFormik } from '../../enhancers/withFormik'
-import FieldProps from '../../types/FieldProps'
-import FormProps from '../../types/FormProps'
 
 describe('CheckboxEnhanced', () => {
   let field: FieldProps

--- a/packages/react-component-library/src/components/DataList/DataList.tsx
+++ b/packages/react-component-library/src/components/DataList/DataList.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { IconKeyboardArrowDown } from '@royalnavy/icon-library'
 
 import { Badge } from '../Badge'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { DataListItemProps } from '.'
 import { getId } from '../../helpers'
 

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import TetherComponent from 'react-tether'
 import DayPicker, { DateUtils, RangeModifier } from 'react-day-picker'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { DatePickerInput } from './DatePickerInput'
 import { useOpenClose } from './useOpenClose'
 import { DATEPICKER_PLACEMENT, DATEPICKER_PLACEMENTS } from '.'

--- a/packages/react-component-library/src/components/DatePicker/DatePickerInput.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePickerInput.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TriangleDown } from '../../icons'
 
 export interface DatePickerInputProps extends ComponentWithClass {

--- a/packages/react-component-library/src/components/Dialog/Dialog.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { Modal } from '../Modal'
 import { ButtonProps } from '../Button'
 import { getId } from '../../helpers'

--- a/packages/react-component-library/src/components/DismissibleBanner/DismissableBanner.tsx
+++ b/packages/react-component-library/src/components/DismissibleBanner/DismissableBanner.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 
 import { Button, BUTTON_SIZE, BUTTON_VARIANT } from '../Button'
 import { Checkbox } from '../Checkbox'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 
 interface DismissibleBannerWithTitleProps extends ComponentWithClass {
   hasCheckbox?: boolean

--- a/packages/react-component-library/src/components/Drawer/Drawer.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import classNames from 'classnames'
 import { IconClose } from '@royalnavy/icon-library'
+
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { useOpenClose } from '../../hooks/useOpenClose'
 
 interface DrawerProps extends ComponentWithClass {

--- a/packages/react-component-library/src/components/FormikGroup/FormikGroup.tsx
+++ b/packages/react-component-library/src/components/FormikGroup/FormikGroup.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useFormikContext } from 'formik'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import {
   FieldError,
   getError,

--- a/packages/react-component-library/src/components/Link/Link.tsx
+++ b/packages/react-component-library/src/components/Link/Link.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { AnchorType } from '../../common/Link'
+
 export const Link: React.FC<AnchorType> = ({
   children,
   className = '',

--- a/packages/react-component-library/src/components/List/List.tsx
+++ b/packages/react-component-library/src/components/List/List.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { ListItem, ListItemProps } from './ListItem'
 import { useListItem } from './useListItem'
 import { warnIfOverwriting } from '../../helpers'

--- a/packages/react-component-library/src/components/List/ListItem.tsx
+++ b/packages/react-component-library/src/components/List/ListItem.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 import { IconChevronRight } from '@royalnavy/icon-library'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { getId } from '../../helpers'
 
 export interface ListItemProps extends ComponentWithClass {

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { IconForward } from '@royalnavy/icon-library'
 
 import { ButtonProps } from '../Button'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { Header } from './Header'
 import { Footer } from './Footer'
 import { useOpenClose } from '../../hooks/useOpenClose'

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import classNames from 'classnames'
 import { IconLoader } from '@royalnavy/icon-library'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+
 export const ProgressIndicator: React.FC<ComponentWithClass> = ({
   className,
 }) => {

--- a/packages/react-component-library/src/components/Radio/Radio.test.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.test.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
 
-import { withFormik } from '../../enhancers/withFormik'
-import FieldProps from '../../types/FieldProps'
-import FormProps from '../../types/FormProps'
+import { FieldProps } from '../../common/FieldProps'
+import { FormProps } from '../../common/FormProps'
 import { Radio } from '.'
+import { withFormik } from '../../enhancers/withFormik'
 
 describe('Radio', () => {
   let field: FieldProps

--- a/packages/react-component-library/src/components/Radio/Radio.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.tsx
@@ -1,6 +1,8 @@
 import React, { forwardRef } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+
 export interface RadioProps extends ComponentWithClass {
   id?: string
   isChecked?: boolean

--- a/packages/react-component-library/src/components/RadioEnhanced/RadioEnhanced.test.tsx
+++ b/packages/react-component-library/src/components/RadioEnhanced/RadioEnhanced.test.tsx
@@ -3,10 +3,10 @@ import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { withFormik } from '../../enhancers/withFormik'
-import FieldProps from '../../types/FieldProps'
-import FormProps from '../../types/FormProps'
+import { FieldProps } from '../../common/FieldProps'
+import { FormProps } from '../../common/FormProps'
 import { RadioEnhanced } from '.'
+import { withFormik } from '../../enhancers/withFormik'
 
 describe('RadioEnhanced', () => {
   let field: FieldProps

--- a/packages/react-component-library/src/components/RangeSlider/ThresholdTrack.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/ThresholdTrack.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import classNames from 'classnames'
 import { TrackItem, GetTrackProps } from 'react-compound-slider'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+
 interface ThresholdTrackProps extends TrackItem {
   getTrackProps: GetTrackProps
   thresholds?: number[]

--- a/packages/react-component-library/src/components/TabNav/TabNav.tsx
+++ b/packages/react-component-library/src/components/TabNav/TabNav.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Nav, NavItem } from '../../types/Nav'
+import { Nav, NavItem } from '../../common/Nav'
 
 export const TabNav: React.FC<Nav<NavItem>> = ({ children, className }) => (
   <nav className={`rn-tab-nav ${className}`}>

--- a/packages/react-component-library/src/components/TabNav/TabNavItem.tsx
+++ b/packages/react-component-library/src/components/TabNav/TabNavItem.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 import { getKey } from '../../helpers'
 
-import { NavItem } from '../../types/Nav'
+import { NavItem } from '../../common/Nav'
 
 export const TabNavItem: React.FC<NavItem> = ({ isActive, link }) => {
   const classes = classNames('rn-tab-nav__item', { 'is-active': isActive })

--- a/packages/react-component-library/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.test.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
 
-import { withFormik } from '../../enhancers/withFormik'
-import FieldProps from '../../types/FieldProps'
-import FormProps from '../../types/FormProps'
+import { FieldProps } from '../../common/FieldProps'
+import { FormProps } from '../../common/FormProps'
 import { TextArea } from '.'
+import { withFormik } from '../../enhancers/withFormik'
 
 describe('TextArea', () => {
   let field: FieldProps

--- a/packages/react-component-library/src/components/TextArea/TextArea.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.tsx
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import classNames from 'classnames'
 
 import { useFocus } from '../../hooks/useFocus'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 
 export interface TextAreaInputProps
   extends TextareaHTMLAttributes<HTMLTextAreaElement>,

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TimelineProvider } from './context'
 import { TimelineComponent } from './types'
 

--- a/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import classNames from 'classnames'
 
-import { getKey, warnIfOverwriting } from '../../helpers'
+import { getKey } from '../../helpers'
 import { TimelineContext } from './context'
 import { TimelineDay } from './TimelineDay'
 import { TimelineHeaderRow } from './TimelineHeaderRow'
-import { BreadcrumbsItem } from '../Breadcrumbs'
 
 export interface TimelineDaysWithRenderContentProps {
   hasSide?: boolean

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { format } from 'date-fns'
 
 import { ACCESSIBLE_DATE_FORMAT } from './constants'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { useTimelinePosition } from './hooks/useTimelinePosition'
 
 export interface TimelineEventWithRenderContentProps

--- a/packages/react-component-library/src/components/Timeline/TimelineEvents.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvents.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TimelineEventProps } from '.'
 
 export interface TimelineEventsProps extends ComponentWithClass {

--- a/packages/react-component-library/src/components/Timeline/TimelineHeaderRow.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineHeaderRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TimelineRow } from './TimelineRow'
 
 interface TimelineHeaderRowProps extends ComponentWithClass {

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { IconChevronRight, IconChevronLeft } from '@royalnavy/icon-library'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { getKey } from '../../helpers'
 import { TimelineContext } from './context'
 import { TimelineHeaderRow } from './TimelineHeaderRow'

--- a/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TimelineEventsProps } from '.'
 
 export interface TimelineRowProps extends ComponentWithClass {

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 import { differenceInDays, endOfWeek, max, min } from 'date-fns'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TimelineRowProps } from '.'
 import { TimelineContext } from './context'
 import { withKey } from '../../helpers'

--- a/packages/react-component-library/src/components/Timeline/TimelineSide.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineSide.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+
 export interface TimelineSideProps extends ComponentWithClass {
   rowGroups?: any[]
   headChildren?: any[]

--- a/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import classNames from 'classnames'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TimelineContext } from './context'
 import { useTimelinePosition } from './hooks/useTimelinePosition'
 

--- a/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { getKey } from '../../helpers'
 import { TimelineContext } from './context'
 import { TimelineHeaderRow } from './TimelineHeaderRow'

--- a/packages/react-component-library/src/components/Toast/Toast.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.tsx
@@ -13,6 +13,7 @@ import {
   IconCheckCircle,
 } from '@royalnavy/icon-library'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { getId } from '../../helpers'
 
 export interface ToastProps extends BaseToastProps, ComponentWithClass {

--- a/packages/react-component-library/src/components/Toast/ToastProvider.tsx
+++ b/packages/react-component-library/src/components/Toast/ToastProvider.tsx
@@ -5,6 +5,7 @@ import {
   ToastProviderProps as BaseToastProviderProps,
 } from 'react-toast-notifications'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { Toast } from '.'
 
 export interface ToastProviderProps

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import classNames from 'classnames'
 
-import { TOOLTIP_POSITION } from '.'
 import { getId } from '../../helpers'
+import { PositionType } from '../../common/Position'
+import { TOOLTIP_POSITION } from '.'
 
 export interface TooltipProps extends PositionType {
   children: React.ReactNode

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
@@ -3,8 +3,9 @@ import classNames from 'classnames'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 
 import { Bell, Logo as DefaultLogo, Search as SearchIcon } from '../../../icons'
+import { LinkTypes } from '../../../common/Link'
 import { MastheadUserProps } from './index'
-import { Nav, NavItem } from '../../../types/Nav'
+import { Nav, NavItem } from '../../../common/Nav'
 import {
   NOTIFICATION_CONTAINER_WIDTH,
   NotificationsProps,

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadNav.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadNav.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ScrollContainer from 'react-indiana-drag-scroll'
 
-import { Nav, NavItem } from '../../../types/Nav'
+import { Nav, NavItem } from '../../../common/Nav'
 
 export const MastheadNav: React.FC<Nav<NavItem>> = ({
   children,

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadNavItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadNavItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { NavItem } from '../../../types/Nav'
+import { NavItem } from '../../../common/Nav'
 import { getKey } from '../../../helpers'
 
 export const MastheadNavItem: React.FC<NavItem> = ({ isActive, link }) => (

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
@@ -2,8 +2,10 @@
 import React, { ReactElement } from 'react'
 
 import { Avatar, AVATAR_VARIANT } from '../../Avatar'
+import { ComponentWithClass } from '../../../common/ComponentWithClass'
+import { LinkTypes } from '../../../common/Link'
 import { MastheadUserItemProps } from './MastheadUserItem'
-import { Nav } from '../../../types/Nav'
+import { Nav } from '../../../common/Nav'
 import { Sheet } from '../Sheet/Sheet'
 import { SheetButton } from '../Sheet/SheetButton'
 import { SHEET_PLACEMENT } from '../Sheet/constants'

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUserItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUserItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { NavItem } from '../../../types/Nav'
+import { NavItem } from '../../../common/Nav'
 
 export interface MastheadUserItemProps extends NavItem {
   icon: React.ReactNode

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/UserLink.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/UserLink.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { Avatar, AVATAR_VARIANT } from '../../Avatar'
 import { Link } from '../../Link'
+import { UserType } from '../../../common/User'
 
 interface UserLinkProps {
   className?: string

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.tsx
@@ -5,6 +5,7 @@ import format from 'date-fns/format'
 
 import { Avatar, AVATAR_VARIANT } from '../../Avatar'
 import { getId } from '../../../helpers'
+import { LinkTypes } from '../../../common/Link'
 
 export interface NotificationProps {
   link: React.ReactElement<LinkTypes>

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react'
 import { IconKeyboardArrowRight } from '@royalnavy/icon-library'
 
+import { LinkTypes } from '../../../common/Link'
 import { NotificationProps } from './index'
 
 export interface NotificationsProps {

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
@@ -6,6 +6,7 @@ import {
   SHEET_PLACEMENT_ARROW_POSITION_MAP,
 } from './constants'
 
+import { ComponentWithClass } from '../../../common/ComponentWithClass'
 import { FloatingBox } from '../../../primitives/FloatingBox'
 import { SheetButtonProps } from './SheetButton'
 import { useSheet } from './useSheet'

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sheet/SheetButton.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sheet/SheetButton.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import classNames from 'classnames'
 
+import { ComponentWithClass } from '../../../common/ComponentWithClass'
+
 export interface SheetButtonProps extends ComponentWithClass {
   children?: React.ReactElement
   icon: React.ReactElement

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sheet/sheetPosition.test.ts
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sheet/sheetPosition.test.ts
@@ -1,4 +1,5 @@
 import { calculate } from './sheetPosition'
+import { PositionType } from '../../../common/Position'
 import { SHEET_PLACEMENT } from './constants'
 
 describe('sheetPosition', () => {

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNav.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNav.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Nav, NavItem } from '../../../types/Nav'
+import { Nav, NavItem } from '../../../common/Nav'
 import { SidebarNavItem, SidebarNavItemProps } from './index'
 import { warnIfOverwriting } from '../../../helpers'
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNavItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNavItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 
-import { NavItem } from '../../../types/Nav'
+import { NavItem } from '../../../common/Nav'
 
 export interface SidebarNavItemProps extends NavItem {
   Image?: React.ComponentType

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
@@ -2,6 +2,8 @@ import React, { ReactElement } from 'react'
 import classNames from 'classnames'
 
 import { Avatar } from '../../Avatar'
+import { ComponentWithClass } from '../../../common/ComponentWithClass'
+import { LinkTypes } from '../../../common/Link'
 
 export interface SidebarUserProps extends ComponentWithClass {
   initials: string

--- a/packages/react-component-library/src/enhancers/withFormik.tsx
+++ b/packages/react-component-library/src/enhancers/withFormik.tsx
@@ -3,8 +3,8 @@ import classNames from 'classnames'
 import get from 'lodash/get'
 import { v4 as uuidv4 } from 'uuid'
 
-import FieldProps from '../types/FieldProps'
-import FormProps from '../types/FormProps'
+import { FieldProps } from '../common/FieldProps'
+import { FormProps } from '../common/FormProps'
 
 export interface FormikProps {
   className?: string

--- a/packages/react-component-library/src/icons/Bell.tsx
+++ b/packages/react-component-library/src/icons/Bell.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { ComponentWithClass } from '../common/ComponentWithClass'
+
 export const Bell: React.FC<ComponentWithClass> = ({ className = '' }) => (
   <svg
     className={className}

--- a/packages/react-component-library/src/icons/Logo.tsx
+++ b/packages/react-component-library/src/icons/Logo.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { ComponentWithClass } from '../common/ComponentWithClass'
+
 export const Logo: React.FC<ComponentWithClass> = ({ className = '', ...rest }) => (
   <svg
     className={className}

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react'
 import classNames from 'classnames'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { FLOATING_BOX_SCHEME, FLOATING_BOX_ARROW_POSITION } from './constants'
 import { getId } from '../../helpers'
+import { PositionType } from '../../common/Position'
 
 export interface FloatingBoxProps extends PositionType, ComponentWithClass {
   role?: string

--- a/packages/react-component-library/src/types/ComponentWithClass.d.ts
+++ b/packages/react-component-library/src/types/ComponentWithClass.d.ts
@@ -1,3 +1,0 @@
-interface ComponentWithClass extends React.ComponentType {
-  className?: string
-}

--- a/packages/react-component-library/src/types/FormProps.d.ts
+++ b/packages/react-component-library/src/types/FormProps.d.ts
@@ -1,4 +1,0 @@
-export default interface FormProps {
-  errors: any
-  touched: any
-}

--- a/packages/react-component-library/src/types/Link.d.ts
+++ b/packages/react-component-library/src/types/Link.d.ts
@@ -1,9 +1,0 @@
-interface AnchorType extends ComponentWithClass {
-  href: string
-}
-
-interface LinkType extends ComponentWithClass {
-  to: string
-}
-
-type LinkTypes = AnchorType | LinkType

--- a/packages/react-component-library/src/types/User.d.ts
+++ b/packages/react-component-library/src/types/User.d.ts
@@ -1,3 +1,0 @@
-interface UserType {
-  initials: string
-}

--- a/packages/react-component-library/src/types/reactIndianaDragScroll.d.ts
+++ b/packages/react-component-library/src/types/reactIndianaDragScroll.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-indiana-drag-scroll'

--- a/packages/react-component-library/src/types/svg.d.ts
+++ b/packages/react-component-library/src/types/svg.d.ts
@@ -1,4 +1,0 @@
-declare module '*.svg' {
-  const content: any
-  export default content
-}

--- a/packages/react-component-library/tsconfig.json
+++ b/packages/react-component-library/tsconfig.json
@@ -1,21 +1,21 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "strict": true,
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "noEmit": true,
-    "jsx": "preserve",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "strict": true,
     "strictNullChecks": false,
-    "suppressImplicitAnyIndexErrors": true
+    "suppressImplicitAnyIndexErrors": true,
+    "target": "esnext"
   },
   "include": ["src", "jest", "jest.config.js"]
 }

--- a/packages/react-component-library/tsconfig.json
+++ b/packages/react-component-library/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
-    "allowJs": true,
     "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
@@ -9,7 +11,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",
-    "noEmit": true,
+    "outDir": "dist/types",
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "strict": true,

--- a/packages/react-component-library/tsconfig.json
+++ b/packages/react-component-library/tsconfig.json
@@ -19,5 +19,5 @@
     "suppressImplicitAnyIndexErrors": true,
     "target": "esnext"
   },
-  "include": ["src", "jest", "jest.config.js"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Related issue
Fixes #1330 

## Overview
~Adds script to copy declaration files after compilation.~
Converts `.d.ts` files to be `.ts`.

## Reason
Declaration files are not being copied during compilation so there are downstream application compilation errors when trying to use `className` and other props.

## Work carried out
- [x] Tidy up
- [x] Copy files

## Developer notes
~The question [Typescript does not copy d.ts files to build](https://stackoverflow.com/a/56440335) on Stack Overflow helped with this.~

After reading [How to configure custom global interfaces (.d.ts files) for TypeScript?
](https://stackoverflow.com/a/42257742) it is clear our approach to "types" needs changing.

I will squash the last two commits and reword so they make more sense.