### PR TITLE
fix(Docs): Update Netlify team name

### DIFF
--- a/docs/deploy_documentation.md
+++ b/docs/deploy_documentation.md
@@ -7,7 +7,7 @@ Ensure you have the [Netlify CLI](https://cli.netlify.com) installed.
 4. `netlify unlink`
 5. `netlify deploy`
 6. Select `Create & configure a new site` when prompted for "What would you like to do?"
-7. Select `standards's team` when prompted for "Team"
+7. Select `Design System team` when prompted for "Team"
 8. Enter `{site_id}-design-system` when prompted for "Site name (optional)". `site_id` is from updating the versions page
 8. Enter `public` when prompted for "Publish directory"
 9. `netlify deploy --prod`


### PR DESCRIPTION
## Related issue
Fixes #1466 

## Overview
Fix typo in documentation.

## Reason
Make it clear.

## Work carried out
- [x] Fix typo