### PR TITLE
fix(RangeSlider): Fix some styled-components warnings

### DIFF
--- a/packages/react-component-library/src/components/RangeSlider/Handle.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Handle.tsx
@@ -25,9 +25,12 @@ interface StyledHandleProps {
 
 const { color, fontSize, spacing } = selectors
 
-const StyledHandle = styled.div<StyledHandleProps>`
+const StyledHandle = styled.div.attrs<StyledHandleProps>(({ $left }) => ({
+  style: {
+    left: $left,
+  },
+}))<StyledHandleProps>`
   position: absolute;
-  left: ${({ $left }) => $left};
   transform: translate(-50%, -50%);
   z-index: 2;
   width: 14px;

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -77,13 +77,6 @@ const StyledRangeSlider = styled.div<StyledRangeSliderProps>`
   align-items: center;
   width: 100%;
 
-  > div {
-    position: relative;
-    width: 100%;
-    height: 40px;
-    padding-top: 20px;
-  }
-
   ${({ $isDisabled }) =>
     $isDisabled &&
     css`
@@ -94,6 +87,29 @@ const StyledRangeSlider = styled.div<StyledRangeSliderProps>`
         cursor: not-allowed;
       }
     `}
+`
+
+const StyledSlider = styled(Slider)`
+  position: relative;
+  width: 100%;
+  height: 40px;
+  padding-top: 20px;
+`
+
+const StyledIconLeft = styled.div`
+  svg {
+    color: ${color('neutral', '400')};
+    overflow: visible;
+    margin-right: ${spacing('2')};
+  }
+`
+
+const StyledIconRight = styled.div`
+  svg {
+    color: ${color('neutral', '400')};
+    overflow: visible;
+    margin-left: ${spacing('2')};
+  }
 `
 
 export const RangeSlider: React.FC<RangeSliderProps> = ({
@@ -134,22 +150,6 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
     [displayUnit]
   )
 
-  const StyledIconLeft = IconLeft
-    ? styled(IconLeft)`
-        color: ${color('neutral', '400')};
-        overflow: visible;
-        margin-right: ${spacing('2')};
-      `
-    : undefined
-
-  const StyledIconRight = IconRight
-    ? styled(IconRight)`
-        color: ${color('neutral', '400')};
-        overflow: visible;
-        margin-left: ${spacing('2')};
-      `
-    : undefined
-
   return (
     <StyledRangeSlider
       className={className}
@@ -159,9 +159,11 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
       data-testid="rangeslider"
     >
       {IconLeft && (
-        <StyledIconLeft aria-hidden data-testid="rangeslider-icon-left" />
+        <StyledIconLeft aria-hidden data-testid="rangeslider-icon-left">
+          <IconLeft />
+        </StyledIconLeft>
       )}
-      <Slider
+      <StyledSlider
         domain={domain}
         reversed={isReversed}
         disabled={isDisabled}
@@ -244,9 +246,11 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
             )}
           </Ticks>
         )}
-      </Slider>
+      </StyledSlider>
       {IconRight && (
-        <StyledIconRight aria-hidden data-testid="rangeslider-icon-right" />
+        <StyledIconRight aria-hidden data-testid="rangeslider-icon-right">
+          <IconRight />
+        </StyledIconRight>
       )}
     </StyledRangeSlider>
   )

--- a/packages/react-component-library/src/components/RangeSlider/ThresholdTrack.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/ThresholdTrack.tsx
@@ -31,16 +31,21 @@ interface StyledChunkProps {
   $maxWidth: string
 }
 
-const StyledChunk = styled.div<StyledChunkProps>`
+const StyledChunk = styled.div.attrs<StyledChunkProps>(
+  ({ $left, $width, $maxWidth }) => ({
+    style: {
+      left: $left,
+      width: $width,
+      maxWidth: $maxWidth,
+    },
+  })
+)<StyledChunkProps>`
   position: absolute;
-  left: ${({ $left }) => $left};
   transform: translate(0%, -50%);
   height: 2px;
   z-index: 1;
   background-color: ${RANGE_SLIDER_TRACK_COLOR};
   cursor: pointer;
-  width: ${({ $width }) => $width};
-  max-width: ${({ $maxWidth }) => $maxWidth};
 
   ${({ $thresholdColor }) => css`
     background-color: ${$thresholdColor};


### PR DESCRIPTION
## Related issue

Closes #1639

## Overview

Resolve some styled-components warnings.

## Reason

>Styled-components was throwing some console warnings.

## Work carried out

- [x] Do not instantiate styled-components within a React component
- [x] Use `attrs` to prevent excessive number of classes being generated
