### PR TITLE
Fix timeline row accessibility

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -618,3 +618,27 @@ export const WithCustomRange = () => {
   )
 }
 WithCustomRange.storyName = 'With custom range'
+
+
+export const NoVisibleCells = () => (
+  <Timeline startDate={new Date(2020, 0, 1)} today={new Date(2020, 0, 1, 12)}>
+    <TimelineTodayMarker />
+    <TimelineMonths />
+    <TimelineWeeks />
+    <TimelineDays />
+    <TimelineRows>
+      <TimelineRow name="Row 1">
+        <TimelineEvents>
+          <TimelineEvent
+            startDate={new Date(2020, 3, 14, 12)}
+            endDate={new Date(2020, 3, 18, 12)}
+          >
+            Event 1
+          </TimelineEvent>
+        </TimelineEvents>
+      </TimelineRow>
+    </TimelineRows>
+  </Timeline>
+)
+NoVisibleCells.parameters = disableScrollableRegionFocusableRule
+NoVisibleCells.storyName = 'No visible cells'

--- a/packages/react-component-library/src/components/Timeline/TimelineNoData.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineNoData.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+import { NO_DATA_MESSAGE } from './constants'
+
+const { color, spacing, zIndex } = selectors
+
+const StyledNoData = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: inherit;
+
+  span {
+    background-color: ${color('neutral', 'white')};
+    padding: ${spacing('2')};
+    z-index: ${zIndex('body', 1)};
+  }
+`
+
+export const TimelineNoData: React.FC = () => (
+  <StyledNoData role="row" data-testid="timeline-no-data">
+    <span role="cell">{NO_DATA_MESSAGE}</span>
+  </StyledNoData>
+)
+
+TimelineNoData.displayName = 'TimelineNoData'

--- a/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import classNames from 'classnames'
 import { selectors } from '@royalnavy/design-tokens'
+import { useTimelineRowContent } from './hooks/useTimelineRowContent'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TimelineContext, TimelineEventsProps } from '.'
@@ -56,6 +57,10 @@ const StyledRowContent = styled.div`
   position: relative;
 `
 
+const StyledNoEvents = styled.span`
+  display: none;
+`
+
 export const TimelineRow: React.FC<TimelineRowProps> = ({
   children,
   name,
@@ -66,6 +71,7 @@ export const TimelineRow: React.FC<TimelineRowProps> = ({
   ...rest
 }) => {
   const classes = classNames('timeline__row', className)
+  const { noCells, rowContentRef } = useTimelineRowContent(isHeader, [children])
 
   return (
     <TimelineContext.Consumer>
@@ -86,7 +92,10 @@ export const TimelineRow: React.FC<TimelineRowProps> = ({
               {renderRowHeader ? renderRowHeader(name) : name}
             </StyledRowHeader>
           )}
-          <StyledRowContent>{children}</StyledRowContent>
+          <StyledRowContent ref={rowContentRef}>
+            {noCells && <StyledNoEvents role="cell">No events</StyledNoEvents>}
+            {children}
+          </StyledRowContent>
         </StyledTimelineRow>
       )}
     </TimelineContext.Consumer>

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -1,16 +1,15 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import classNames from 'classnames'
 import { differenceInDays, endOfWeek, max, min } from 'date-fns'
-import { selectors } from '@royalnavy/design-tokens'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { TimelineNoData } from './TimelineNoData'
 import { TimelineRowProps } from '.'
 import { TimelineContext } from './context'
 import { withKey } from '../../helpers'
 import { formatPx, isOdd } from './helpers'
 import {
-  NO_DATA_MESSAGE,
   WEEK_START,
   TIMELINE_BG_COLOR,
   TIMELINE_ALT_BG_COLOR,
@@ -29,27 +28,6 @@ export interface TimelineRowsProps extends ComponentWithClass {
     widthPx: string
   ) => React.ReactElement
 }
-
-const { color, spacing, zIndex } = selectors
-
-const StyledNoData = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: inherit;
-
-  span {
-    background-color: ${color('neutral', 'white')};
-    padding: ${spacing('2')};
-    z-index: ${zIndex('body', 1)};
-  }
-`
-
-const noData = (
-  <StyledNoData role="row" data-testid="timeline-no-data">
-    <span role="cell">{NO_DATA_MESSAGE}</span>
-  </StyledNoData>
-)
 
 interface StyledTimelineRowWeekProps {
   isOddNumber: boolean
@@ -174,7 +152,7 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
         role="rowgroup"
         data-testid="timeline-rows"
       >
-        {hasChildren ? children : noData}
+        {hasChildren ? children : <TimelineNoData />}
       </StyledTimelineMain>
     </>
   )

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -323,6 +323,10 @@ describe('Timeline', () => {
         'Event 1 begins on 13th April 2020 and ends on 18th April 2020'
       )
     })
+
+    it('should not render a "No events" cell', () => {
+      expect(wrapper.queryByText('No events')).toBeNull()
+    })
   })
 
   describe('when `hasSide` is specified', () => {
@@ -1386,6 +1390,42 @@ describe('Timeline', () => {
 
     it('renders the event', () => {
       expect(wrapper.queryByTestId('timeline-event')).toBeInTheDocument()
+    })
+  })
+
+  describe('when all events are outside the range', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Timeline
+          startDate={new Date(2020, 0, 1)}
+          today={new Date(2020, 0, 15)}
+        >
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineWeeks />
+          <TimelineDays />
+          <TimelineRows>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={new Date(2020, 3, 13)}
+                  endDate={new Date(2020, 3, 18)}
+                >
+                  Event 1
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('should display 0 events', () => {
+      expect(wrapper.queryAllByTestId('timeline-event-wrapper')).toHaveLength(0)
+    })
+
+    it('should render the "No events" cell', () => {
+      expect(wrapper.getByText('No events')).toBeInTheDocument()
     })
   })
 })

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineRowContent.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineRowContent.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState, MutableRefObject } from 'react'
+
+export function useTimelineRowContent(
+  isHeader: boolean,
+  deps?: ReadonlyArray<any>
+): {
+  noCells: boolean
+  rowContentRef: MutableRefObject<HTMLDivElement>
+} {
+  const rowContentRef = useRef(null)
+  const [noCells, setNoCells] = useState<boolean>(false)
+
+  if (!isHeader) {
+    useEffect(() => {
+      const cells = rowContentRef.current.querySelectorAll('[role="cell"]')
+      if (!cells.length) {
+        setNoCells(true)
+      }
+    }, deps)
+  }
+
+  return {
+    noCells,
+    rowContentRef,
+  }
+}


### PR DESCRIPTION
## Related issue
Fixes #1446 

## Overview
When all events are outside of the range then rows are rendered but no events are rendered. This change checks the rendered cells and if there are not any then it shows the `No events` hidden cell.

## Reason
This causes accessibility issues because there is a row without cells.

## Work carried out
- [x] Refactor existing `noData`
- [x] Fix missing cell