### PR TITLE
docs(RangeSlider): Fix typo

### DIFF
--- a/packages/docs-site/src/library/pages/components/range-slider.md
+++ b/packages/docs-site/src/library/pages/components/range-slider.md
@@ -307,7 +307,7 @@ Additional details about props can be found [here](https://sghall.github.io/reac
     Type: 'number[]',
     Required: 'True',
     Default: '',
-    Description: 'An array of numbers. You can supply one for a value slider, two for a range slider or more to create n-handled sliders. The values should correspond to valid step values in the domain. The numbers will be forced into the domain if they are two small or large.',
+    Description: 'An array of numbers. You can supply one for a value slider, two for a range slider or more to create n-handled sliders. The values should correspond to valid step values in the domain. The numbers will be forced into the domain if they are too small or too large.',
   },
   {
     Name: 'thresholds',


### PR DESCRIPTION
## Related issue

Closes #1530

## Overview

Fix typo in `RangeSlider` documentation.