### PR TITLE
fix(RangeSlider): Set correct handle `tabIndex`

### DIFF
--- a/packages/react-component-library/src/components/RangeSlider/Handle.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Handle.tsx
@@ -11,7 +11,6 @@ interface HandleProps {
   getHandleProps: GetHandleProps
   displayUnit?: string
   thresholds?: number[]
-  tabIndex: number
 }
 
 export const Handle: React.FC<HandleProps> = ({
@@ -21,7 +20,6 @@ export const Handle: React.FC<HandleProps> = ({
   getHandleProps,
   displayUnit,
   thresholds,
-  tabIndex,
 }) => {
   const isActive: boolean = activeHandleID === id
 
@@ -32,7 +30,7 @@ export const Handle: React.FC<HandleProps> = ({
 
   return (
     <div
-      tabIndex={tabIndex}
+      tabIndex={0}
       role="slider"
       aria-label="Select range"
       aria-valuemin={min}

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
@@ -238,18 +238,6 @@ describe('RangeSlider', () => {
     it('should render two handles', () => {
       expect(wrapper.queryAllByTestId('rangeslider-handle')).toHaveLength(3)
     })
-
-    it('should set the correct `tabindex`', () => {
-      expect(wrapper.getAllByTestId('rangeslider-handle')[0]).toHaveAttribute(
-        'tabindex',
-        '0'
-      )
-
-      expect(wrapper.getAllByTestId('rangeslider-handle')[1]).toHaveAttribute(
-        'tabindex',
-        '1'
-      )
-    })
   })
 
   describe('when the `hasPercentage` prop is provided', () => {

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -88,9 +88,8 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
         <Handles>
           {({ activeHandleID, handles, getHandleProps }) => (
             <div className="rn-rangeslider__handles">
-              {handles.map((handle, index) => (
+              {handles.map((handle) => (
                 <Handle
-                  tabIndex={index}
                   key={handle.id}
                   handle={handle}
                   domain={domain}


### PR DESCRIPTION
# Overview

`tabIndex` for all handles should actually be 0. Although it works in isolation values greater than 0 interferes with the tab flow of a page and flags an AXE a11y violation.

