### PR TITLE
Add prop to specify TimelineEvent bar colour

### DIFF
--- a/packages/docs-site/src/library/pages/timeline/index.md
+++ b/packages/docs-site/src/library/pages/timeline/index.md
@@ -1131,6 +1131,27 @@ Here you will find comprehensive API documentation for the Timeline Components.
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
     <h1 className="rn-fw-api-title">
+      barColor
+    </h1>
+    <Badge color="supa" colorVariant="faded" size="small">string</Badge>
+  </div>
+  <div className="rn-fw-api-body">
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Default Value</div>
+      <div className="rn-fw-api-value">
+        <code>ColorSuccess500</code>
+      </div>
+    </div>
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Description</div>
+      <p className="rn-fw-api-value">The colour of the bar.</p>
+    </div>
+  </div>
+</div>
+
+<div className="rn-fw-api">
+  <div className="rn-fw-api-header">
+    <h1 className="rn-fw-api-title">
       startDate
       <Badge className="rn_ml-4" color="danger" colorVariant="faded" variant="pill" size="small">Required</Badge>
     </h1>

--- a/packages/react-component-library/src/components/Timeline/README.md
+++ b/packages/react-component-library/src/components/Timeline/README.md
@@ -552,6 +552,13 @@ Through the use of clever composition and custom styling, it's possible to creat
       <th>Description</th>
     </tr>
     <tr>
+      <td>barColor</td>
+      <td>string</td>
+      <td>False</td>
+      <td>ColorSuccess500</td>
+      <td>The colour of the bar</td>
+    </tr>
+    <tr>
       <td>startDate</td>
       <td>Date</td>
       <td>True</td>

--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Meta } from '@storybook/react/types-6-0'
-
 import { format } from 'date-fns'
+import { Meta } from '@storybook/react/types-6-0'
+import { ColorDanger500 } from '@royalnavy/design-tokens'
 
 import {
   Timeline,
@@ -395,6 +395,32 @@ export const WithCustomColumns = () => {
   )
 }
 WithCustomColumns.storyName = 'With custom columns'
