### PR TITLE
ci(GHA): Bump node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 13
+          node-version: 14
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
## Related issue

closes #1760 

## Overview

Update node version in release workflow to v14

## Reason

Release workflow has started failing due to dependency on node v14

## Work carried out

- [x] Edit release.yml

