### PR TITLE
fix(DesignTokens): Resolve mq selector nested interpolations

### DIFF
--- a/packages/design-tokens/src/__tests__/__snapshots__/selectors.test.tsx.snap
+++ b/packages/design-tokens/src/__tests__/__snapshots__/selectors.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`mediaQuery / mq with valid breakpoints snapshot test 1`] = `
   .c0 {
     font-size: 94%;
     background-color: blue;
+    padding: 0.25rem;
   }
 }
 
@@ -17,6 +18,7 @@ exports[`mediaQuery / mq with valid breakpoints snapshot test 1`] = `
   .c0 {
     font-size: 96%;
     background-color: green;
+    padding: 0.5rem;
   }
 }
 
@@ -24,6 +26,7 @@ exports[`mediaQuery / mq with valid breakpoints snapshot test 1`] = `
   .c0 {
     font-size: 100%;
     background-color: black;
+    padding: 0.75rem;
   }
 }
 

--- a/packages/design-tokens/src/__tests__/selectors.test.tsx
+++ b/packages/design-tokens/src/__tests__/selectors.test.tsx
@@ -6,7 +6,7 @@ import 'jest-styled-components'
 
 import { selectors } from '..'
 
-const { mediaQuery, mq } = selectors
+const { mediaQuery, mq, spacing } = selectors
 
 describe('mediaQuery / mq', () => {
   let wrapper: RenderResult
@@ -29,14 +29,17 @@ describe('mediaQuery / mq', () => {
 
       ${mediaQuery({ gte: 'xs' })`
         background-color: blue;
+        padding: ${spacing('2')};
       `}
 
       ${mq({ gte: 's', lt: 'm' })`
         background-color: green;
+        padding: ${spacing('4')};
       `}
 
       ${mq({ gte: 'l', lt: 'xl', media: '' })`
         background-color: black;
+        padding: ${spacing('6')};
       `}
     `
 
@@ -63,6 +66,15 @@ describe('mediaQuery / mq', () => {
           media: 'only screen and (min-width:576px)',
         }
       )
+
+      expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
+        'padding',
+        '0.25rem',
+        {
+          media: 'only screen and (min-width:576px)',
+        }
+      )
+
       expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
         'background-color',
         'green',
@@ -72,8 +84,24 @@ describe('mediaQuery / mq', () => {
       )
 
       expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
+        'padding',
+        '0.5rem',
+        {
+          media: 'only screen and (min-width:768px) and (max-width:1024px)',
+        }
+      )
+
+      expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
         'background-color',
         'black',
+        {
+          media: '(min-width:1200px) and (max-width:1400px)',
+        }
+      )
+
+      expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
+        'padding',
+        '0.75rem',
         {
           media: '(min-width:1200px) and (max-width:1400px)',
         }

--- a/packages/design-tokens/src/getters.ts
+++ b/packages/design-tokens/src/getters.ts
@@ -43,7 +43,10 @@ export function getMediaQuery(options: {
   gte: BreakpointSize
   lt?: BreakpointSize
   media?: string
-}): (strings: TemplateStringsArray) => string {
+}): (
+  strings: TemplateStringsArray,
+  ...interpolations: StyledComponentsInterpolation[]
+) => string {
   const { gte, lt, media } = {
     media: 'only screen and',
     ...options,
@@ -69,21 +72,21 @@ export function getMediaQuery(options: {
     ...interpolations: StyledComponentsInterpolation[]
   ): string {
     if (breakpointGTE && !breakpointLT) {
-      return `
+      return css`
         @media ${media} (min-width: ${breakpointGTE}) {
           font-size: ${baseFontSize};
           ${css(strings, ...interpolations)}
         }
-      `
+      `.join('') // Join prevents commas e.g. `padding: ,1.25rem,`
     }
 
     if (breakpointGTE && breakpointLT) {
-      return `
+      return css`
         @media ${media} (min-width: ${breakpointGTE}) and (max-width: ${breakpointLT}) {
           font-size: ${baseFontSize};
           ${css(strings, ...interpolations)}
         }
-      `
+      `.join('')
     }
 
     throw new Error(`Invalid breakpoints: gte: ${gte} - lt: ${lt}`)

--- a/packages/react-component-library/src/components/Alert/partials/StyledAlert.tsx
+++ b/packages/react-component-library/src/components/Alert/partials/StyledAlert.tsx
@@ -17,7 +17,7 @@ interface StyledAlertProps {
   $variant?: AlertVariantType
 }
 
-const { spacing, breakpoint } = selectors
+const { spacing, mq } = selectors
 
 const STATE_VARIANT_MAP = {
   [ALERT_VARIANT.DANGER]: DANGER_ALERT_STATE_COLOR,
@@ -35,9 +35,9 @@ export const StyledAlert = styled.div<StyledAlertProps>`
   display: flex;
   align-items: flex-start;
 
-  @media only screen and (min-width: ${breakpoint('xs').breakpoint}) {
+  ${mq({ gte: 'xs' })`
     padding-right: ${spacing('18')};
-  }
+  `}
 
   &::before {
     position: absolute;


### PR DESCRIPTION
## Related issue

Closes #1794

## Overview

Fix broken selectors.

## Reason

>Nested interpolations were broken when using the `mq` or `mediaQuery` tagged literal design token selectors.

## Work carried out

- [x] Make nested interpolations work
- [x] Fix typings
- [x] Add additional assertions to tests
- [x] Refactor `Alert` to consume working `mq` selector (with nested interpolation)
