### PR TITLE
ci(CodeOwners): Update to use correct syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,8 @@
-*       @elglup
-*       @hxltrhuxze
-*       @m7kvqbe1
-*       @thyhjwb6
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @thyhjwb6 and @m7kvqbe1 will be requested for
+# review when someone opens a pull request.
+*       @thyhjwb6 @m7kvqbe1


### PR DESCRIPTION
CodeOwners feature was not working correctly because syntax was slightly wrong.