### PR TITLE
feat(Checkbox): Expose input checked prop

### DIFF
--- a/packages/docs-site/src/library/pages/components/form/checkbox.md
+++ b/packages/docs-site/src/library/pages/components/form/checkbox.md
@@ -133,7 +133,21 @@ with the field:
     Description: 'Provide the ID for a field and tie it to its label. If one is not provided then a unique id will be created',
   },
   {
-    Name: 'isChecked',
+    Name: 'checked',
+    Type: 'boolean',
+    Required: 'False',
+    Default: 'false',
+    Description: 'Whether the checkbox is checked or not.',
+  },
+  {
+    Name: 'defaultChecked',
+    Type: 'boolean',
+    Required: 'False',
+    Default: 'false',
+    Description: 'Whether the checkbox is checked by default or not.',
+  },
+  {
+    Name: 'isChecked (Deprecated)',
     Type: 'boolean',
     Required: 'False',
     Default: 'false',

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
@@ -56,18 +56,21 @@ stories.add('Formik', () => {
             name="example1"
             component={FormikCheckbox}
             label="My Label 1"
+            type="checkbox"
           />
           <Field
             className="rn-checkbox--is-valid"
             name="example2"
             component={FormikCheckbox}
             label="My Label 2"
+            type="checkbox"
           />
           <Field
             className="rn-checkbox--is-valid"
             name="example3"
             component={FormikCheckbox}
             label="My Label 3"
+            type="checkbox"
           />
           <button type="submit">Submit</button>
         </Form>
@@ -110,18 +113,21 @@ stories.add('Formik checkbox group', () => {
               name="example"
               label="Option 1"
               value="1"
+              type="checkbox"
             />
             <Field
               component={FormikCheckbox}
               name="example"
               label="Option 2"
               value="2"
+              type="checkbox"
             />
             <Field
               component={FormikCheckbox}
               name="example"
               label="Option 3"
               value="3"
+              type="checkbox"
             />
           </FormikGroup>
           <FormikGroup label="Select another option">
@@ -130,18 +136,21 @@ stories.add('Formik checkbox group', () => {
               name="exampleWithError"
               label="Another option 1"
               value="1"
+              type="checkbox"
             />
             <Field
               component={FormikCheckbox}
               name="exampleWithError"
               label="Another option 2"
               value="2"
+              type="checkbox"
             />
             <Field
               component={FormikCheckbox}
               name="exampleWithError"
               label="Another option 3"
               value="3"
+              type="checkbox"
             />
           </FormikGroup>
           <button type="submit">Submit</button>

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.test.tsx
@@ -54,6 +54,52 @@ describe('Checkbox', () => {
         'false'
       )
     })
+
+    it('should not initially render as checked', () => {
+      expect(checkbox.getByTestId('checkbox')).not.toHaveAttribute('checked')
+    })
+  })
+
+  describe('when a field has defaultChecked prop set', () => {
+    beforeEach(() => {
+      label = 'My Label 1'
+      field.value = 'false'
+
+      checkbox = render(
+        <Checkbox
+          name={field.name}
+          value={field.value}
+          label={label}
+          onChange={field.onChange}
+          defaultChecked
+        />
+      )
+    })
+
+    it('should initially render as checked', () => {
+      expect(checkbox.getByTestId('checkbox')).toHaveAttribute('checked')
+    })
+  })
+
+  describe('when a field has checked prop set', () => {
+    beforeEach(() => {
+      label = 'My Label 1'
+      field.value = 'false'
+
+      checkbox = render(
+        <Checkbox
+          name={field.name}
+          value={field.value}
+          label={label}
+          onChange={field.onChange}
+          checked
+        />
+      )
+    })
+
+    it('should initially render as checked', () => {
+      expect(checkbox.getByTestId('checkbox')).toHaveAttribute('checked')
+    })
   })
 
   describe('when a field has an error and the form has not been touched', () => {

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
@@ -9,6 +9,8 @@ export interface CheckboxProps
   extends ComponentWithClass,
     InputValidationProps {
   id?: string
+  checked?: boolean
+  defaultChecked?: boolean
   isChecked?: boolean
   isDisabled?: boolean
   label: string
@@ -23,6 +25,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     {
       className = '',
       id = uuidv4(),
+      checked,
+      defaultChecked,
       isChecked,
       isDisabled,
       label,
@@ -35,6 +39,10 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     },
     ref
   ) => {
+    console.warn(
+      '`isChecked` prop has been deprecated, use `checked` and `defaultChecked`'
+    )
+
     const classes = classNames(
       'rn-checkbox',
       {
@@ -58,10 +66,11 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
               type="checkbox"
               name={name}
               value={value}
-              defaultChecked={isChecked}
+              defaultChecked={isChecked || defaultChecked}
               onChange={onChange}
               onBlur={onBlur}
               disabled={isDisabled}
+              checked={checked}
               {...rest}
               data-testid="checkbox"
             />


### PR DESCRIPTION
## Related issue

Closes #1398

## Overview

Explicitly expose `checked` and `defaultChecked` props and mark `isChecked` as deprecated.

## Reason

>Currently, there is an isChecked prop which maps to the input defaultChecked prop. However, the input's checked prop should be exposed.

## Work carried out

- [x] Explicitly expose new props
- [x] Mark old prop as deprecated
- [x] Add automated tests
- [x] Fix some Formik stories
- [x] Update docs-site documentation