### PR TITLE
fix(DatePicker): Fix lag in values passed to onChange

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -144,20 +144,20 @@ describe('DatePicker', () => {
 
       describe('and clicks on a day', () => {
         beforeEach(() => {
-          click(wrapper.getByText('1'))
+          click(wrapper.getByText('31'))
         })
 
         it('set the value of the component to this date', () => {
           expect(
             wrapper.getByTestId('datepicker-input').getAttribute('value')
-          ).toBe('12/1/2019')
+          ).toBe('12/31/2019')
         })
 
         it('invokes the onChange callback', () => {
           expect(onChange).toHaveBeenCalledTimes(1)
           expect(onChange).toHaveBeenCalledWith({
-            startDate: new Date('2019-12-01T00:00:00.000Z'),
-            endDate: undefined,
+            startDate: new Date('2019-12-31T12:00:00.000Z'),
+            endDate: new Date('2019-12-31T12:00:00.000Z'),
           })
         })
 
@@ -263,20 +263,20 @@ describe('DatePicker', () => {
 
         describe('and clicks on a day in the first month', () => {
           beforeEach(() => {
-            click(wrapper.getAllByText('1')[0])
+            click(wrapper.getAllByText('31')[0])
           })
 
           it('set the value of the component to this date', () => {
             expect(
               wrapper.getByTestId('datepicker-input').getAttribute('value')
-            ).toBe('12/1/2019 - 12/1/2019')
+            ).toBe('12/1/2019 - 12/31/2019')
           })
 
           it('invokes the onChange callback', () => {
             expect(onChange).toHaveBeenCalledTimes(1)
             expect(onChange).toHaveBeenCalledWith({
               startDate: new Date('2019-12-01T00:00:00.000Z'),
-              endDate: undefined,
+              endDate: new Date('2019-12-31T12:00:00.000Z'),
             })
           })
         })
@@ -297,11 +297,11 @@ describe('DatePicker', () => {
             expect(onChange).toHaveBeenCalledTimes(2)
             expect(onChange).toHaveBeenCalledWith({
               startDate: new Date('2019-12-01T00:00:00.000Z'),
-              endDate: undefined,
+              endDate: new Date('2020-01-20T12:00:00.000Z'),
             })
             expect(onChange).toHaveBeenCalledWith({
               startDate: new Date('2019-12-01T00:00:00.000Z'),
-              endDate: undefined,
+              endDate: new Date('2020-01-20T12:00:00.000Z'),
             })
           })
         })

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -80,8 +80,8 @@ export const DatePicker: React.FC<DatePickerProps> = ({
 
     if (onChange) {
       onChange({
-        startDate: from,
-        endDate: to,
+        startDate: newState.from,
+        endDate: newState.to,
       })
     }
   }


### PR DESCRIPTION
## Related issue

Fixes #1384

## Overview

This fixes a problem where the `onChange` DatePicker callback was being called with the previous values rather than the new ones just selected.

This was happening as the values were being read from the old state rather than the new state.

## Reason

So applications receive the correct values from the control.

## Work carried out

- [x] Call `onChange` with the correct values
- [x] Update tests

## Developer notes

Some additional problems were noted as part of this work:

- #1391 – Start date difficult to change in range DatePicker if dates selected
- The time parts of the `Date`s passed to `onChange` is now midday instead of midnight (not clear if this is a big problem yet, so haven't created an issue for this)
