### PR TITLE
test(ReactComponentLibrary): Catch React runtime console errors in Jest

### DIFF
--- a/packages/react-component-library/jest/setupTests.js
+++ b/packages/react-component-library/jest/setupTests.js
@@ -1,3 +1,15 @@
 import 'babel-polyfill'
 import 'jest-canvas-mock'
 import 'jest-styled-components'
+import { format } from 'util'
+
+const originalConsoleError = global.console.error
+
+global.console.error = (...args) => {
+  const reactFailures = [/Failed prop type/, /Warning: /]
+
+  if (reactFailures.some((p) => p.test(args[0]))) {
+    originalConsoleError(...args)
+    throw new Error(format(...args))
+  }
+}

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
@@ -30,6 +30,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       onBlur,
       onChange,
       value,
+      isInvalid,
       ...rest
     },
     ref

--- a/packages/react-component-library/src/components/CheckboxEnhanced/CheckboxEnhanced.tsx
+++ b/packages/react-component-library/src/components/CheckboxEnhanced/CheckboxEnhanced.tsx
@@ -14,6 +14,7 @@ export const CheckboxEnhanced: React.FC<CheckboxEnhancedProps> = ({
   name,
   tabIndex = 0,
   title,
+  isInvalid,
   ...rest
 }) => {
   const ref = useRef(null)

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import { RenderResult, render, fireEvent } from '@testing-library/react'
+import { RenderResult, render, fireEvent, act } from '@testing-library/react'
 import { IconSettings } from '@royalnavy/icon-library'
 
 import { ContextMenu, ContextMenuItem, ContextMenuDivider } from '.'
@@ -112,9 +112,13 @@ describe('ContextMenu', () => {
 
       wrapper = render(<ContextExample />)
 
-      fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+      act(() => {
+        fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+      })
 
-      wrapper.getByTestId('context-menu-custom-link').click()
+      act(() => {
+        wrapper.getByTestId('context-menu-custom-link').click()
+      })
     })
 
     it('invokes the supplied onClick callback when the custom link is clicked', () => {
@@ -163,7 +167,7 @@ describe('ContextMenu', () => {
             <ContextMenu attachedToRef={ref}>
               <ContextMenuDivider />
               <ContextMenuItem
-                icon={IconSettings}
+                icon={<IconSettings />}
                 link={<Link href="/hello-foo">Hello, Foo!</Link>}
               />
               <ContextMenuDivider />

--- a/packages/react-component-library/src/components/Nav/Nav.tsx
+++ b/packages/react-component-library/src/components/Nav/Nav.tsx
@@ -16,7 +16,7 @@ function renderMenu(LinkComponent: any, navItems: any[]) {
   return (
     <ul className="rn-nav__list">
       {navItems.map((item) => {
-        const { active, children, label } = item
+        const { active, children, label, ...rest } = item
 
         const hasChildren: boolean = children && children.length > 0
         let subMenu: React.ReactNode | undefined
@@ -29,7 +29,7 @@ function renderMenu(LinkComponent: any, navItems: any[]) {
           <NavItem key={getKey('nav-item', label)} hasChildren={hasChildren}>
             <LinkComponent
               className={`rn-nav__item ${active ? 'is-active' : ''}`}
-              {...item}
+              {...rest}
             >
               {label}
             </LinkComponent>

--- a/packages/react-component-library/src/components/Radio/Radio.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.tsx
@@ -28,6 +28,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
       onChange,
       onBlur,
       value,
+      isInvalid,
       ...rest
     },
     ref

--- a/packages/react-component-library/src/components/RadioEnhanced/RadioEnhanced.tsx
+++ b/packages/react-component-library/src/components/RadioEnhanced/RadioEnhanced.tsx
@@ -14,6 +14,7 @@ export const RadioEnhanced: React.FC<RadioEnhancedProps> = ({
   name,
   tabIndex = 0,
   title,
+  isInvalid,
   ...rest
 }) => {
   const ref = useRef(null)

--- a/packages/react-component-library/src/enhancers/__tests__/withFormik.test.tsx
+++ b/packages/react-component-library/src/enhancers/__tests__/withFormik.test.tsx
@@ -6,7 +6,7 @@ import { FieldProps } from '../../common/FieldProps'
 import { FormProps } from '../../common/FormProps'
 import { withFormik } from '../withFormik'
 
-const DummyComponent: React.FC = (props) => (
+const DummyComponent: React.FC = ({ isInvalid, ...props }: any) => (
   <div data-testid="dummy-component" {...props} />
 )
 const DummyFormikComponent = withFormik(DummyComponent)

--- a/packages/react-component-library/tsconfig.json
+++ b/packages/react-component-library/tsconfig.json
@@ -19,5 +19,5 @@
     "suppressImplicitAnyIndexErrors": true,
     "target": "esnext"
   },
-  "include": ["src"]
+  "include": ["src", "jest"]
 }


### PR DESCRIPTION
## Related issue

Closes #1657

## Overview

Catch React runtime console errors in Jest.

## Reason

>These runtime console errors should not be making their way into prod.

## Work carried out

- [x] Monkey-patch console.error in Jest global setup
- [x] Resolve numerous React console errors

## Screenshot

<img width="1522" alt="Screenshot 2020-11-13 at 11 50 15" src="https://user-images.githubusercontent.com/48086589/99069825-ff1fb900-25a6-11eb-82a1-b4ebd6c93f9c.png">


## Developer notes

I've identified an additional part to this work which is to wrap the console logger so that we can improve the component library warnings (adding types for log levels, globally disable the warnings etc). A ticket has been created: #1666
 