### PR TITLE
feat(Select): Add ability to display `icon`

### DIFF
--- a/packages/docs-site/src/library/pages/components/form/select.md
+++ b/packages/docs-site/src/library/pages/components/form/select.md
@@ -163,6 +163,13 @@ with the field.
     Default: '',
     Description: 'An optional thing to show inside a badge in the option, such as a count',
   },
+  {
+    Name: 'icon',
+    Type: 'React.ReactNode',
+    Required: 'False',
+    Default: '',
+    Description: 'A component that renders an icon to the right of the option',
+  },
 ]} />
 
 </Tab>

--- a/packages/react-component-library/src/components/Select/Option.tsx
+++ b/packages/react-component-library/src/components/Select/Option.tsx
@@ -1,30 +1,51 @@
 import React from 'react'
 import { components } from 'react-select'
 import { OptionProps } from 'react-select/src/components/Option'
+import { selectors } from '@royalnavy/design-tokens'
+import styled, { css } from 'styled-components'
 
 import { Badge } from '../Badge'
 
+const { spacing } = selectors
+
 export interface SelectOptionWithBadgeType {
   badge?: string | number
+  icon?: React.ReactNode
   label: string
   value: string
 }
 
-export const Option: React.FC<OptionProps<
-  SelectOptionWithBadgeType
->> = props => {
+const StyledOption = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1;
+`
+
+const StyledEndAdornment = styled.span`
+  position: absolute;
+  top: ${spacing('px')};
+  right: 0;
+`
+
+export const Option: React.FC<OptionProps<SelectOptionWithBadgeType>> = (
+  props
+) => {
   const {
-    data: { badge, label },
+    data: { badge, icon, label },
   } = props
 
   return (
     <components.Option {...props} data-testid="select-option">
-      <span data-testid="select-option-label">{label}</span>
-      {badge && (
-        <Badge className="rn-select__badge rn_ml-3" size="small">
-          {badge}
-        </Badge>
-      )}
+      <StyledOption>
+        <span data-testid="select-option-label">{label}</span>
+        {badge && (
+          <Badge className="rn-select__badge rn_ml-3" size="small">
+            {badge}
+          </Badge>
+        )}
+        {icon && <StyledEndAdornment>{icon}</StyledEndAdornment>}
+      </StyledOption>
     </components.Option>
   )
 }

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -1,6 +1,7 @@
-import { action } from '@storybook/addon-actions'
-import { storiesOf } from '@storybook/react'
 import React from 'react'
+import { action } from '@storybook/addon-actions'
+import { IconAnchor } from '@royalnavy/icon-library'
+import { storiesOf } from '@storybook/react'
 
 import { Select } from './index'
 
@@ -16,6 +17,11 @@ const options = [
   { value: 'vanilla', label: 'Vanilla', badge: 50 },
 ]
 
+const iconOptions = options.map(option => ({
+  ...option,
+  icon: <IconAnchor />,
+}))
+
 stories.add('Default', () => (
   <Select
     options={options}
@@ -30,5 +36,13 @@ examples.add('Disabled', () => (
     label="Example Label"
     onChange={action('onChange')}
     isDisabled
+  />
+))
+
+examples.add('Icons', () => (
+  <Select
+    options={iconOptions}
+    label="Example Label"
+    onChange={action('onChange')}
   />
 ))

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { fireEvent, render, RenderResult } from '@testing-library/react'
+import { IconAnchor } from '@royalnavy/icon-library'
+import userEvent from '@testing-library/user-event'
 
 import { Select } from '.'
 
@@ -101,6 +103,30 @@ describe('Select', () => {
 
     it('should find the input using the new `data-testid`', () => {
       expect(wrapper.getByTestId('select-1')).toBeInTheDocument()
+    })
+  })
+
+  describe('when provided with options that have icons', () => {
+    beforeEach(() => {
+      onChangeSpy = jest.fn()
+
+      const iconOptions = options.map((option) => ({
+        ...option,
+        icon: <IconAnchor data-testid="select-option-icon" />,
+      }))
+
+      wrapper = render(<Select label="Select label" options={iconOptions} />)
+
+      const input = wrapper.getByTestId('react-select-vendor-input')
+      fireEvent.focus(input)
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown',
+        code: 40,
+      })
+    })
+
+    it('should render the icons', () => {
+      expect(wrapper.getAllByTestId('select-option-icon')).toHaveLength(2)
     })
   })
 })


### PR DESCRIPTION
## Related issue
Closes #1557 

## Overview
Adds the ability to display an `icon` with the `Select` option.

## Reason
Feature required by exemplar.

## Work carried out
- [x] Add `icon`

## Screenshot
![Screenshot 2020-11-12 at 11 32 48](https://user-images.githubusercontent.com/56078793/98969916-40608c00-2507-11eb-8830-e3da6d0d0fdb.png)
