### PR TITLE
DRAFT: Feature/update lint config

### DIFF
--- a/packages/docs-site/src/components/presenters/data-table/table-body.js
+++ b/packages/docs-site/src/components/presenters/data-table/table-body.js
@@ -4,15 +4,13 @@ import { v4 as uuidv4 } from 'uuid'
 
 import TableRow from './table-row'
 
-const TableBody = ({ rows }) => {
-  return (
-    <tbody className="data-table__body">
-      {rows.map((row) => {
-        return <TableRow key={uuidv4()} cells={row} />
-      })}
-    </tbody>
-  )
-}
+const TableBody = ({ rows }) => (
+  <tbody className="data-table__body">
+    {rows.map((row) => (
+      <TableRow key={uuidv4()} cells={row} />
+    ))}
+  </tbody>
+)
 
 TableBody.propTypes = {
   rows: PropTypes.instanceOf(Array),

--- a/packages/docs-site/src/components/presenters/data-table/table-cell.js
+++ b/packages/docs-site/src/components/presenters/data-table/table-cell.js
@@ -1,13 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const TableCell = ({ column, content }) => {
-  return (
-    <td data-column={column} className="data-table__cell">
-      <span>{content || 'n/a'}</span>
-    </td>
-  )
-}
+const TableCell = ({ column, content }) => (
+  <td data-column={column} className="data-table__cell">
+    <span>{content || 'n/a'}</span>
+  </td>
+)
 
 TableCell.propTypes = {
   column: PropTypes.string.isRequired,

--- a/packages/docs-site/src/components/presenters/data-table/table-head.js
+++ b/packages/docs-site/src/components/presenters/data-table/table-head.js
@@ -4,30 +4,26 @@ import { v4 as uuidv4 } from 'uuid'
 
 import DownArrowIcon from './images/DownArrowIcon'
 
-const TableHead = ({ headings, onClickHeading }) => {
-  return (
-    <thead className="data-table__head">
-      <tr>
-        {headings.map((heading) => {
-          return (
-            <th key={uuidv4()} scope="col" className="data-table__heading">
-              {heading}
-              <button
-                className="data-table__btn-sort"
-                type="button"
-                data-column={heading}
-                onClick={onClickHeading}
-                data-testid={`sort-${heading}`}
-              >
-                <DownArrowIcon />
-              </button>
-            </th>
-          )
-        })}
-      </tr>
-    </thead>
-  )
-}
+const TableHead = ({ headings, onClickHeading }) => (
+  <thead className="data-table__head">
+    <tr>
+      {headings.map((heading) => (
+        <th key={uuidv4()} scope="col" className="data-table__heading">
+          {heading}
+          <button
+            className="data-table__btn-sort"
+            type="button"
+            data-column={heading}
+            onClick={onClickHeading}
+            data-testid={`sort-${heading}`}
+          >
+            <DownArrowIcon />
+          </button>
+        </th>
+      ))}
+    </tr>
+  </thead>
+)
 
 TableHead.propTypes = {
   headings: PropTypes.arrayOf(PropTypes.string),

--- a/packages/docs-site/src/components/presenters/data-table/table-row.js
+++ b/packages/docs-site/src/components/presenters/data-table/table-row.js
@@ -4,21 +4,17 @@ import { v4 as uuidv4 } from 'uuid'
 
 import TableCell from './table-cell'
 
-const TableRow = ({ cells }) => {
-  return (
-    <tr className="data-table__row">
-      {Object.values(cells).map((value, index) => {
-        return (
-          <TableCell
-            key={uuidv4()}
-            column={Object.keys(cells)[index]}
-            content={value}
-          />
-        )
-      })}
-    </tr>
-  )
-}
+const TableRow = ({ cells }) => (
+  <tr className="data-table__row">
+    {Object.values(cells).map((value, index) => (
+      <TableCell
+        key={uuidv4()}
+        column={Object.keys(cells)[index]}
+        content={value}
+      />
+    ))}
+  </tr>
+)
 
 TableRow.propTypes = {
   cells: PropTypes.instanceOf(Object).isRequired,

--- a/packages/docs-site/src/components/presenters/example-timeline.js
+++ b/packages/docs-site/src/components/presenters/example-timeline.js
@@ -13,40 +13,38 @@ import {
   TimelineEvent,
 } from '@royalnavy/react-component-library'
 
-export const ExampleTimeline = () => {
-  return (
-    <Timeline
-      hasSide
-      startDate={new Date(2020, 3, 1)}
-      today={new Date(2020, 3, 3)}
-    >
-      <TimelineTodayMarker />
-      <TimelineMonths />
-      <TimelineWeeks />
-      <TimelineDays />
-      <TimelineHours />
-      <TimelineRows>
-        <TimelineRow name="Row 1">
-          <TimelineEvents>
-            <TimelineEvent
-              startDate={new Date(2020, 2, 14)}
-              endDate={new Date(2020, 3, 4)}
-            >
-              Event 1
-            </TimelineEvent>
-          </TimelineEvents>
-        </TimelineRow>
-        <TimelineRow name="Row 2">
-          <TimelineEvents>
-            <TimelineEvent
-              startDate={new Date(2020, 3, 2)}
-              endDate={new Date(2020, 3, 5)}
-            >
-              Event 2
-            </TimelineEvent>
-          </TimelineEvents>
-        </TimelineRow>
-      </TimelineRows>
-    </Timeline>
-  )
-}
+export const ExampleTimeline = () => (
+  <Timeline
+    hasSide
+    startDate={new Date(2020, 3, 1)}
+    today={new Date(2020, 3, 3)}
+  >
+    <TimelineTodayMarker />
+    <TimelineMonths />
+    <TimelineWeeks />
+    <TimelineDays />
+    <TimelineHours />
+    <TimelineRows>
+      <TimelineRow name="Row 1">
+        <TimelineEvents>
+          <TimelineEvent
+            startDate={new Date(2020, 2, 14)}
+            endDate={new Date(2020, 3, 4)}
+          >
+            Event 1
+          </TimelineEvent>
+        </TimelineEvents>
+      </TimelineRow>
+      <TimelineRow name="Row 2">
+        <TimelineEvents>
+          <TimelineEvent
+            startDate={new Date(2020, 3, 2)}
+            endDate={new Date(2020, 3, 5)}
+          >
+            Event 2
+          </TimelineEvent>
+        </TimelineEvents>
+      </TimelineRow>
+    </TimelineRows>
+  </Timeline>
+)

--- a/packages/docs-site/src/components/presenters/post-article/index.js
+++ b/packages/docs-site/src/components/presenters/post-article/index.js
@@ -2,19 +2,17 @@ import { MDXRenderer } from 'gatsby-plugin-mdx'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const PostArticle = ({ mdx, className, title, description, header }) => {
-  return (
-    <article className={`post-article ${className}`}>
-      {header && (
-        <div className="post-article__header">
-          <h1 className="post-article__title">{title}</h1>
-          <p className="post-article__lede">{description}</p>
-        </div>
-      )}
-      <MDXRenderer>{mdx}</MDXRenderer>
-    </article>
-  )
-}
+const PostArticle = ({ mdx, className, title, description, header }) => (
+  <article className={`post-article ${className}`}>
+    {header && (
+      <div className="post-article__header">
+        <h1 className="post-article__title">{title}</h1>
+        <p className="post-article__lede">{description}</p>
+      </div>
+    )}
+    <MDXRenderer>{mdx}</MDXRenderer>
+  </article>
+)
 
 PostArticle.propTypes = {
   className: PropTypes.string,

--- a/packages/docs-site/src/components/presenters/sketch-widget/index.js
+++ b/packages/docs-site/src/components/presenters/sketch-widget/index.js
@@ -4,31 +4,29 @@ import PropTypes from 'prop-types'
 import SketchLogo from './images/SketchLogo'
 import DownloadIcon from './images/DownloadIcon'
 
-const SketchWidget = ({ name, href }) => {
-  return (
-    <article className="sketch-widget">
-      <header className="sketch-widget__head">
-        <span className="sketch-widget__title">Name in Sketch toolkit</span>
+const SketchWidget = ({ name, href }) => (
+  <article className="sketch-widget">
+    <header className="sketch-widget__head">
+      <span className="sketch-widget__title">Name in Sketch toolkit</span>
 
-        <a
-          className="sketch-widget__link"
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <DownloadIcon />
-          Download Sketch toolkit
-        </a>
-      </header>
-      <section className="sketch-widget__body">
-        <SketchLogo className="sketch-widget__sketch-logo" />
-        <span data-testid="name" className="sketch-widget__name">
-          {name}
-        </span>
-      </section>
-    </article>
-  )
-}
+      <a
+        className="sketch-widget__link"
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <DownloadIcon />
+        Download Sketch toolkit
+      </a>
+    </header>
+    <section className="sketch-widget__body">
+      <SketchLogo className="sketch-widget__sketch-logo" />
+      <span data-testid="name" className="sketch-widget__name">
+        {name}
+      </span>
+    </section>
+  </article>
+)
 
 SketchWidget.propTypes = {
   name: PropTypes.string,

--- a/packages/docs-site/src/utils/nav.js
+++ b/packages/docs-site/src/utils/nav.js
@@ -28,12 +28,10 @@ export function stripLeadingSlash(href) {
  * @returns {array}
  */
 export function restructureNodes(nodes) {
-  return nodes.map((node) => {
-    return {
-      href: stripTrailingSlash(node.node.fields.slug),
-      label: node.node.frontmatter.title,
-    }
-  })
+  return nodes.map((node) => ({
+    href: stripTrailingSlash(node.node.fields.slug),
+    label: node.node.frontmatter.title,
+  }))
 }
 
 /**

--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -33,6 +33,7 @@ module.exports = {
     'import/prefer-default-export': 0,
     'jsx-a11y/label-has-for': 0,
     'no-underscore-dangle': ['error', { allow: ['__typename'] }],
+    'no-use-before-define': 0,
     'prefer-destructuring': 0,
     'prettier/prettier': 0,
     'react/button-has-type': 0,
@@ -47,6 +48,7 @@ module.exports = {
     '@typescript-eslint/ban-ts-ignore': 0,
     '@typescript-eslint/ban-ts-comment': 0,
     '@typescript-eslint/explicit-function-return-type': 0,
+    '@typescript-eslint/no-use-before-define': [1],
     // https://github.com/benmosher/eslint-plugin-import/issues/1615
     'import/extensions': [
       'error',

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -11,22 +11,22 @@
     "access": "public"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.7.0",
-    "@typescript-eslint/parser": "^2.31.0",
-    "eslint": "^7.3.1",
-    "eslint-config-airbnb": "^18.1.0",
-    "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-jest": "^23.9.0",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-prettier": "^3.1.3",
-    "eslint-plugin-react": "^7.19.0",
-    "eslint-plugin-react-hooks": "^4.0.0",
-    "prettier": "^2.0.5"
+    "@typescript-eslint/eslint-plugin": "^4.9.1",
+    "@typescript-eslint/parser": "^4.9.1",
+    "eslint": "^7.15.0",
+    "eslint-config-airbnb": "^18.2.1",
+    "eslint-config-prettier": "^7.0.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jest": "^24.1.3",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-prettier": "^3.2.0",
+    "eslint-plugin-react": "^7.21.5",
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "prettier": "^2.2.1"
   },
   "peerDependencies": {
-    "eslint": "^5.16.0 || ^6.1.0",
-    "prettier": "^1.18.2"
+    "eslint": "^5.16.0 || ^6.1.0 || ^7",
+    "prettier": "^1.18.2 || ^2"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4555,6 +4555,19 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/eslint-plugin@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.9.1.tgz#66758cbe129b965fe9c63b04b405d0cf5280868b"
+  integrity sha512-QRLDSvIPeI1pz5tVuurD+cStNR4sle4avtHhxA+2uyixWGFjKzJ+EaFVRW6dA/jOgjV5DTAjOxboQkRDE8cRlQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.9.1"
+    "@typescript-eslint/scope-manager" "4.9.1"
+    debug "^4.1.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/experimental-utils@2.34.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
@@ -4577,7 +4590,19 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^2.24.0", "@typescript-eslint/parser@^2.31.0":
+"@typescript-eslint/experimental-utils@4.9.1", "@typescript-eslint/experimental-utils@^4.0.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.9.1.tgz#86633e8395191d65786a808dc3df030a55267ae2"
+  integrity sha512-c3k/xJqk0exLFs+cWSJxIjqLYwdHCuLWhnpnikmPQD2+NGAx9KjLYlBDcSI81EArh9FDYSL6dslAUSwILeWOxg==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/scope-manager" "4.9.1"
+    "@typescript-eslint/types" "4.9.1"
+    "@typescript-eslint/typescript-estree" "4.9.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@^2.24.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
   integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
@@ -4587,6 +4612,16 @@
     "@typescript-eslint/typescript-estree" "2.34.0"
     eslint-visitor-keys "^1.1.0"
 
+"@typescript-eslint/parser@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.9.1.tgz#2d74c4db5dd5117379a9659081a4d1ec02629055"
+  integrity sha512-Gv2VpqiomvQ2v4UL+dXlQcZ8zCX4eTkoIW+1aGVWT6yTO+6jbxsw7yQl2z2pPl/4B9qa5JXeIbhJpONKjXIy3g==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.9.1"
+    "@typescript-eslint/types" "4.9.1"
+    "@typescript-eslint/typescript-estree" "4.9.1"
+    debug "^4.1.1"
+
 "@typescript-eslint/scope-manager@4.9.0":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.9.0.tgz#5eefe305d6b71d1c85af6587b048426bfd4d3708"
@@ -4595,10 +4630,23 @@
     "@typescript-eslint/types" "4.9.0"
     "@typescript-eslint/visitor-keys" "4.9.0"
 
+"@typescript-eslint/scope-manager@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.9.1.tgz#cc2fde310b3f3deafe8436a924e784eaab265103"
+  integrity sha512-sa4L9yUfD/1sg9Kl8OxPxvpUcqxKXRjBeZxBuZSSV1v13hjfEJkn84n0An2hN8oLQ1PmEl2uA6FkI07idXeFgQ==
+  dependencies:
+    "@typescript-eslint/types" "4.9.1"
+    "@typescript-eslint/visitor-keys" "4.9.1"
+
 "@typescript-eslint/types@4.9.0":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.9.0.tgz#3fe8c3632abd07095c7458f7451bd14c85d0033c"
   integrity sha512-luzLKmowfiM/IoJL/rus1K9iZpSJK6GlOS/1ezKplb7MkORt2dDcfi8g9B0bsF6JoRGhqn0D3Va55b+vredFHA==
+
+"@typescript-eslint/types@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.9.1.tgz#a1a7dd80e4e5ac2c593bc458d75dd1edaf77faa2"
+  integrity sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA==
 
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
@@ -4627,12 +4675,34 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.9.1.tgz#6e5b86ff5a5f66809e1f347469fadeec69ac50bf"
+  integrity sha512-bzP8vqwX6Vgmvs81bPtCkLtM/Skh36NE6unu6tsDeU/ZFoYthlTXbBmpIrvosgiDKlWTfb2ZpPELHH89aQjeQw==
+  dependencies:
+    "@typescript-eslint/types" "4.9.1"
+    "@typescript-eslint/visitor-keys" "4.9.1"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/visitor-keys@4.9.0":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.9.0.tgz#f284e9fac43f2d6d35094ce137473ee321f266c8"
   integrity sha512-sV45zfdRqQo1A97pOSx3fsjR+3blmwtdCt8LDrXgCX36v4Vmz4KHrhpV6Fo2cRdXmyumxx11AHw0pNJqCNpDyg==
   dependencies:
     "@typescript-eslint/types" "4.9.0"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.9.1.tgz#d76374a58c4ead9e92b454d186fea63487b25ae1"
+  integrity sha512-9gspzc6UqLQHd7lXQS7oWs+hrYggspv/rk6zzEMhCbYwPE/sF7oxo7GAjkS35Tdlt7wguIG+ViWCPtVZHz/ybQ==
+  dependencies:
+    "@typescript-eslint/types" "4.9.1"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.9.0":
@@ -9525,7 +9595,7 @@ eslint-config-airbnb-base@^14.2.1:
     object.assign "^4.1.2"
     object.entries "^1.1.2"
 
-eslint-config-airbnb@^18.0.1, eslint-config-airbnb@^18.1.0:
+eslint-config-airbnb@^18.0.1, eslint-config-airbnb@^18.2.1:
   version "18.2.1"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz#b7fe2b42f9f8173e825b73c8014b592e449c98d9"
   integrity sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==
@@ -9534,12 +9604,17 @@ eslint-config-airbnb@^18.0.1, eslint-config-airbnb@^18.1.0:
     object.assign "^4.1.2"
     object.entries "^1.1.2"
 
-eslint-config-prettier@^6.11.0, eslint-config-prettier@^6.9.0:
+eslint-config-prettier@^6.9.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
   integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
   dependencies:
     get-stdin "^6.0.0"
+
+eslint-config-prettier@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.0.0.tgz#c1ae4106f74e6c0357f44adb076771d032ac0e97"
+  integrity sha512-8Y8lGLVPPZdaNA7JXqnvETVC7IiVRgAP6afQu9gOQRn90YY3otMNh+x7Vr2vMePQntF+5erdSUBqSzCmU/AxaQ==
 
 eslint-config-react-app@^5.2.1:
   version "5.2.1"
@@ -9601,7 +9676,7 @@ eslint-plugin-graphql@^4.0.0:
     lodash.flatten "^4.4.0"
     lodash.without "^4.4.0"
 
-eslint-plugin-import@^2.20.2, eslint-plugin-import@^2.22.0:
+eslint-plugin-import@^2.20.2, eslint-plugin-import@^2.22.0, eslint-plugin-import@^2.22.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
   integrity sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
@@ -9620,14 +9695,21 @@ eslint-plugin-import@^2.20.2, eslint-plugin-import@^2.22.0:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-plugin-jest@^23.6.0, eslint-plugin-jest@^23.9.0:
+eslint-plugin-jest@^23.6.0:
   version "23.20.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz#e1d69c75f639e99d836642453c4e75ed22da4099"
   integrity sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
-eslint-plugin-jsx-a11y@^6.2.3, eslint-plugin-jsx-a11y@^6.3.1:
+eslint-plugin-jest@^24.1.3:
+  version "24.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz#fa3db864f06c5623ff43485ca6c0e8fc5fe8ba0c"
+  integrity sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^4.0.1"
+
+eslint-plugin-jsx-a11y@^6.2.3, eslint-plugin-jsx-a11y@^6.3.1, eslint-plugin-jsx-a11y@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz#a2d84caa49756942f42f1ffab9002436391718fd"
   integrity sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==
@@ -9644,7 +9726,7 @@ eslint-plugin-jsx-a11y@^6.2.3, eslint-plugin-jsx-a11y@^6.3.1:
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
 
-eslint-plugin-prettier@^3.1.2, eslint-plugin-prettier@^3.1.3:
+eslint-plugin-prettier@^3.1.2, eslint-plugin-prettier@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.2.0.tgz#af391b2226fa0e15c96f36c733f6e9035dbd952c"
   integrity sha512-kOUSJnFjAUFKwVxuzy6sA5yyMx6+o9ino4gCdShzBNx4eyFRudWRYKCFolKjoM40PEiuU6Cn7wBLfq3WsGg7qg==
@@ -9656,12 +9738,12 @@ eslint-plugin-react-hooks@^1.7.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
   integrity sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
 
-eslint-plugin-react-hooks@^4.0.0:
+eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
   integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
 
-eslint-plugin-react@^7.18.0, eslint-plugin-react@^7.19.0, eslint-plugin-react@^7.20.6:
+eslint-plugin-react@^7.18.0, eslint-plugin-react@^7.20.6, eslint-plugin-react@^7.21.5:
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz#50b21a412b9574bfe05b21db176e8b7b3b15bff3"
   integrity sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==
@@ -9761,7 +9843,7 @@ eslint@^6.8.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^7.3.1:
+eslint@^7.15.0, eslint@^7.3.1:
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.15.0.tgz#eb155fb8ed0865fcf5d903f76be2e5b6cd7e0bc7"
   integrity sha512-Vr64xFDT8w30wFll643e7cGrIkPEU50yIiI36OdSIDoSGguIeaLzBo0vpGvzo9RECUqq7htURfwEtKqwytkqzA==
@@ -18437,7 +18519,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.0.5, prettier@^2.1.2:
+prettier@^2.0.5, prettier@^2.1.2, prettier@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==


### PR DESCRIPTION
The existing lint package uses an outdated version of the eslint typescript parser (if you look in the react component package you can see it was overriden).

This change fixes the issue and also adds a rule to address a known problem when trying to lint react projects that incorrectly report that 'React' is used before it is defined.