### PR TITLE
feat(ContextMenu): Prevent padding without icons

### DIFF
--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -57,3 +57,44 @@ export const Default = () => {
 }
 
 Default.storyName = 'Default'
+
+export const NoIcons = () => {
+  const ref = useRef()
+
+  return (
+    <>
+      <div
+        ref={ref}
+        style={{
+          display: 'inline-block',
+          padding: '1rem',
+          backgroundColor: '#c9c9c9',
+        }}
+      >
+        Right click me!
+      </div>
+
+      <ContextMenu attachedToRef={ref}>
+        <ContextMenuItem link={<Link href="/edit">Edit</Link>} />
+        <ContextMenuItem link={<Link href="/delete">Delete</Link>} />
+        <ContextMenuItem link={<Link href="/delete">Action</Link>} />
+        <ContextMenuDivider />
+        <ContextMenuItem link={<Link href="/add">Add</Link>} />
+        <ContextMenuDivider />
+        <ContextMenuItem
+          link={<Link href="/something-else">Do something else</Link>}
+        />
+        <ContextMenuDivider />
+        <ContextMenuItem
+          link={(
+            <Link href="/something-else">
+              This is too much text to put into a context menu item
+            </Link>
+          )}
+        />
+      </ContextMenu>
+    </>
+  )
+}
+
+NoIcons.storyName = 'No icons'

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { RenderResult, render, fireEvent, act } from '@testing-library/react'
 import { IconSettings } from '@royalnavy/icon-library'
+import 'jest-styled-components'
 
 import { ContextMenu, ContextMenuItem, ContextMenuDivider } from '.'
 import { Link } from '../Link'
