### PR TITLE
refactor(Select): Leverage more of `components` from react-select

### DIFF
--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -83,7 +83,7 @@
     "@types/node": "^14.0.26",
     "@types/react": "^16.9.19",
     "@types/react-dom": "^17.0.0",
-    "@types/react-select": "^3.0.10",
+    "@types/react-select": "^3.0.27",
     "@types/react-transition-group": "^4.2.3",
     "@types/styled-components": "^5.1.3",
     "@types/testing-library__react": "^10.0.1",
@@ -161,7 +161,7 @@
     "react-day-picker": "^7.4.8",
     "react-indiana-drag-scroll": "^1.5.5",
     "react-responsive": "^8.0.3",
-    "react-select": "^3.0.8",
+    "react-select": "^3.1.1",
     "react-tether": "^2.0.7",
     "react-toast-notifications": "^2.4.0",
     "react-transition-group": "^4.4.1"

--- a/packages/react-component-library/src/components/Badge/Badge.tsx
+++ b/packages/react-component-library/src/components/Badge/Badge.tsx
@@ -24,7 +24,7 @@ export type BadgeSizeType =
   | typeof BADGE_SIZE.LARGE
   | typeof BADGE_SIZE.XLARGE
 
-interface BadgeProps extends ComponentWithClass {
+export interface BadgeProps extends ComponentWithClass {
   color?: BadgeColorType
   colorVariant?:
     | typeof BADGE_COLOR_VARIANT.FADED

--- a/packages/react-component-library/src/components/Select/Input.tsx
+++ b/packages/react-component-library/src/components/Select/Input.tsx
@@ -4,7 +4,9 @@ import { components, InputProps } from 'react-select'
 import { selectors } from '@royalnavy/design-tokens'
 import styled from 'styled-components'
 
-const { color, fontSize, spacing } = selectors
+import { StyledLabel } from './partials/StyledLabel'
+
+const { fontSize, spacing } = selectors
 
 export interface SelectInputProps extends InputProps {
   'aria-label'?: string
@@ -20,19 +22,6 @@ const StyledInputContainer = styled.div`
     padding: 0;
     margin: 0;
   }
-`
-
-export const StyledLabel = styled.label`
-  display: block;
-  font-size: ${fontSize('base')};
-  color: ${color('neutral', '400')};
-  position: absolute;
-  top: 0;
-  left: 0;
-  transform-origin: top left;
-  transform: translate(${spacing('6')}, ${spacing('6')}) scale(1);
-  transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
-    transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
 `
 
 const StyledInput = styled(components.Input)`

--- a/packages/react-component-library/src/components/Select/Input.tsx
+++ b/packages/react-component-library/src/components/Select/Input.tsx
@@ -1,33 +1,15 @@
 import React from 'react'
 import get from 'lodash/get'
-import { components, InputProps } from 'react-select'
-import { selectors } from '@royalnavy/design-tokens'
-import styled from 'styled-components'
+import { InputProps } from 'react-select'
 
+import { StyledInput } from './partials/StyledInput'
+import { StyledInputContainer } from './partials/StyledInputContainer'
 import { StyledLabel } from './partials/StyledLabel'
-
-const { fontSize, spacing } = selectors
 
 export interface SelectInputProps extends InputProps {
   'aria-label'?: string
   id?: string
 }
-
-const StyledInputContainer = styled.div`
-  display: flex;
-  align-items: center;
-  height: inherit;
-
-  &&& > * {
-    padding: 0;
-    margin: 0;
-  }
-`
-
-const StyledInput = styled(components.Input)`
-  font-size: ${fontSize('base')};
-  margin: ${spacing('6')} 0 0;
-`
 
 export const Input: React.FC<SelectInputProps> = (props) => {
   const { 'aria-label': ariaLabel, ...rest } = props

--- a/packages/react-component-library/src/components/Select/Option.tsx
+++ b/packages/react-component-library/src/components/Select/Option.tsx
@@ -14,9 +14,9 @@ export interface SelectOptionWithBadgeType {
   value: string
 }
 
-export const Option: React.FC<
-  OptionProps<SelectOptionWithBadgeType, boolean>
-> = (props) => {
+export const Option: React.FC<OptionProps<SelectOptionWithBadgeType, false>> = (
+  props
+) => {
   const {
     data: { badge, icon, label },
   } = props

--- a/packages/react-component-library/src/components/Select/Option.tsx
+++ b/packages/react-component-library/src/components/Select/Option.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
-import { components } from 'react-select'
 import { OptionProps } from 'react-select/src/components/Option'
-import { selectors } from '@royalnavy/design-tokens'
-import styled from 'styled-components'
 
-import { Badge, BADGE_SIZE } from '../Badge'
-
-const { color, fontSize, spacing } = selectors
+import { BADGE_SIZE } from '../Badge'
+import { StyledBadge } from './partials/StyledBadge'
+import { StyledOption } from './partials/StyledOption'
+import { StyledOptionEndAdornment } from './partials/StyledOptionEndAdornment'
+import { StyledOptionLabel } from './partials/StyledOptionLabel'
 
 export interface SelectOptionWithBadgeType {
   badge?: string | number
@@ -14,47 +13,6 @@ export interface SelectOptionWithBadgeType {
   label: string
   value: string
 }
-
-const StyledOption = styled(components.Option)`
-  position: relative;
-  border-radius: 2px;
-  color: ${color('neutral', '500')};
-  display: flex;
-  align-items: center;
-
-  .rn-select__option--is-focused {
-    background-color: ${color('neutral', '100')};
-    color: ${color('neutral', '500')};
-  }
-
-  .rn-select__option--is-selected {
-    background-color: ${color('action', '600')};
-    color: ${color('neutral', 'white')};
-  }
-
-  &&& {
-    padding: ${spacing('4')};
-    margin: 0;
-  }
-`
-
-const StyledLabel = styled.span`
-  font-size: ${fontSize('base')};
-  font-weight: 500;
-`
-
-const StyledEndAdornment = styled.span`
-  position: absolute;
-  right: ${spacing('4')};
-  top: 50%;
-  transform: translateY(-50%);
-  height: ${spacing('7')};
-`
-
-const StyledBadge = styled(Badge)`
-  transform: translateY(-1px);
-  margin-left: ${spacing('2')};
-`
 
 export const Option: React.FC<
   OptionProps<SelectOptionWithBadgeType, boolean>
@@ -65,9 +23,11 @@ export const Option: React.FC<
 
   return (
     <StyledOption data-testid="select-option" {...props}>
-      <StyledLabel data-testid="select-option-label">{label}</StyledLabel>
+      <StyledOptionLabel data-testid="select-option-label">
+        {label}
+      </StyledOptionLabel>
       {badge && <StyledBadge size={BADGE_SIZE.SMALL}>{badge}</StyledBadge>}
-      {icon && <StyledEndAdornment>{icon}</StyledEndAdornment>}
+      {icon && <StyledOptionEndAdornment>{icon}</StyledOptionEndAdornment>}
     </StyledOption>
   )
 }

--- a/packages/react-component-library/src/components/Select/Option.tsx
+++ b/packages/react-component-library/src/components/Select/Option.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { components } from 'react-select'
 import { OptionProps } from 'react-select/src/components/Option'
 import { selectors } from '@royalnavy/design-tokens'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import { Badge, BADGE_SIZE } from '../Badge'
 

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { fireEvent, render, RenderResult } from '@testing-library/react'
 import { IconAnchor } from '@royalnavy/icon-library'
-import userEvent from '@testing-library/user-event'
 
 import { Select } from '.'
 

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -1,16 +1,17 @@
 import React from 'react'
 import ReactSelect, { Props as ReactSelectProps } from 'react-select'
-import { selectors } from '@royalnavy/design-tokens'
-import styled from 'styled-components'
 
 import { DropdownIndicator } from '../Dropdown/DropdownIndicator'
-import { Input, StyledLabel } from './Input'
+import { Input } from './Input'
 import { SingleValue } from './SingleValue'
 import { Option, SelectOptionWithBadgeType } from './Option'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { InputValidationProps } from '../../common/InputValidationProps'
-
-const { color, spacing } = selectors
+import { StyledMenuList } from './partials/StyledMenuList'
+import { StyledMenu } from './partials/StyledMenu'
+import { StyledValueContainer } from './partials/StyledValueContainer'
+import { StyledIndicatorSeparator } from './partials/StyledIndicatorSeparator'
+import { StyledControl } from './partials/StyledControl'
 
 export interface SelectProps
   extends ReactSelectProps<any>,
@@ -22,70 +23,6 @@ export interface SelectProps
   options: SelectOptionWithBadgeType[]
   value?: string
 }
-
-const StyledReactSelect = styled(ReactSelect)`
-  .rn-select__control {
-    padding: 0;
-    margin: 0;
-    height: 44px;
-  }
-
-  .rn-select__control--is-focused,
-  .rn-select__control:hover {
-    border-color: ${color('action', '600')};
-    box-shadow: 0 0 0 1px ${color('action', '600')},
-      0 0 0 4px ${color('action', '100')};
-  }
-
-  .rn-select__control--is-focused
-    ${StyledLabel},
-    .rn-select__value-container--has-value
-    ${StyledLabel} {
-    transform: translate(${spacing('6')}, ${spacing('2')}) scale(0.8);
-  }
-
-  .rn-select__control--menu-is-open {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-    border-bottom-color: transparent;
-  }
-
-  .rn-select__indicator-separator {
-    margin-right: ${spacing('3')};
-  }
-
-  .rn-select__menu {
-    margin-top: -${spacing('px')};
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-    box-shadow: 0 0 0 1px ${color('action', '600')},
-      -2px 2px 0 2px ${color('action', '100')},
-      2px 2px 0 2px ${color('action', '100')};
-    border: 1px solid ${color('action', '600')};
-    border-top: 0;
-    background: ${color('neutral', 'white')};
-    
-    &::after {
-      position: absolute;
-      top: -1px;
-      right: 0;
-      left: 0;
-      height: 1px;
-      background: ${color('neutral', 'white')};
-      content: '';
-    }
-  }
-
-  .rn-select__menu-list {
-    padding-left: ${spacing('2')};
-    padding-right: ${spacing('2')};
-  }
-
-  .rn-select__value-container {
-    padding: 0 0 0 ${spacing('6')};
-    height: inherit;
-  }
-`
 
 export const Select: React.FC<SelectProps> = ({
   label,
@@ -110,7 +47,7 @@ export const Select: React.FC<SelectProps> = ({
   const selectedOption = options.find((option) => option.value === value)
 
   return (
-    <StyledReactSelect
+    <ReactSelect
       aria-label={label}
       classNamePrefix="rn-select"
       components={{
@@ -118,6 +55,11 @@ export const Select: React.FC<SelectProps> = ({
         Input,
         Option,
         SingleValue,
+        Control: StyledControl,
+        IndicatorSeparator: StyledIndicatorSeparator,
+        Menu: StyledMenu,
+        MenuList: StyledMenuList,
+        ValueContainer: StyledValueContainer,
       }}
       isClearable
       name={name}

--- a/packages/react-component-library/src/components/Select/SingleValue.tsx
+++ b/packages/react-component-library/src/components/Select/SingleValue.tsx
@@ -1,31 +1,14 @@
 import React from 'react'
-import { components } from 'react-select'
-import { selectors } from '@royalnavy/design-tokens'
 import { SingleValueProps } from 'react-select/src/components/SingleValue'
-import styled from 'styled-components'
 
-import { Badge, BADGE_SIZE } from '../Badge'
+import { BADGE_SIZE } from '../Badge'
+import { StyledBadge } from './partials/StyledBadge'
 import { SelectOptionWithBadgeType } from './Option'
+import { StyledSingleValue } from './partials/StyledSingleValue'
 
-const { fontSize, spacing } = selectors
-
-const StyledSingleValue = styled(components.SingleValue)`
-  font-size: ${fontSize('base')};
-  overflow: visible;
-  
-  &&& {
-    margin: ${spacing('3')} 0 0 0;
-  }
-`
-
-const StyledBadge = styled(Badge)`
-  transform: translateY(-1px);
-  margin-left: ${spacing('2')};
-`
-
-export const SingleValue: React.FC<SingleValueProps<
-  SelectOptionWithBadgeType
->> = ({ children, ...props }) => {
+export const SingleValue: React.FC<
+  SingleValueProps<SelectOptionWithBadgeType>
+> = ({ children, ...props }) => {
   const { badge } = props.data
 
   return (

--- a/packages/react-component-library/src/components/Select/partials/StyledBadge.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledBadge.tsx
@@ -1,0 +1,10 @@
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+import { Badge, BadgeProps } from '../../Badge'
+
+const { spacing } = selectors
+
+export const StyledBadge = styled(Badge)<BadgeProps>`
+  transform: translateY(-1px);
+  margin-left: ${spacing('2')};
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledControl.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledControl.tsx
@@ -1,0 +1,30 @@
+import { components } from 'react-select'
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+import { StyledLabel } from './StyledLabel'
+
+const { color, spacing } = selectors
+
+export const StyledControl = styled(components.Control)`
+  padding: 0;
+  margin: 0;
+  height: 44px;
+
+  .rn-select__control--is-focused,
+  &:hover {
+    border-color: ${color('action', '600')};
+    box-shadow: 0 0 0 1px ${color('action', '600')},
+      0 0 0 4px ${color('action', '100')};
+  }
+
+  .rn-select__control--menu-is-open {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-color: transparent;
+  }
+
+  &.rn-select__control--is-focused ${StyledLabel} {
+    transform: translate(${spacing('6')}, ${spacing('2')}) scale(0.8);
+  }
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledIndicatorSeparator.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledIndicatorSeparator.tsx
@@ -1,0 +1,9 @@
+import { components } from 'react-select'
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { spacing } = selectors
+
+export const StyledIndicatorSeparator = styled(components.IndicatorSeparator)`
+  margin-right: ${spacing('3')};
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledInput.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledInput.tsx
@@ -1,0 +1,10 @@
+import { components } from 'react-select'
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { fontSize, spacing } = selectors
+
+export const StyledInput = styled(components.Input)`
+  font-size: ${fontSize('base')};
+  margin: ${spacing('6')} 0 0;
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledInputContainer.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledInputContainer.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components'
+
+export const StyledInputContainer = styled.div`
+  display: flex;
+  align-items: center;
+  height: inherit;
+
+  &&& > * {
+    padding: 0;
+    margin: 0;
+  }
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledLabel.tsx
@@ -1,0 +1,17 @@
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { color, fontSize, spacing } = selectors
+
+export const StyledLabel = styled.label`
+  display: block;
+  font-size: ${fontSize('base')};
+  color: ${color('neutral', '400')};
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: top left;
+  transform: translate(${spacing('6')}, ${spacing('6')}) scale(1);
+  transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
+    transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledMenu.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledMenu.tsx
@@ -1,0 +1,27 @@
+import { components } from 'react-select'
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { color, spacing } = selectors
+
+export const StyledMenu = styled(components.Menu)`
+  margin-top: -${spacing('px')};
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  box-shadow: 0 0 0 1px ${color('action', '600')},
+    -2px 2px 0 2px ${color('action', '100')},
+    2px 2px 0 2px ${color('action', '100')};
+  border: 1px solid ${color('action', '600')};
+  border-top: 0;
+  background: ${color('neutral', 'white')};
+
+  &::after {
+    position: absolute;
+    top: -1px;
+    right: 0;
+    left: 0;
+    height: 1px;
+    background: ${color('neutral', 'white')};
+    content: '';
+  }
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledMenuList.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledMenuList.tsx
@@ -1,0 +1,10 @@
+import { components } from 'react-select'
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { spacing } = selectors
+
+export const StyledMenuList = styled(components.MenuList)`
+  padding-left: ${spacing('2')};
+  padding-right: ${spacing('2')};
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledOption.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledOption.tsx
@@ -1,0 +1,28 @@
+import { components } from 'react-select'
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { color, spacing } = selectors
+
+export const StyledOption = styled(components.Option)`
+  position: relative;
+  border-radius: 2px;
+  color: ${color('neutral', '500')};
+  display: flex;
+  align-items: center;
+
+  .rn-select__option--is-focused {
+    background-color: ${color('neutral', '100')};
+    color: ${color('neutral', '500')};
+  }
+
+  .rn-select__option--is-selected {
+    background-color: ${color('action', '600')};
+    color: ${color('neutral', 'white')};
+  }
+
+  &&& {
+    padding: ${spacing('4')};
+    margin: 0;
+  }
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledOptionEndAdornment.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledOptionEndAdornment.tsx
@@ -1,0 +1,12 @@
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { spacing } = selectors
+
+export const StyledOptionEndAdornment = styled.span`
+  position: absolute;
+  right: ${spacing('4')};
+  top: 50%;
+  transform: translateY(-50%);
+  height: ${spacing('7')};
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledOptionLabel.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledOptionLabel.tsx
@@ -1,0 +1,9 @@
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { fontSize } = selectors
+
+export const StyledOptionLabel = styled.span`
+  font-size: ${fontSize('base')};
+  font-weight: 500;
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledSingleValue.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledSingleValue.tsx
@@ -1,0 +1,14 @@
+import { components } from 'react-select'
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { fontSize, spacing } = selectors
+
+export const StyledSingleValue = styled(components.SingleValue)`
+  font-size: ${fontSize('base')};
+  overflow: visible;
+
+  &&& {
+    margin: ${spacing('3')} 0 0 0;
+  }
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledValueContainer.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledValueContainer.tsx
@@ -1,0 +1,16 @@
+import { components } from 'react-select'
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+import { StyledLabel } from './StyledLabel'
+
+const { spacing } = selectors
+
+export const StyledValueContainer = styled(components.ValueContainer)`
+  padding: 0 0 0 ${spacing('6')};
+  height: inherit;
+
+  &.rn-select__value-container--has-value ${StyledLabel} {
+    transform: translate(${spacing('6')}, ${spacing('2')}) scale(0.8);
+  }
+`

--- a/yarn.lock
+++ b/yarn.lock
@@ -4307,7 +4307,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-select@^3.0.10":
+"@types/react-select@^3.0.27":
   version "3.0.27"
   resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-3.0.27.tgz#ef0f114458a5eb063e14e99cc6d8d17dec92de60"
   integrity sha512-UBZgS1O/BaXo27F6a5+OGMpOFmpsFWb5HyZ8DyuJ5EOCT57ZKwWS4ko9Eqxb3CzVsyKLAp5BXoZtHZbqaFN7ww==
@@ -6162,7 +6162,15 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bl@^1.0.0, bl@^4.0.0, bl@^4.0.3:
+bl@^1.0.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.3.tgz#1e8dd80142eac80d7158c9dccc047fb620e035e7"
+  integrity sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
+
+bl@^4.0.0, bl@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
   integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
@@ -9007,7 +9015,14 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
-dot-prop@^4.2.0, dot-prop@^5.1.0, dot-prop@^5.2.0:
+dot-prop@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
+  integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
+  dependencies:
+    is-obj "^1.0.0"
+
+dot-prop@^5.1.0, dot-prop@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
@@ -13471,7 +13486,7 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.1:
+is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
@@ -19153,7 +19168,7 @@ react-responsive@^8.0.3:
     prop-types "^15.6.1"
     shallow-equal "^1.1.0"
 
-react-select@^3.0.8:
+react-select@^3.0.8, react-select@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.1.tgz#156a5b4a6c22b1e3d62a919cb1fd827adb4060bc"
   integrity sha512-HjC6jT2BhUxbIbxMZWqVcDibrEpdUJCfGicN0MMV+BQyKtCaPTgFekKWiOizSCy4jdsLMGjLqcFGJMhVGWB0Dg==
@@ -19382,7 +19397,7 @@ read@1, read@^1.0.7, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==


### PR DESCRIPTION
## Related issue
Closes #1709 

## Overview
Refactor existing code to further utilise `react-select` `components`. This change also makes further use of the `partials` pattern for styled-components.

## Reason
Existing code could be simplified and easier to understand with consistent patterns.

## Work carried out
- [x] Refactor to use react-select components
- [x] Refactor to use partials