### PR TITLE
feat(Drawer): Add ability to drill `ref`

### DIFF
--- a/packages/docs-site/src/library/pages/components/drawer.md
+++ b/packages/docs-site/src/library/pages/components/drawer.md
@@ -57,7 +57,7 @@ Drawer is a simple panel that can be triggered to appear on the right hand side 
 </CodeHighlighter>
 
 
-### Avatar Properties
+### Drawer Properties
 <DataTable data={[
   {
     Name: 'className',
@@ -79,6 +79,13 @@ Drawer is a simple panel that can be triggered to appear on the right hand side 
     Required: 'False',
     Default: '',
     Description: 'Callback which is invoked when the the drawer is closed.',
+  },
+  {
+    Name: 'ref',
+    Type: 'React.RefObject<HTMLDivElement>',
+    Required: 'False',
+    Default: '',
+    Description: 'A ref object associated with the drawer wrapper.',
   },
 ]} />
 </Tab>

--- a/packages/react-component-library/src/components/Drawer/Drawer.test.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.test.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React from 'react'
+import React, { useState } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import '@testing-library/jest-dom/extend-expect'
 import {
@@ -131,6 +131,32 @@ describe('Drawer', () => {
           })
         })
       })
+    })
+  })
+
+  describe('when a `ref` prop is specified', () => {
+    beforeEach(() => {
+      const DrawerWithRef: React.FC = () => {
+        const [content, setContent] = useState<string>('Not set')
+
+        return (
+          <Drawer
+            ref={(el) => {
+              if (el) setContent(el.getAttribute('data-testid'))
+            }}
+          >
+            {content}
+          </Drawer>
+        )
+      }
+
+      wrapper = render(<DrawerWithRef />)
+    })
+
+    it('has set the `ref` on the wrapper', () => {
+      expect(wrapper.getByTestId('drawer-content')).toHaveTextContent(
+        'drawer-wrapper'
+      )
     })
   })
 })

--- a/packages/react-component-library/src/components/Drawer/Drawer.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import classNames from 'classnames'
 import { IconClose } from '@royalnavy/icon-library'
 
@@ -11,34 +11,32 @@ interface DrawerProps extends ComponentWithClass {
   onClose?: (event: React.FormEvent<HTMLButtonElement>) => void
 }
 
-export const Drawer: React.FC<DrawerProps> = ({
-  children,
-  onClose,
-  isOpen,
-}) => {
-  const { handleOnClose, open } = useOpenClose(isOpen, onClose)
+export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
+  ({ children, onClose, isOpen }, ref) => {
+    const { handleOnClose, open } = useOpenClose(isOpen, onClose)
 
-  const classes = classNames('rn-drawer', {
-    'is-open': open,
-  })
+    const classes = classNames('rn-drawer', {
+      'is-open': open,
+    })
 
-  return (
-    <div className={classes} data-testid="drawer-wrapper">
-      <div className="rn-drawer__inner">
-        <button
-          className="rn-drawer__close"
-          onClick={handleOnClose}
-          data-testid="drawer-close"
-          aria-label="close"
-        >
-          <IconClose />
-        </button>
-        <div className="rn-drawer__content" data-testid="drawer-content">
-          {children}
+    return (
+      <div className={classes} data-testid="drawer-wrapper" ref={ref}>
+        <div className="rn-drawer__inner">
+          <button
+            className="rn-drawer__close"
+            onClick={handleOnClose}
+            data-testid="drawer-close"
+            aria-label="close"
+          >
+            <IconClose />
+          </button>
+          <div className="rn-drawer__content" data-testid="drawer-content">
+            {children}
+          </div>
         </div>
       </div>
-    </div>
-  )
-}
+    )
+  }
+)
 
 Drawer.displayName = 'Drawer'


### PR DESCRIPTION
## Related issue
Closes #1714 

## Overview
Adds ability to drill `ref` to `Drawer`.

## Reason
Feature is required to implement clicking outside of `Drawer` and closing.

## Work carried out
- [x] Drill `ref`