### PR TITLE
fix(Breadcrumb): Use flex for vertical center

### DIFF
--- a/packages/css-framework/src/components/_breadcrumbs.scss
+++ b/packages/css-framework/src/components/_breadcrumbs.scss
@@ -2,19 +2,18 @@
 @use "../config" as config;
 
 .rn-breadcrumbs__list {
-  display: block;
+  display: flex;
   font-size: f.font-size("base");
   margin: 0;
   padding: 0;
   list-style: none;
-  line-height: 1;
+  align-items: center;
 }
 
 .rn-breadcrumbs__breadcrumb {
-  display: inline-block;
-  vertical-align: top;
+  display: inline-flex;
   transition: all config.$animation-timing;
-  line-height: 1;
+  align-items: center;
 
   > a {
     color: f.color("neutral", "400");


### PR DESCRIPTION
## Related issue

Closes #1338

## Overview

Use flexbox to vertically center breadcrumb items.

## Reason

>Breadcrumbs would be misalgined in some browsers.

## Work carried out

- [x] Use flexbox for vertical alignment
