### PR TITLE
fix(Timeline): Adjust z-index

### DIFF
--- a/packages/css-framework/src/components/_sidebar.scss
+++ b/packages/css-framework/src/components/_sidebar.scss
@@ -1,4 +1,5 @@
 @use "../abstracts/functions" as f;
+@use "../abstracts/mixins" as m;
 
 $bar-width: 60px;
 $bar-width-open: 180px;
@@ -19,7 +20,7 @@ body.has-sidebar {
   left: 0;
   background: f.color("neutral", "600");
   color: f.color("neutral", "white");
-  z-index: 700;
+  @include m.z-index("header");
 
   // Mobile browsers include their navbar in the height so a bottom aligned element needs to be moved up
   padding-bottom: 30px;

--- a/packages/css-framework/src/components/_timeline.scss
+++ b/packages/css-framework/src/components/_timeline.scss
@@ -40,7 +40,7 @@ $timeline-row-header-width: 16rem;
   width: f.spacing("px");
   height: 100vh;
   background-color: f.color("danger", "500");
-  @include m.z-index("overlay", 1);
+  @include m.z-index("body", 1);
 
   &::before {
     content: "Today";
@@ -60,7 +60,7 @@ $timeline-row-header-width: 16rem;
   span {
     background-color: f.color("neutral", "white");
     padding: f.spacing("2");
-    @include m.z-index("overlay", 1);
+    @include m.z-index("body", 1);
   }
 }
 
@@ -108,7 +108,7 @@ $timeline-row-header-width: 16rem;
     width: 1rem;
     height: 100vh;
     border-right: f.spacing("px") dashed f.color("neutral", "200");
-    @include m.z-index("overlay", 1);
+    @include m.z-index("body", 1);
   }
 }
 
@@ -143,7 +143,7 @@ $timeline-row-header-width: 16rem;
   color: f.color("neutral", "400");
   margin-left: f.spacing("4");
   background-color: $timeline-bg-color;
-  @include m.z-index("overlay", 2);
+  @include m.z-index("body", 2);
 }
 
 .timeline__week--renderDefault.timeline__week--alt {
@@ -179,7 +179,7 @@ $timeline-row-header-width: 16rem;
   background-color: f.color("neutral", "white");
   border-right: f.spacing("px") solid $timeline-border-color;
   box-shadow: inset 0px 0px 0px 0px $timeline-border-color, 5px 0px 5px 0px rgba(0, 0, 0, 0.04);
-  @include m.z-index("overlay", 3);
+  @include m.z-index("body", 3);
   justify-content: flex-end;
   display: inline-flex;
   align-items: center;
@@ -232,7 +232,7 @@ $timeline-row-header-width: 16rem;
   padding: f.spacing("2") 0;
   background-color: $timeline-bg-color;
   overflow: visible;
-  @include m.z-index("overlay", 2);
+  @include m.z-index("body", 2);
 }
 
 .timeline__event--renderDefault.timeline__event--alt {


### PR DESCRIPTION
## Related issue
#1422 

## Overview
Use correct `z-index` mixins for `Sidebar` and `Timeline`.

## Reason
`Timeline` elements are showing above `Sidebar`.

## Work carried out
- [x] Adjust `z-index`