@@ -18,7 +19,7 @@ describe('ContextMenu', () => {
   let wrapper: RenderResult
   let onClickSpy: (e: React.MouseEvent<HTMLElement>) => void
 
-  describe('With links and closed', () => {
+  describe('With links, no icons and closed', () => {
     beforeEach(() => {
       const ContextExample = () => {
         const ref = useRef()
@@ -46,7 +47,7 @@ describe('ContextMenu', () => {
     })
   })
 
-  describe('With links and open', () => {
+  describe('With links, no icons and and open', () => {
     beforeEach(() => {
       const ContextExample = () => {
         const ref = useRef()
@@ -69,6 +70,12 @@ describe('ContextMenu', () => {
       wrapper = render(<ContextExample />)
 
       fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+    })
+
+    it('should add margin to items', () => {
+      wrapper.getAllByTestId('context-menu-item-text').forEach((item) => {
+        expect(item).toHaveStyleRule('margin-left', '1.25rem')
+      })
     })
 
     it('is rendered to the DOM', () => {
@@ -147,6 +154,12 @@ describe('ContextMenu', () => {
       wrapper = render(<ContextExample />)
 
       fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+    })
+
+    it('should not add margin to items', () => {
+      wrapper.getAllByTestId('context-menu-item-text').forEach((item) => {
+        expect(item).not.toHaveStyleRule('margin-left', '1.25rem')
+      })
     })
 
     it('renders the icons', () => {

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
@@ -1,44 +1,12 @@
 import React from 'react'
-import styled, { css } from 'styled-components'
-import { selectors } from '@royalnavy/design-tokens'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { useRightClick } from '../../hooks/useRightClick'
-import { StyledText } from './ContextMenuItem'
+import { StyledContextMenu } from './partials/StyledContextMenu'
 
 interface ContextMenuProps extends ComponentWithClass {
   attachedToRef?: React.RefObject<HTMLElement>
 }
-
-interface StyledContextMenuProps {
-  top: number
-  left: number
-  $hasIcons: boolean
-}
-
-const { color, spacing } = selectors
-
-const StyledContextMenu = styled.ol<StyledContextMenuProps>`
-  position: fixed;
-  top: ${({ top }) => `${top}px`};
-  left: ${({ left }) => `${left}px`};
-  min-width: 120px;
-  max-width: 240px;
-  padding: ${spacing('2')};
-  list-style-type: none;
-  background-color: ${color('neutral', 'white')};
-  border-radius: 4px;
-  border: 1px solid ${color('neutral', '200')};
-  box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.12), 0 1px 3px 0 rgba(0, 0, 0, 0.04);
-
-  ${({ $hasIcons }) =>
-    !$hasIcons &&
-    css`
-      ${StyledText} {
-        margin-left: 0;
-      }
-    `}
-`
 
 export const ContextMenu: React.FC<ContextMenuProps> = ({
   className,

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { useRightClick } from '../../hooks/useRightClick'
+import { StyledText } from './ContextMenuItem'
 
 interface ContextMenuProps extends ComponentWithClass {
   attachedToRef?: React.RefObject<HTMLElement>
@@ -12,6 +13,7 @@ interface ContextMenuProps extends ComponentWithClass {
 interface StyledContextMenuProps {
   top: number
   left: number
+  $hasIcons: boolean
 }
 
 const { color, spacing } = selectors
@@ -28,6 +30,14 @@ const StyledContextMenu = styled.ol<StyledContextMenuProps>`
   border-radius: 4px;
   border: 1px solid ${color('neutral', '200')};
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.12), 0 1px 3px 0 rgba(0, 0, 0, 0.04);
+
+  ${({ $hasIcons }) =>
+    !$hasIcons &&
+    css`
+      ${StyledText} {
+        margin-left: 0;
+      }
+    `}
 `
 
 export const ContextMenu: React.FC<ContextMenuProps> = ({
@@ -37,6 +47,10 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
 }) => {
   const { position, isOpen } = useRightClick(attachedToRef)
 
+  const hasIcons = !!React.Children.toArray(children).filter(
+    (child: React.ReactNode) => (child as React.ReactElement)?.props?.icon
+  ).length
+
   return (
     <>
       {isOpen && (
@@ -44,6 +58,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
           className={className}
           top={position.y}
           left={position.x}
+          $hasIcons={hasIcons}
           data-testid="context-menu"
         >
           {children}

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenuDivider.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenuDivider.tsx
@@ -1,14 +1,6 @@
 import React from 'react'
-import styled from 'styled-components'
-import { selectors } from '@royalnavy/design-tokens'
 
-const { color, spacing } = selectors
-
-const StyledContextMenuDivider = styled.div`
-  height: 1px;
-  background-color: ${color('neutral', '100')};
-  margin: ${spacing('2')} -${spacing('2')};
-`
+import { StyledContextMenuDivider } from './partials/StyledContextMenuDivider'
 
 export const ContextMenuDivider: React.FC = () => {
   return <StyledContextMenuDivider data-testid="context-menu-divider" />

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenuItem.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenuItem.tsx
@@ -1,62 +1,13 @@
 import React from 'react'
-import styled from 'styled-components'
-import { selectors } from '@royalnavy/design-tokens'
 
 import { NavItem } from '../../common/Nav'
+import { StyledContextMenuItem } from './partials/StyledContextMenuItem'
+import { StyledIcon } from './partials/StyledIcon'
+import { StyledText } from './partials/StyledText'
 
 interface ContextMenuItemProps extends NavItem {
   icon?: React.ReactNode
 }
-
-interface StyledTextProps {
-  hasIcon?: boolean
-}
-
-const { color, fontSize, spacing } = selectors
-
-export const StyledContextMenuItem = styled.li`
-  border-radius: 2px;
-
-  > * {
-    text-overflow: ellipsis;
-    display: flex;
-    padding: ${spacing('3')} ${spacing('4')};
-    line-height: 1.2;
-  }
-
-  &:hover {
-    background-color: ${color('neutral', '100')};
-
-    > * {
-      text-decoration: none;
-    }
-  }
-`
-
-export const StyledIcon = styled.div`
-  display: inline-flex;
-  align-items: center;
-  margin-right: ${spacing('2')};
-
-  svg {
-    color: ${color('neutral', '300')};
-  }
-`
-
-export const StyledText = styled.div<StyledTextProps>`
-  color: ${color('neutral', '400')};
-  font-weight: 600;
-  font-size: ${fontSize('base')};
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-
-  ${({ hasIcon }) => !hasIcon && `margin-left: 1.25rem;`}
-
-  ${StyledContextMenuItem}:hover & {
-    color: ${color('neutral', '400')};
-  }
-`
 
 export const ContextMenuItem: React.FC<ContextMenuItemProps> = ({
   icon,

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenuItem.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenuItem.tsx
@@ -14,8 +14,9 @@ interface StyledTextProps {
 
 const { color, fontSize, spacing } = selectors
 
-const StyledContextMenuItem = styled.li`
+export const StyledContextMenuItem = styled.li`
   border-radius: 2px;
+
   > * {
     text-overflow: ellipsis;
     display: flex;
@@ -32,7 +33,7 @@ const StyledContextMenuItem = styled.li`
   }
 `
 
-const StyledIcon = styled.div`
+export const StyledIcon = styled.div`
   display: inline-flex;
   align-items: center;
   margin-right: ${spacing('2')};
@@ -42,7 +43,7 @@ const StyledIcon = styled.div`
   }
 `
 
-const StyledText = styled.div<StyledTextProps>`
+export const StyledText = styled.div<StyledTextProps>`
   color: ${color('neutral', '400')};
   font-weight: 600;
   font-size: ${fontSize('base')};
@@ -68,7 +69,9 @@ export const ContextMenuItem: React.FC<ContextMenuItemProps> = ({
     children: (
       <>
         {icon && <StyledIcon>{icon}</StyledIcon>}
-        <StyledText hasIcon={!!icon}>{linkElement.props.children}</StyledText>
+        <StyledText hasIcon={!!icon} data-testid="context-menu-item-text">
+          {linkElement.props.children}
+        </StyledText>
       </>
     ),
   })

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenu.tsx
@@ -1,0 +1,34 @@
+import { selectors } from '@royalnavy/design-tokens'
+import styled, { css } from 'styled-components'
+
+import { StyledText } from './StyledText'
+
+interface StyledContextMenuProps {
+  top: number
+  left: number
+  $hasIcons: boolean
+}
+
+const { color, spacing } = selectors
+
+export const StyledContextMenu = styled.ol<StyledContextMenuProps>`
+  position: fixed;
+  top: ${({ top }) => `${top}px`};
+  left: ${({ left }) => `${left}px`};
+  min-width: 120px;
+  max-width: 240px;
+  padding: ${spacing('2')};
+  list-style-type: none;
+  background-color: ${color('neutral', 'white')};
+  border-radius: 4px;
+  border: 1px solid ${color('neutral', '200')};
+  box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.12), 0 1px 3px 0 rgba(0, 0, 0, 0.04);
+
+  ${({ $hasIcons }) =>
+    !$hasIcons &&
+    css`
+      ${StyledText} {
+        margin-left: 0;
+      }
+    `}
+`

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenuDivider.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenuDivider.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, spacing } = selectors
+
+export const StyledContextMenuDivider = styled.div`
+  height: 1px;
+  background-color: ${color('neutral', '100')};
+  margin: ${spacing('2')} -${spacing('2')};
+`

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenuItem.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenuItem.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, spacing } = selectors
+
+export const StyledContextMenuItem = styled.li`
+  border-radius: 2px;
+
+  > * {
+    text-overflow: ellipsis;
+    display: flex;
+    padding: ${spacing('3')} ${spacing('4')};
+    line-height: 1.2;
+  }
+
+  &:hover {
+    background-color: ${color('neutral', '100')};
+
+    > * {
+      text-decoration: none;
+    }
+  }
+`

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledIcon.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledIcon.tsx
@@ -1,0 +1,14 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { spacing, color } = selectors
+
+export const StyledIcon = styled.div`
+  display: inline-flex;
+  align-items: center;
+  margin-right: ${spacing('2')};
+
+  svg {
+    color: ${color('neutral', '300')};
+  }
+`

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledText.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledText.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+import { StyledContextMenuItem } from './StyledContextMenuItem'
+
+interface StyledTextProps {
+  hasIcon?: boolean
+}
+
+const { color, fontSize } = selectors
+
+export const StyledText = styled.div<StyledTextProps>`
+  color: ${color('neutral', '400')};
+  font-weight: 600;
+  font-size: ${fontSize('base')};
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+
+  ${({ hasIcon }) => !hasIcon && `margin-left: 1.25rem;`}
+
+  ${StyledContextMenuItem}:hover & {
+    color: ${color('neutral', '400')};
+  }
+`


### PR DESCRIPTION
## Related issue

Closes #1756

## Overview

Break out into partials and prevent padding of text when no icons are supplied.

## Reason

>Currently when you want to have a list of ContextMenuItems with no icons passed into them, a padding for the icons is still applied.

## Work carried out

- [x] Prevent padding without icons
- [x] Refactor to use partials pattern

## Screenshot

<img width="313" alt="Screenshot 2020-12-14 at 09 30 01" src="https://user-images.githubusercontent.com/48086589/102067206-b439d100-3df2-11eb-8c65-4cb7ad0a2c7f.png">
