### PR TITLE
Fix NumberInput visual regression test reliability

### DIFF
--- a/packages/react-component-library/src/components/NumberInput/EndAdornmentButton.tsx
+++ b/packages/react-component-library/src/components/NumberInput/EndAdornmentButton.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import classNames from 'classnames'
 import capitalize from 'lodash/capitalize'
 import { selectors } from '@royalnavy/design-tokens'
 import styled, { css } from 'styled-components'
@@ -91,10 +90,6 @@ export const EndAdornmentButton: React.FC<EndAdornmentButtonProps> = ({
   onClick,
   type,
 }) => {
-  const classes = classNames(`rn-numberinput__${type}`, {
-    [`rn-numberinput__${type}--condensed`]: isCondensed,
-  })
-
   const Button =
     type === END_ADORNMENT_TYPE.DECREASE
       ? StyledDecreaseButton
@@ -106,7 +101,6 @@ export const EndAdornmentButton: React.FC<EndAdornmentButtonProps> = ({
       data-testid={`number-input-${type}`}
       isCondensed={isCondensed}
       type="button"
-      className={classes}
       disabled={isDisabled}
       onClick={onClick}
     >

--- a/packages/react-component-library/src/components/NumberInput/Footnote.tsx
+++ b/packages/react-component-library/src/components/NumberInput/Footnote.tsx
@@ -6,12 +6,7 @@ interface FootnoteProps {
 
 export const Footnote: React.FC<FootnoteProps> = ({ children }) => {
   return children ? (
-    <small
-      className="rn-numberinput__footnote"
-      data-testid="number-input-footnote"
-    >
-      {children}
-    </small>
+    <small data-testid="number-input-footnote">{children}</small>
   ) : null
 }
 

--- a/packages/react-component-library/src/components/NumberInput/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInput/Input.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import classNames from 'classnames'
 import { isFinite, isNil } from 'lodash'
 import { ColourGroup, selectors } from '@royalnavy/design-tokens'
 import styled, { css } from 'styled-components'
@@ -129,10 +128,6 @@ export const Input: React.FC<InputProps> = ({
     unitPosition
   )
 
-  const inputClasses = classNames('rn-numberinput__input', {
-    'rn-numberinput__input--condensed': isCondensed,
-  })
-
   return (
     <StyledInputWrapper
       hasFocus={hasFocus}
@@ -141,7 +136,6 @@ export const Input: React.FC<InputProps> = ({
     >
       {hasLabel && (
         <StyledLabel
-          className="rn-numberinput__label"
           data-testid="number-input-label"
           hasFocus={hasFocus}
           hasContent={!isNil(value)}
@@ -162,7 +156,6 @@ export const Input: React.FC<InputProps> = ({
       )}
 
       <StyledInput
-        className={inputClasses}
         data-testid="number-input-input"
         disabled={isDisabled}
         hasLabel={hasLabel}

--- a/packages/react-component-library/src/components/NumberInput/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInput/Input.tsx
@@ -124,7 +124,7 @@ export const Input: React.FC<InputProps> = ({
 }) => {
   const hasLabel = !!(label && label.length)
   const [hasFocus, setHasFocus] = useState<boolean>(false)
-  const { inputOffset, inputRef, unitOffset } = useInputText(
+  const { canShow, inputOffset, inputRef, unitOffset } = useInputText(
     value,
     unitPosition
   )
@@ -152,9 +152,14 @@ export const Input: React.FC<InputProps> = ({
         </StyledLabel>
       )}
 
-      <NumberInputUnit left={`${unitOffset}px`} top={hasLabel && spacing('4')}>
-        {unit}
-      </NumberInputUnit>
+      {canShow && (
+        <NumberInputUnit
+          left={`${unitOffset}px`}
+          top={hasLabel && spacing('4')}
+        >
+          {unit}
+        </NumberInputUnit>
+      )}
 
       <StyledInput
         className={inputClasses}
@@ -176,7 +181,7 @@ export const Input: React.FC<InputProps> = ({
         placeholder={placeholder}
         ref={inputRef}
         type="text"
-        value={isFinite(value) ? value : ''}
+        value={isFinite(value) && canShow ? value : ''}
         {...rest}
       />
     </StyledInputWrapper>

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import classNames from 'classnames'
 import { isFinite, isNil } from 'lodash'
 import { selectors } from '@royalnavy/design-tokens'
 import styled from 'styled-components'
@@ -125,8 +124,6 @@ export const NumberInput: React.FC<NumberInputProps> = ({
 }) => {
   const { committedValue, setCommittedValue } = useValue(value)
 
-  const classes = classNames('rn-numberinput', className)
-
   function setCommittedValueWithinRange(newValue: number) {
     if (
       (isFinite(newValue) && isWithinRange(max, min, newValue)) ||
@@ -147,7 +144,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   return (
     <StyledNumberInput
       aria-label={label || 'Number input'}
-      className={classes}
+      className={className}
       data-testid="number-input-container"
       id={numberInputId}
       role="spinbutton"
@@ -156,7 +153,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
       aria-valuenow={committedValue}
       aria-valuetext={String(formatValue(committedValue, unit, unitPosition))}
     >
-      <StyledNumberInputOuterWrapper className="rn-numberinput__outer-wrapper">
+      <StyledNumberInputOuterWrapper>
         <StartAdornment>{startAdornment}</StartAdornment>
 
         <Input

--- a/packages/react-component-library/src/components/NumberInput/NumberInputUnit.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInputUnit.tsx
@@ -30,13 +30,7 @@ export const NumberInputUnit: React.FC<NumberInputUnitProps> = (props) => {
     return null
   }
 
-  return (
-    <StyledNumberInputUnit
-      className="rn-numberinput__unit"
-      data-testid="number-input-unit"
-      {...props}
-    />
-  )
+  return <StyledNumberInputUnit data-testid="number-input-unit" {...props} />
 }
 
 NumberInputUnit.displayName = 'NumberInputUnit'

--- a/packages/react-component-library/src/components/NumberInput/StartAdornment.tsx
+++ b/packages/react-component-library/src/components/NumberInput/StartAdornment.tsx
@@ -35,10 +35,7 @@ export const StartAdornment: React.FC<StartAdornmentProps> = ({ children }) => {
   }
 
   return (
-    <StyledStartAdornment
-      className="rn-numberinput__start-adornment"
-      data-testid="number-input-start-adornment"
-    >
+    <StyledStartAdornment data-testid="number-input-start-adornment">
       {children}
     </StyledStartAdornment>
   )

--- a/packages/react-component-library/src/components/NumberInput/useInputText.ts
+++ b/packages/react-component-library/src/components/NumberInput/useInputText.ts
@@ -44,6 +44,7 @@ export function useInputText(value: number, unitPosition: UnitPosition) {
   const inputRef = useRef<HTMLInputElement>(null)
   const [inputOffset, setInputOffset] = useState<number>()
   const [unitOffset, setUnitOffset] = useState<number>()
+  const [canShow, setCanShow] = useState<boolean>(false)
 
   useEffect(() => {
     if (!unitPosition) return
@@ -55,13 +56,14 @@ export function useInputText(value: number, unitPosition: UnitPosition) {
 
     if (unitPosition === UNIT_POSITION.AFTER) {
       const offset = textWidth + paddingLeft + EXTRA_SPACING
-      const roundedUpToNearestThree = 3 * Math.round(offset / 3)
-      setUnitOffset(roundedUpToNearestThree)
+      setUnitOffset(offset)
+      setCanShow(true)
     } else {
       setInputOffset(paddingLeft)
       setUnitOffset(paddingLeft)
+      setCanShow(true)
     }
   }, [value])
 
-  return { inputRef, inputOffset, unitOffset }
+  return { canShow, inputRef, inputOffset, unitOffset }
 }


### PR DESCRIPTION
## Related issue
Fixes #1552 

## Overview
Fix `NumberInput` visual regression test reliability.

## Reason
Current thinking is that the snapshot is being taken whilst the unit is moving.

## Work carried out
- [x] Show elements once position has been decided