### PR TITLE
fix(Timeline): Correct row column background mismatch

### DIFF
--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -61,7 +61,7 @@ const StyledTimelineRowWeek = styled.div<StyledTimelineRowWeekProps>`
   display: inline-block;
   height: 100vh;
   background-color: ${({ isOddNumber }) =>
-    isOddNumber ? TIMELINE_BG_COLOR : TIMELINE_ALT_BG_COLOR};
+    isOddNumber ?  TIMELINE_ALT_BG_COLOR : TIMELINE_BG_COLOR};
   margin-left: ${({ marginLeft }) => marginLeft};
   width: ${({ width }) => width};
 `


### PR DESCRIPTION
## Related issue

Closes #1656

## Overview

Correct row column background mismatch.

## Reason

>The background colours for the row and header columns were not matched.

## Work carried out

- [x] Adjust ternary logic in styled-component

## Screenshot

<img width="1509" alt="Screenshot 2020-11-13 at 12 08 58" src="https://user-images.githubusercontent.com/48086589/99070894-047e0300-25a9-11eb-8669-f3a87aad3857.png">

