### PR TITLE
feat(RangeSlider): Improve keyboard control

### DIFF
--- a/packages/react-component-library/src/components/RangeSlider/Handle.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Handle.tsx
@@ -11,6 +11,7 @@ interface HandleProps {
   getHandleProps: GetHandleProps
   displayUnit?: string
   thresholds?: number[]
+  tabIndex: number
 }
 
 export const Handle: React.FC<HandleProps> = ({
@@ -20,6 +21,7 @@ export const Handle: React.FC<HandleProps> = ({
   getHandleProps,
   displayUnit,
   thresholds,
+  tabIndex,
 }) => {
   const isActive: boolean = activeHandleID === id
 
@@ -30,6 +32,7 @@ export const Handle: React.FC<HandleProps> = ({
 
   return (
     <div
+      tabIndex={tabIndex}
       role="slider"
       aria-label="Select range"
       aria-valuemin={min}

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
@@ -35,6 +35,13 @@ describe('RangeSlider', () => {
       )
     })
 
+    it('should set the correct `tabindex`', () => {
+      expect(wrapper.getByTestId('rangeslider-handle')).toHaveAttribute(
+        'tabindex',
+        '0'
+      )
+    })
+
     it('should render the ticks', () => {
       expect(wrapper.getAllByTestId('rangeslider-tick')).toHaveLength(5)
     })
@@ -230,6 +237,18 @@ describe('RangeSlider', () => {
 
     it('should render two handles', () => {
       expect(wrapper.queryAllByTestId('rangeslider-handle')).toHaveLength(3)
+    })
+
+    it('should set the correct `tabindex`', () => {
+      expect(wrapper.getAllByTestId('rangeslider-handle')[0]).toHaveAttribute(
+        'tabindex',
+        '0'
+      )
+
+      expect(wrapper.getAllByTestId('rangeslider-handle')[1]).toHaveAttribute(
+        'tabindex',
+        '1'
+      )
     })
   })
 

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -88,8 +88,9 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
         <Handles>
           {({ activeHandleID, handles, getHandleProps }) => (
             <div className="rn-rangeslider__handles">
-              {handles.map((handle) => (
+              {handles.map((handle, index) => (
                 <Handle
+                  tabIndex={index}
                   key={handle.id}
                   handle={handle}
                   domain={domain}


### PR DESCRIPTION
## Related issue

Closes #1429

## Overview

~~Use `button` instead of `div` for handle. Improve keyboard control.~~

Apply `tabIndex` to Handles and maintain `div` element due to accessibility AXE role error.

## Reason

>There were some weird edge cases where the handle wouldn't be controllable via the keyboard. Despite automated tests that were passing.

## Work carried out

- [x] Change handle element
