### PR TITLE
fix(Dropdown): Fix label in ie 11

### DIFF
--- a/packages/react-component-library/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.tsx
@@ -23,6 +23,13 @@ const StyledSelect = styled(Select)`
     border-color: ${color('neutral', '200')};
   }
 
+  // ie 11 fix: https://github.com/philipwalton/flexbugs/issues/231#issuecomment-362790042
+  .rn-dropdown__control:after {
+    content: '';
+    min-height: inherit;
+    font-size: 0;
+  }
+
   .rn-dropdown__placeholder {
     color: ${color('neutral', '500')};
   }


### PR DESCRIPTION
## Related issue
Fixes #1580 

## Overview
Fixes the `Dropdown` label positioning in IE 11.

## Reason
This is because of an issue with `align-items: center` and `min-height: x` in IE 11 which can be worked around by adding a pseudo element.

## Work carried out
- [x] Fix ie 11 issue

## Screenshot
Look at the Chromatic differences.

## Developer notes
The proposed workaround was taken from [a Github comment](https://github.com/philipwalton/flexbugs/issues/231#issuecomment-362790042).
