### PR TITLE
Fix shrinking of label when there is a unit

### DIFF
--- a/packages/react-component-library/src/components/NumberInput/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInput/Input.tsx
@@ -26,6 +26,7 @@ interface InputProps extends InputValidationProps {
 }
 
 interface StyledInputProps {
+  hasLabel: boolean
   isCondensed: boolean
   offset: number
 }
@@ -37,6 +38,7 @@ interface StyledInputWrapperProps extends InputValidationProps {
 interface StyledLabelProps {
   hasContent: boolean
   hasFocus: boolean
+  hasUnit: boolean
 }
 
 function getInputBorder(group: ColourGroup) {
@@ -71,8 +73,8 @@ const StyledLabel = styled.label<StyledLabelProps>`
   color: ${color('neutral', '400')};
   font-size: ${fontSize('base')};
 
-  ${({ hasContent, hasFocus }) =>
-    (hasContent || hasFocus) &&
+  ${({ hasContent, hasFocus, hasUnit }) =>
+    (hasContent || hasFocus || hasUnit) &&
     css`
       transform: translate(${spacing('6')}, 6px) scale(0.8);
     `}
@@ -83,7 +85,17 @@ const StyledInput = styled.input<StyledInputProps>`
   box-sizing: border-box;
   width: 100%;
   margin: 0 0 0 ${({ offset }) => `${offset}px`};
-  padding: ${({ isCondensed }) => (isCondensed ? spacing('3') : spacing('6'))};
+  padding: ${({ hasLabel, isCondensed }) => {
+    if (isCondensed) {
+      return spacing('3')
+    }
+
+    if (hasLabel) {
+      return `${spacing('10')} ${spacing('6')} ${spacing('2')}`
+    }
+
+    return spacing('6')
+  }};
   border: 0;
   background: none;
   -webkit-tap-highlight-color: transparent;
@@ -91,10 +103,6 @@ const StyledInput = styled.input<StyledInputProps>`
 
   &:focus {
     outline: 0;
-  }
-
-  ${StyledLabel} + & {
-    padding: ${spacing('10')} ${spacing('6')} ${spacing('2')};
   }
 `
 
@@ -114,7 +122,7 @@ export const Input: React.FC<InputProps> = ({
   value,
   ...rest
 }) => {
-  const hasLabel = label && label.length
+  const hasLabel = !!(label && label.length)
   const [hasFocus, setHasFocus] = useState<boolean>(false)
   const { inputOffset, inputRef, unitOffset } = useInputText(
     value,
@@ -137,18 +145,22 @@ export const Input: React.FC<InputProps> = ({
           data-testid="number-input-label"
           hasFocus={hasFocus}
           hasContent={!isNil(value)}
+          hasUnit={!isNil(unit)}
           htmlFor={id}
         >
           {label}
         </StyledLabel>
       )}
 
-      <NumberInputUnit unit={unit} offset={unitOffset} />
+      <NumberInputUnit left={`${unitOffset}px`} top={hasLabel && spacing('4')}>
+        {unit}
+      </NumberInputUnit>
 
       <StyledInput
         className={inputClasses}
         data-testid="number-input-input"
         disabled={isDisabled}
+        hasLabel={hasLabel}
         id={id}
         isCondensed={isCondensed}
         name={name}

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -88,6 +88,16 @@ examples.add('Unit', () => (
   />
 ))
 
+examples.add('Unit and label', () => (
+  <NumberInput
+    label="Cost"
+    name="number-input"
+    onChange={action('onChange')}
+    value={1000}
+    unit="m&sup3;"
+  />
+))
+
 examples.add('Unit before', () => (
   <NumberInput
     name="number-input"

--- a/packages/react-component-library/src/components/NumberInput/NumberInputUnit.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInputUnit.tsx
@@ -5,12 +5,14 @@ import styled from 'styled-components'
 const { fontSize } = selectors
 
 interface NumberInputUnitProps {
-  offset: number
-  unit: string
+  children: string
+  left: string
+  top: string
 }
 
 interface StyledNumberInputUnitProps {
-  offset: number
+  left: string
+  top: string
 }
 
 const StyledNumberInputUnit = styled.span<StyledNumberInputUnitProps>`
@@ -19,14 +21,12 @@ const StyledNumberInputUnit = styled.span<StyledNumberInputUnitProps>`
   height: 100%;
   position: absolute;
   font-size: ${fontSize('base')};
-  left: ${({ offset }) => `${offset}px`};
+  left: ${({ left }) => left};
+  top: ${({ top }) => top};
 `
 
-export const NumberInputUnit: React.FC<NumberInputUnitProps> = ({
-  offset,
-  unit,
-}) => {
-  if (!unit) {
+export const NumberInputUnit: React.FC<NumberInputUnitProps> = (props) => {
+  if (!props.children) {
     return null
   }
 
@@ -34,10 +34,8 @@ export const NumberInputUnit: React.FC<NumberInputUnitProps> = ({
     <StyledNumberInputUnit
       className="rn-numberinput__unit"
       data-testid="number-input-unit"
-      offset={offset}
-    >
-      {unit}
-    </StyledNumberInputUnit>
+      {...props}
+    />
   )
 }
 


### PR DESCRIPTION
## Related issue
Fixes #1546 

## Overview
The label was not being shrunk when there was a unit which was causing overlap.

## Reason
Text becomes difficult to read.

## Work carried out
- [x] Fix label

## Screenshot
![number-input-unit-label](https://user-images.githubusercontent.com/56078793/96695234-543e2580-1381-11eb-8caa-855acf2fccf6.gif)