### PR TITLE
feat(Select): Document `isDisabled` prop

### DIFF
--- a/packages/docs-site/src/library/pages/components/form/select.md
+++ b/packages/docs-site/src/library/pages/components/form/select.md
@@ -98,6 +98,13 @@ with the field.
 
 <DataTable caption="Select" data={[
   {
+    Name: 'isDisabled',
+    Type: 'boolean',
+    Required: 'False',
+    Default: 'false',
+    Description: 'Mark the field as disabled/inactive',
+  },
+  {
     Name: 'name',
     Type: 'string',
     Required: 'True',


### PR DESCRIPTION
## Related issue
Fixes #1495 

## Overview
Documents the `isDisabled` prop for the `Select` component.

## Reason
Make it clearer for consumers.

## Work carried out
- [x] Document prop
