### PR TITLE
Add hide and show events to context menu

### DIFF
--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react'
+import { action } from '@storybook/addon-actions'
 import { Meta } from '@storybook/react/types-6-0'
 
 import { IconEdit, IconDelete, IconAdd } from '@royalnavy/icon-library'
@@ -24,7 +25,11 @@ export const Default = () => {
         Right click me!
       </div>
 
-      <ContextMenu attachedToRef={ref}>
+      <ContextMenu
+        attachedToRef={ref}
+        onHide={action('onHide')}
+        onShow={action('onShow')}
+      >
         <ContextMenuItem
           icon={<IconEdit />}
           link={<Link href="/edit">Edit</Link>}

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
@@ -236,4 +236,60 @@ describe('ContextMenu', () => {
       expect(wrapper.queryAllByTestId('context-menu-divider')).toHaveLength(2)
     })
   })
+
+  describe('With onShow and onHide', () => {
+    let onShowSpy: () => void
+    let onHideSpy: () => void
+
+    beforeEach(() => {
+      onShowSpy = jest.fn()
+      onHideSpy = jest.fn()
+
+      const ContextExample = () => {
+        const ref = useRef()
+
+        return (
+          <>
+            <div>Click elsewhere</div>
+            <div ref={ref}>Click me!</div>
+            <ContextMenu
+              attachedToRef={ref}
+              clickType="left"
+              onShow={onShowSpy}
+              onHide={onHideSpy}
+            >
+              <ContextMenuItem
+                link={<Link href="/hello-foo">Hello, Foo!</Link>}
+              />
+              <ContextMenuItem
+                link={<Link href="/hello-bar">Hello, Bar!</Link>}
+              />
+            </ContextMenu>
+          </>
+        )
+      }
+
+      wrapper = render(<ContextExample />)
+
+      act(() => {
+        fireEvent.click(wrapper.getByText('Click me!'))
+      })
+    })
+
+    it('it fires the onShow event', () => {
+      expect(onShowSpy).toBeCalledTimes(1)
+    })
+
+    describe('when the user closes the context', () => {
+      beforeEach(() => {
+        act(() => {
+          fireEvent.click(wrapper.getByText('Click elsewhere'))
+        })
+      })
+
+      it('it fires the onHide event', () => {
+        expect(onHideSpy).toBeCalledTimes(1)
+      })
+    })
+  })
 })

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
@@ -5,8 +5,22 @@ import { useClickMenu, ClickType } from '../../hooks/useClickMenu'
 import { StyledContextMenu } from './partials/StyledContextMenu'
 
 interface ContextMenuProps extends ComponentWithClass {
-  attachedToRef?: React.RefObject<HTMLElement>
+  /**
+   * attachedToRef: A ref object for the element associated with the context menu
+   */
+  attachedToRef: React.RefObject<HTMLElement>
+  /**
+   * clickType: Should the menu display when the user uses a left or right mouse click?
+   */
   clickType?: ClickType
+  /**
+   * onHide: Optional handler function to be called when the context menu is hidden
+   */
+  onHide?: () => void
+  /**
+   * onShow: Optional handler function to be called when the context menu is displayed
+   */
+  onShow?: () => void
 }
 
 export const ContextMenu: React.FC<ContextMenuProps> = ({
@@ -14,8 +28,15 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   children,
   attachedToRef,
   clickType = 'right',
+  onHide,
+  onShow,
 }) => {
-  const { position, isOpen } = useClickMenu(attachedToRef, clickType)
+  const { position, isOpen } = useClickMenu({
+    attachedToRef,
+    clickType,
+    onHide,
+    onShow,
+  })
 
   const hasIcons = !!React.Children.toArray(children).filter(
     (child: React.ReactNode) => (child as React.ReactElement)?.props?.icon

--- a/packages/react-component-library/src/hooks/useClickMenu.ts
+++ b/packages/react-component-library/src/hooks/useClickMenu.ts
@@ -8,10 +8,22 @@ export type Coordinate = {
 
 export type ClickType = 'left' | 'right'
 
-export const useClickMenu = (
-  attachedToRef: React.RefObject<HTMLElement>,
+interface useClickMenuParams {
+  attachedToRef: React.RefObject<HTMLElement>
   clickType: ClickType
-): { position: Coordinate; isOpen: boolean } => {
+  onHide?: () => void
+  onShow?: () => void
+}
+
+export const useClickMenu = ({
+  attachedToRef,
+  clickType,
+  onHide,
+  onShow,
+}: useClickMenuParams): {
+  position: Coordinate
+  isOpen: boolean
+} => {
   const { open, setOpen } = useOpenClose<boolean>(false)
   const [position, setPosition] = useState<Coordinate>({ x: 0, y: 0 })
 
@@ -22,14 +34,17 @@ export const useClickMenu = (
     if (e.target === attachedToRef.current) {
       e.preventDefault()
       setOpen(true)
+      if (onShow) onShow()
       return
     }
 
     setOpen(false)
+    if (onHide) onHide()
   }
 
   function hideMenu() {
     setOpen(false)
+    if (onHide) onHide()
   }
 
   useEffect(() => {


### PR DESCRIPTION
This change allows an app to be notified when a context menu is shown or hidden.

If the event handlers are optional so do not change existing behaviour.

In the case of MSP this feature is required so the associated element can have it's display state changed when the context menu is displayed.
