### PR TITLE
fix(SidebarE): Resolve legacy Chrome squashed icon

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledHandle.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledHandle.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
 
-const { color } = selectors
+const { color, zIndex } = selectors
 
 export const StyledHandle = styled.button`
   position: absolute;
@@ -17,6 +17,7 @@ export const StyledHandle = styled.button`
   border: none;
   box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.25);
   transition: 100ms opacity linear;
+  z-index: ${zIndex('sidebar', 2)};
 
   &:hover {
     cursor: pointer;

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledHead.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledHead.tsx
@@ -4,6 +4,7 @@ import { selectors } from '@royalnavy/design-tokens'
 const { spacing, color } = selectors
 
 export const StyledHead = styled.div`
+  position: relative;
   display: flex;
   align-items: center;
   padding: ${spacing('8')} ${spacing('6')};

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledHeadIcon.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledHeadIcon.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
 
+import { StyledHeadTitle } from './StyledHeadTitle'
+
 const { color, spacing } = selectors
 
 export const StyledHeadIcon = styled.div`
@@ -9,7 +11,14 @@ export const StyledHeadIcon = styled.div`
   border-radius: 4px;
   background-color: ${color('neutral', '500')};
   padding: 0.55rem;
-  margin-right: ${spacing('7')};
+  min-width: 18px;
+
+  & + ${StyledHeadTitle} {
+    position: absolute;
+    top: 50%;
+    left: ${spacing('15')};
+    transform: translateY(-50%);
+  }
 
   svg {
     width: 18px;


### PR DESCRIPTION
## Related issue

Closes #1817

## Overview

Resolve squashed icon in legacy Chrome.

## Reason

Legacy Chrome has some issues with flexbox.

## Work carried out

- [x] Resolve squash icon styles
- [x] Tested using BrowserStack

## Screenshot

<img width="1491" alt="Screenshot 2021-01-25 at 12 01 26" src="https://user-images.githubusercontent.com/48086589/105706048-f59cc080-5f08-11eb-9ca5-71e04478bdf5.png">

## Developer notes

Including repro screenshot for reference purposes. 

There is a lot of overhead involved in getting reproductions working in legacy chrome.
