### PR TITLE
feat(Masthead): Make avatar accessible

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
@@ -386,6 +386,13 @@ describe('Masthead', () => {
       expect(wrapper.getByText('AB')).toBeInTheDocument()
     })
 
+    it('should set the `aria-label` attribute on the search button to `Show search`', () => {
+      expect(wrapper.queryByTestId('user-button')).toHaveAttribute(
+        'aria-label',
+        'Show user options'
+      )
+    })
+
     it('should not show the links', () => {
       expect(wrapper.queryByText('Profile')).toBeNull()
       expect(wrapper.queryByText('Settings')).toBeNull()

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
@@ -50,8 +50,9 @@ const MastheadUserWithItems: React.FC<MastheadUserWithItemsProps> = ({
   <Sheet
     button={(
       <SheetButton
+        aria-label="Show user options"
         className="rn-masthead__option"
-        data-testid="notification-button"
+        data-testid="user-button"
         icon={(
           <Avatar
             data-testid="masthead-avatar"


### PR DESCRIPTION
## Related issue
Closes #1262 

## Overview
Adds missing ARIA attributes for `Masthead` avatar.

## Reason
Required for accessibility.

## Work carried out
- [x] Add attributes