### PR TITLE
Fix docs site, add legacy `.rn-container`

### DIFF
--- a/packages/docs-site/src/components/presenters/Masthead/_masthead.scss
+++ b/packages/docs-site/src/components/presenters/Masthead/_masthead.scss
@@ -50,6 +50,14 @@
   margin-left: rn.spacing("6");
 }
 
+.rn-container {
+  max-width: 1280px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: rn.spacing("12");
+  padding-right: rn.spacing("12");
+}
+
 .masthead__nav {
   display: none;
   padding-top: rn.spacing("6");


### PR DESCRIPTION
## Related issue
Fixes #1846 

## Overview
`.rn-container` is required for the Docs site and was removed in a [recent change](https://github.com/Royal-Navy/design-system/commit/68b6b45296c8e082f61156f69206b25f33a35cda).

## Reason
Layout is broken.

## Work carried out
- [x] Fix