### PR TITLE
fix(Timeline): Allow arbitrary event `children`

### DIFF
--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -8,6 +8,7 @@ import {
   ColorNeutral600,
   ColorSuccess500,
 } from '@royalnavy/design-tokens'
+import { isString } from 'lodash'
 
 import { ACCESSIBLE_DATE_FORMAT, TIMELINE_BG_COLOR } from './constants'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
@@ -28,7 +29,7 @@ export interface TimelineEventWithRenderContentProps
 }
 
 export interface TimelineEventWithChildrenProps extends ComponentWithClass {
-  children: string
+  children: React.ReactNode
   endDate: Date
   render?: never
   startDate: Date
@@ -73,7 +74,7 @@ const StyledEventBar = styled.div<StyledEventBarProps>`
 `
 
 function renderDefault(
-  children: string,
+  children: React.ReactNode,
   offsetPx: string,
   startDate: Date,
   widthPx: string
@@ -91,8 +92,8 @@ function renderDefault(
   )
 }
 
-function getTitle(children: string, startDate: Date, endDate: Date) {
-  const start = children ? `${children} begins` : `Begins`
+function getTitle(children: React.ReactNode, startDate: Date, endDate: Date) {
+  const start = isString(children) ? `${children} begins` : `Begins`
 
   return `${start} on ${format(
     startDate,

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -1259,4 +1259,47 @@ describe('Timeline', () => {
       expect(wrapper.getByText('Another row')).toBeInTheDocument()
     })
   })
+
+  describe('when an event has arbitrary `children`', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Timeline
+          startDate={new Date(2020, 3, 1)}
+          today={new Date(2020, 3, 15)}
+        >
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineWeeks />
+          <TimelineDays />
+          <TimelineRows>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={new Date(2020, 3, 13)}
+                  endDate={new Date(2020, 3, 18)}
+                >
+                  <div>Arbitrary event content</div>
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('should render the arbitrary content', () => {
+      expect(
+        wrapper.getByText('Arbitrary event content')
+      ).toBeInTheDocument()
+    })
+
+    it('should set the `aria-label` on the event', () => {
+      const week = wrapper.getAllByTestId('timeline-event')[0]
+
+      expect(week).toHaveAttribute(
+        'aria-label',
+        'Begins on 13th April 2020 and ends on 18th April 2020'
+      )
+    })
+  })
 })


### PR DESCRIPTION
## Related issue
Closes #1444 

## Overview
`TimelineEvent` only allows `string` `children` and not arbitrary `children`. This changes the `children` type to `ReactNode`.

## Reason
It should be possible to compose `TimelineEvent` with elements other than `string`.

## Work carried out
- [x] Update type

## Developer notes
A previously developed `render` prop allows for custom content too.
