### PR TITLE
Add ContextMenu position

### DIFF
--- a/packages/docs-site/src/library/pages/components/context-menu.md
+++ b/packages/docs-site/src/library/pages/components/context-menu.md
@@ -85,6 +85,13 @@ Right clicking on this component will open the context menu in place of the defa
 ### ContextMenu Properties
 <DataTable data={[
   {
+    Name: 'attachedToRef',
+    Type: 'React.RefObject<HTMLElement>',
+    Required: 'True',
+    Default: '',
+    Description: 'A ref object associated with the component or element the context menu is attached to',
+  },
+  {
     Name: 'children',
     Type: 'React.ReactElement<ContextMenuItemProps>[]',
     Required: 'True',
@@ -92,11 +99,39 @@ Right clicking on this component will open the context menu in place of the defa
     Description: 'Supply menu items and dividers as children',
   },
   {
-    Name: 'attachedToRef',
-    Type: 'React.RefObject<HTMLElement>',
-    Required: 'True',
+    Name: 'className',
+    Type: 'string',
+    Required: 'False',
     Default: '',
-    Description: 'A ref object associated with the component or element the context menu is attached to',
+    Description: 'CSS class name to modify properties',
+  },
+  {
+    Name: 'clickType',
+    Type: 'left | right',
+    Required: 'False',
+    Default: 'right',
+    Description: 'Button to be clicked to show menu',
+  },
+  {
+    Name: 'onHide',
+    Type: '() => void',
+    Required: 'False',
+    Default: '',
+    Description: 'Callback for when the menu is hidden',
+  },
+  {
+    Name: 'onShow',
+    Type: '() => void',
+    Required: 'False',
+    Default: '',
+    Description: 'Callback for when the menu is shown',
+  },
+  {
+    Name: 'position',
+    Type: 'above | below',
+    Required: 'False',
+    Default: 'below',
+    Description: 'Where the menu is positioned',
   },
 ]} />
 

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -8,6 +8,8 @@ import { ContextMenu, ContextMenuItem, ContextMenuDivider } from '.'
 import { Link } from '../Link'
 import {
   CLICK_BUTTON,
+  CLICK_MENU_POSITION,
+  ClickMenuPositionType,
   ClickType,
 } from '../../hooks/useClickMenu'
 
