### PR TITLE
fix(TextArea): Remove rogue z-index

### DIFF
--- a/packages/css-framework/src/components/_textarea.scss
+++ b/packages/css-framework/src/components/_textarea.scss
@@ -36,10 +36,8 @@
   box-shadow: 0 0 0 1px f.color("success", "700");
 }
 
-
 .rn-textarea__label {
   display: block;
-  z-index: 1;
   position: absolute;
   padding-top: 6px;
   padding-left: f.spacing("6");

--- a/packages/css-framework/src/components/_textarea.scss
+++ b/packages/css-framework/src/components/_textarea.scss
@@ -39,7 +39,6 @@
 .rn-textarea__label {
   display: block;
   position: absolute;
-  padding-top: 6px;
   padding-left: f.spacing("6");
   padding-bottom: f.spacing("2");
   right: 14px;


### PR DESCRIPTION
## Related issue

Closes #1357

## Overview

Remove rogue z-index.

## Reason

>This z-index would cause the label to display above an open Select.

## Work carried out

- [x] Remove rogue z-index
- [x] Adjust TextArea label positioning

## Screenshot

<img width="390" alt="Screenshot 2020-09-08 at 10 42 54" src="https://user-images.githubusercontent.com/48086589/92460616-136ac280-f1c0-11ea-8710-2f34310d63f5.png">
