### PR TITLE
fix(RangeSlider): Only invoke `onUpdate` if provided

### DIFF
--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
@@ -285,4 +285,31 @@ describe('RangeSlider', () => {
       )
     })
   })
+
+  describe('without the `onUpdate` callback', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <RangeSlider mode={mode} domain={domain} values={values} step={step} />
+      )
+    })
+
+    describe('and the end user moves the handle to the right using keyboard', () => {
+      it('does not throw an error', () => {
+        expect(() => {
+          fireEvent(
+            wrapper.getByTestId('rangeslider-handle'),
+            new MouseEvent('click', {
+              bubbles: true,
+              cancelable: true,
+            })
+          )
+
+          fireEvent.keyDown(wrapper.getByTestId('rangeslider-handle'), {
+            key: 'ArrowRight',
+            code: 39,
+          })
+        }).not.toThrow(TypeError)
+      })
+    })
+  })
 })

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -50,7 +50,10 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
 
   const onUpdateHandler = (newValues: ReadonlyArray<number>): void => {
     setSliderValues(newValues)
-    onUpdate(newValues)
+
+    if (onUpdate) {
+      onUpdate(newValues)
+    }
   }
 
   const classes = classNames('rn-rangeslider', className, {


### PR DESCRIPTION
## Related issue

Closes #1528

## Overview

Only invoke the optional `onUpdate` callback if it is provided.