### PR TITLE
build(ReleaseWorkflow): Fix release note generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name:  Pull all tags
         # pulls all tags (needed for lerna / semantic release to correctly version)
-        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        run: git fetch --all --tags
 
       - name: Setup Node.js
         uses: actions/setup-node@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,13 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-# [2.24.0](https://github.com/Royal-Navy/design-system/compare/2.23.2...2.24.0) (2020-12-14)
+#  (2020-12-14)
 
 
 ### Features
 
-* **ReactComponentLibrary:** Add logging wrapper ([e53568a](https://github.com/Royal-Navy/design-system/commit/e53568a2e2672fc77f2e2c3ea8e37e191538718a))
+* **Drawer:** Add ability to drill `ref` ([ff21bfd](https://github.com/Royal-Navy/design-system/commit/ff21bfd9fda5b8ffbcc6286dc9294e117d2d4829))
 
 
 
-## [2.23.1](https://github.com/Royal-Navy/design-system/compare/2.23.0...2.23.1) (2020-12-10)
-
-
-
-# 2.23.0 (2020-12-09)
-
-
-
-
-
-#  (2020-12-11)
+# [2.24.0](https://github.com/Royal-Navy/design-system/compare/2.23.2...2.24.0) (2020-12-14)
 
 
 ### Features
@@ -784,3 +769,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 # 0.1.0 (2019-03-15)
+
+
+

--- a/packages/cra-template-royalnavy/CHANGELOG.md
+++ b/packages/cra-template-royalnavy/CHANGELOG.md
@@ -1,13 +1,4 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
 # [2.24.0](https://github.com/royal-navy/design-system/compare/2.23.2...2.24.0) (2020-12-14)
-
-**Note:** Version bump only for package cra-template-royalnavy
-
-
 
 
 
@@ -101,3 +92,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 * **CRATemplateRoyalNavy:** Create CRA template ([ff818bb](https://github.com/royal-navy/design-system/commit/ff818bbd816e7eab18eb4e77dc19b33a20283488))
+
+
+

--- a/packages/css-framework/CHANGELOG.md
+++ b/packages/css-framework/CHANGELOG.md
@@ -1,13 +1,4 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
 # [2.24.0](https://github.com/Royal-Navy/design-system/compare/2.23.2...2.24.0) (2020-12-14)
-
-**Note:** Version bump only for package @royalnavy/css-framework
-
-
 
 
 
@@ -432,3 +423,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 ## [1.0.2](https://github.com/Royal-Navy/design-system/compare/1.0.1...1.0.2) (2019-08-01)
+
+
+

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -1,13 +1,4 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
 # [2.24.0](https://github.com/Royal-Navy/design-system/compare/2.23.2...2.24.0) (2020-12-14)
-
-**Note:** Version bump only for package @royalnavy/design-tokens
-
-
 
 
 
@@ -91,3 +82,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **DesignTokens:** Create base package ([36d0594](https://github.com/Royal-Navy/design-system/commit/36d059415af44816af9662521e1698c9fcb5edd9))
 * **DesignTokens:** Link tokens to existing contexts ([d2c0270](https://github.com/Royal-Navy/design-system/commit/d2c0270ca7da6d3bdd3e4802a53d17e0691fc3d4))
+
+
+

--- a/packages/docs-site/CHANGELOG.md
+++ b/packages/docs-site/CHANGELOG.md
@@ -1,13 +1,4 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
 # [2.24.0](https://github.com/Royal-Navy/design-system/compare/2.23.2...2.24.0) (2020-12-14)
-
-**Note:** Version bump only for package royalnavy.io
-
-
 
 
 
@@ -344,3 +335,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 ## [1.0.2](https://github.com/Royal-Navy/design-system/compare/1.0.1...1.0.2) (2019-08-01)
+
+
+

--- a/packages/eslint-config-react/CHANGELOG.md
+++ b/packages/eslint-config-react/CHANGELOG.md
@@ -1,13 +1,4 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
 # [2.24.0](https://github.com/Royal-Navy/design-system/compare/2.23.2...2.24.0) (2020-12-14)
-
-**Note:** Version bump only for package @royalnavy/eslint-config-react
-
-
 
 
 
@@ -236,3 +227,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 ## [1.0.2](https://github.com/Royal-Navy/design-system/compare/1.0.1...1.0.2) (2019-08-01)
+
+
+

--- a/packages/fonts/CHANGELOG.md
+++ b/packages/fonts/CHANGELOG.md
@@ -1,13 +1,4 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
 # [2.24.0](https://github.com/Royal-Navy/design-system/compare/2.23.2...2.24.0) (2020-12-14)
-
-**Note:** Version bump only for package @royalnavy/fonts
-
-
 
 
 
@@ -162,3 +153,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 # [2.1.0-alpha.0](https://github.com/Royal-Navy/design-system/compare/2.0.1...2.1.0-alpha.0) (2020-01-28)
+
+
+

--- a/packages/icon-library/CHANGELOG.md
+++ b/packages/icon-library/CHANGELOG.md
@@ -1,13 +1,4 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
 # [2.24.0](https://github.com/Royal-Navy/design-system/compare/2.23.2...2.24.0) (2020-12-14)
-
-**Note:** Version bump only for package @royalnavy/icon-library
-
-
 
 
 
@@ -247,3 +238,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 # [1.3.0](https://github.com/Royal-Navy/design-system/compare/1.2.1...1.3.0) (2019-09-19)
+
+
+

--- a/packages/react-component-library/CHANGELOG.md
+++ b/packages/react-component-library/CHANGELOG.md
@@ -1,16 +1,9 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
 # [2.24.0](https://github.com/Royal-Navy/design-system/compare/2.23.2...2.24.0) (2020-12-14)
 
 
 ### Features
 
 * **ReactComponentLibrary:** Add logging wrapper ([e53568a](https://github.com/Royal-Navy/design-system/commit/e53568a2e2672fc77f2e2c3ea8e37e191538718a))
-
-
 
 
 
@@ -647,3 +640,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 # 0.1.0 (2019-03-15)
+
+
+


### PR DESCRIPTION
## Related issue

Closes #1784

## Overview

The old way of fetching tags would cause Lerna to get confused when generating release notes.

## Developer notes

I've also re-generated the release notes from the start of the history: [see gist](https://gist.github.com/m7kvqbe1/ecdbdd0d658d0af593b447e9d0a09976).