### PR TITLE
ci(Circle): Increase timeout for visual regression job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ jobs:
             else
               yarn --cwd packages/react-component-library chromatic --app-code=$CHROMATIC_APP_CODE
             fi
+          no_output_timeout: 20m
   publish_latest:
     docker: *docker
     steps:


### PR DESCRIPTION
## Related issue

closes #1437 

## Overview

Increase timeout value for visual regression job 

## Reason

Occasionally the job is exceeding the default 10 minute timeout causing the workflow to fail


## Work carried out

- [x] Edited Circle config


