### PR TITLE
ci(Docs): Change readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Royal Navy [Design System](https://docs.royalnavy.io/)
 
- ![Release](https://github.com/Royal-Navy/design-system/workflows/Release/badge.svg)
+ ![Build & Test Master](https://github.com/Royal-Navy/design-system/workflows/Build%20&%20Test%20Master/badge.svg)
  [![GitHub release](https://img.shields.io/github/release/royal-navy/design-system.svg)](https://github.com/Royal-Navy/design-system/releases) [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://github.com/design-system/blob/master/LICENSE) [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/) [![codecov](https://codecov.io/gh/Royal-Navy/design-system/branch/master/graph/badge.svg)](https://codecov.io/gh/Royal-Navy/design-system)
 
 


### PR DESCRIPTION
## Related issue

closes #1758 

## Overview

Change readme badge

## Link to preview

https://github.com/Royal-Navy/design-system/blob/ci/readme/README.md

## Reason

Replace Release workflow badge with Build & Test Master linked badge

