### PR TITLE
fix(Timeline): Change z-indexes to fix stacking of Timeline elements

### DIFF
--- a/packages/design-tokens/src/tokens/zindex.json
+++ b/packages/design-tokens/src/tokens/zindex.json
@@ -6,17 +6,26 @@
     "modal": {
       "value": "8000"
     },
-    "overlay": {
+    "masthead": {
       "value": "7000"
     },
-    "dropdown": {
+    "sidebar": {
+      "value": "7000"
+    },
+    "overlay": {
       "value": "6000"
     },
-    "header": {
+    "dropdown": {
       "value": "5000"
     },
-    "footer": {
+    "header": {
       "value": "4000"
+    },
+    "footer": {
+      "value": "3000"
+    },
+    "timeline": {
+     "value": "0"
     },
     "body": {
       "value": "0"

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -108,10 +108,11 @@ function getDayWidth(
   return (dayWidth || unitWidth || DEFAULTS.UNIT_WIDTH) * multiplier
 }
 
-const { color, spacing } = selectors
+const { color, spacing, zIndex } = selectors
 
 const StyledTimeline = styled.div`
   position: relative;
+  z-index: ${zIndex('timeline', 0)};
   display: flex;
   width: 100%;
   background-color: ${color('neutral', 'white')};

--- a/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
@@ -41,7 +41,7 @@ const StyledTimelineMonth = styled.div`
     width: 1rem;
     height: 100vh;
     border-right: ${spacing('px')} dashed ${color('neutral', '200')};
-    z-index ${zIndex('body', 1)}
+    z-index: ${zIndex('body', 1)};
   }
 `
 

--- a/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
@@ -33,7 +33,7 @@ const StyledTimelineTodayMarker = styled.div`
   width: ${spacing('px')};
   height: 100vh;
   background-color: ${color('danger', '500')};
-  z-index: ${zIndex('body', 2)};
+  z-index: ${zIndex('body', 999)};
 
   &::before {
     content: 'Today';

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/Sidebar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/Sidebar.tsx
@@ -23,12 +23,13 @@ interface StyledSidebarProps {
   isOpen?: boolean
 }
 
-const { color, spacing, fontSize } = selectors
+const { color, spacing, fontSize, zIndex } = selectors
 
 const StyledSidebar = styled.aside<StyledSidebarProps>`
   display: inline-flex;
   flex-direction: column;
   position: relative;
+  z-index: ${zIndex('sidebar', 0)};
   width: ${({ isOpen }) => (isOpen ? '18rem' : '3.75rem')};
   height: 100vh;
   background-color: ${color('neutral', '700')};


### PR DESCRIPTION
- Added Masthead, Timeline, and Sidebar global z-index tokens
- Added missing colon to the `StyledTimelineMonth` component z-index rule
- Scoped the Timeline to its own stacking context
- Bumped SidebarE's z-index to the new design token
- Bump the z-index of the Today marker to be higher than all other components in the Timeline


This should fix the immediate issues in #1565, however we will need a z-index review at some point to ensure we can prevent these bugs happening again.