### PR TITLE
fix(Popover): Prevent hidden Popover blocking covered content

### DIFF
--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -16,24 +16,36 @@ const HOVER_ON_ME = 'Hover on me!'
 describe('Popover', () => {
   let wrapper: RenderResult
   let children: React.ReactElement
+  let clickSpy: (e: React.MouseEvent) => void
 
   describe('when provided a placement and arbitrary JSX content', () => {
     beforeEach(() => {
       children = <pre>This is some arbitrary JSX</pre>
+      clickSpy = jest.fn()
 
       wrapper = render(
-        <Popover placement={POPOVER_PLACEMENT.BELOW} content={children}>
-          <div
-            style={{
-              display: 'inline-block',
-              padding: '1rem',
-              backgroundColor: '#c9c9c9',
-            }}
-          >
-            {HOVER_ON_ME}
-          </div>
-        </Popover>
+        <>
+          <Popover placement={POPOVER_PLACEMENT.BELOW} content={children}>
+            <div
+              style={{
+                display: 'inline-block',
+                padding: '1rem',
+                backgroundColor: '#c9c9c9',
+              }}
+            >
+              {HOVER_ON_ME}
+            </div>
+          </Popover>
+          <button onClick={clickSpy} style={{ margin: '2rem' }}>
+            Click me!
+          </button>
+        </>
       )
+    })
+
+    it('allows button covered by Popover to be clicked when Popover is hidden', () => {
+      wrapper.queryByText('Click me!').click()
+      expect(clickSpy).toHaveBeenCalledTimes(1)
     })
 
     it('should set the `aria-describedby` attribute to the ID of the content', () => {

--- a/packages/react-component-library/src/components/Popover/Popover.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.tsx
@@ -32,14 +32,12 @@ interface StyledFloatingBoxProps {
 }
 
 const StyledFloatingBox = styled(FloatingBox)<StyledFloatingBoxProps>`
-  pointer-events: none;
   opacity: 0;
   transition: linear opacity 0.3s;
 
   ${({ $isVisible }) =>
     $isVisible &&
     css`
-      pointer-events: all;
       opacity: 1;
     `}
 `
@@ -102,6 +100,7 @@ export const Popover: React.FC<PopoverProps> = ({
         offset: PLACEMENTS.OFFSET,
         attachment: PLACEMENTS.ATTACHMENT,
         targetAttachment: PLACEMENTS.TARGET_ATTACHMENT,
+        style: { pointerEvents: isVisible ? 'all' : 'none' },
       })}
     </>
   )


### PR DESCRIPTION
## Related issue

Closes #1564

## Overview

Prevent hidden Popover blocking mouse events.

## Reason

>Popover component 'covers' UI area when not visible.

## Work carried out

- [x] Prevent hidden Popover blocking mouse events
- [x] Add automated test

## Developer notes

This is a short term fix.

A ticket has been created to replace `react-tether` with another underlying library: https://github.com/Royal-Navy/design-system/issues/1642

The library is used in numerous places throughout the codebase.