### PR TITLE
Fix TextArea label styling

### DIFF
--- a/packages/css-framework/src/components/_textarea.scss
+++ b/packages/css-framework/src/components/_textarea.scss
@@ -14,8 +14,7 @@
   background-color: f.color("neutral", "white");
   border: 1px solid f.color("neutral", "200");
   border-radius: 4px;
-  transition:
-    border-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
+  transition: border-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
     box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   position: relative;
 }
@@ -31,18 +30,16 @@
   box-shadow: 0 0 0 1px f.color("danger", "700");
 }
 
-.rn-textarea.is-valid .rn-textarea__wrapper {
-  border-color: f.color("success", "700");
-  box-shadow: 0 0 0 1px f.color("success", "700");
-}
-
 .rn-textarea__label {
   display: block;
   position: absolute;
-  padding-left: f.spacing("6");
   padding-bottom: f.spacing("2");
-  right: 14px;
+  top: 0;
   left: 0;
+  transform-origin: top left;
+  transform: translate(f.spacing("6"), f.spacing("6")) scale(1);
+  transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
+    transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
   pointer-events: none;
   color: f.color("neutral", "400");
   font-size: f.font-size("s");
@@ -50,12 +47,21 @@
   border-radius: 3px 3px 0 0;
 }
 
+.rn-textarea.has-focus .rn-textarea__label,
+.rn-textarea.has-content .rn-textarea__label {
+  transform: translate(f.spacing("6"), 6px) scale(0.8);
+}
+
+.rn-textarea.has-focus .rn-textarea__label,
+.rn-textarea.has-content .rn-textarea__label {
+  transform: translate(f.spacing("6"), 6px) scale(0.8);
+}
+
 .rn-textarea__label-inner {
   display: inline-block;
   transform-origin: top left;
   transform: translate(0, f.spacing("2")) scale(1.2);
-  transition:
-    color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
+  transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
     transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
 }
 

