### PR TITLE
fix(ContextMenu): Add scoped `z-index`

### DIFF
--- a/packages/design-tokens/src/tokens/zindex.json
+++ b/packages/design-tokens/src/tokens/zindex.json
@@ -1,5 +1,8 @@
 {
   "zindex": {
+    "context": {
+      "value": "10000"
+    },
     "dialog": {
       "value": "9000"
     },

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenu.tsx
@@ -9,7 +9,7 @@ interface StyledContextMenuProps {
   $hasIcons: boolean
 }
 
-const { color, spacing } = selectors
+const { color, spacing, zIndex } = selectors
 
 export const StyledContextMenu = styled.ol<StyledContextMenuProps>`
   position: fixed;
@@ -23,6 +23,7 @@ export const StyledContextMenu = styled.ol<StyledContextMenuProps>`
   border-radius: 4px;
   border: 1px solid ${color('neutral', '200')};
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.12), 0 1px 3px 0 rgba(0, 0, 0, 0.04);
+  z-index: ${zIndex('context', 1)};
 
   ${({ $hasIcons }) =>
     !$hasIcons &&


### PR DESCRIPTION
## Related issue

Closes #1831

## Overview

Add scoped `z-index` to ContextMenu.

## Reason

>ContextMenu would get hidden behind other DOM elements within the page flow.

## Work carried out

- [x] Add scope to to design-tokens package
- [x] Add missing `z-index` to ContextMenu