### PR TITLE
fix(DatePicker): Ensure `en-GB` is used for format

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -15,7 +15,7 @@ const examples = storiesOf('DatePicker/Examples', module)
 stories.add('Default', () => {
   return (
     <DatePicker
-      startDate={new Date('11/01/2018')}
+      startDate={new Date(2018, 0, 11)}
       onBlur={action('onBlur')}
       onChange={action('onChange')}
       placement={DATEPICKER_PLACEMENT.BELOW}
@@ -39,7 +39,7 @@ examples.add('Custom initial month', () => {
 examples.add('Custom label', () => {
   return (
     <DatePicker
-      startDate={new Date('11/01/2018')}
+      startDate={new Date(2018, 0, 11)}
       onBlur={action('onBlur')}
       onChange={action('onChange')}
       label="Some other label"
@@ -51,7 +51,7 @@ examples.add('Custom label', () => {
 examples.add('Disabled', () => {
   return (
     <DatePicker
-      startDate={new Date('11/01/2018')}
+      startDate={new Date(2018, 0, 11)}
       onBlur={action('onBlur')}
       onChange={action('onChange')}
       isDisabled
@@ -97,8 +97,8 @@ const DatePickerForm = () => {
 
   const initialValues: Data = {
     foo: '',
-    startDate: new Date('01/01/2020'),
-    endDate: new Date('01/05/2020'),
+    startDate: new Date(2020, 0, 1),
+    endDate: new Date(2020, 4, 1),
   }
 
   const FormikTextInput = withFormik(TextInput)

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -58,7 +58,7 @@ describe('DatePicker', () => {
 
   describe('default props', () => {
     beforeEach(() => {
-      startDate = new Date('12/01/2019')
+      startDate = new Date(2019, 11, 1)
       onChange = jest.fn()
       onBlur = jest.fn()
 
@@ -184,7 +184,7 @@ describe('DatePicker', () => {
         it('set the value of the component to this date', () => {
           expect(
             wrapper.getByTestId('datepicker-input').getAttribute('value')
-          ).toBe('12/31/2019')
+          ).toBe('31/12/2019')
         })
 
         it('invokes the onChange callback', () => {
@@ -261,7 +261,7 @@ describe('DatePicker', () => {
   describe('when selecting a date range', () => {
     beforeEach(() => {
       onChange = jest.fn()
-      startDate = new Date('12/01/2019')
+      startDate = new Date(2019, 11, 1)
 
       wrapper = render(
         <DatePicker
@@ -303,7 +303,7 @@ describe('DatePicker', () => {
           it('set the value of the component to this date', () => {
             expect(
               wrapper.getByTestId('datepicker-input').getAttribute('value')
-            ).toBe('12/1/2019 - 12/31/2019')
+            ).toBe('01/12/2019 - 31/12/2019')
           })
 
           it('invokes the onChange callback', () => {
@@ -324,7 +324,7 @@ describe('DatePicker', () => {
           it('set the value of the component to this date', () => {
             expect(
               wrapper.getByTestId('datepicker-input').getAttribute('value')
-            ).toBe('12/1/2019 - 1/20/2020')
+            ).toBe('01/12/2019 - 20/01/2020')
           })
 
           it('invokes the onChange callback', () => {

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react'
 import differenceInMinutes from 'date-fns/differenceInMinutes'
 import { v4 as uuidv4 } from 'uuid'
 import classNames from 'classnames'
+import { format } from 'date-fns'
 import TetherComponent from 'react-tether'
 import DayPicker, {
   DateUtils,
@@ -11,6 +12,7 @@ import DayPicker, {
 } from 'react-day-picker'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { DATE_FORMAT } from '../../constants'
 import { DatePickerInput } from './DatePickerInput'
 import { useOpenClose } from './useOpenClose'
 import { DATEPICKER_PLACEMENT, DATEPICKER_PLACEMENTS } from '.'
@@ -45,11 +47,14 @@ export interface DatePickerProps extends ComponentWithClass {
 
 function transformDates(startDate: Date, endDate: Date) {
   if (startDate && endDate && differenceInMinutes(endDate, startDate) > 0) {
-    return `${startDate.toLocaleDateString()} - ${endDate.toLocaleDateString()}`
+    return `${format(startDate, DATE_FORMAT.SHORT)} - ${format(
+      endDate,
+      DATE_FORMAT.SHORT
+    )}`
   }
 
   if (startDate) {
-    return startDate.toLocaleDateString()
+    return format(startDate, DATE_FORMAT.SHORT)
   }
 
   return ''

--- a/packages/react-component-library/src/components/DatePicker/constants.ts
+++ b/packages/react-component-library/src/components/DatePicker/constants.ts
@@ -34,7 +34,12 @@ const DATEPICKER_PLACEMENTS = {
   }
 }
 
+const LOCALE = {
+  UK: 'en-GB',
+}
+
 export {
   DATEPICKER_PLACEMENT,
   DATEPICKER_PLACEMENTS,
+  LOCALE,
 }

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -4,6 +4,7 @@ import { format } from 'date-fns'
 
 import { ACCESSIBLE_DATE_FORMAT } from './constants'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { DATE_FORMAT } from '../../constants'
 import { useTimelinePosition } from './hooks/useTimelinePosition'
 
 export interface TimelineEventWithRenderContentProps
@@ -51,7 +52,7 @@ function renderDefault(
         className="timeline__event-title"
         data-testid="timeline-event-title"
       >
-        {children || `Task ${format(new Date(startDate), 'dd/mm/yyyy')}`}
+        {children || `Task ${format(new Date(startDate), DATE_FORMAT.SHORT)}`}
       </span>
       <div className="timeline__event-bar" style={{ width: widthPx }} />
     </div>

--- a/packages/react-component-library/src/constants.ts
+++ b/packages/react-component-library/src/constants.ts
@@ -1,0 +1,7 @@
+const DATE_FORMAT = {
+  SHORT: 'dd/MM/yyyy'
+}
+
+export {
+  DATE_FORMAT,
+}


### PR DESCRIPTION
## Related issue
Fixes #1427 

## Overview
Old versions of Chrome do not have English UK in the language list. Rather than expecting the browsers to update language settings this change will provide consistency for all implementations of the `DatePicker`.

## Reason
Consistency across different versions of Chrome.

## Work carried out
- [x] Specify format