### PR TITLE
ci(Gha): Fix visual regression checks

### DIFF
--- a/.github/workflows/build_and_test_feature.yml
+++ b/.github/workflows/build_and_test_feature.yml
@@ -225,28 +225,30 @@ jobs:
             path: packages/react-component-library/test-results/jest/react-component-results.xml
 
 
-    #  Test_visual_regression:
-    #   runs-on: ubuntu-latest
-    #   needs: [Build_icon_library, Test_react-component-library]
-    #   steps:
-    #     - name: Git clone repository
-    #       uses: actions/checkout@v2
+     Test_visual_regression:
+      runs-on: ubuntu-latest
+      needs: [Build_icon_library, Test_react-component-library]
+      steps:
+        - name: Git clone repository
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
 
-    #     - name: Cache Node modules
-    #       uses: actions/cache@v2
-    #       with:
-    #         path: '**/node_modules'
-    #         key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+        - name: Cache Node modules
+          uses: actions/cache@v2
+          with:
+            path: '**/node_modules'
+            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-    #     - name: Attach workspace
-    #       uses: actions/download-artifact@v2
-    #       with:
-    #         name: dist
+        - name: Attach workspace
+          uses: actions/download-artifact@v2
+          with:
+            name: dist
 
-    #     - name: Run visual regression tests
-    #       run: |
-    #         cd packages/icon-library/ && tar -xzf ../../dist.tar.gz && cd ../..
-    #         yarn --cwd packages/react-component-library chromatic --app-code=${{secrets.CHROMATIC_TOKEN}}
+        - name: Run visual regression tests
+          run: |
+            cd packages/icon-library/ && tar -xzf ../../dist.tar.gz && cd ../..
+            yarn --cwd packages/react-component-library chromatic --app-code=${{secrets.CHROMATIC_TOKEN}}
 
 
 


### PR DESCRIPTION
fixes #1364 

## Overview

Fix unexpected behavior with visual regression tests running under GHA build_and_test_feature

## Work carried out
- [x] Added 'fetch depth: 0' to visual regression job to fix issue with baseline association in chromatic
- [x] Re-enabled visual regression job in workflow

