### PR TITLE
fix(Timeline): Fix duplicated elements in some environments

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TimelineProvider } from './context'
-import { TimelineComponent } from './types'
 
 import {
   TimelineDays,
@@ -48,29 +47,20 @@ export interface TimelineProps extends ComponentWithClass {
   range?: number
 }
 
-function isComponentOf<T extends TimelineComponent>(
-  item: T,
-  names: string[]
-): item is T {
-  const typeName: string | null = (item as T)?.type?.name
-
-  return names.includes(typeName)
-}
-
 function extractChildren(
   children: timelineChildrenType | timelineChildrenType[],
-  names: string[],
+  types: React.ReactElement['type'][],
   inverse?: boolean
 ) {
-  return (children as []).filter((child) => {
-    return inverse ? !isComponentOf(child, names) : isComponentOf(child, names)
+  return (children as []).filter((child: React.ReactElement) => {
+    return inverse ? !types.includes(child?.type) : types.includes(child?.type)
   })
 }
 
 function hasTimelineSideComponent(
   children: timelineChildrenType | timelineChildrenType[]
 ) {
-  const sideChildren = extractChildren(children, [TimelineSide.name])
+  const sideChildren = extractChildren(children, [TimelineSide])
 
   if (!sideChildren.length) {
     return false
@@ -97,12 +87,12 @@ export const Timeline: React.FC<TimelineProps> = ({
   const rootChildren = extractChildren(
     children,
     [
-      TimelineDays.name,
-      TimelineMonths.name,
-      TimelineRows.name,
-      TimelineSide.name,
-      TimelineTodayMarker.name,
-      TimelineWeeks.name,
+      TimelineDays,
+      TimelineMonths,
+      TimelineRows,
+      TimelineSide,
+      TimelineTodayMarker,
+      TimelineWeeks,
     ],
     true
   )
@@ -110,13 +100,13 @@ export const Timeline: React.FC<TimelineProps> = ({
   const hasTimelineSide = hasTimelineSideComponent(children)
 
   const headChildren = extractChildren(children, [
-    TimelineDays.name,
-    TimelineWeeks.name,
-    TimelineMonths.name,
-    TimelineTodayMarker.name,
+    TimelineDays,
+    TimelineWeeks,
+    TimelineMonths,
+    TimelineTodayMarker,
   ])
 
-  const bodyChildren = extractChildren(children, [TimelineRows.name])
+  const bodyChildren = extractChildren(children, [TimelineRows])
 
   const innerClasses = classNames('timeline__inner', {
     'timeline__inner--has-side': hasSide || hasTimelineSide,

--- a/packages/react-component-library/src/components/Timeline/types.ts
+++ b/packages/react-component-library/src/components/Timeline/types.ts
@@ -1,5 +1,0 @@
-export interface TimelineComponent {
-  type: {
-    name: string
-  }
-}


### PR DESCRIPTION
## Related issue

Fixes #1153

## Overview

This fixes problems with duplicated elements in the Timeline component in production builds and/or in older browsers.

## Reason

Duplicated elements make the Timeline unusable.

## Work carried out

- [x] Changed Timeline logic to use reorganise child components based on function references instead of function names
- [x] Manually tested in various environments and browsers

## Screenshot

### fp-grey-box

#### Before

![timeline-prod-dupe](https://user-images.githubusercontent.com/66470099/92497610-77f24580-f1f1-11ea-93f6-a80ff5408606.png)

#### After

![timeline-prod-after](https://user-images.githubusercontent.com/66470099/92497609-7759af00-f1f1-11ea-92be-cc4ad4a46600.png)

## Developer notes

These occurred because the Timeline logic was using the name property of functions (the functions being the Timeline components) to reorganise child components, however this failed in a few situations:

- after minification, the component function names weren't always unique
- after minification, the component functions were changed to anonymous functions, of which names are not supported in older browsers
- very old browsers don't support Function.name at all

(See also https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name.)

This change switches to using a strict equality on the types instead. This compares the functions by reference instead of name, which overcomes those three classes of problems from testing.
