### PR TITLE
docs(Timeline): Fix typo

### DIFF
--- a/packages/docs-site/src/library/pages/timeline/index.md
+++ b/packages/docs-site/src/library/pages/timeline/index.md
@@ -182,7 +182,7 @@ yarn add @royalnavy/css-framework @royalnavy/react-component-library
 
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
-    <h1 className="rn-fw-api-title">withSide</h1>
+    <h1 className="rn-fw-api-title">hasSide</h1>
     <Badge color="supa" colorVariant="faded" size="small">Boolean</Badge>
   </div>
   <div className="rn-fw-api-body">
@@ -651,7 +651,7 @@ Here you will find comprehensive API documentation for the Timeline Components.
 
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
-    <h1 className="rn-fw-api-title">withSide</h1>
+    <h1 className="rn-fw-api-title">hasSide</h1>
     <Badge color="supa" colorVariant="faded" size="small">Boolean</Badge>
   </div>
   <div className="rn-fw-api-body">


### PR DESCRIPTION
## Related issue
#1423 

## Overview
Fix typo in documentation.

## Reason
Not clear.

## Work carried out
- [x] Fix typo