### PR TITLE
Update Timeline accessibility

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
+
 import { format } from 'date-fns'
 
 import {
@@ -15,9 +16,9 @@ import {
   TimelineSide,
 } from '.'
 
-const stories = storiesOf('Timeline', module)
+export default { component: Timeline, title: 'Timeline' } as Meta
 
-stories.add('No data', () => (
+export const NoData = () => (
   <Timeline startDate={new Date(2020, 0, 1)} today={new Date(2020, 0, 15)}>
     <TimelineTodayMarker />
     <TimelineMonths />
@@ -25,9 +26,10 @@ stories.add('No data', () => (
     <TimelineDays />
     <TimelineRows>{}</TimelineRows>
   </Timeline>
-))
+)
+NoData.storyName = 'No data'
 
-stories.add('Bound by fixed dates', () => (
+export const BoundByFixedDates = () => (
   <Timeline
     startDate={new Date(2020, 0, 13)}
     endDate={new Date(2020, 1, 15)}
@@ -39,9 +41,10 @@ stories.add('Bound by fixed dates', () => (
     <TimelineDays />
     <TimelineRows>{}</TimelineRows>
   </Timeline>
-))
+)
+BoundByFixedDates.storyName = 'Bound by fixed dates'
 
-stories.add('With data', () => (
+export const WithData = () => (
   <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15)}>
     <TimelineTodayMarker />
     <TimelineMonths />
@@ -70,9 +73,10 @@ stories.add('With data', () => (
       </TimelineRow>
     </TimelineRows>
   </Timeline>
-))
+)
+WithData.storyName = 'With data'
 
-stories.add('With sidebar', () => (
+export const WithSidebar = () => (
   <Timeline
     hasSide
     startDate={new Date(2020, 3, 1)}
@@ -105,9 +109,10 @@ stories.add('With sidebar', () => (
       </TimelineRow>
     </TimelineRows>
   </Timeline>
-))
+)
+WithSidebar.storyName = 'With sidebar'
 
-stories.add('With custom months', () => {
+const WithCustomMonths = () => {
   const CustomTimelineMonth = (
     index: number,
     dayWidth: number,
@@ -141,9 +146,10 @@ stories.add('With custom months', () => {
       <TimelineRows>{}</TimelineRows>
     </Timeline>
   )
-})
+}
+WithCustomMonths.storyName = 'With custom months'
 
-stories.add('With custom weeks', () => {
+const WithCustomWeeks = () => {
   const CustomTimelineWeek = (
     index: number,
     isOddNumber: boolean,
@@ -182,9 +188,10 @@ stories.add('With custom weeks', () => {
       <TimelineRows>{}</TimelineRows>
     </Timeline>
   )
-})
+}
+WithCustomWeeks.storyName = 'With custom weeks'
 
-stories.add('With custom days', () => {
+export const WithCustomDays = () => {
   const CustomTimelineDays = (index: number, dayWidth: number, date: Date) => {
     return (
       <span
@@ -211,9 +218,10 @@ stories.add('With custom days', () => {
       <TimelineRows>{}</TimelineRows>
     </Timeline>
   )
-})
+}
+WithCustomDays.storyName = 'With custom days'
 
-stories.add('With custom today marker', () => {
+export const WithCustomTodayMarker = () => {
   const CustomTodayMarker = (date: Date, offset: string) => {
     return (
       <span
@@ -245,9 +253,10 @@ stories.add('With custom today marker', () => {
       <TimelineRows>{}</TimelineRows>
     </Timeline>
   )
-})
+}
+WithCustomTodayMarker.storyName = 'With custom today marker'
 
-stories.add('With custom columns', () => {
+export const WithCustomColumns = () => {
   const CustomTimelineColumn = (
     index: number,
     isOddNumber: boolean,
@@ -298,9 +307,10 @@ stories.add('With custom columns', () => {
       </TimelineRows>
     </Timeline>
   )
-})
+}
+WithCustomColumns.storyName = 'With custom columns'
 
-stories.add('With custom event content', () => {
+export const WithCustomEventContent = () => {
   const CustomEvent = ({
     children,
     startDate,
@@ -406,9 +416,10 @@ stories.add('With custom event content', () => {
       </TimelineRows>
     </Timeline>
   )
-})
+}
+WithCustomEventContent.storyName = 'With custom event content'
 
-stories.add('With custom day width', () => {
+export const WithCustomDayWidth = () => {
   return (
     <Timeline
       startDate={new Date(2020, 3, 1)}
@@ -444,9 +455,10 @@ stories.add('With custom day width', () => {
       </TimelineRows>
     </Timeline>
   )
-})
+}
+WithCustomDayWidth.storyName = 'With custom day width'
 
-stories.add('With custom range', () => {
+export const WithCustomRange = () => {
   return (
     <Timeline
       startDate={new Date(2020, 3, 1)}
@@ -482,4 +494,5 @@ stories.add('With custom range', () => {
       </TimelineRows>
     </Timeline>
   )
-})
+}
+WithCustomRange.storyName = 'With custom range'

--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -18,6 +18,19 @@ import {
 
 export default { component: Timeline, title: 'Timeline' } as Meta
 
+const disableScrollableRegionFocusableRule = {
+  a11y: {
+    config: {
+      rules: [
+        {
+          id: 'scrollable-region-focusable',
+          enabled: false,
+        },
+      ],
+    },
+  },
+}
+
 export const NoData = () => (
   <Timeline startDate={new Date(2020, 0, 1)} today={new Date(2020, 0, 15)}>
     <TimelineTodayMarker />
@@ -27,6 +40,7 @@ export const NoData = () => (
     <TimelineRows>{}</TimelineRows>
   </Timeline>
 )
+NoData.parameters = disableScrollableRegionFocusableRule
 NoData.storyName = 'No data'
 
 export const BoundByFixedDates = () => (
@@ -74,6 +88,7 @@ export const WithData = () => (
     </TimelineRows>
   </Timeline>
 )
+WithData.parameters = disableScrollableRegionFocusableRule
 WithData.storyName = 'With data'
 
 export const WithSidebar = () => (

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -43,17 +43,18 @@ export const TimelineMonths: React.FC<TimelineMonthsProps> = ({ render }) => (
         renderRowHeader={(name) => (
           <>
             <div
-              aria-hidden
               className="timeline__navigation"
               data-testid="timeline-navigation"
             >
               <Button
+                aria-label="Navigate left"
                 variant="secondary"
                 icon={<IconChevronLeft />}
                 onClick={(_) => dispatch({ type: TIMELINE_ACTIONS.GET_PREV })}
                 data-testid="timeline-side-button-left"
               />
               <Button
+                aria-label="Navigate right"
                 variant="secondary"
                 icon={<IconChevronRight />}
                 onClick={(_) => dispatch({ type: TIMELINE_ACTIONS.GET_NEXT })}

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -24,8 +24,8 @@ export interface TimelineRowsProps extends ComponentWithClass {
 }
 
 const noData = (
-  <div className="timeline__empty" data-testid="timeline-no-data">
-    <span>{NO_DATA_MESSAGE}</span>
+  <div className="timeline__empty" data-testid="timeline-no-data" role="row">
+    <span role="cell">{NO_DATA_MESSAGE}</span>
   </div>
 )
 

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -359,10 +359,14 @@ describe('Timeline', () => {
         expect(rowHeaders[4]).toHaveTextContent('Row 2')
       })
 
-      it('should set the `aria-hidden` to `true` for the timeline navigation', () => {
-        expect(wrapper.getByTestId('timeline-navigation')).toHaveAttribute(
-          'aria-hidden',
-          'true'
+      it('should set the `aria-label` attributes for the timeline navigation buttons', () => {
+        expect(wrapper.getByTestId('timeline-side-button-left')).toHaveAttribute(
+          'aria-label',
+          'Navigate left'
+        )
+        expect(wrapper.getByTestId('timeline-side-button-right')).toHaveAttribute(
+          'aria-label',
+          'Navigate right'
         )
       })
 

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult, fireEvent } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
-import { DEFAULTS } from '../constants'
+import { DEFAULTS, NO_DATA_MESSAGE } from '../constants'
 import {
   Timeline,
   TimelineDays,
@@ -147,6 +147,14 @@ describe('Timeline', () => {
 
     it('should display the no data message', () => {
       expect(wrapper.queryByTestId('timeline-no-data')).toBeInTheDocument()
+    })
+
+    it('should set the `role` attribute to `row` on the no data message', () => {
+      expect(wrapper.queryByTestId('timeline-no-data')).toHaveAttribute('role', 'row')
+    })
+
+    it('should set the `role` attribute to `cell` on the no data message text', () => {
+      expect(wrapper.getByText(NO_DATA_MESSAGE)).toHaveAttribute('role', 'cell')
     })
 
     it('should not display any rows', () => {


### PR DESCRIPTION
## Related issue
Closes #1347 

## Overview
Updates accessibility for `Timeline`.

## Reason
There are violations in the a11y add on which need addressing.

## Work carried out
- [x] Update stories
- [x] Fix violations

## Developer notes
We are not addressing keyboard navigation within the `Timeline` at this stage.