### PR TITLE
Remove Timeline warnings

### DIFF
--- a/packages/react-component-library/src/components/Timeline/README.md
+++ b/packages/react-component-library/src/components/Timeline/README.md
@@ -250,11 +250,11 @@ const CustomTimelineComponent = ({
   const {
     width,
     offset,
-    isBeforeStart,
-    isAfterEnd
+    startsBeforeStart,
+    startsAfterEnd
   } = useTimelinePosition(startDate, endDate)
 
-  if (isBeforeStart || isAfterEnd) return null
+  if (startsBeforeStart || startsAfterEnd) return null
 
   return (
     <div style={{

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
@@ -70,8 +70,6 @@ export function useTimelinePosition(
     ? getWidth(firstDateDisplayed, lastDateDisplayed) + 1
     : getWidth(startDate, lastDateDisplayed) + 1
 
-  logger.warn('`isBeforeStart` and `isAfterEnd` are deprecated')
-
   return {
     width: formatPx(options.dayWidth, width),
     offset: formatPx(options.dayWidth, offset),


### PR DESCRIPTION
## Related issue
Fixes #1835 

## Overview
Removes the `console.warning` in `useTimelinePosition`.

## Reason
Confusing for consumers.

## Work carried out
- [x] Remove log
- [x] Update docs