### PR TITLE
feat(DatePicker): Add ability to disable days

### DIFF
--- a/packages/css-framework/src/components/_date-picker.scss
+++ b/packages/css-framework/src/components/_date-picker.scss
@@ -323,3 +323,8 @@
   border-top-right-radius: 50%;
   border-bottom-right-radius: 50%;
 }
+
+.DayPicker-Day--disabled {
+  color: f.color("neutral", "200");
+  pointer-events: none;
+}

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -47,6 +47,24 @@ examples.add('Disabled', () => {
   )
 })
 
+examples.add('Disabled days', () => {
+  return (
+    <DatePicker
+      startDate={new Date(2020, 3, 1)}
+      onBlur={action('onBlur')}
+      onChange={action('onChange')}
+      disabledDays={[
+        new Date(2020, 3, 12),
+        new Date(2020, 3, 2),
+        {
+          after: new Date(2020, 3, 20),
+          before: new Date(2020, 3, 25),
+        },
+      ]}
+    />
+  )
+})
+
 examples.add('Range', () => {
   return (
     <DatePicker

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -24,6 +24,18 @@ stories.add('Default', () => {
   )
 })
 
+examples.add('Custom initial month', () => {
+  return (
+    <DatePicker
+      initialMonth={new Date(2020, 1)}
+      onBlur={action('onBlur')}
+      onChange={action('onChange')}
+      placement={DATEPICKER_PLACEMENT.BELOW}
+      isOpen
+    />
+  )
+})
+
 examples.add('Custom label', () => {
   return (
     <DatePicker

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -15,7 +15,7 @@ describe('DatePicker', () => {
   let wrapper: RenderResult
   let startDate: Date
   let label: string
-  let onChange: (data: { startDate: Date, endDate: Date }) => void
+  let onChange: (data: { startDate: Date; endDate: Date }) => void
   let onBlur: (e: React.FormEvent) => void
   let dateSpy: jest.SpyInstance
   let days: string[]
@@ -355,6 +355,35 @@ describe('DatePicker', () => {
       expect(wrapper.getByTestId('datepicker-input')).toHaveAttribute(
         'disabled'
       )
+    })
+  })
+
+  describe('when the `disabledDays` prop is provided', () => {
+    beforeEach(() => {
+      onChange = jest.fn()
+
+      wrapper = render(
+        <DatePicker
+          isOpen
+          onChange={onChange}
+          startDate={new Date(2020, 3, 1)}
+          disabledDays={[new Date(2020, 3, 12)]}
+        />
+      )
+    })
+
+    it('applies the disabled modifier class to the correct days', () => {
+      expect(wrapper.getByText('12')).toHaveClass('DayPicker-Day--disabled')
+    })
+
+    describe('and a disabled day is clicked', () => {
+      beforeEach(() => {
+        click(wrapper.getByText('12'))
+      })
+
+      it('does not set the picker to that day', () => {
+        expect(onChange).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -386,4 +386,21 @@ describe('DatePicker', () => {
       })
     })
   })
+
+  describe('when the `initialMonth` prop is provided and no `startDate`', () => {
+    beforeEach(() => {
+      wrapper = render(<DatePicker isOpen initialMonth={new Date(2020, 1)} />)
+    })
+
+    it('displays the correct month initially', () => {
+      expect(wrapper.queryByText('February 2020')).toBeInTheDocument()
+    })
+
+    it('does not set a startDate', () => {
+      expect(wrapper.getByTestId('datepicker-input')).toHaveAttribute(
+        'value',
+        ''
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -3,7 +3,12 @@ import differenceInMinutes from 'date-fns/differenceInMinutes'
 import { v4 as uuidv4 } from 'uuid'
 import classNames from 'classnames'
 import TetherComponent from 'react-tether'
-import DayPicker, { DateUtils, RangeModifier } from 'react-day-picker'
+import DayPicker, {
+  DateUtils,
+  RangeModifier,
+  DayPickerProps,
+  DayModifiers,
+} from 'react-day-picker'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { DatePickerInput } from './DatePickerInput'
@@ -34,6 +39,7 @@ export interface DatePickerProps extends ComponentWithClass {
   startDate?: Date
   value?: string
   isOpen?: boolean
+  disabledDays?: DayPickerProps['disabledDays']
 }
 
 function transformDates(startDate: Date, endDate: Date) {
@@ -62,6 +68,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   startDate,
   value,
   isOpen,
+  disabledDays,
 }) => {
   const [state, setState] = useState<StateObject>({
     from: startDate,
@@ -71,7 +78,9 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   const { from, to } = state
   const modifiers = { start: from, end: to }
 
-  function handleDayClick(day: Date) {
+  function handleDayClick(day: Date, { disabled }: DayModifiers) {
+    if (disabled) return
+
     const newState = isRange
       ? DateUtils.addDayToRange(day, state as RangeModifier)
       : { from: day, to: day }
@@ -160,6 +169,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
               modifiers={modifiers}
               onDayClick={handleDayClick}
               initialMonth={startDate}
+              disabledDays={disabledDays}
             />
           </FloatingBox>
         ),

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -40,6 +40,7 @@ export interface DatePickerProps extends ComponentWithClass {
   value?: string
   isOpen?: boolean
   disabledDays?: DayPickerProps['disabledDays']
+  initialMonth?: DayPickerProps['initialMonth']
 }
 
 function transformDates(startDate: Date, endDate: Date) {
@@ -69,6 +70,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   value,
   isOpen,
   disabledDays,
+  initialMonth,
 }) => {
   const [state, setState] = useState<StateObject>({
     from: startDate,
@@ -168,7 +170,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
               selectedDays={[from, { from, to }]}
               modifiers={modifiers}
               onDayClick={handleDayClick}
-              initialMonth={startDate}
+              initialMonth={startDate || initialMonth}
               disabledDays={disabledDays}
             />
           </FloatingBox>


### PR DESCRIPTION
## Related issue

Closes #1346

## Overview

Add ability to disable specific days.

## Link to preview

More detail about the underlying implementation is available here:

https://react-day-picker.js.org/examples/disabled

## Reason

>For our exemplar project, we'd like the ability to restrict selection of a date in the DatePicker component to within two dates (including when in range mode).

## Work carried out

- [x] Extend base interface
- [x] Add ability to disable dates (individual and chunks)
- [x] Allow `initialMonth` to be set without `startDate`
- [x] Add automated tests

## Screenshot

<img width="299" alt="Screenshot 2020-09-07 at 14 22 53" src="https://user-images.githubusercontent.com/48086589/92392814-c979d200-f116-11ea-8354-a22f52f79f5f.png">
