### PR TITLE
docs(ReactComponentLibrary): Add note about peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ npm install @royalnavy/css-framework @royalnavy/react-component-library
 yarn add @royalnavy/css-framework @royalnavy/react-component-library
 ```
 
+Note: As of `2.16.0` the [`styled-components`](https://github.com/styled-components/styled-components) package is now a required [peerDependency](https://nodejs.org/en/blog/npm/peer-dependencies/).
+
 ### Quick start
 
 Here's a quick example application to get you started:

--- a/packages/docs-site/src/library/pages/get-started/development/installation.md
+++ b/packages/docs-site/src/library/pages/get-started/development/installation.md
@@ -18,6 +18,8 @@ npm install @royalnavy/css-framework @royalnavy/react-component-library
 yarn add @royalnavy/css-framework @royalnavy/react-component-library
 ```
 
+Note: As of `2.16.0` the [`styled-components`](https://github.com/styled-components/styled-components) package is now a required [peerDependency](https://nodejs.org/en/blog/npm/peer-dependencies/).
+
 ### Quick start
 
 Here's a quick example of an application to get you started:


### PR DESCRIPTION
## Related issue

Closes #1684

## Overview

`styled-components` is marked as a peerDependency as of `2.16.0`.