### PR TITLE
feat(Pagination): Expose `initialPage` prop

### DIFF
--- a/packages/docs-site/src/library/pages/components/pagination.md
+++ b/packages/docs-site/src/library/pages/components/pagination.md
@@ -70,6 +70,13 @@ The Pagination component allows an end user to navigate between pages of records
 ### Pagination Properties
 <DataTable data={[
   {
+    Name: 'initialPage',
+    Type: 'Number',
+    Required: 'False',
+    Default: '1',
+    Description: 'The active page presented when loaded.',
+  },
+  {
     Name: 'onChange',
     Type: 'Function<any>',
     Required: 'False',

--- a/packages/react-component-library/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.stories.tsx
@@ -9,3 +9,12 @@ const stories = storiesOf('Pagination', module)
 stories.add('Default', () => (
   <Pagination onChange={action('onChange')} pageSize={10} total={1000} />
 ))
+
+stories.add('Initial page 5', () => (
+  <Pagination
+    initialPage={5}
+    onChange={action('onChange')}
+    pageSize={10}
+    total={1000}
+  />
+))

--- a/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
@@ -347,4 +347,15 @@ describe('Pagination', () => {
       expect(wrapper.getByText('Next')).not.toHaveAttribute('disabled')
     })
   })
+
+  describe('when the initial page is 5', () => {
+    beforeEach(() => {
+      wrapper = render(<Pagination initialPage={5} pageSize={10} total={45} />)
+    })
+
+    it('should apply the `is-active` class to the appropriate page', () => {
+      expect(wrapper.getByText('5').classList.contains('is-active')).toBe(true)
+    })
+  })
+
 })

--- a/packages/react-component-library/src/components/Pagination/Pagination.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.tsx
@@ -7,12 +7,14 @@ import { usePageChange, ELLIPSIS } from './usePageChange'
 import { getKey } from '../../helpers'
 
 interface PaginationProps {
+  initialPage?: number
   onChange?: (currentPage: number, totalPages: number) => void
   pageSize: number
   total: number
 }
 
 export const Pagination: React.FC<PaginationProps> = ({
+  initialPage = 1,
   onChange,
   pageSize,
   total,
@@ -20,7 +22,7 @@ export const Pagination: React.FC<PaginationProps> = ({
   const totalPages = Math.ceil(total / pageSize)
 
   const { currentPage, changePage, pageNumbers } = usePageChange(
-    1,
+    initialPage,
     totalPages,
     onChange
   )


### PR DESCRIPTION
## Related issue
Fixes #1617 

## Overview
Exposes `initialPage` for selecting the active page when loading the component.

## Reason
Consumers currently have no way of selecting the initial page when the component is loaded.

## Work carried out
- [x] Expose `initialPage` prop
