### PR TITLE
fix(Timeline): Resolve inconsistent TodayMarker snapshot

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -334,7 +334,7 @@ export const WithCustomTodayMarker = () => {
           zIndex: 1,
         }}
       >
-        {date.toString()}
+        {date.toUTCString()}
       </span>
     )
   }
@@ -618,7 +618,6 @@ export const WithCustomRange = () => {
   )
 }
 WithCustomRange.storyName = 'With custom range'
-
 
 export const NoVisibleCells = () => (
   <Timeline startDate={new Date(2020, 0, 1)} today={new Date(2020, 0, 1, 12)}>

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
@@ -8,7 +8,6 @@ import {
 
 import { TimelineContext } from '../context'
 import { formatPx } from '../helpers'
-import logger from '../../../utils/logger'
 
 const timeOffset = (date: Date) => 1 / 24 * new Date(date).getHours()
 


### PR DESCRIPTION
## Related issue

Closes #1836

## Overview

Prevent inconsistent snapshot generation.

## Reason

>`toString` converts the date object to the users timezone and snapshots are generated in varying georgraphic regions in the cloud, causing snapshots to mistmatch.

## Work carried out

- [x] Remove unused import
- [x] Use `.toUTCString` for TimelineTodayMarker story output

## Screenshot

<img width="405" alt="Screenshot 2021-01-21 at 10 39 05" src="https://user-images.githubusercontent.com/48086589/105339713-e948f880-5bd4-11eb-8617-53d415ebe4df.png">
