### PR TITLE
ci(Chromatic): Add `--exit-once-uploaded` flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
           name: Run visual regression tests
           command: |
             if [ "${CIRCLE_BRANCH}" = "master" ]; then
-              yarn --cwd packages/react-component-library chromatic --app-code=$CHROMATIC_APP_CODE --auto-accept-changes
+              yarn --cwd packages/react-component-library chromatic --app-code=$CHROMATIC_APP_CODE --auto-accept-changes --exit-once-uploaded
             else
               yarn --cwd packages/react-component-library chromatic --app-code=$CHROMATIC_APP_CODE
             fi


### PR DESCRIPTION
## Overview

https://app.circleci.com/pipelines/github/Royal-Navy/design-system/4870/workflows/836053bb-d4bb-42c0-9a03-ff39ef022209/jobs/40175

>Your project is linked to GitHub so Chromatic will report results there.
>This means you can pass the --exit-once-uploaded flag to skip waiting for build results.
>Read more here: https://www.chromatic.com/docs/cli#chromatic-options