### PR TITLE
fix(Select): Tweak styling and add additional story

### DIFF
--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -17,7 +17,7 @@ const options = [
   { value: 'vanilla', label: 'Vanilla', badge: 50 },
 ]
 
-const iconOptions = options.map(option => ({
+const iconOptions = options.map((option) => ({
   ...option,
   icon: <IconAnchor />,
 }))
@@ -27,6 +27,15 @@ stories.add('Default', () => (
     options={options}
     label="Example label"
     onChange={action('onChange')}
+  />
+))
+
+examples.add('Open by default', () => (
+  <Select
+    options={options}
+    label="Example label"
+    onChange={action('onChange')}
+    defaultMenuIsOpen
   />
 ))
 

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -30,6 +30,7 @@ export const Select: React.FC<SelectProps> = ({
   onChange,
   options,
   value,
+  defaultMenuIsOpen,
   ...rest
 }) => {
   const onSelectChange = (option: any) => {
@@ -67,6 +68,8 @@ export const Select: React.FC<SelectProps> = ({
       options={options}
       placeholder={null}
       value={selectedOption}
+      autoFocus={defaultMenuIsOpen}
+      defaultMenuIsOpen={defaultMenuIsOpen}
       {...rest}
     />
   )

--- a/packages/react-component-library/src/components/Select/partials/StyledMenu.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledMenu.tsx
@@ -2,10 +2,10 @@ import { components } from 'react-select'
 import { selectors } from '@royalnavy/design-tokens'
 import styled from 'styled-components'
 
-const { color, spacing } = selectors
+const { color } = selectors
 
 export const StyledMenu = styled(components.Menu)`
-  margin-top: -${spacing('px')};
+  margin-top: -2px;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   box-shadow: 0 0 0 1px ${color('action', '600')},


### PR DESCRIPTION
## Related issue

Closes #1914

## Overview

Resolves a 1px positioning issue introduced as regression from styled-components works.

## Reason

>Select options container would sit 1px below the input. There was no visual regression state capturing the open state.

## Work carried out

- [x] Fix styling bug
- [x] Add 'Open by default' story for visual regression test

## Developer notes

We should review stories for components that have hidden display states to prevent visual regressions slipping through the net.

I have created a card for this.