### PR TITLE
ci(GHA): Project automation for issues

### DIFF
--- a/.github/workflows/issues_to_candidates.yml
+++ b/.github/workflows/issues_to_candidates.yml
@@ -1,0 +1,15 @@
+name: Move issues to Candidates
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Royal-Navy/github-project-automation-plus@v0.3.0
+        with:
+          project: "Design System Tactical Board"
+          column: "Candidates for Ready"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Related issue

closes #1453 

## Overview

Add GitHub Action workflow to automatically move new issues to project board 

## Work carried out

- [x] Added issue_to_ready.yml