+
+export const WithCustomEventBarColor = () => {
+  return (
+    <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15)}>
+      <TimelineSide />
+      <TimelineTodayMarker />
+      <TimelineMonths />
+      <TimelineWeeks />
+      <TimelineDays />
+      <TimelineRows>
+        <TimelineRow name="Row 1">
+          <TimelineEvents>
+            <TimelineEvent
+              barColor={ColorDanger500}
+              startDate={new Date(2020, 3, 14)}
+              endDate={new Date(2020, 3, 18)}
+            >
+              Event 1
+            </TimelineEvent>
+          </TimelineEvents>
+        </TimelineRow>
+      </TimelineRows>
+    </Timeline>
+  )
+}
+WithCustomEventBarColor.storyName = 'With custom event bar color'
 
 export const WithCustomEventContent = () => {
   const CustomEvent = ({

--- a/packages/react-component-library/src/components/Timeline/TimelineDay.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDay.tsx
@@ -38,7 +38,7 @@ const StyledTitle = styled.div`
   z-index: ${zIndex('body', 2)};
 `
 
-function renderDefault(index: number, dayWidth: number, date: Date) {
+function renderDefault({ dayWidth, date }: { dayWidth: number; date: Date }) {
   return (
     <StyledTimelineDay
       data-testid="timeline-day"
@@ -65,7 +65,7 @@ export const TimelineDay: React.FC<TimelineDayProps> = ({
 
   const child = render
     ? render(index, dayWidth, date)
-    : renderDefault(index, dayWidth, date)
+    : renderDefault({ dayWidth, date })
 
   return React.cloneElement(child, {
     role: 'columnheader',

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -11,6 +11,7 @@ import { useTimelinePosition } from './hooks/useTimelinePosition'
 
 export interface TimelineEventWithRenderContentProps
   extends ComponentWithClass {
+  barColor?: never
   children?: never
   endDate: Date
   render: (
@@ -23,6 +24,7 @@ export interface TimelineEventWithRenderContentProps
 }
 
 export interface TimelineEventWithChildrenProps extends ComponentWithClass {
+  barColor?: string
   children: React.ReactNode
   endDate: Date
   render?: never
@@ -57,24 +59,32 @@ const StyledEventTitle = styled.span`
 `
 
 interface StyledEventBarProps {
+  barColor: string
   width: string
 }
 
 const StyledEventBar = styled.div<StyledEventBarProps>`
   display: inline-block;
-  background-color: ${color('success', '500')};
+  background-color: ${({ barColor = color('success', '500') }) => barColor};
   border-radius: 4px;
   height: 16px;
   min-width: 1rem;
   width: ${({ width }) => width};
 `
 
-function renderDefault(
-  children: React.ReactNode,
-  offsetPx: string,
-  startDate: Date,
+function renderDefault({
+  barColor,
+  children,
+  offsetPx,
+  startDate,
+  widthPx,
+}: {
+  barColor: string
+  children: React.ReactNode
+  offsetPx: string
+  startDate: Date
   widthPx: string
-) {
+}) {
   return (
     <StyledTimelineEvent
       style={{ left: offsetPx }}
@@ -83,7 +93,7 @@ function renderDefault(
       <StyledEventTitle data-testid="timeline-event-title">
         {children || `Task ${format(new Date(startDate), DATE_FORMAT.SHORT)}`}
       </StyledEventTitle>
-      <StyledEventBar width={widthPx} />
+      <StyledEventBar barColor={barColor} width={widthPx} />
     </StyledTimelineEvent>
   )
 }
@@ -98,6 +108,7 @@ function getTitle(children: React.ReactNode, startDate: Date, endDate: Date) {
 }
 
 export const TimelineEvent: React.FC<TimelineEventProps> = ({
+  barColor,
   children,
   endDate,
   render,
@@ -114,7 +125,7 @@ export const TimelineEvent: React.FC<TimelineEventProps> = ({
 
   const event = render
     ? render(startDate, endDate, widthPx, offsetPx)
-    : renderDefault(children, offsetPx, startDate, widthPx)
+    : renderDefault({ barColor, children, offsetPx, startDate, widthPx })
 
   const title = getTitle(children, startDate, endDate)
 

--- a/packages/react-component-library/src/components/Timeline/TimelineHour.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineHour.tsx
@@ -34,7 +34,7 @@ const StyledTitle = styled.span`
   z-index: ${zIndex('body', 2)};
 `
 
-function renderDefault(width: number, time: string) {
+function renderDefault({ width, time }: { width: number; time: string }) {
   return (
     <StyledTimelineHour
       data-testid="timeline-hour"
@@ -57,7 +57,7 @@ export const TimelineHour: React.FC<TimelineHourProps> = ({
 }) => {
   if (isAfter(date, timelineEndDate)) return null
 
-  const child = render ? render(width, time) : renderDefault(width, time)
+  const child = render ? render(width, time) : renderDefault({ width, time })
 
   return React.cloneElement(child, {
     role: 'columnheader',

--- a/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
@@ -52,12 +52,15 @@ const StyledTitle = styled.span`
   padding-left: ${spacing('8')};
 `
 
-function renderDefault(
-  index: number,
-  dayWidth: number,
-  daysTotal: number,
+function renderDefault({
+  dayWidth,
+  daysTotal,
+  startDate,
+}: {
+  dayWidth: number
+  daysTotal: number
   startDate: Date
-): React.ReactElement {
+}): React.ReactElement {
   return (
     <StyledTimelineMonth
       style={{
@@ -87,7 +90,7 @@ export const TimelineMonth: React.FC<TimelineMonthProps> = ({
 
   const child = render
     ? render(index, dayWidth, daysTotal, startDate)
-    : renderDefault(index, dayWidth, daysTotal, startDate)
+    : renderDefault({ dayWidth, daysTotal, startDate })
 
   return React.cloneElement(child, {
     role: 'columnheader',

--- a/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
@@ -50,7 +50,7 @@ const StyledTimelineTodayMarker = styled.div<StyledTimelineTodayMarkerProps>`
   left: ${({ left }) => left};
 `
 
-function renderDefault(offset: string) {
+function renderDefault({ offset }: { offset: string }) {
   return <StyledTimelineTodayMarker left={offset} />
 }
 
@@ -70,7 +70,7 @@ export const TimelineTodayMarker: React.FC<TimelineTodayMarkerProps> = ({
       data-testid="timeline-today-marker-wrapper"
       role="presentation"
     >
-      {render ? render(today, offset) : renderDefault(offset)}
+      {render ? render(today, offset) : renderDefault({ offset })}
     </StyledTimelineTodayMarkerWrapper>
   )
 }

--- a/packages/react-component-library/src/components/Timeline/TimelineWeek.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeek.tsx
@@ -61,15 +61,17 @@ const StyledTitle = styled.span`
   margin-left: ${spacing('4')};
 `
 
-function renderDefault(
-  index: number,
-  isOddNumber: boolean,
-  offsetPx: string,
-  widthPx: string,
-  dayWidth: number,
-  daysTotal: number,
+function renderDefault({
+  isOddNumber,
+  offsetPx,
+  widthPx,
+  startDate,
+}: {
+  isOddNumber: boolean
+  offsetPx: string
+  widthPx: string
   startDate: Date
-) {
+}) {
   return (
     <StyledTimelineWeek
       isOddNumber={isOddNumber}
@@ -104,7 +106,7 @@ export const TimelineWeek: React.FC<TimelineWeekProps> = ({
 
   const isOddNumber = isOdd(index)
 
-  const args = [
+  const args = {
     index,
     isOddNumber,
     offsetPx,
@@ -112,10 +114,10 @@ export const TimelineWeek: React.FC<TimelineWeekProps> = ({
     dayWidth,
     daysTotal,
     startDate,
-  ]
+  }
 
   // @ts-ignore
-  const child = render ? render(...args) : renderDefault(...args)
+  const child = render ? render(...Object.values(args)) : renderDefault(args)
 
   const title = `Week beginning ${format(startDate, ACCESSIBLE_DATE_FORMAT)}`
 


### PR DESCRIPTION
## Related issue
Closes #1424 

## Overview
Added prop to change colour of `TimelineEvent` bar.

## Reason
Required by applications without needing to implement `render`.

## Work carried out
- [x] Add prop

## Screenshot
![Screenshot 2020-09-29 at 09 49 25](https://user-images.githubusercontent.com/56078793/94535142-1c880600-0239-11eb-9fb4-83d7333eae87.png)