### PR TITLE
feat(RangeSlider): Threshold and multiple handle enhancements

### DIFF
--- a/packages/css-framework/src/components/_range-slider.scss
+++ b/packages/css-framework/src/components/_range-slider.scss
@@ -88,15 +88,26 @@ $range-slider-above-thresholds: f.color("action", "500");
     transform: translate(-50%, -225%);
     font-size: f.font-size("xs");
     color: f.color("neutral", "600");
-    opacity: 0;
+    opacity: 1;
     transition: opacity 0.15s ease-in-out;
+  }
+
+  &::before {
+    content: attr(data-percent);
+    position: absolute;
+    transform: translate(-50%, -325%);
+    font-size: f.font-size("s");
+    color: f.color("neutral", "300");
+    opacity: 1;
+    transition: opacity 0.15s ease-in-out;
+    font-weight: 600;
   }
 
   &.is-active, &:focus {
     box-shadow: 0px 0px 0px 7px rgba(f.color("action", "200"), 0.5);
     outline: none;
 
-    &::after {
+    &::after, &::before {
       opacity: 1;
     }
   }
@@ -150,4 +161,10 @@ $range-slider-above-thresholds: f.color("action", "500");
   font-size: f.font-size("xs");
   color: f.color("neutral", "400");
   text-align: center;
+}
+
+.rn-rangeslider:not(.has-percentage) {
+  .rn-rangeslider__handle::before {
+    display: none;
+  }
 }

--- a/packages/css-framework/src/components/_range-slider.scss
+++ b/packages/css-framework/src/components/_range-slider.scss
@@ -78,33 +78,46 @@ $range-slider-above-thresholds: f.color("action", "500");
   border-radius: 9999px;
   background-color: $range-slider-handle-colour;
   text-align: center;