--- a/packages/react-component-library/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.stories.tsx
@@ -21,6 +21,11 @@ stories.add('Vanilla', () => {
     >
       <TextArea className="is-valid" name="colour" label="My Label" />
       <TextArea name="name" label="Name" />
+      <TextArea
+        name="description"
+        label="Description"
+        value="Some content has already been entered"
+      />
       <button type="submit">Submit</button>
     </form>
   )

--- a/packages/react-component-library/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { FieldProps } from '../../common/FieldProps'
 import { FormProps } from '../../common/FormProps'
@@ -36,6 +37,12 @@ describe('TextArea', () => {
     it('adds the CSS modifier', () => {
       expect(wrapper.getByTestId('textarea-container').classList).toContain(
         'rn-textarea--modifier'
+      )
+    })
+
+    it('should add the `has-content` to the container', () => {
+      expect(wrapper.getByTestId('textarea-container').classList).toContain(
+        'has-content'
       )
     })
 
@@ -88,6 +95,38 @@ describe('TextArea', () => {
 
       it('should call the onBlur callback once', () => {
         expect(onBlurSpy).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('when the value is changed', () => {
+      beforeEach(async () => {
+        await userEvent.type(
+          wrapper.getByTestId('textarea-input'),
+          '{backspace}'
+        )
+      })
+
+      it('should update the value', () => {
+        expect(wrapper.getByTestId('textarea-input')).toHaveValue('a')
+      })
+    })
+
+    describe('when the value is deleted', () => {
+      beforeEach(async () => {
+        await userEvent.type(
+          wrapper.getByTestId('textarea-input'),
+          '{backspace}{backspace}'
+        )
+      })
+
+      it('should remove the `has-content` to the container', () => {
+        expect(
+          wrapper.getByTestId('textarea-container').classList
+        ).not.toContain('has-content')
+      })
+
+      it('should update the value', () => {
+        expect(wrapper.getByTestId('textarea-input')).toHaveValue('')
       })
     })
   })

--- a/packages/react-component-library/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.test.tsx
@@ -8,237 +8,173 @@ import { TextArea } from '.'
 import { withFormik } from '../../enhancers/withFormik'
 
 describe('TextArea', () => {
-  let field: FieldProps
-  let form: FormProps
-  let label = ''
-  let textInput: RenderResult
+  let onBlurSpy: (event: React.FormEvent) => void
+  let onChangeSpy: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
+  let wrapper: RenderResult
 
-  beforeEach(() => {
-    field = {
-      name: 'colour',
-      value: '',
-      onBlur: null,
-      onChange: jest.fn(),
-    }
-
-    form = {
-      errors: {},
-      touched: {},
-    }
-  })
-
-  describe('when a field has no errors', () => {
+  describe('all props', () => {
     beforeEach(() => {
-      form.errors = {}
-    })
+      onBlurSpy = jest.fn()
+      onChangeSpy = jest.fn()
 
-    describe('and the field has a label', () => {
-      beforeEach(() => {
-        label = 'Colour'
-      })
-
-      describe('and the field has a value', () => {
-        beforeEach(() => {
-          field.value = 'Green'
-
-          textInput = render(
-            <TextArea
-              value={field.value}
-              name={field.name}
-              onChange={field.onChange}
-              label={label}
-            />
-          )
-        })
-
-        it('should render a field with a label', () => {
-          expect(textInput.getByTestId('textarea-label')).toHaveTextContent(
-            'Colour'
-          )
-        })
-
-        it('should indicate that the field has content so the field is shrunk', () => {
-          expect(textInput.queryByTestId('textarea-container')).toHaveClass(
-            'has-content'
-          )
-        })
-
-        it('should populate the field value', () => {
-          expect(textInput.queryByTestId('textarea-input')).toHaveTextContent(
-            'Green'
-          )
-        })
-      })
-    })
-
-    describe('and the field has no label but a placeholder', () => {
-      beforeEach(() => {
-        textInput = render(
-          <TextArea
-            value={field.value}
-            name={field.name}
-            onChange={field.onChange}
-            placeholder="Search"
-          />
-        )
-      })
-
-      it('should not include a label', () => {
-        expect(textInput.queryByTestId('textarea-label')).toBeNull()
-      })
-
-      it('should adjust the styles to signify there is no label', () => {
-        expect(textInput.queryByTestId('textarea-container')).toHaveClass(
-          'no-label'
-        )
-      })
-
-      it('should include the placeholder in the field', () => {
-        expect(textInput.getByTestId('textarea-input')).toHaveAttribute(
-          'placeholder',
-          'Search'
-        )
-      })
-    })
-  })
-
-  describe('when a Formik enhanced field has an error', () => {
-    beforeEach(() => {
-      form.errors = {
-        colour: 'Something bad',
-      }
-    })
-
-    describe('and the form has not been touched', () => {
-      beforeEach(() => {
-        form.touched = {}
-
-        const FormikTextArea = withFormik(TextArea)
-
-        textInput = render(<FormikTextArea field={field} form={form} />)
-      })
-
-      it('should add the aria attributes', () => {
-        expect(textInput.getByTestId('textarea-input')).not.toHaveAttribute(
-          'aria-invalid'
-        )
-        expect(textInput.getByTestId('textarea-input')).not.toHaveAttribute(
-          'aria-describedby'
-        )
-      })
-
-      it('should not indicate the field has an error', () => {
-        expect(textInput.queryByTestId('textarea-container')).not.toHaveClass(
-          'is-invalid'
-        )
-      })
-
-      it('should not show the error', () => {
-        expect(textInput.queryAllByText('Something bad')).toHaveLength(0)
-      })
-    })
-
-    describe('and the form has been touched', () => {
-      beforeEach(() => {
-        form.touched.colour = true
-
-        const FormikTextArea = withFormik(TextArea)
-
-        textInput = render(<FormikTextArea field={field} form={form} />)
-      })
-
-      it('should add the aria attributes', () => {
-        expect(textInput.getByTestId('textarea-input')).toHaveAttribute(
-          'aria-invalid'
-        )
-        expect(textInput.getByTestId('textarea-input')).toHaveAttribute(
-          'aria-describedby'
-        )
-      })
-
-      it('should indicate the field has an error', () => {
-        expect(textInput.queryByTestId('textarea-container')).toHaveClass(
-          'is-invalid'
-        )
-      })
-
-      it('should show the error', () => {
-        expect(textInput.getByText('Something bad')).toBeInTheDocument()
-      })
-    })
-  })
-
-  describe('when an additional class it provided', () => {
-    beforeEach(() => {
-      textInput = render(
+      wrapper = render(
         <TextArea
-          className="test"
-          value={field.value}
-          name={field.name}
-          onChange={field.onChange}
-          label={label}
+          className="rn-textarea--modifier"
+          footnote="footnote"
+          id="id"
+          label="label"
+          name="name"
+          onBlur={onBlurSpy}
+          onChange={onChangeSpy}
+          placeholder="placeholder"
+          value="ab"
+          data-arbitrary="123"
         />
       )
     })
 
-    it('should attach the class to the wrapper', () => {
-      expect(textInput.queryByTestId('textarea-container')).toHaveClass('test')
-    })
-  })
-
-  describe('when an id is provided', () => {
-    beforeEach(() => {
-      textInput = render(
-        <TextArea
-          id="test"
-          value={field.value}
-          name={field.name}
-          onChange={field.onChange}
-          label={label}
-        />
+    it('adds the CSS modifier', () => {
+      expect(wrapper.getByTestId('textarea-container').classList).toContain(
+        'rn-textarea--modifier'
       )
     })
 
-    it('should attach the id to the field', () => {
-      expect(textInput.queryByTestId('textarea-input')).toHaveAttribute(
-        'id',
-        'test'
-      )
+    it('renders the footnote', () => {
+      expect(wrapper.getByText('footnote')).toBeInTheDocument()
+    })
+
+    it('sets the `id` on the input', () => {
+      expect(wrapper.getByTestId('textarea-input')).toHaveAttribute('id', 'id')
+    })
+
+    it('renders the label', () => {
+      expect(wrapper.getByText('label')).toBeInTheDocument()
     })
 
     it('should associate the label to the field with the custom id', () => {
-      expect(textInput.queryByTestId('textarea-label')).toHaveAttribute(
-        'for',
-        'test'
+      expect(wrapper.getByTestId('textarea-label')).toHaveAttribute('for', 'id')
+    })
+
+    it('sets the `name` on the input', () => {
+      expect(wrapper.getByTestId('textarea-input')).toHaveAttribute(
+        'name',
+        'name'
       )
     })
-  })
 
-  describe('when the onBlur callback is provided', () => {
-    let onBlurSpy: jest.SpyInstance
+    it('sets the `placeholder` on the input', () => {
+      expect(wrapper.getByTestId('textarea-input')).toHaveAttribute(
+        'placeholder',
+        'placeholder'
+      )
+    })
 
-    beforeEach(() => {
-      field.onBlur = () => {
-        return true
-      }
-      onBlurSpy = jest.spyOn(field, 'onBlur')
+    it('sets the `value` on the input', () => {
+      expect(wrapper.getByTestId('textarea-input')).toHaveValue('ab')
+    })
 
-      textInput = render(
-        <div>
-          <TextArea {...field} />
-          <input type="text" data-testid="next-field" />
-        </div>
+    it('drills arbitrary props to the input', () => {
+      expect(wrapper.getByTestId('textarea-input')).toHaveAttribute(
+        'data-arbitrary',
+        '123'
       )
     })
 
     describe('when the text area loses focus', () => {
       beforeEach(() => {
-        textInput.getByTestId('textarea-input').focus()
-        textInput.getByTestId('next-field').focus()
+        wrapper.getByTestId('textarea-input').focus()
+        wrapper.getByTestId('textarea-input').blur()
       })
 
       it('should call the onBlur callback once', () => {
         expect(onBlurSpy).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('when a Formik enhanced field has an error', () => {
+    let field: FieldProps
+    let form: FormProps
+
+    describe('and the form has not been touched', () => {
+      beforeEach(() => {
+        field = {
+          name: 'colour',
+          value: '',
+          onBlur: null,
+          onChange: jest.fn(),
+        }
+        form = {
+          errors: {
+            colour: 'Something bad',
+          },
+          touched: {},
+        }
+
+        const FormikTextArea = withFormik(TextArea)
+
+        wrapper = render(<FormikTextArea field={field} form={form} />)
+      })
+
+      it('should add the aria attributes', () => {
+        expect(wrapper.getByTestId('textarea-input')).not.toHaveAttribute(
+          'aria-invalid'
+        )
+        expect(wrapper.getByTestId('textarea-input')).not.toHaveAttribute(
+          'aria-describedby'
+        )
+      })
+
+      it('should not indicate the field has an error', () => {
+        expect(wrapper.queryByTestId('textarea-container')).not.toHaveClass(
+          'is-invalid'
+        )
+      })
+
+      it('should not show the error', () => {
+        expect(wrapper.queryAllByText('Something bad')).toHaveLength(0)
+      })
+    })
+
+    describe('and the form has been touched', () => {
+      beforeEach(() => {
+        field = {
+          name: 'colour',
+          value: '',
+          onBlur: null,
+          onChange: jest.fn(),
+        }
+        form = {
+          errors: {
+            colour: 'Something bad',
+          },
+          touched: {
+            colour: true,
+          },
+        }
+
+        const FormikTextArea = withFormik(TextArea)
+
+        wrapper = render(<FormikTextArea field={field} form={form} />)
+      })
+
+      it('should add the aria attributes', () => {
+        expect(wrapper.getByTestId('textarea-input')).toHaveAttribute(
+          'aria-invalid'
+        )
+        expect(wrapper.getByTestId('textarea-input')).toHaveAttribute(
+          'aria-describedby'
+        )
+      })
+
+      it('should indicate the field has an error', () => {
+        expect(wrapper.queryByTestId('textarea-container')).toHaveClass(
+          'is-invalid'
+        )
+      })
+
+      it('should show the error', () => {
+        expect(wrapper.getByText('Something bad')).toBeInTheDocument()
       })
     })
   })

--- a/packages/react-component-library/src/components/TextArea/TextArea.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.tsx
@@ -1,9 +1,10 @@
-import React, { TextareaHTMLAttributes } from 'react'
+import React, { ChangeEvent, TextareaHTMLAttributes } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import classNames from 'classnames'
 
 import { useFocus } from '../../hooks/useFocus'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { useInputValue } from '../../hooks/useInputValue'
 
 export interface TextAreaInputProps
   extends TextareaHTMLAttributes<HTMLTextAreaElement>,
@@ -31,14 +32,14 @@ export const TextArea: React.FC<TextAreaInputProps> = (props) => {
   } = props
 
   const { focus, onLocalBlur, onFocus } = useFocus(onBlur)
-  const hasContent = value && value.length
+  const { committedValue, hasValue, onValueChange } = useInputValue(value)
   const hasLabel = label && label.length
 
   const classes = classNames(
-    'rn-textinput',
+    'rn-textarea',
     {
       'has-focus': focus,
-      'has-content': hasContent,
+      'has-content': hasValue,
       'no-label': !hasLabel,
     },
     className
@@ -63,10 +64,15 @@ export const TextArea: React.FC<TextAreaInputProps> = (props) => {
           id={id}
           name={name}
           onBlur={onLocalBlur}
-          onChange={onChange}
+          onChange={(e) => {
+            onValueChange(e)
+            if (onChange) {
+              onChange(e)
+            }
+          }}
           onFocus={onFocus}
           placeholder={placeholder}
-          value={value}
+          value={committedValue}
           {...rest}
         />
       </div>

--- a/packages/react-component-library/src/components/TextInput/TextInput.test.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { withFormik } from '../../enhancers/withFormik'
 import { TextInput } from '.'
@@ -114,6 +115,38 @@ describe('TextInput', () => {
         })
       })
     })
+
+    describe('when the value is changed', () => {
+      beforeEach(async () => {
+        await userEvent.type(
+          wrapper.getByTestId('input'),
+          '{backspace}'
+        )
+      })
+
+      it('should update the value', () => {
+        expect(wrapper.getByTestId('input')).toHaveValue('valu')
+      })
+    })
+
+    describe('when the value is deleted', () => {
+      beforeEach(async () => {
+        await userEvent.type(
+          wrapper.getByTestId('input'),
+          '{backspace}{backspace}{backspace}{backspace}{backspace}'
+        )
+      })
+
+      it('should remove the `has-content` to the container', () => {
+        expect(
+          wrapper.getByTestId('container').classList
+        ).not.toContain('has-content')
+      })
+
+      it('should update the value', () => {
+        expect(wrapper.getByTestId('input')).toHaveValue('')
+      })
+    })
   })
 
   describe('minimal props', () => {
@@ -212,9 +245,7 @@ describe('TextInput', () => {
           'aria-invalid',
           'true'
         )
-        expect(wrapper.getByTestId('input')).toHaveAttribute(
-          'aria-describedby',
-        )
+        expect(wrapper.getByTestId('input')).toHaveAttribute('aria-describedby')
       })
 
       it('should have an error', () => {

--- a/packages/react-component-library/src/components/TextInput/TextInput.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.tsx
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import classNames from 'classnames'
 
 import { useFocus } from '../../hooks/useFocus'
+import { useInputValue } from '../../hooks/useInputValue'
 
 export interface TextInputProps {
   autoFocus?: boolean
@@ -55,14 +56,14 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
   } = props
 
   const { focus, onLocalBlur, onFocus } = useFocus(onBlur)
-  const hasContent = value && value.length
+  const { committedValue, hasValue, onValueChange } = useInputValue(value)
   const hasLabel = label && label.length
 
   const classes = classNames(
     'rn-textinput',
     {
       'has-focus': focus,
-      'has-content': hasContent,
+      'has-content': hasValue,
       'no-label': !hasLabel,
     },
     className
@@ -87,11 +88,16 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
             id={id}
             name={name}
             onBlur={onLocalBlur}
-            onChange={onChange}
+            onChange={(e) => {
+              onValueChange(e)
+              if (onChange) {
+                onChange(e)
+              }
+            }}
             onFocus={onFocus}
             placeholder={placeholder}
             type={type}
-            value={value}
+            value={committedValue}
             {...rest}
           />
         </div>

--- a/packages/react-component-library/src/hooks/useInputValue.ts
+++ b/packages/react-component-library/src/hooks/useInputValue.ts
@@ -1,0 +1,23 @@
+import { get } from 'lodash'
+import { ChangeEvent, useMemo, useState } from 'react'
+
+export function useInputValue(value: string) {
+  const [committedValue, setCommittedValue] = useState<string>()
+
+  useMemo(() => setCommittedValue(value), [value])
+
+  const hasValue = useMemo(() => {
+    return !!(committedValue && committedValue.length)
+  }, [committedValue])
+
+  function onValueChange(event: ChangeEvent<HTMLTextAreaElement>) {
+    const newValue = get(event, 'target.value')
+    setCommittedValue(newValue)
+  }
+
+  return {
+    committedValue,
+    hasValue,
+    onValueChange,
+  }
+}

--- a/packages/react-component-library/src/hooks/useInputValue.ts
+++ b/packages/react-component-library/src/hooks/useInputValue.ts
@@ -10,7 +10,7 @@ export function useInputValue(value: string) {
     return !!(committedValue && committedValue.length)
   }, [committedValue])
 
-  function onValueChange(event: ChangeEvent<HTMLTextAreaElement>) {
+  function onValueChange<T>(event: ChangeEvent<T>) {
     const newValue = get(event, 'target.value')
     setCommittedValue(newValue)
   }


### PR DESCRIPTION
## Related issue
Closes #1409 

## Overview
The `TextArea` `label` styling is not correct when the element has text content.

## Reason
Classes are missing and the state is not being correctly managed. It becomes difficult to read.

## Work carried out
- [x] Fix CSS
- [x] Fix state management
- [x] Apply same change to `TextInput`

## Screenshot
![textarea](https://user-images.githubusercontent.com/56078793/94118282-3befef00-fe45-11ea-86e2-10405915ff20.gif)
