### PR TITLE
feat(Popover): Add prop for altering close delay

### DIFF
--- a/packages/docs-site/src/library/pages/components/popover.md
+++ b/packages/docs-site/src/library/pages/components/popover.md
@@ -88,6 +88,13 @@ A popover is a self-contained modal or dialogue that appears in context next to 
     Description: 'Custom CSS class to add to the Popover element.',
   },
   {
+    Name: 'closeDelay',
+    Type: 'number',
+    Required: 'False',
+    Default: '1000',
+    Description: 'Length of time in milliseconds when the Popover will close after the mouse leaves the target element.',
+  },
+  {
     Name: 'content',
     Type: 'React.ReactElement',
     Required: 'False',

--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -13,19 +13,20 @@ import { Popover, POPOVER_PLACEMENT } from '.'
 
 const HOVER_ON_ME = 'Hover on me!'
 
+jest.useFakeTimers()
+
 describe('Popover', () => {
-  let wrapper: RenderResult
-  let children: React.ReactElement
+  const content: React.ReactElement = <pre>This is some arbitrary JSX</pre>
   let clickSpy: (e: React.MouseEvent) => void
+  let wrapper: RenderResult
 
   describe('when provided a placement and arbitrary JSX content', () => {
     beforeEach(() => {
-      children = <pre>This is some arbitrary JSX</pre>
       clickSpy = jest.fn()
 
       wrapper = render(
         <>
-          <Popover placement={POPOVER_PLACEMENT.BELOW} content={children}>
+          <Popover placement={POPOVER_PLACEMENT.BELOW} content={content}>
             <div
               style={{
                 display: 'inline-block',
@@ -73,13 +74,17 @@ describe('Popover', () => {
 
       it('renders the provided arbitrary JSX', () => {
         expect(wrapper.getByTestId('floating-box-content').innerHTML).toContain(
-          renderToStaticMarkup(children)
+          renderToStaticMarkup(content)
         )
       })
 
       describe('and the user unhovers from the target element', () => {
         beforeEach(() => {
           fireEvent.mouseOut(wrapper.getByText(HOVER_ON_ME))
+        })
+
+        it('hid the `Popover` after 1000ms', () => {
+          expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1000)
         })
 
         it('to not be visible to the end user', () => {
@@ -164,6 +169,32 @@ describe('Popover', () => {
               '0'
             )
           })
+        })
+      })
+    })
+  })
+
+  describe('when using a custom `closeDelay`', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Popover content={content} closeDelay={100}>
+          <div>{HOVER_ON_ME}</div>
+        </Popover>
+      )
+    })
+
+    describe('and the user hovers on the target element', () => {
+      beforeEach(() => {
+        fireEvent.mouseEnter(wrapper.getByText(HOVER_ON_ME))
+      })
+
+      describe('and the user unhovers from the target element', () => {
+        beforeEach(() => {
+          fireEvent.mouseOut(wrapper.getByText(HOVER_ON_ME))
+        })
+
+        it('hid the `Popover` after 100ms', () => {
+          expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 100)
         })
       })
     })

--- a/packages/react-component-library/src/components/Popover/Popover.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import TetherComponent from 'react-tether'
 
-import { POPOVER_PLACEMENT, POPOVER_PLACEMENTS } from './constants'
+import { POPOVER_CLOSE_DELAY, POPOVER_PLACEMENT, POPOVER_PLACEMENTS } from './constants'
 
 import {
   FLOATING_BOX_SCHEME,
@@ -17,6 +17,7 @@ import { useHideShow } from './useHideShow'
 interface PopoverProps
   extends Omit<FloatingBoxProps, 'onMouseEnter' | 'onMouseLeave'> {
   children: React.ReactElement
+  closeDelay?: number,
   content: React.ReactElement
   isClick?: boolean
   placement:
@@ -44,6 +45,7 @@ const StyledFloatingBox = styled(FloatingBox)<StyledFloatingBoxProps>`
 
 export const Popover: React.FC<PopoverProps> = ({
   children,
+  closeDelay = POPOVER_CLOSE_DELAY,
   content,
   isClick,
   placement = POPOVER_PLACEMENT.BELOW,
@@ -51,7 +53,8 @@ export const Popover: React.FC<PopoverProps> = ({
   ...rest
 }) => {
   const { floatingBoxChildrenRef, isVisible, mouseEvents } = useHideShow(
-    isClick
+    isClick,
+    closeDelay
   )
   const PLACEMENTS = POPOVER_PLACEMENTS[placement]
 

--- a/packages/react-component-library/src/components/Popover/useHideShow.ts
+++ b/packages/react-component-library/src/components/Popover/useHideShow.ts
@@ -1,9 +1,8 @@
 import { useRef, useState } from 'react'
 
-import { POPOVER_CLOSE_DELAY } from './constants'
 import { useDocumentClick } from '../../hooks'
 
-export function useHideShow(isClick: boolean) {
+export function useHideShow(isClick: boolean, closeDelay: number) {
   const [isVisible, setIsVisible] = useState(false)
   const timerRef = useRef(null)
   const floatingBoxChildrenRef = useRef()
@@ -13,7 +12,7 @@ export function useHideShow(isClick: boolean) {
       timerRef.current = setTimeout(() => {
         timerRef.current = null
         setIsVisible(false)
-      }, POPOVER_CLOSE_DELAY)
+      }, closeDelay)
     }
   }
 


### PR DESCRIPTION
## Related issue
Closes #1759 

## Overview
Once the mouse leaves the target element then there is a delay before the `Popover` closes. This defaults to `1000` and can now be modified via the `closeDelay` prop.

## Reason
Downstream applications need more control over the delay.

## Work carried out
- [x] Expose prop