-  box-shadow: 0px 0px 0px 0px rgba(f.color("action", "200"), 0.5);
+  box-shadow: 0px 0px 0px 0px rgba(f.color("neutral", "200"), 0.5);
   transition: box-shadow 0.15s ease-in-out;
   cursor: pointer;
 
   &::after {
     content: attr(data-value);
     position: absolute;
-    transform: translate(-50%, -225%);
+    transform: translate(-50%, -155%);
     font-size: f.font-size("xs");
     color: f.color("neutral", "600");
     opacity: 1;
     transition: opacity 0.15s ease-in-out;
+    padding: f.spacing("2") f.spacing("3");
+    border-radius: 12px;
+    font-weight: 600;
   }
 
   &::before {
     content: attr(data-percent);
     position: absolute;
-    transform: translate(-50%, -325%);
+    transform: translate(-50%, -355%);
     font-size: f.font-size("s");
     color: f.color("neutral", "300");
     opacity: 1;
     transition: opacity 0.15s ease-in-out;
-    font-weight: 600;
+    font-weight: 700;
+  }
+
+  &:nth-of-type(2n) {
+    &::after {
+      transform: translate(-50%, 125%);
+    }
+
+    &::before {
+      transform: translate(-50%, 355%);
+    }
   }
 
   &.is-active, &:focus {
-    box-shadow: 0px 0px 0px 7px rgba(f.color("action", "200"), 0.5);
+    box-shadow: 0px 0px 0px 7px rgba(f.color("neutral", "200"), 0.5);
     outline: none;
 
     &::after, &::before {
@@ -123,18 +136,36 @@ $range-slider-above-thresholds: f.color("action", "500");
 }
 
 .rn-rangeslider__tick--below-first-threshold,
-.rn-rangeslider__track--below-first-threshold {
+.rn-rangeslider__track--below-first-threshold,
+.rn-rangeslider__handle--below-first-threshold {
   background-color: $range-slider-track-below-first-threshold;
+
+  &::after {
+    color: $range-slider-track-below-first-threshold;
+    background-color: rgba($range-slider-track-below-first-threshold, .25);
+  }
 }
 
 .rn-rangeslider__tick--between-thresholds,
-.rn-rangeslider__track--between-thresholds {
+.rn-rangeslider__track--between-thresholds,
+.rn-rangeslider__handle--between-thresholds {
   background-color: $range-slider-track-between-thresholds;
+
+  &::after {
+    color: $range-slider-track-between-thresholds;
+    background-color: rgba($range-slider-track-between-thresholds, .25);
+  }
 }
 
 .rn-rangeslider__tick--above-thresholds,
-.rn-rangeslider__track--above-thresholds {
+.rn-rangeslider__track--above-thresholds,
+.rn-rangeslider__handle--above-thresholds {
   background-color: $range-slider-above-thresholds;
+
+  &::after {
+    color: $range-slider-above-thresholds;
+    background-color: rgba($range-slider-above-thresholds, .25);
+  }
 }
 
 .rn-rangeslider__ticks {

--- a/packages/css-framework/src/components/_range-slider.scss
+++ b/packages/css-framework/src/components/_range-slider.scss
@@ -122,14 +122,17 @@ $range-slider-above-thresholds: f.color("action", "500");
   cursor: pointer;
 }
 
+.rn-rangeslider__tick--below-first-threshold,
 .rn-rangeslider__track--below-first-threshold {
   background-color: $range-slider-track-below-first-threshold;
 }
 
+.rn-rangeslider__tick--between-thresholds,
 .rn-rangeslider__track--between-thresholds {
   background-color: $range-slider-track-between-thresholds;
 }
 
+.rn-rangeslider__tick--above-thresholds,
 .rn-rangeslider__track--above-thresholds {
   background-color: $range-slider-above-thresholds;
 }
@@ -148,10 +151,9 @@ $range-slider-above-thresholds: f.color("action", "500");
   width: 2px;
   height: 12px;
   transform: translateY(-50%);
-  background-color: $range-slider-bg-colour;
 
-  &.is-active {
-    background-color: $range-slider-track-colour;
+  &:not(.is-active) {
+    background-color: $range-slider-bg-colour;
   }
 }
 

--- a/packages/css-framework/src/components/_range-slider.scss
+++ b/packages/css-framework/src/components/_range-slider.scss
@@ -135,6 +135,35 @@ $range-slider-above-thresholds: f.color("action", "500");
   cursor: pointer;
 }
 
+.rn-rangeslider__ticks {
+  div:first-of-type,
+  div:last-of-type {
+    .rn-rangeslider__tick {
+      height: 16px;
+    }
+  }
+}
+
+.rn-rangeslider__tick {
+  position: absolute;
+  width: 2px;
+  height: 12px;
+  transform: translateY(-50%);
+  background-color: $range-slider-above-thresholds;
+
+  &:not(.is-active) {
+    background-color: $range-slider-bg-colour;
+  }
+}
+
+.rn-rangeslider__label {
+  position: absolute;
+  margin-top: 22px;
+  font-size: f.font-size("xs");
+  color: f.color("neutral", "400");
+  text-align: center;
+}
+
 .rn-rangeslider__tick--below-first-threshold,
 .rn-rangeslider__track--below-first-threshold,
 .rn-rangeslider__handle--below-first-threshold {
@@ -166,34 +195,6 @@ $range-slider-above-thresholds: f.color("action", "500");
     color: $range-slider-above-thresholds;
     background-color: rgba($range-slider-above-thresholds, .25);
   }
-}
-
-.rn-rangeslider__ticks {
-  div:first-of-type,
-  div:last-of-type {
-    .rn-rangeslider__tick {
-      height: 16px;
-    }
-  }
-}
-
-.rn-rangeslider__tick {
-  position: absolute;
-  width: 2px;
-  height: 12px;
-  transform: translateY(-50%);
-
-  &:not(.is-active) {
-    background-color: $range-slider-bg-colour;
-  }
-}
-
-.rn-rangeslider__label {
-  position: absolute;
-  margin-top: 22px;
-  font-size: f.font-size("xs");
-  color: f.color("neutral", "400");
-  text-align: center;
 }
 
 .rn-rangeslider:not(.has-percentage) {

--- a/packages/react-component-library/src/components/RangeSlider/Handle.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Handle.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { GetHandleProps, SliderItem } from 'react-compound-slider'
 import classNames from 'classnames'
 
+import { useThresholdClasses } from './useThresholdClasses'
+
 interface HandleProps {
   activeHandleID: string
   domain: ReadonlyArray<number>
@@ -9,21 +11,6 @@ interface HandleProps {
   getHandleProps: GetHandleProps
   displayUnit?: string
   thresholds?: number[]
-}
-
-function getThresholdClasses(percent: number, thresholds: number[]) {
-  const singleThreshold = thresholds?.length === 1
-  const doubleThreshold = thresholds?.length === 2
-
-  return {
-    'rn-rangeslider__handle--below-first-threshold':
-      (singleThreshold || doubleThreshold) && percent <= thresholds[0],
-    'rn-rangeslider__handle--between-thresholds':
-      doubleThreshold && percent < thresholds[1] && percent >= thresholds[0],
-    'rn-rangeslider__handle--above-thresholds':
-      (singleThreshold || doubleThreshold) &&
-      percent >= thresholds[thresholds.length - 1],
-  }
 }
 
 export const Handle: React.FC<HandleProps> = ({
@@ -38,7 +25,7 @@ export const Handle: React.FC<HandleProps> = ({
 
   const classes = classNames('rn-rangeslider__handle', {
     'is-active': isActive,
-    ...getThresholdClasses(percent, thresholds),
+    ...useThresholdClasses(percent, thresholds, 'handle'),
   })
 
   return (

--- a/packages/react-component-library/src/components/RangeSlider/Handle.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Handle.tsx
@@ -6,6 +6,7 @@ interface HandleProps {
   domain: ReadonlyArray<number>
   handle: SliderItem
   getHandleProps: GetHandleProps
+  displayUnit?: string
 }
 
 export const Handle: React.FC<HandleProps> = ({
@@ -13,6 +14,7 @@ export const Handle: React.FC<HandleProps> = ({
   domain: [min, max],
   handle: { id, value, percent },
   getHandleProps,
+  displayUnit,
 }) => {
   const isActive: boolean = activeHandleID === id
 
@@ -28,7 +30,7 @@ export const Handle: React.FC<HandleProps> = ({
         left: `${percent}%`,
       }}
       {...getHandleProps(id)}
-      data-value={Math.floor(value)}
+      data-value={`${Math.floor(value)}${displayUnit || ''}`}
       data-percent={`${Math.floor(percent)}%`}
       data-testid="rangeslider-handle"
     />

--- a/packages/react-component-library/src/components/RangeSlider/Handle.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Handle.tsx
@@ -29,6 +29,7 @@ export const Handle: React.FC<HandleProps> = ({
       }}
       {...getHandleProps(id)}
       data-value={Math.floor(value)}
+      data-percent={`${Math.floor(percent)}%`}
       data-testid="rangeslider-handle"
     />
   )

--- a/packages/react-component-library/src/components/RangeSlider/Handle.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Handle.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { GetHandleProps, SliderItem } from 'react-compound-slider'
+import classNames from 'classnames'
 
 interface HandleProps {
   activeHandleID: string
@@ -7,6 +8,22 @@ interface HandleProps {
   handle: SliderItem
   getHandleProps: GetHandleProps
   displayUnit?: string
+  thresholds?: number[]
+}
+
+function getThresholdClasses(percent: number, thresholds: number[]) {
+  const singleThreshold = thresholds?.length === 1
+  const doubleThreshold = thresholds?.length === 2
+
+  return {
+    'rn-rangeslider__handle--below-first-threshold':
+      (singleThreshold || doubleThreshold) && percent <= thresholds[0],
+    'rn-rangeslider__handle--between-thresholds':
+      doubleThreshold && percent < thresholds[1] && percent >= thresholds[0],
+    'rn-rangeslider__handle--above-thresholds':
+      (singleThreshold || doubleThreshold) &&
+      percent >= thresholds[thresholds.length - 1],
+  }
 }
 
 export const Handle: React.FC<HandleProps> = ({
@@ -15,8 +32,14 @@ export const Handle: React.FC<HandleProps> = ({
   handle: { id, value, percent },
   getHandleProps,
   displayUnit,
+  thresholds,
 }) => {
   const isActive: boolean = activeHandleID === id
+
+  const classes = classNames('rn-rangeslider__handle', {
+    'is-active': isActive,
+    ...getThresholdClasses(percent, thresholds),
+  })
 
   return (
     <div
@@ -25,7 +48,7 @@ export const Handle: React.FC<HandleProps> = ({
       aria-valuemin={min}
       aria-valuemax={max}
       aria-valuenow={value}
-      className={`rn-rangeslider__handle ${isActive ? 'is-active' : ''}`}
+      className={classes}
       style={{
         left: `${percent}%`,
       }}

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -19,6 +19,23 @@ stories.add('Default', () => (
   />
 ))
 
+examples.add('Multiple handles', () => (
+  <div style={{ margin: '4rem' }}>
+    <RangeSlider
+      domain={[0, 40]}
+      mode={2}
+      values={[10, 20, 30]}
+      onChange={action('onChange')}
+      onUpdate={action('onUpdate')}
+      tracksLeft
+      tickCount={10}
+      thresholds={[40, 60]}
+      hasPercentage
+      displayUnit="pt"
+    />
+  </div>
+))
+
 examples.add('Stepped', () => (
   <RangeSlider
     domain={[0, 40]}
@@ -53,18 +70,6 @@ examples.add('Double threshold', () => (
     onUpdate={action('onUpdate')}
     tracksLeft
     thresholds={[40, 60]}
-  />
-))
-
-examples.add('Multiple handles', () => (
-  <RangeSlider
-    domain={[0, 40]}
-    step={10}
-    mode={1}
-    values={[10, 30]}
-    onChange={action('onChange')}
-    onUpdate={action('onUpdate')}
-    tickCount={4}
   />
 ))
 

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
@@ -40,7 +40,7 @@ describe('RangeSlider', () => {
     })
 
     it('should render a single handle', () => {
-      expect(wrapper.queryAllByTestId('rangeslider-handle').length).toBe(1)
+      expect(wrapper.queryAllByTestId('rangeslider-handle')).toHaveLength(1)
     })
 
     it('should set the ARIA attributes on the handle', () => {
@@ -54,15 +54,15 @@ describe('RangeSlider', () => {
     })
 
     it('should render correct number of ticks', () => {
-      expect(wrapper.queryAllByTestId('rangeslider-tick').length).toBe(5)
+      expect(wrapper.queryAllByTestId('rangeslider-tick')).toHaveLength(5)
     })
 
     it('should not render any tracks', () => {
-      expect(wrapper.queryAllByTestId('rangeslider-track').length).toBe(0)
+      expect(wrapper.queryAllByTestId('rangeslider-track')).toHaveLength(0)
     })
 
     it('should not render any labels', () => {
-      expect(wrapper.queryAllByTestId('rangeslider-label').length).toBe(0)
+      expect(wrapper.queryAllByTestId('rangeslider-label')).toHaveLength(0)
     })
 
     describe('and the end user moves the handle to the right using keyboard', () => {
@@ -229,7 +229,7 @@ describe('RangeSlider', () => {
     })
 
     it('should render two handles', () => {
-      expect(wrapper.queryAllByTestId('rangeslider-handle').length).toBe(3)
+      expect(wrapper.queryAllByTestId('rangeslider-handle')).toHaveLength(3)
     })
   })
 

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
@@ -35,6 +35,10 @@ describe('RangeSlider', () => {
       )
     })
 
+    it('should render the ticks', () => {
+      expect(wrapper.getAllByTestId('rangeslider-tick')).toHaveLength(5)
+    })
+
     it('should render a single handle', () => {
       expect(wrapper.queryAllByTestId('rangeslider-handle').length).toBe(1)
     })

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
@@ -228,4 +228,27 @@ describe('RangeSlider', () => {
       expect(wrapper.queryAllByTestId('rangeslider-handle').length).toBe(3)
     })
   })
+
+  describe('when the `hasPercentage` prop is provided', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <RangeSlider
+          domain={[0, 40]}
+          mode={1}
+          values={[20]}
+          tracksLeft
+          tickCount={4}
+          thresholds={[40, 60]}
+          hasPercentage
+        />
+      )
+    })
+
+    it('should display the percentage value next to the handle', () => {
+      expect(wrapper.getByTestId('rangeslider-handle')).toHaveAttribute(
+        'data-percent',
+        '50%'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
@@ -255,4 +255,27 @@ describe('RangeSlider', () => {
       )
     })
   })
+
+  describe('when the `displayUnit` prop is provided', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <RangeSlider
+          domain={[0, 40]}
+          mode={1}
+          values={[20]}
+          tracksLeft
+          tickCount={4}
+          thresholds={[40, 60]}
+          displayUnit="pt"
+        />
+      )
+    })
+
+    it('should append the display unit to the handle label', () => {
+      expect(wrapper.getByTestId('rangeslider-handle')).toHaveAttribute(
+        'data-value',
+        '20pt'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -23,6 +23,7 @@ interface RangeSliderProps
   isDisabled?: boolean
   isReversed?: boolean
   thresholds?: number[]
+  hasPercentage?: boolean
 }
 
 export const RangeSlider: React.FC<RangeSliderProps> = ({
@@ -40,6 +41,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
   values,
   onUpdate,
   thresholds,
+  hasPercentage,
   ...rest
 }) => {
   const [sliderValues, setSliderValues] = useState(values)
@@ -52,6 +54,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
   const classes = classNames('rn-rangeslider', className, {
     'is-reversed': isReversed,
     'is-disabled': isDisabled,
+    'has-percentage': hasPercentage,
   })
 
   return (

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -24,6 +24,7 @@ interface RangeSliderProps
   isReversed?: boolean
   thresholds?: number[]
   hasPercentage?: boolean
+  displayUnit?: string
 }
 
 export const RangeSlider: React.FC<RangeSliderProps> = ({
@@ -42,6 +43,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
   onUpdate,
   thresholds,
   hasPercentage,
+  displayUnit,
   ...rest
 }) => {
   const [sliderValues, setSliderValues] = useState(values)
@@ -93,6 +95,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
                   domain={domain}
                   activeHandleID={activeHandleID}
                   getHandleProps={getHandleProps}
+                  displayUnit={displayUnit}
                 />
               ))}
             </div>

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -141,6 +141,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
                     values={sliderValues}
                     domain={domain}
                     isReversed={isReversed}
+                    thresholds={thresholds}
                   />
                 ))}
               </div>

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -128,7 +128,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
             </div>
           )}
         </Tracks>
-        {step && (
+        {tickCount && (
           <Ticks count={tickCount}>
             {({ ticks }) => (
               <div className="rn-rangeslider__ticks">

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -96,6 +96,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
                   activeHandleID={activeHandleID}
                   getHandleProps={getHandleProps}
                   displayUnit={displayUnit}
+                  thresholds={thresholds}
                 />
               ))}
             </div>

--- a/packages/react-component-library/src/components/RangeSlider/Tick.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Tick.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { SliderItem } from 'react-compound-slider'
 import classNames from 'classnames'
 
+import { useThresholdClasses } from './useThresholdClasses'
+
 interface TickProps {
   tick: SliderItem
   count: number
@@ -14,21 +16,6 @@ interface TickProps {
 
 function isActive(values: ReadonlyArray<number>, tickValue: number): boolean {
   return values.some((item) => item >= tickValue)
-}
-
-function getThresholdClasses(percent: number, thresholds: number[]) {
-  const singleThreshold = thresholds?.length === 1
-  const doubleThreshold = thresholds?.length === 2
-
-  return {
-    'rn-rangeslider__tick--below-first-threshold':
-      (singleThreshold || doubleThreshold) && percent <= thresholds[0],
-    'rn-rangeslider__tick--between-thresholds':
-      doubleThreshold && percent < thresholds[1] && percent >= thresholds[0],
-    'rn-rangeslider__tick--above-thresholds':
-      (singleThreshold || doubleThreshold) &&
-      percent >= thresholds[thresholds.length - 1],
-  }
 }
 
 export const Tick: React.FC<TickProps> = ({
@@ -45,7 +32,7 @@ export const Tick: React.FC<TickProps> = ({
 
   const tickClasses = classNames('rn-rangeslider__tick', {
     'is-active': isActive(values, tickValue),
-    ...getThresholdClasses(percent, thresholds),
+    ...useThresholdClasses(percent, thresholds, 'tick'),
   })
 
   return (

--- a/packages/react-component-library/src/components/RangeSlider/Tick.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Tick.tsx
@@ -13,13 +13,7 @@ interface TickProps {
 }
 
 function isActive(values: ReadonlyArray<number>, tickValue: number): boolean {
-  const valuesBelow = values.some((item) => item <= tickValue)
-  const valuesAbove = values.some((item) => item >= tickValue)
-
-  const belowSingleHandle = values.length === 1 && values[0] >= tickValue
-  const betweenMultipleHandles = valuesBelow && valuesAbove
-
-  return belowSingleHandle || betweenMultipleHandles
+  return values.some((item) => item >= tickValue)
 }
 
 function getThresholdClasses(percent: number, thresholds: number[]) {

--- a/packages/react-component-library/src/components/RangeSlider/Tick.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Tick.tsx
@@ -9,16 +9,32 @@ interface TickProps {
   values: ReadonlyArray<number>
   domain: ReadonlyArray<number>
   isReversed?: boolean
+  thresholds?: number[]
 }
 
 function isActive(values: ReadonlyArray<number>, tickValue: number): boolean {
-  const valuesBelow = values.some(item => item <= tickValue)
-  const valuesAbove = values.some(item => item >= tickValue)
+  const valuesBelow = values.some((item) => item <= tickValue)
+  const valuesAbove = values.some((item) => item >= tickValue)
 
   const belowSingleHandle = values.length === 1 && values[0] >= tickValue
   const betweenMultipleHandles = valuesBelow && valuesAbove
 
   return belowSingleHandle || betweenMultipleHandles
+}
+
+function getThresholdClasses(percent: number, thresholds: number[]) {
+  const singleThreshold = thresholds?.length === 1
+  const doubleThreshold = thresholds?.length === 2
+
+  return {
+    'rn-rangeslider__tick--below-first-threshold':
+      (singleThreshold || doubleThreshold) && percent <= thresholds[0],
+    'rn-rangeslider__tick--between-thresholds':
+      doubleThreshold && percent < thresholds[1] && percent >= thresholds[0],
+    'rn-rangeslider__tick--above-thresholds':
+      (singleThreshold || doubleThreshold) &&
+      percent >= thresholds[thresholds.length - 1],
+  }
 }
 
 export const Tick: React.FC<TickProps> = ({
@@ -28,11 +44,14 @@ export const Tick: React.FC<TickProps> = ({
   values,
   domain,
   isReversed,
+  thresholds,
 }) => {
   const percent: number = isReversed ? 100 - tick.percent : tick.percent // invert if reversed
   const tickValue: number = (domain[1] / 100) * percent
+
   const tickClasses = classNames('rn-rangeslider__tick', {
     'is-active': isActive(values, tickValue),
+    ...getThresholdClasses(percent, thresholds),
   })
 
   return (

--- a/packages/react-component-library/src/components/RangeSlider/useThresholdClasses.ts
+++ b/packages/react-component-library/src/components/RangeSlider/useThresholdClasses.ts
@@ -1,0 +1,20 @@
+export function useThresholdClasses(
+  percent: number,
+  thresholds: number[],
+  componentName: string
+): { [key: string]: boolean } {
+  const singleThreshold = thresholds?.length === 1
+  const doubleThreshold = thresholds?.length === 2
+
+  const lowerCaseName = componentName.toLowerCase()
+
+  return {
+    [`rn-rangeslider__${lowerCaseName}--below-first-threshold`]:
+      (singleThreshold || doubleThreshold) && percent <= thresholds[0],
+    [`rn-rangeslider__${lowerCaseName}--between-thresholds`]:
+      doubleThreshold && percent < thresholds[1] && percent >= thresholds[0],
+    [`rn-rangeslider__${lowerCaseName}--above-thresholds`]:
+      (singleThreshold || doubleThreshold) &&
+      percent >= thresholds[thresholds.length - 1],
+  }
+}


### PR DESCRIPTION
## Related issue

Closes #1318

## Overview

Enhance the RangeSlider for threshold and multiple handle use cases.

## Reason

>In our exemplar project, we need a range slider with multiple threshold points. Initially there are two thresholds, and later there will be three.

## Work carried out

- [x] Render ticks active if values above
- [x] Add ability to apply custom value unit
- [x] Colour code ticks and handles with thresholds
- [x] Allow for tick display without step
- [x] Fix broken tick display with multiple handles
- [x] Add percentage badge variant
- [x] Update multiple handle example story

## Screenshot

![2020-09-14 13 16 01](https://user-images.githubusercontent.com/48086589/93084773-778ff980-f68c-11ea-9af0-63b633d35a78.gif)

## Developer notes

I've created another ticket for keyboard control: https://github.com/Royal-Navy/design-system/issues/1429