### PR TITLE
ci(GHA): Update issues token

### DIFF
--- a/.github/workflows/issues_to_candidates.yml
+++ b/.github/workflows/issues_to_candidates.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           project: "Design System Tactical Board"
           column: "Candidates for Ready"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GHA_ISSUES_TOKEN }}


### PR DESCRIPTION
## Related issue

closes #1522 

## Overview

Add new token for GHA issues

## Reason

Current token has insufficient permissions for action

