### PR TITLE
feat(DatePicker): Add ability to customise format

### DIFF
--- a/packages/docs-site/src/components/presenters/data-table/table-cell.js
+++ b/packages/docs-site/src/components/presenters/data-table/table-cell.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 const TableCell = ({ column, content }) => {
   return (
     <td data-column={column} className="data-table__cell">
-      <span>{content || 'n/a'}</span>
+      <span dangerouslySetInnerHTML={{ __html: content || 'n/a' }} />
     </td>
   )
 }

--- a/packages/docs-site/src/library/pages/components/date-picker.md
+++ b/packages/docs-site/src/library/pages/components/date-picker.md
@@ -95,6 +95,13 @@ The Date Picker with Range Selection component is very similar to the standard D
     Description: 'Selects the specified date as the end date',
   },
   {
+    Name: 'format',
+    Type: 'string',
+    Required: 'False',
+    Default: 'dd/MM/yyyy',
+    Description: 'Specify a custom format for presenting dates. Format is based on <a href="https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table" target="_blank">Unicode Technical Standard #35</a>.',
+  },
+  {
     Name: 'id',
     Type: '',
     Required: 'False',

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -24,6 +24,16 @@ stories.add('Default', () => {
   )
 })
 
+stories.add('Custom format', () => {
+  return (
+    <DatePicker
+      format="yyyy/MM/dd"
+      startDate={new Date(2018, 0, 11)}
+      placement={DATEPICKER_PLACEMENT.BELOW}
+    />
+  )
+})
+
 examples.add('Custom initial month', () => {
   return (
     <DatePicker

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useRef, useState } from 'react'
 import differenceInMinutes from 'date-fns/differenceInMinutes'
 import { v4 as uuidv4 } from 'uuid'
 import styled, { css } from 'styled-components'
@@ -7,9 +7,9 @@ import { format } from 'date-fns'
 import TetherComponent from 'react-tether'
 import DayPicker, {
   DateUtils,
-  RangeModifier,
-  DayPickerProps,
   DayModifiers,
+  DayPickerProps,
+  RangeModifier,
 } from 'react-day-picker'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
@@ -17,7 +17,7 @@ import { DATE_FORMAT } from '../../constants'
 import { DatePickerInput } from './DatePickerInput'
 import { useDatePickerOpenClose } from './useDatePickerOpenClose'
 import { DATEPICKER_PLACEMENT, DATEPICKER_PLACEMENTS } from '.'
-import { FloatingBox, FLOATING_BOX_SCHEME } from '../../primitives/FloatingBox'
+import { FLOATING_BOX_SCHEME, FloatingBox } from '../../primitives/FloatingBox'
 import { getId } from '../../helpers'
 
 export interface StateObject {
@@ -33,6 +33,7 @@ export type DatePickerPlacement =
 
 export interface DatePickerProps extends ComponentWithClass {
   endDate?: Date
+  format?: string
   id?: string
   isDisabled?: boolean
   isRange?: boolean
@@ -274,16 +275,20 @@ const StyledDayPicker = styled<any>(DayPicker)`
 
 const StyledDatePicker = styled.div``
 
-function transformDates(startDate: Date, endDate: Date) {
+function transformDates(
+  startDate: Date,
+  endDate: Date,
+  datePickerFormat: string
+) {
   if (startDate && endDate && differenceInMinutes(endDate, startDate) > 0) {
-    return `${format(startDate, DATE_FORMAT.SHORT)} - ${format(
+    return `${format(startDate, datePickerFormat)} - ${format(
       endDate,
-      DATE_FORMAT.SHORT
+      datePickerFormat
     )}`
   }
 
   if (startDate) {
-    return format(startDate, DATE_FORMAT.SHORT)
+    return format(startDate, datePickerFormat)
   }
 
   return ''
@@ -308,6 +313,7 @@ function getNewState(
 export const DatePicker: React.FC<DatePickerProps> = ({
   className,
   endDate,
+  format: datePickerFormat = DATE_FORMAT.SHORT,
   id = uuidv4(),
   isDisabled,
   isRange,
@@ -383,7 +389,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
             id={id}
             name={name}
             label={label}
-            value={transformDates(from, to)}
+            value={transformDates(from, to, datePickerFormat)}
             onBlur={onBlur}
             onFocus={handleOnFocus}
             isDisabled={isDisabled}


### PR DESCRIPTION
## Related issue
Closes #1399

## Overview
Added a `format` prop allows the consumer to supply a custom format based on [Unicode Technical Standard #35](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table)

## Reason
Applications need consistent formatting for their context.

## Work carried out
- [x] Expose ability to customise date format