### PR TITLE
fix(ReactComponentLibrary): Prevent `isInvalid` prop drill to DOM node

### DIFF
--- a/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
@@ -3,8 +3,11 @@ import classNames from 'classnames'
 import { v4 as uuidv4 } from 'uuid'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { InputValidationProps } from '../../common/InputValidationProps'
 
-export interface CheckboxProps extends ComponentWithClass {
+export interface CheckboxProps
+  extends ComponentWithClass,
+    InputValidationProps {
   id?: string
   isChecked?: boolean
   isDisabled?: boolean

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -9,6 +9,7 @@ import { Footnote } from './Footnote'
 import { getId } from '../../helpers'
 import { Input } from './Input'
 import { InputValidationProps } from '../../common/InputValidationProps'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { StartAdornment } from './StartAdornment'
 import { useValue } from './useValue'
 import { UNIT_POSITION } from './constants'
@@ -20,10 +21,11 @@ export type UnitPosition =
   | typeof UNIT_POSITION.AFTER
   | typeof UNIT_POSITION.BEFORE
 
-export interface NumberInputProps extends InputValidationProps {
+export interface NumberInputProps
+  extends ComponentWithClass,
+    InputValidationProps {
   autoFocus?: boolean
   canClear?: boolean
-  className?: string
   footnote?: string
   id?: string
   isCondensed?: boolean

--- a/packages/react-component-library/src/components/Radio/Radio.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.tsx
@@ -3,8 +3,9 @@ import { v4 as uuidv4 } from 'uuid'
 import classNames from 'classnames'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { InputValidationProps } from '../../common/InputValidationProps'
 
-export interface RadioProps extends ComponentWithClass {
+export interface RadioProps extends ComponentWithClass, InputValidationProps {
   id?: string
   isChecked?: boolean
   isDisabled?: boolean

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -6,9 +6,13 @@ import { DropdownIndicator } from '../Dropdown/DropdownIndicator'
 import { Input } from './Input'
 import { SingleValue } from './SingleValue'
 import { Option, SelectOptionWithBadgeType } from './Option'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { InputValidationProps } from '../../common/InputValidationProps'
 
-export interface SelectProps extends ReactSelectProps<any> {
-  className?: string
+export interface SelectProps
+  extends ReactSelectProps<any>,
+    ComponentWithClass,
+    InputValidationProps {
   label?: string
   name?: string
   onChange?: (event: any) => void
@@ -37,7 +41,7 @@ export const Select: React.FC<SelectProps> = ({
     })
   }
 
-  const selectedOption = options.find(option => option.value === value)
+  const selectedOption = options.find((option) => option.value === value)
 
   const classes = classNames('rn-select', className)
 

--- a/packages/react-component-library/src/components/Switch/Switch.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.tsx
@@ -3,6 +3,8 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { getKey } from '../../helpers'
 import { SWITCH_SIZE } from '.'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { InputValidationProps } from '../../common/InputValidationProps'
 
 function getActiveOption(options: SwitchOptionProps[], value: string) {
   const initial: SwitchOptionProps | string = options.find(
@@ -17,11 +19,10 @@ export interface SwitchOptionProps {
   value: string
 }
 
-export interface SwitchProps {
+export interface SwitchProps extends ComponentWithClass, InputValidationProps {
   name: string
   value?: string
   label?: string
-  className?: string
   onChange?: (event: React.FormEvent<HTMLInputElement>) => void
   options: SwitchOptionProps[]
   size?:

--- a/packages/react-component-library/src/components/TextArea/TextArea.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.tsx
@@ -4,11 +4,13 @@ import classNames from 'classnames'
 
 import { useFocus } from '../../hooks/useFocus'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { InputValidationProps } from '../../common/InputValidationProps'
 import { useInputValue } from '../../hooks/useInputValue'
 
 export interface TextAreaInputProps
   extends TextareaHTMLAttributes<HTMLTextAreaElement>,
-    ComponentWithClass {
+    ComponentWithClass,
+    InputValidationProps {
   isDisabled?: boolean
   footnote?: string
   label?: string

--- a/packages/react-component-library/src/components/TextInput/TextInput.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.tsx
@@ -4,10 +4,13 @@ import classNames from 'classnames'
 
 import { useFocus } from '../../hooks/useFocus'
 import { useInputValue } from '../../hooks/useInputValue'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { InputValidationProps } from '../../common/InputValidationProps'
 
-export interface TextInputProps {
+export interface TextInputProps
+  extends ComponentWithClass,
+    InputValidationProps {
   autoFocus?: boolean
-  className?: string
   endAdornment?: React.ReactNode
   footnote?: string
   id?: string

--- a/packages/react-component-library/src/components/TextInput/TextInput.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.tsx
@@ -55,6 +55,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     placeholder = '',
     startAdornment,
     type = 'text',
+    isInvalid,
     ...rest
   } = props
 


### PR DESCRIPTION
## Related issue

Closes #1591

## Overview

Prevent prop from being incorrectly applied to DOM node.

## Reason

>Warning emitted to console for Formik TextInputs

## Work carried out

- [x] Fix up some interfaces
- [x] Do not drill prop to DOM node