@@ -65,6 +67,7 @@ const PirateContent: React.FC = () => (
 interface ContentMenuExampleProps {
   clickType?: ClickType
   hasIcons?: boolean
+  position?: ClickMenuPositionType
 }
 
 const ContextMenuExample: React.FC<ContentMenuExampleProps> = ({
@@ -133,3 +136,8 @@ export const LeftClick = () => (
   <ContextMenuExample clickType={CLICK_BUTTON.LEFT} />
 )
 LeftClick.storyName = 'Left click to open'
+
+export const Above = () => (
+  <ContextMenuExample position={CLICK_MENU_POSITION.ABOVE} />
+)
+Above.storyName = 'Above'

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -6,6 +6,10 @@ import { IconEdit, IconDelete, IconAdd } from '@royalnavy/icon-library'
 
 import { ContextMenu, ContextMenuItem, ContextMenuDivider } from '.'
 import { Link } from '../Link'
+import {
+  CLICK_BUTTON,
+  ClickType,
+} from '../../hooks/useClickMenu'
 
 export default { component: ContextMenu, title: 'ContextMenu' } as Meta
 
@@ -58,7 +62,15 @@ const PirateContent: React.FC = () => (
   </>
 )
 
-export const Default = () => {
+interface ContentMenuExampleProps {
+  clickType?: ClickType
+  hasIcons?: boolean
+}
+
+const ContextMenuExample: React.FC<ContentMenuExampleProps> = ({
+  hasIcons,
+  ...rest
+}) => {
   const ref = useRef()
 
   return (
@@ -78,19 +90,20 @@ export const Default = () => {
         attachedToRef={ref}
         onHide={action('onHide')}
         onShow={action('onShow')}
+        {...rest}
       >
         <ContextMenuItem
-          icon={<IconEdit />}
+          icon={hasIcons && <IconEdit />}
           link={<Link href="/edit">Edit</Link>}
         />
         <ContextMenuItem
-          icon={<IconDelete />}
+          icon={hasIcons && <IconDelete />}
           link={<Link href="/delete">Delete</Link>}
         />
         <ContextMenuItem link={<Link href="/delete">Action</Link>} />
         <ContextMenuDivider />
         <ContextMenuItem
-          icon={<IconAdd />}
+          icon={hasIcons && <IconAdd />}
           link={<Link href="/add">Add</Link>}
         />
         <ContextMenuDivider />
@@ -110,87 +123,13 @@ export const Default = () => {
   )
 }
 
+export const Default = () => <ContextMenuExample hasIcons />
 Default.storyName = 'Default'
 
-export const NoIcons = () => {
-  const ref = useRef()
-
-  return (
-    <>
-      <div
-        ref={ref}
-        style={{
-          display: 'inline-block',
-          padding: '3rem',
-
-          backgroundColor: '#12202b',
-        }}
-      >
-        <PirateContent />
-      </div>
-
-      <ContextMenu attachedToRef={ref}>
-        <ContextMenuItem link={<Link href="/edit">Edit</Link>} />
-        <ContextMenuItem link={<Link href="/delete">Delete</Link>} />
-        <ContextMenuItem link={<Link href="/delete">Action</Link>} />
-        <ContextMenuDivider />
-        <ContextMenuItem link={<Link href="/add">Add</Link>} />
-        <ContextMenuDivider />
-        <ContextMenuItem
-          link={<Link href="/something-else">Do something else</Link>}
-        />
-        <ContextMenuDivider />
-        <ContextMenuItem
-          link={(
-            <Link href="/something-else">
-              This is too much text to put into a context menu item
-            </Link>
-          )}
-        />
-      </ContextMenu>
-    </>
-  )
-}
-
+export const NoIcons = () => <ContextMenuExample />
 NoIcons.storyName = 'No icons'
 
-export const LeftClick = () => {
-  const ref = useRef()
-
-  return (
-    <>
-      <div
-        ref={ref}
-        style={{
-          display: 'inline-block',
-          padding: '3rem',
-          backgroundColor: '#12202b',
-        }}
-      >
-        <PirateContent />
-      </div>
-
-      <ContextMenu attachedToRef={ref} clickType="left">
-        <ContextMenuItem link={<Link href="/edit">Edit</Link>} />
-        <ContextMenuItem link={<Link href="/delete">Delete</Link>} />
-        <ContextMenuItem link={<Link href="/delete">Action</Link>} />
-        <ContextMenuDivider />
-        <ContextMenuItem link={<Link href="/add">Add</Link>} />
-        <ContextMenuDivider />
-        <ContextMenuItem
-          link={<Link href="/something-else">Do something else</Link>}
-        />
-        <ContextMenuDivider />
-        <ContextMenuItem
-          link={(
-            <Link href="/something-else">
-              This is too much text to put into a context menu item
-            </Link>
-          )}
-        />
-      </ContextMenu>
-    </>
-  )
-}
-
+export const LeftClick = () => (
+  <ContextMenuExample clickType={CLICK_BUTTON.LEFT} />
+)
 LeftClick.storyName = 'Left click to open'

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
@@ -6,6 +6,7 @@ import 'jest-styled-components'
 
 import { ContextMenu, ContextMenuItem, ContextMenuDivider } from '.'
 import { Link } from '../Link'
+import { CLICK_MENU_POSITION } from '../../hooks/useClickMenu'
 
 const CustomLink = ({ children, onClick }: any) => {
   return (
@@ -43,7 +44,7 @@ describe('ContextMenu', () => {
     })
 
     it('is not rendered to the DOM', () => {
-      expect(wrapper.queryByTestId('context-menu')).not.toBeInTheDocument()
+      expect(wrapper.queryByTestId('context-menu')).not.toBeVisible()
     })
   })
 
@@ -68,10 +69,15 @@ describe('ContextMenu', () => {
       }
 
       wrapper = render(<ContextExample />)
+
+      // @ts-ignore
+      wrapper.getByTestId('context-menu').getBoundingClientRect = () => ({
+        height: 100,
+      })
     })
 
     it('is not rendered to the DOM', () => {
-      expect(wrapper.queryByTestId('context-menu')).not.toBeInTheDocument()
+      expect(wrapper.queryByTestId('context-menu')).not.toBeVisible()
     })
 
     describe('and the user left clicks on the target area', () => {
@@ -80,7 +86,59 @@ describe('ContextMenu', () => {
       })
 
       it('is is rendered to the DOM', () => {
-        expect(wrapper.queryByTestId('context-menu')).toBeInTheDocument()
+        expect(wrapper.queryByTestId('context-menu')).toBeVisible()
+      })
+
+      it('is is rendered below the mouse pointer', () => {
+        expect(wrapper.queryByTestId('context-menu')).toHaveStyleRule(
+          'top',
+          '0px'
+        )
+      })
+    })
+  })
+
+  describe('with a position of above', () => {
+    beforeEach(() => {
+      const ContextExample = () => {
+        const ref = useRef()
+
+        return (
+          <>
+            <div ref={ref}>Right click me!</div>
+            <ContextMenu
+              attachedToRef={ref}
+              position={CLICK_MENU_POSITION.ABOVE}
+            >
+              <ContextMenuItem
+                link={<Link href="/hello-foo">Hello, Foo!</Link>}
+              />
+              <ContextMenuItem
+                link={<Link href="/hello-bar">Hello, Bar!</Link>}
+              />
+            </ContextMenu>
+          </>
+        )
+      }
+
+      wrapper = render(<ContextExample />)
+
+      // @ts-ignore
+      wrapper.getByTestId('context-menu').getBoundingClientRect = () => ({
+        height: 100,
+      })
+    })
+
+    describe('and the user right clicks on the target area', () => {
+      beforeEach(() => {
+        fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+      })
+
+      it('is is rendered above the mouse pointer', () => {
+        expect(wrapper.queryByTestId('context-menu')).toHaveStyleRule(
+          'top',
+          '-100px'
+        )
       })
     })
   })
@@ -117,12 +175,12 @@ describe('ContextMenu', () => {
     })
 
     it('is rendered to the DOM', () => {
-      expect(wrapper.queryByTestId('context-menu')).toBeInTheDocument()
+      expect(wrapper.queryByTestId('context-menu')).toBeVisible()
     })
 
     it('renders the links', () => {
-      expect(wrapper.queryByText('Hello, Foo!')).toBeInTheDocument()
-      expect(wrapper.queryByText('Hello, Bar!')).toBeInTheDocument()
+      expect(wrapper.queryByText('Hello, Foo!')).toBeVisible()
+      expect(wrapper.queryByText('Hello, Bar!')).toBeVisible()
     })
 
     describe('and the user clicks somewhere in the DOM', () => {
@@ -131,7 +189,7 @@ describe('ContextMenu', () => {
       })
 
       it('hides the context menu', () => {
-        expect(wrapper.queryByTestId('context-menu')).not.toBeInTheDocument()
+        expect(wrapper.queryByTestId('context-menu')).not.toBeVisible()
       })
     })
   })
@@ -203,7 +261,7 @@ describe('ContextMenu', () => {
     it('renders the icons', () => {
       expect(
         wrapper.queryByTestId('context-menu-item-icon')
-      ).toBeInTheDocument()
+      ).toBeVisible()
     })
   })
 

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
@@ -31,7 +31,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   onHide,
   onShow,
 }) => {
-  const { position, isOpen } = useClickMenu({
+  const { coordinates, isOpen } = useClickMenu({
     attachedToRef,
     clickType,
     onHide,
@@ -47,8 +47,8 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
       {isOpen && (
         <StyledContextMenu
           className={className}
-          top={position.y}
-          left={position.x}
+          top={coordinates.y}
+          left={coordinates.x}
           $hasIcons={hasIcons}
           data-testid="context-menu"
         >

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
-import { useClickMenu, ClickType } from '../../hooks/useClickMenu'
+import {
+  useClickMenu,
+  ClickType,
+  ClickMenuPositionType,
+  CLICK_MENU_POSITION,
+} from '../../hooks/useClickMenu'
 import { StyledContextMenu } from './partials/StyledContextMenu'
 
 interface ContextMenuProps extends ComponentWithClass {
@@ -21,6 +26,7 @@ interface ContextMenuProps extends ComponentWithClass {
    * onShow: Optional handler function to be called when the context menu is displayed
    */
   onShow?: () => void
+  position?: ClickMenuPositionType
 }
 
 export const ContextMenu: React.FC<ContextMenuProps> = ({
@@ -30,12 +36,14 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   clickType = 'right',
   onHide,
   onShow,
+  position = CLICK_MENU_POSITION.BELOW,
 }) => {
-  const { coordinates, isOpen } = useClickMenu({
+  const { coordinates, isOpen, menuRef } = useClickMenu<HTMLOListElement>({
     attachedToRef,
     clickType,
     onHide,
     onShow,
+    position,
   })
 
   const hasIcons = !!React.Children.toArray(children).filter(
@@ -43,19 +51,17 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   ).length
 
   return (
-    <>
-      {isOpen && (
-        <StyledContextMenu
-          className={className}
-          top={coordinates.y}
-          left={coordinates.x}
-          $hasIcons={hasIcons}
-          data-testid="context-menu"
-        >
-          {children}
-        </StyledContextMenu>
-      )}
-    </>
+    <StyledContextMenu
+      $hasIcons={hasIcons}
+      $isOpen={isOpen}
+      className={className}
+      data-testid="context-menu"
+      left={coordinates.x}
+      ref={menuRef}
+      top={coordinates.y}
+    >
+      {children}
+    </StyledContextMenu>
   )
 }
 

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenu.tsx
@@ -7,6 +7,7 @@ interface StyledContextMenuProps {
   top: number
   left: number
   $hasIcons: boolean
+  $isOpen: boolean
 }
 
 const { color, spacing, zIndex } = selectors
@@ -24,7 +25,8 @@ export const StyledContextMenu = styled.ol<StyledContextMenuProps>`
   border: 1px solid ${color('neutral', '200')};
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.12), 0 1px 3px 0 rgba(0, 0, 0, 0.04);
   z-index: ${zIndex('context', 1)};
-
+  visibility: ${({ $isOpen }) => $isOpen ? 'visible' : 'hidden'};
+  
   ${({ $hasIcons }) =>
     !$hasIcons &&
     css`

--- a/packages/react-component-library/src/hooks/useClickMenu.ts
+++ b/packages/react-component-library/src/hooks/useClickMenu.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useOpenClose } from './useOpenClose'
 
-export type Coordinate = {
+export type Coordinates = {
   x: number
   y: number
 }
@@ -21,15 +21,15 @@ export const useClickMenu = ({
   onHide,
   onShow,
 }: useClickMenuParams): {
-  position: Coordinate
+  coordinates: Coordinates
   isOpen: boolean
 } => {
   const { open, setOpen } = useOpenClose<boolean>(false)
-  const [position, setPosition] = useState<Coordinate>({ x: 0, y: 0 })
+  const [coordinates, setCoordinates] = useState<Coordinates>({ x: 0, y: 0 })
 
   function displayMenu(e: MouseEvent) {
-    const mousePoint: Coordinate = { x: e.clientX, y: e.clientY }
-    setPosition(mousePoint)
+    const mousePoint: Coordinates = { x: e.clientX, y: e.clientY }
+    setCoordinates(mousePoint)
 
     if (attachedToRef.current.contains(e.target as Node)) {
       e.preventDefault()
@@ -65,7 +65,7 @@ export const useClickMenu = ({
   })
 
   return {
-    position,
+    coordinates,
     isOpen: open,
   }
 }

--- a/packages/react-component-library/src/hooks/useClickMenu.ts
+++ b/packages/react-component-library/src/hooks/useClickMenu.ts
@@ -6,7 +6,12 @@ export type Coordinates = {
   y: number
 }
 
-export type ClickType = 'left' | 'right'
+export const CLICK_BUTTON = {
+  LEFT: 'left',
+  RIGHT: 'right',
+} as const
+
+export type ClickType = typeof CLICK_BUTTON.LEFT | typeof CLICK_BUTTON.RIGHT
 
 interface useClickMenuParams {
   attachedToRef: React.RefObject<HTMLElement>
@@ -48,11 +53,11 @@ export const useClickMenu = ({
   }
 
   useEffect(() => {
-    if (clickType === 'left') {
+    if (clickType === CLICK_BUTTON.LEFT) {
       document.addEventListener('click', displayMenu)
     }
 
-    if (clickType === 'right') {
+    if (clickType === CLICK_BUTTON.RIGHT) {
       document.addEventListener('contextmenu', displayMenu)
       document.addEventListener('click', hideMenu)
     }


### PR DESCRIPTION
## Related issue
Closes #1787 

## Overview
Adds ability to show menu above or below mouse pointer through the user of a `position` prop.

## Reason
There are instances where a menu showing below is not visible on the screen.

## Work carried out
- [x] Refactor existing code
- [x] Add `position`
- [x] Update docs

## Screenshot
TODO