### PR TITLE
docs(DocsSite): Update migration title

### DIFF
--- a/packages/docs-site/src/library/pages/get-started/development/v2-migration.md
+++ b/packages/docs-site/src/library/pages/get-started/development/v2-migration.md
@@ -1,5 +1,5 @@
 ---
-title: Migrating to Royal Navy Design System v2
+title: Migrating to v2
 description: 'This guide will show you how to upgrade your codebase to work with v2'
 header: true
 ---


### PR DESCRIPTION
## Overview

The old title was too long and wrapped in the navigation.