### PR TITLE
feat(NumberInput): Add clear button

### DIFF
--- a/packages/docs-site/src/library/pages/components/form/number-input.md
+++ b/packages/docs-site/src/library/pages/components/form/number-input.md
@@ -161,6 +161,13 @@ The NumberInput can be used in conjunction with `withFormik` to allow it to be u
     Description: 'Sets focus on the field when it is loaded',
   },
   {
+    Name: 'canClear',
+    Type: 'boolean',
+    Required: 'False',
+    Default: '',
+    Description: 'Optional flag to show a clear button',
+  },
+  {
     Name: 'className',
     Type: 'string',
     Required: 'False',

--- a/packages/react-component-library/src/components/NumberInput/ClearButton.tsx
+++ b/packages/react-component-library/src/components/NumberInput/ClearButton.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { IconCancel } from '@royalnavy/icon-library'
+import { selectors } from '@royalnavy/design-tokens'
+import styled, { css } from 'styled-components'
+
+const { color, spacing } = selectors
+
+interface ClearButtonProps {
+  isCondensed: boolean
+  isDisabled: boolean
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+interface StyledButtonProps {
+  isCondensed: boolean
+}
+
+const StyledButton = styled.button<StyledButtonProps>`
+  background-color: ${color('neutral', 'white')};
+  border: none;
+  color: ${color('neutral', '300')};
+  cursor: pointer;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 1rem;
+  right: 54px;
+  padding: unset;
+  display: flex;
+  align-items: center;
+
+  ${({ isCondensed }) =>
+    isCondensed &&
+    css`
+      right: 44px;
+
+      & > svg {
+        transform: scale(0.8);
+      }
+    `}
+`
+
+export const ClearButton: React.FC<ClearButtonProps> = ({
+  isCondensed,
+  isDisabled,
+  onClick,
+}) => {
+  return (
+    <StyledButton
+      aria-label="Clear the input value"
+      data-testid="number-input-clear"
+      disabled={isDisabled}
+      isCondensed={isCondensed}
+      onClick={onClick}
+      type="button"
+    >
+      <IconCancel />
+    </StyledButton>
+  )
+}
+
+ClearButton.displayName = 'ClearButton'

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -13,6 +13,8 @@ import { UNIT_POSITION } from './constants'
 const stories = storiesOf('Number Input', module)
 const examples = storiesOf('Number Input/Examples', module)
 
+const chromaticIgnore = { chromatic: { disable: true } }
+
 stories.add('Default', () => (
   <NumberInput name="number-input" onChange={action('onChange')} />
 ))
@@ -88,24 +90,32 @@ examples.add('Value', () => (
   <NumberInput name="number-input" onChange={action('onChange')} value={10} />
 ))
 
-examples.add('Unit', () => (
-  <NumberInput
-    name="number-input"
-    onChange={action('onChange')}
-    value={1000}
-    unit="m&sup3;"
-  />
-))
+examples.add(
+  'Unit',
+  () => (
+    <NumberInput
+      name="number-input"
+      onChange={action('onChange')}
+      value={1000}
+      unit="m&sup3;"
+    />
+  ),
+  chromaticIgnore
+)
 
-examples.add('Unit and label', () => (
-  <NumberInput
-    label="Cost"
-    name="number-input"
-    onChange={action('onChange')}
-    value={1000}
-    unit="m&sup3;"
-  />
-))
+examples.add(
+  'Unit and label',
+  () => (
+    <NumberInput
+      label="Cost"
+      name="number-input"
+      onChange={action('onChange')}
+      value={1000}
+      unit="m&sup3;"
+    />
+  ),
+  chromaticIgnore
+)
 
 examples.add('Unit before', () => (
   <NumberInput

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -21,6 +21,15 @@ examples.add('Condensed', () => (
   <NumberInput isCondensed name="number-input" onChange={action('onChange')} />
 ))
 
+examples.add('Clear', () => (
+  <NumberInput
+    canClear
+    name="number-input"
+    onChange={action('onChange')}
+    value={10}
+  />
+))
+
 examples.add('Disabled', () => (
   <NumberInput isDisabled name="number-input" onChange={action('onChange')} />
 ))

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
@@ -640,4 +640,23 @@ describe('NumberInput', () => {
       })
     })
   })
+
+  describe('when there is a clear button', () => {
+    describe('and the clear button is clicked', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <NumberInput
+            canClear
+            name="number-input"
+            onChange={onChangeSpy}
+            value={1000}
+          />
+        )
+
+        wrapper.getByTestId('number-input-clear').click()
+      })
+
+      assertInputValue('')
+    })
+  })
 })

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -12,6 +12,7 @@ import { InputValidationProps } from '../../common/InputValidationProps'
 import { StartAdornment } from './StartAdornment'
 import { useValue } from './useValue'
 import { UNIT_POSITION } from './constants'
+import { ClearButton } from './ClearButton'
 
 const { color, spacing } = selectors
 
@@ -21,6 +22,7 @@ export type UnitPosition =
 
 export interface NumberInputProps extends InputValidationProps {
   autoFocus?: boolean
+  canClear?: boolean
   className?: string
   footnote?: string
   id?: string
@@ -101,6 +103,7 @@ function hasClass(allClasses: string, className: string) {
 }
 
 export const NumberInput: React.FC<NumberInputProps> = ({
+  canClear,
   className,
   footnote,
   id = uuidv4(),
@@ -183,6 +186,16 @@ export const NumberInput: React.FC<NumberInputProps> = ({
           value={committedValue}
           {...rest}
         />
+
+        {canClear && (
+          <ClearButton
+            isCondensed={isCondensed}
+            isDisabled={isDisabled}
+            onClick={() => {
+              setCommittedValueWithinRange(null)
+            }}
+          />
+        )}
 
         <EndAdornment
           isCondensed={isCondensed}


### PR DESCRIPTION
## Related issue
Fixes #1457 

## Overview
Adds optional prop `canClear` to display clear button for clearing value of `NumberInput`.

## Reason
This was on the original design and has never been implemented.

## Work carried out
- [x] Add clear button

## Screenshot
![number-input-clear](https://user-images.githubusercontent.com/56078793/96845116-3e476800-1448-11eb-91e7-c4559a3d1795.gif)
