### PR TITLE
fix(Timeline): Resolve daylight savings offset issue

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -62,7 +62,7 @@ BoundByFixedDates.parameters = disableScrollableRegionFocusableRule
 BoundByFixedDates.storyName = 'Bound by fixed dates'
 
 export const WithData = () => (
-  <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15)}>
+  <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15, 12)}>
     <TimelineTodayMarker />
     <TimelineMonths />
     <TimelineWeeks />
@@ -71,8 +71,8 @@ export const WithData = () => (
       <TimelineRow name="Row 1">
         <TimelineEvents>
           <TimelineEvent
-            startDate={new Date(2020, 3, 14)}
-            endDate={new Date(2020, 3, 18)}
+            startDate={new Date(2020, 3, 14, 12)}
+            endDate={new Date(2020, 3, 18, 12)}
           >
             Event 1
           </TimelineEvent>

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -59,7 +59,6 @@ const StyledEventTitle = styled.span`
 
 interface StyledEventBarProps {
   barColor: string
-  width: string
 }
 
 const StyledEventBar = styled.div<StyledEventBarProps>`
@@ -68,7 +67,6 @@ const StyledEventBar = styled.div<StyledEventBarProps>`
   border-radius: 4px;
   height: 16px;
   min-width: 1rem;
-  width: ${({ width }) => width};
 `
 
 function renderDefault({
@@ -92,7 +90,11 @@ function renderDefault({
       <StyledEventTitle data-testid="timeline-event-title">
         {children || `Task ${format(new Date(startDate), DATE_FORMAT.SHORT)}`}
       </StyledEventTitle>
-      <StyledEventBar barColor={barColor} width={widthPx} />
+      <StyledEventBar
+        barColor={barColor}
+        style={{ width: widthPx }}
+        data-testid="timeline-event-bar"
+      />
     </StyledTimelineEvent>
   )
 }

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -46,7 +46,6 @@ const StyledTimelineEvent = styled.div`
   display: inline-flex;
   flex-direction: column;
   padding: ${spacing('2')} 0;
-  background-color: ${TIMELINE_BG_COLOR};
   overflow: visible;
   z-index: ${zIndex('body', 2)};
 `

--- a/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
@@ -37,7 +37,7 @@ const StyledTimelineTodayMarker = styled.div<StyledTimelineTodayMarkerProps>`
   width: ${spacing('px')};
   height: 100vh;
   background-color: ${color('danger', '500')};
-  z-index: ${zIndex('body', 1)};
+  z-index: ${zIndex('body', 2)};
 
   &::before {
     content: 'Today';

--- a/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
@@ -26,11 +26,7 @@ const StyledTimelineTodayMarkerWrapper = styled.div`
   position: relative;
 `
 
-interface StyledTimelineTodayMarkerProps {
-  left: string
-}
-
-const StyledTimelineTodayMarker = styled.div<StyledTimelineTodayMarkerProps>`
+const StyledTimelineTodayMarker = styled.div`
   position: absolute;
   top: 4rem;
   display: inline-block;
@@ -46,12 +42,15 @@ const StyledTimelineTodayMarker = styled.div<StyledTimelineTodayMarkerProps>`
     font-size: ${fontSize('s')};
     transform: translate(-50%, -175%);
   }
-
-  left: ${({ left }) => left};
 `
 
 function renderDefault({ offset }: { offset: string }) {
-  return <StyledTimelineTodayMarker left={offset} />
+  return (
+    <StyledTimelineTodayMarker
+      data-testid="timeline-today-marker"
+      style={{ left: offset }}
+    />
+  )
 }
 
 export const TimelineTodayMarker: React.FC<TimelineTodayMarkerProps> = ({

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -807,15 +807,18 @@ describe('Timeline', () => {
       wrapper = render(
         <Timeline
           startDate={new Date(2020, 3, 1)}
-          today={new Date(2020, 3, 15)}
+          today={new Date(2020, 3, 15, 12)}
         >
-          <TimelineHours blockSize={TIMELINE_BLOCK_SIZE.HALF_DAY} />
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineWeeks />
+          <TimelineDays />
           <TimelineRows>
             <TimelineRow name="Row 1">
               <TimelineEvents>
                 <TimelineEvent
-                  startDate={new Date(2020, 3, 5, 6, 0, 0)}
-                  endDate={new Date(2020, 3, 7, 18, 0, 0)}
+                  startDate={new Date(2020, 3, 14, 12)}
+                  endDate={new Date(2020, 3, 18, 12)}
                 >
                   Event 1
                 </TimelineEvent>
@@ -826,9 +829,21 @@ describe('Timeline', () => {
       )
     })
 
+    it('positions the TodayMarker correct', () => {
+      expect(wrapper.getByTestId('timeline-today-marker')).toHaveStyle({
+        left: '435px',
+      })
+    })
+
     it('positions the event correctly', () => {
       expect(wrapper.getByTestId('timeline-event')).toHaveStyle({
-        left: `255px`,
+        left: '405px',
+      })
+    })
+
+    it('sets the event width correctly', () => {
+      expect(wrapper.getByTestId('timeline-event-bar')).toHaveStyle({
+        width: '120px',
       })
     })
   })

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 
 import {
-  differenceInSeconds,
+  differenceInCalendarDays,
   isBefore,
   isAfter,
 } from 'date-fns'
@@ -9,20 +9,26 @@ import {
 import { TimelineContext } from '../context'
 import { formatPx } from '../helpers'
 
-const SECONDS_IN_DAY = 86400
+const timeOffset = (date: Date) => 1 / 24 * new Date(date).getHours()
 
-function getWidth(startDate: Date, endDate: Date): number {
-  return (
-    differenceInSeconds(new Date(endDate), new Date(startDate)) /
-    SECONDS_IN_DAY
-  )
+function getWidth (
+  startDate: Date,
+  endDate: Date
+): number {
+  return differenceInCalendarDays(
+    new Date(endDate),
+    new Date(startDate)
+  ) - timeOffset(startDate) + timeOffset(endDate)
 }
 
-function getOffset(startDate: Date, timelineStart: Date): number {
-  return (
-    differenceInSeconds(new Date(startDate), new Date(timelineStart)) /
-    SECONDS_IN_DAY
-  )
+function getOffset (
+  startDate: Date,
+  timelineStart: Date
+): number {
+  return differenceInCalendarDays(
+    new Date(startDate),
+    new Date(timelineStart)
+  ) + timeOffset(startDate)
 }
 
 export function useTimelinePosition(


### PR DESCRIPTION
## Related issue

Closes #1489

## Overview

Resolve daylight savings offset issue in `useTimelinePosition` hook.

## Reason

>Daylight savings meant that objects utilising the useTimelinePosition hook were incorrectly offset.

## Work carried out

- [x] Fix some styling issues
- [x] Change the way `getOffset` and `getWidth` are calculated

## Screenshot

`new Date(2020, 10, 1, 12)`:

<img width="1453" alt="Screenshot 2020-10-06 at 11 11 29" src="https://user-images.githubusercontent.com/48086589/95189656-0db7cb00-07c6-11eb-8658-67e0928d5855.png">

`new Date(2020, 10, 1)`:

<img width="1453" alt="Screenshot 2020-10-06 at 11 09 43" src="https://user-images.githubusercontent.com/48086589/95189746-2aec9980-07c6-11eb-8a1f-50abdca3f255.png">

## Developer notes

I've limited the granularity to hours.