### PR TITLE
test(Popover): Fix broken test resulting in infinite loop

### DIFF
--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -65,6 +65,10 @@ describe('Popover', () => {
         fireEvent.mouseEnter(wrapper.getByText(HOVER_ON_ME))
       })
 
+      afterEach(() => {
+        jest.clearAllTimers()
+      })
+
       it('to be visible to the end user', () => {
         expect(wrapper.getByTestId('floating-box')).toHaveStyleRule(
           'opacity',


### PR DESCRIPTION
## Overview

Jest was getting stuck in an infinite loop due to the use of waitFor and fake timers.

Now invoking clearAllTimers in an afterEach.

## Reason

<img width="1622" alt="Screenshot 2021-01-05 at 16 57 49" src="https://user-images.githubusercontent.com/48086589/103675585-06948a80-4f78-11eb-8237-e452cb1d55e3.png">
