### PR TITLE
fix(IconLibrary): Ensure dependency is installed downstream

### DIFF
--- a/packages/icon-library/package.json
+++ b/packages/icon-library/package.json
@@ -29,7 +29,8 @@
     "prepare": "yarn build"
   },
   "dependencies": {
-    "react": "^16.12.0"
+    "react": "^16.12.0",
+    "react-svg-unique-id": "^1.3.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.3",
@@ -43,7 +44,6 @@
     "babel-loader": "^8.0.6",
     "clean-webpack-plugin": "^3.0.0",
     "npm-run-all": "^4.1.5",
-    "react-svg-unique-id": "^1.3.3",
     "source-map-loader": "^1.0.1",
     "typescript": "^3.7.5",
     "webpack": "^4.41.5",


### PR DESCRIPTION
## Related issue

Closes #1450

## Overview

We don't bundle this sub-dependency in the ES modules used for tree shaking.

It should be marked as a normal dependency instead of a devDependency.

This is currently breaking builds downstream.