### PR TITLE
Add ability to spread arbitrary props on all components

### DIFF
--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -7,7 +7,7 @@ import { Alert, ALERT_VARIANT } from '.'
 describe('Alert', () => {
   let wrapper: RenderResult
 
-  describe('when only the description is specified', () => {
+  describe('when minimal props are provided', () => {
     beforeEach(() => {
       wrapper = render(<Alert>Description</Alert>)
     })
@@ -55,9 +55,39 @@ describe('Alert', () => {
     })
   })
 
-  describe('when the title is specified', () => {
+  describe('when composing with different variants', () => {
+    it.each`
+      variant
+      ${ALERT_VARIANT.DANGER}
+      ${ALERT_VARIANT.INFO}
+      ${ALERT_VARIANT.SUCCESS}
+      ${ALERT_VARIANT.WARNING}
+    `('should render the $variant icon', ({ variant }) => {
+      wrapper = render(
+        <Alert title="Title" variant={variant}>
+          Description
+        </Alert>
+      )
+
+      expect(wrapper.getByTestId(`icon-${variant}`)).toBeInTheDocument()
+    })
+  })
+
+  describe('when all props are provided', () => {
+    let onCloseSpy: (event: React.FormEvent<HTMLButtonElement>) => void
+
     beforeEach(() => {
-      wrapper = render(<Alert title="Title">Description</Alert>)
+      onCloseSpy = jest.fn()
+
+      wrapper = render(
+        <Alert
+          onClose={onCloseSpy}
+          title="Title"
+          variant={ALERT_VARIANT.DANGER}
+        >
+          Description
+        </Alert>
+      )
     })
 
     it('should set the `aria-labelledby` attribute to the ID of the title', () => {
@@ -91,8 +121,10 @@ describe('Alert', () => {
       )
     })
 
-    it('should render the default info icon', () => {
-      expect(wrapper.getByTestId('icon-info')).toBeInTheDocument()
+    it('should render the danger icon', () => {
+      expect(
+        wrapper.getByTestId(`icon-${ALERT_VARIANT.DANGER}`)
+      ).toBeInTheDocument()
     })
 
     it('should render the content title', () => {
@@ -103,34 +135,6 @@ describe('Alert', () => {
       expect(wrapper.getByTestId('content-description')).toHaveTextContent(
         'Description'
       )
-    })
-  })
-
-  describe('when composing with different variants', () => {
-    it.each`
-      variant
-      ${ALERT_VARIANT.DANGER}
-      ${ALERT_VARIANT.INFO}
-      ${ALERT_VARIANT.SUCCESS}
-      ${ALERT_VARIANT.WARNING}
-    `('should render the $variant icon', ({ variant }) => {
-      wrapper = render(
-        <Alert title="Title" variant={variant}>
-          Description
-        </Alert>
-      )
-
-      expect(wrapper.getByTestId(`icon-${variant}`)).toBeInTheDocument()
-    })
-  })
-
-  describe('when the onClose callback is specified', () => {
-    let onCloseSpy: (event: React.FormEvent<HTMLButtonElement>) => void
-
-    beforeEach(() => {
-      onCloseSpy = jest.fn()
-
-      wrapper = render(<Alert onClose={onCloseSpy}>Description</Alert>)
     })
 
     describe('when the close button is clicked', () => {

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -81,12 +81,20 @@ describe('Alert', () => {
 
       wrapper = render(
         <Alert
+          data-arbitrary="arbitrary"
           onClose={onCloseSpy}
           title="Title"
           variant={ALERT_VARIANT.DANGER}
         >
           Description
         </Alert>
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('alert')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
       )
     })
 

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -48,6 +48,7 @@ export const Alert: React.FC<AlertProps> = ({
   onClose,
   title,
   variant = ALERT_VARIANT.INFO,
+  ...rest
 }) => {
   const { open, handleOnClose } = useOpenClose(true, onClose)
 
@@ -62,6 +63,7 @@ export const Alert: React.FC<AlertProps> = ({
         aria-labelledby={titleId}
         data-testid="alert"
         role="alert"
+        {...rest}
       >
         <StyledIcon
           $variant={variant}

--- a/packages/react-component-library/src/components/Avatar/Avatar.test.tsx
+++ b/packages/react-component-library/src/components/Avatar/Avatar.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, RenderResult } from '@testing-library/react'
+
+import { Avatar } from './Avatar'
+
+describe('Avatar', () => {
+  describe('when props are provided', () => {
+    let wrapper: RenderResult
+
+    beforeEach(() => {
+      wrapper = render(
+        <Avatar className="modifier" data-arbitrary="arbitrary" initials="AB" />
+      )
+    })
+
+    it('should apply the CSS modifier', () => {
+      expect(wrapper.getByText('AB').classList).toContain('modifier')
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByText('AB')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+
+    it('should render the initials', () => {
+      expect(wrapper.getByText('AB')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/react-component-library/src/components/Avatar/Avatar.tsx
+++ b/packages/react-component-library/src/components/Avatar/Avatar.tsx
@@ -10,15 +10,13 @@ export interface AvatarProps {
 }
 
 export const Avatar: React.FC<AvatarProps> = ({
-  className,
   initials,
   variant,
-}) => {
-  return (
-    <StyledAvatar className={className} $dark={variant === AVATAR_VARIANT.DARK}>
-      {initials}
-    </StyledAvatar>
-  )
-}
+  ...rest
+}) => (
+  <StyledAvatar $dark={variant === AVATAR_VARIANT.DARK} {...rest}>
+    {initials}
+  </StyledAvatar>
+)
 
 Avatar.displayName = 'Avatar'

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -11,13 +11,30 @@ describe('Breadcrumbs', () => {
   describe('when called with regular links', () => {
     beforeEach(() => {
       wrapper = render(
-        <Breadcrumbs>
-          <BreadcrumbsItem link={<Link href="#home">Home</Link>} />
+        <Breadcrumbs data-arbitrary="arbitrary-breadcrumbs">
+          <BreadcrumbsItem
+            data-arbitrary="arbitrary-breadcrumbs-item"
+            link={<Link href="#home">Home</Link>}
+          />
           <BreadcrumbsItem link={<Link href="#ships">Ships</Link>} />
           <BreadcrumbsItem link={<Link href="#reports">Reports</Link>} />
           <BreadcrumbsItem link={<Link href="#stuff">Stuff</Link>} />
           <BreadcrumbsItem link={<Link href="#22">22nd April 2019</Link>} />
         </Breadcrumbs>
+      )
+    })
+
+    it('should spread arbitrary props for breadcrumbs', () => {
+      expect(wrapper.getByTestId('breadcrumb-wrapper')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-breadcrumbs'
+      )
+    })
+
+    it('should spread arbitrary props for breadcrumbs items', () => {
+      expect(wrapper.getAllByTestId('breadcrumb')[0]).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-breadcrumbs-item'
       )
     })
 

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -7,7 +7,7 @@ import { StyledBreadcrumbsList } from './partials/StyledBreadcrumbsList'
 
 export const Breadcrumbs: React.FC<Nav<BreadcrumbsItemProps>> = ({
   children,
-  className,
+  ...rest
 }) => {
   const mapped = React.Children.map(
     children,
@@ -24,11 +24,7 @@ export const Breadcrumbs: React.FC<Nav<BreadcrumbsItemProps>> = ({
   )
 
   return (
-    <nav
-      className={className}
-      aria-label="Breadcrumb"
-      data-testid="breadcrumb-wrapper"
-    >
+    <nav aria-label="Breadcrumb" data-testid="breadcrumb-wrapper" {...rest}>
       <StyledBreadcrumbsList>{mapped}</StyledBreadcrumbsList>
     </nav>
   )

--- a/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -27,9 +27,10 @@ export const BreadcrumbsItem: React.FC<BreadcrumbsItemProps> = ({
   isFirst,
   isLast,
   link,
+  ...rest
 }) => {
   return (
-    <StyledBreadcrumbsItem data-testid="breadcrumb">
+    <StyledBreadcrumbsItem data-testid="breadcrumb" {...rest}>
       {!isFirst && (
         <StyledIcon aria-hidden data-testid="breadcrumb-separator" />
       )}

--- a/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -11,6 +11,18 @@ export interface BreadcrumbsItemProps {
   link: React.ReactElement<LinkTypes>
 }
 
+function getText(isLast: boolean, link: React.ReactElement<LinkTypes>) {
+  if (isLast) {
+    return (
+      <StyledEndTitle aria-current="page" data-testid="breadcrumb-end-title">
+        {(link as ReactElement).props.children}
+      </StyledEndTitle>
+    )
+  }
+
+  return link
+}
+
 export const BreadcrumbsItem: React.FC<BreadcrumbsItemProps> = ({
   isFirst,
   isLast,
@@ -21,13 +33,8 @@ export const BreadcrumbsItem: React.FC<BreadcrumbsItemProps> = ({
       {!isFirst && (
         <StyledIcon aria-hidden data-testid="breadcrumb-separator" />
       )}
-      {isLast ? (
-        <StyledEndTitle aria-current="page" data-testid="breadcrumb-end-title">
-          {(link as ReactElement).props.children}
-        </StyledEndTitle>
-      ) : (
-        link
-      )}
+
+      {getText(isLast, link)}
     </StyledBreadcrumbsItem>
   )
 }

--- a/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.test.tsx
@@ -99,6 +99,34 @@ describe('ButtonGroup', () => {
     })
   })
 
+  describe('provide arbitrary props', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <ButtonGroup data-arbitrary="arbitrary-buttongroup">
+          <ButtonGroupItem data-arbitrary="arbitrary-button" onClick={oneClickSpy}>One</ButtonGroupItem>
+          <ButtonGroupItem onClick={twoClickSpy}>Two</ButtonGroupItem>
+          <ButtonGroupItem onClick={threeClickSpy} isDisabled>
+            Three
+          </ButtonGroupItem>
+        </ButtonGroup>
+      )
+    })
+
+    it('should spread arbitrary props to the button group', () => {
+      expect(wrapper.getByTestId('buttongroup')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-buttongroup'
+      )
+    })
+
+    it('should spread arbitrary props to the button group item', () => {
+      expect(wrapper.getAllByTestId('button')[0]).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-button'
+      )
+    })
+  })
+
   describe('when a different size is provided for each item', () => {
     beforeEach(() => {
       wrapper = render(

--- a/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.tsx
@@ -17,8 +17,8 @@ export interface ButtonGroupProps extends ComponentWithClass {
 
 export const ButtonGroup: React.FC<ButtonGroupProps> = ({
   children,
-  className,
   size = BUTTON_SIZE.REGULAR,
+  ...rest
 }) => {
   const mappedChildren = React.Children.map(
     children,
@@ -38,10 +38,10 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = ({
 
   return (
     <StyledButtonGroup
-      className={className}
       $size={size}
       role="group"
       data-testid="buttongroup"
+      {...rest}
     >
       {mappedChildren}
     </StyledButtonGroup>

--- a/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.tsx
@@ -2,12 +2,12 @@ import React from 'react'
 
 import { ButtonGroupItemProps } from '.'
 import { BUTTON_SIZE } from '../Button'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import logger from '../../utils/logger'
 import { StyledButtonGroup } from './partials/StyledButtonGroup'
 
-export interface ButtonGroupProps {
+export interface ButtonGroupProps extends ComponentWithClass {
   children: React.ReactElement<ButtonGroupItemProps>[]
-  className?: string
   size?:
     | typeof BUTTON_SIZE.LARGE
     | typeof BUTTON_SIZE.REGULAR
@@ -20,6 +20,22 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = ({
   className,
   size = BUTTON_SIZE.REGULAR,
 }) => {
+  const mappedChildren = React.Children.map(
+    children,
+    (child: React.ReactElement<ButtonGroupItemProps>) => {
+      if (child.props.size) {
+        logger.warn(
+          'Prop `size` on `ButtonGroupItem` will be replaced by `size` from `ButtonGroup`'
+        )
+      }
+
+      return React.cloneElement(child, {
+        ...child.props,
+        size,
+      })
+    }
+  )
+
   return (
     <StyledButtonGroup
       className={className}
@@ -27,21 +43,7 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = ({
       role="group"
       data-testid="buttongroup"
     >
-      {React.Children.map(
-        children,
-        (child: React.ReactElement<ButtonGroupItemProps>) => {
-          if (child.props.size) {
-            logger.warn(
-              'Prop `size` on `ButtonGroupItem` will be replaced by `size` from `ButtonGroup`'
-            )
-          }
-
-          return React.cloneElement(child, {
-            ...child.props,
-            size,
-          })
-        }
-      )}
+      {mappedChildren}
     </StyledButtonGroup>
   )
 }

--- a/packages/react-component-library/src/components/ButtonGroup/ButtonGroupItem.tsx
+++ b/packages/react-component-library/src/components/ButtonGroup/ButtonGroupItem.tsx
@@ -20,6 +20,7 @@ export const ButtonGroupItem: React.FC<ButtonGroupItemProps> = ({
   icon,
   onClick,
   size,
+  ...rest
 }) => (
   <Button
     isDisabled={isDisabled}
@@ -29,6 +30,7 @@ export const ButtonGroupItem: React.FC<ButtonGroupItemProps> = ({
     type="button"
     variant="secondary"
     size={size}
+    {...rest}
   >
     {children}
   </Button>

--- a/packages/react-component-library/src/components/CardFrame/CardFrame.test.tsx
+++ b/packages/react-component-library/src/components/CardFrame/CardFrame.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { render, RenderResult } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
 
 import { CardFrame } from './index'
 
@@ -7,7 +8,11 @@ describe('CardFrame', () => {
   let wrapper: RenderResult
 
   beforeEach(() => {
-    wrapper = render(<CardFrame className="example-class">Content</CardFrame>)
+    wrapper = render(
+      <CardFrame className="example-class" data-arbitrary="arbitrary">
+        Content
+      </CardFrame>
+    )
   })
 
   it('should render the content', () => {
@@ -17,6 +22,13 @@ describe('CardFrame', () => {
   it('should apply the injected custom class', () => {
     expect(wrapper.getByTestId('cardframe-wrapper').classList).toContain(
       'example-class'
+    )
+  })
+
+  it('should spread arbitrary props', () => {
+    expect(wrapper.getByTestId('cardframe-wrapper')).toHaveAttribute(
+      'data-arbitrary',
+      'arbitrary'
     )
   })
 })

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.test.tsx
@@ -204,4 +204,25 @@ describe('Checkbox', () => {
       expect(checkbox.queryByTestId('label')).toHaveAttribute('for', 'test')
     })
   })
+
+  describe('when an arbitrary prop is provided', () => {
+    beforeEach(() => {
+      checkbox = render(
+        <Checkbox
+          data-arbitrary="arbitrary"
+          name={field.name}
+          value={field.value}
+          label={label}
+          onChange={field.onChange}
+        />
+      )
+    })
+
+    it('should drill the arbitrary prop', () => {
+      expect(checkbox.queryByTestId('checkbox')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/CheckboxEnhanced/CheckboxEnhanced.test.tsx
+++ b/packages/react-component-library/src/components/CheckboxEnhanced/CheckboxEnhanced.test.tsx
@@ -222,4 +222,26 @@ describe('CheckboxEnhanced', () => {
       ).toEqual('Hello, World!')
     })
   })
+
+  describe('when an abritrary prop is provided', () => {
+    beforeEach(() => {
+      checkbox = render(
+        <CheckboxEnhanced
+          data-arbitrary="arbitrary"
+          name={field.name}
+          value={field.value}
+          onChange={field.onChange}
+          title={label}
+          description="Hello, World!"
+        />
+      )
+    })
+
+    it('should drill the arbitrary prop', () => {
+      expect(checkbox.queryByTestId('checkbox')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
@@ -350,4 +350,37 @@ describe('ContextMenu', () => {
       })
     })
   })
+
+  describe('With arbitrary props', () => {
+    beforeEach(() => {
+      const ContextExample = () => {
+        const ref = useRef()
+
+        return (
+          <>
+            <div>Click elsewhere</div>
+            <div ref={ref}><p>Click me!</p></div>
+            <ContextMenu
+              attachedToRef={ref}
+              clickType="left"
+              data-arbitrary="arbitrary"
+            >
+              <ContextMenuItem
+                link={<Link href="/hello-foo">Hello, Foo!</Link>}
+              />
+            </ContextMenu>
+          </>
+        )
+      }
+
+      wrapper = render(<ContextExample />)
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('context-menu')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
@@ -30,13 +30,13 @@ interface ContextMenuProps extends ComponentWithClass {
 }
 
 export const ContextMenu: React.FC<ContextMenuProps> = ({
-  className,
   children,
   attachedToRef,
   clickType = 'right',
   onHide,
   onShow,
   position = CLICK_MENU_POSITION.BELOW,
+  ...rest
 }) => {
   const { coordinates, isOpen, menuRef } = useClickMenu<HTMLOListElement>({
     attachedToRef,
@@ -54,11 +54,11 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
     <StyledContextMenu
       $hasIcons={hasIcons}
       $isOpen={isOpen}
-      className={className}
       data-testid="context-menu"
       left={coordinates.x}
       ref={menuRef}
       top={coordinates.y}
+      {...rest}
     >
       {children}
     </StyledContextMenu>

--- a/packages/react-component-library/src/components/DataList/DataList.test.tsx
+++ b/packages/react-component-library/src/components/DataList/DataList.test.tsx
@@ -10,11 +10,25 @@ describe('DataList', () => {
   describe('default props', () => {
     beforeEach(() => {
       wrapper = render(
-        <DataList title="title">
-          <DataListItem description="One">1</DataListItem>
+        <DataList data-arbitrary="arbitrary" title="title">
+          <DataListItem data-arbitrary="arbitrary-item" description="One">1</DataListItem>
           <DataListItem description="Two">2</DataListItem>
           <DataListItem description="Three">3</DataListItem>
         </DataList>
+      )
+    })
+
+    it('should spread arbitrary props to the data list', () => {
+      expect(wrapper.getByTestId('data-list')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+
+    it('should spread arbitrary props to the data list items', () => {
+      expect(wrapper.getAllByTestId('data-list-item')[0]).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-item'
       )
     })
 

--- a/packages/react-component-library/src/components/DataList/DataList.tsx
+++ b/packages/react-component-library/src/components/DataList/DataList.tsx
@@ -35,17 +35,21 @@ function getAriaAttributes(isCollapsible: boolean, expanded: boolean) {
 }
 
 export const DataList: React.FC<DataListProps> = ({
-  className,
   isCollapsible,
   title,
   children,
+  ...rest
 }) => {
   const { open, toggle } = useOpenClose(false)
   const ariaAttributes = getAriaAttributes(isCollapsible, open)
   const sheetId = ariaAttributes && ariaAttributes['aria-owns']
 
   return (
-    <StyledDataList $isCollapsible={isCollapsible} className={className}>
+    <StyledDataList
+      $isCollapsible={isCollapsible}
+      data-testid="data-list"
+      {...rest}
+    >
       <StyledHeader
         $isCollapsible={isCollapsible}
         onClick={toggle}

--- a/packages/react-component-library/src/components/DataList/DataListItem.tsx
+++ b/packages/react-component-library/src/components/DataList/DataListItem.tsx
@@ -14,8 +14,13 @@ export const DataListItem: React.FC<DataListItemProps> = ({
   children,
   description,
   isCollapsible,
+  ...rest
 }) => (
-  <StyledItem $isCollapsible={isCollapsible} data-testid="data-list-item">
+  <StyledItem
+    $isCollapsible={isCollapsible}
+    data-testid="data-list-item"
+    {...rest}
+  >
     <StyledItemKey>{description}</StyledItemKey>
     <StyledItemValue>{children}</StyledItemValue>
   </StyledItem>

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -437,4 +437,17 @@ describe('DatePicker', () => {
       )
     })
   })
+
+  describe('when arbitrary props are provided', () => {
+    beforeEach(() => {
+      wrapper = render(<DatePicker data-arbitrary="arbitrary" />)
+    })
+
+    it('sets the disabled attribute correctly for the input', () => {
+      expect(wrapper.getByTestId('datepicker-input')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -311,15 +311,11 @@ function getNewState(
 }
 
 export const DatePicker: React.FC<DatePickerProps> = ({
-  className,
   endDate,
   format: datePickerFormat = DATE_FORMAT.SHORT,
   id = uuidv4(),
-  isDisabled,
   isRange,
   label = 'Select Date',
-  name,
-  onBlur,
   onChange,
   placement = DATEPICKER_PLACEMENT.BELOW,
   startDate,
@@ -327,6 +323,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   isOpen,
   disabledDays,
   initialMonth,
+  ...rest
 }) => {
   const componentRef = useRef(null)
 
@@ -383,19 +380,16 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         $isVisible: open,
         renderTarget: (ref: React.RefObject<HTMLDivElement>) => (
           <DatePickerInput
-            className={className}
             ref={ref}
             dayPickerId={contentId}
             id={id}
-            name={name}
             label={label}
             value={transformDates(from, to, datePickerFormat)}
-            onBlur={onBlur}
             onFocus={handleOnFocus}
-            isDisabled={isDisabled}
             isOpen={open}
             onClose={handleOnClose}
             hasContent={!!hasContent}
+            {...rest}
           />
         ),
         renderElement: (ref: React.RefObject<HTMLDivElement>) => (

--- a/packages/react-component-library/src/components/DatePicker/DatePickerInput.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePickerInput.tsx
@@ -7,7 +7,6 @@ import { DropdownIndicatorIcon } from '../Dropdown/DropdownIndicatorIcon'
 import { getOuterWrapperBorder } from '../../styled-components'
 
 export interface DatePickerInputProps extends ComponentWithClass {
-  ref: React.Ref<HTMLDivElement>
   dayPickerId?: string
   id?: string
   label?: string
@@ -161,6 +160,7 @@ export const DatePickerInput = forwardRef(
       isOpen,
       onClose,
       hasContent,
+      ...rest
     } = props
 
     return (
@@ -191,6 +191,7 @@ export const DatePickerInput = forwardRef(
               readOnly
               aria-label="Choose date"
               data-testid="datepicker-input"
+              {...rest}
             />
           </StyledInputWrapper>
           <StyledButton

--- a/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
@@ -25,6 +25,7 @@ describe('Modal', () => {
       beforeEach(() => {
         wrapper = render(
           <Dialog
+            data-arbitrary="arbitrary"
             title={title}
             description={description}
             onConfirm={onConfirm}
@@ -34,10 +35,17 @@ describe('Modal', () => {
         )
       })
 
+      it('should spread arbitrary props', () => {
+        expect(wrapper.getByTestId('dialog')).toHaveAttribute(
+          'data-arbitrary',
+          'arbitrary'
+        )
+      })
+
       it('should set the `aria-labelledby` attribute to the ID of the title', () => {
         const titleId = wrapper.getByTestId('dialog-title').getAttribute('id')
 
-        expect(wrapper.getByTestId('modal-wrapper')).toHaveAttribute(
+        expect(wrapper.getByTestId('dialog')).toHaveAttribute(
           'aria-labelledby',
           titleId
         )

--- a/packages/react-component-library/src/components/Dialog/Dialog.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.tsx
@@ -43,6 +43,7 @@ export const Dialog: React.FC<DialogProps> = ({
 
   return (
     <StyledDialog
+      data-testid="dialog"
       titleId={titleId}
       descriptionId={descriptionId}
       primaryButton={confirmButton}

--- a/packages/react-component-library/src/components/DismissibleBanner/DismissableBanner.test.tsx
+++ b/packages/react-component-library/src/components/DismissibleBanner/DismissableBanner.test.tsx
@@ -98,4 +98,24 @@ describe('DismissibleBanner', () => {
       expect(wrapper.queryAllByTestId('checkbox')).toHaveLength(0)
     })
   })
+
+  describe('with arbitrary props', () => {
+    beforeEach(() => {
+      const props = {
+        children: 'content',
+        'data-arbitrary': 'arbitrary',
+        title: 'title',
+        onDismiss: () => true,
+      }
+
+      wrapper = render(<DismissibleBanner {...props} />)
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('dimissablebanner-wrapper')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Drawer/Drawer.test.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.test.tsx
@@ -166,4 +166,19 @@ describe('Drawer', () => {
       )
     })
   })
+
+  describe('when an arbitrary prop is specified', () => {
+    beforeEach(() => {
+      children = <h1>Arbitrary JSX</h1>
+
+      wrapper = render(<Drawer data-arbitrary="arbitrary">{children}</Drawer>)
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('drawer-wrapper')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Drawer/Drawer.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.tsx
@@ -15,7 +15,7 @@ interface DrawerProps extends ComponentWithClass {
 }
 
 export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
-  ({ children, onClose, isOpen, className }, ref) => {
+  ({ children, onClose, isOpen, className, ...rest }, ref) => {
     const { handleOnClose, open } = useOpenClose(isOpen, onClose)
 
     return (
@@ -24,6 +24,7 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
         $isOpen={open}
         data-testid="drawer-wrapper"
         ref={ref}
+        {...rest}
       >
         <StyledDrawerInner>
           <StyledDrawerButton

--- a/packages/react-component-library/src/components/List/List.test.tsx
+++ b/packages/react-component-library/src/components/List/List.test.tsx
@@ -253,4 +253,44 @@ describe('List', () => {
       )
     })
   })
+
+  describe('when arbitrary props are specified', () => {
+    beforeEach(() => {
+      onClickSpy1 = jest.fn()
+      onClickSpy2 = jest.fn()
+      onClickSpy3 = jest.fn()
+
+      wrapper = render(
+        <List data-arbitrary="arbitrary-list">
+          <ListItem
+            data-arbitrary="arbitrary-list-item"
+            onClick={onClickSpy1}
+            title="List item"
+          >
+            This is the description
+          </ListItem>
+          <ListItem onClick={onClickSpy2} title="List item">
+            This is the description
+          </ListItem>
+          <ListItem onClick={onClickSpy3} title="List item">
+            This is the description
+          </ListItem>
+        </List>
+      )
+    })
+
+    it('should spread arbitrary props to the list', () => {
+      expect(wrapper.getByTestId('list')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-list'
+      )
+    })
+
+    it('should spread arbitrary props to the list item', () => {
+      expect(wrapper.getAllByTestId('list-item')[0]).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-list-item'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Modal/Modal.test.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.test.tsx
@@ -270,4 +270,21 @@ describe('Modal', () => {
       })
     })
   })
+
+  describe('when the component has arbitrary props', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Modal data-arbitrary="arbitrary">
+          <span>Example child JSX</span>
+        </Modal>
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('modal-wrapper')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -45,6 +45,7 @@ export const Modal: React.FC<ModalProps> = ({
   tertiaryButton,
   title,
   titleId,
+  ...rest
 }) => {
   const { handleOnClose, open } = useOpenClose(isOpen, onClose)
   const primaryButtonWithIcon = primaryButton && {
@@ -63,6 +64,7 @@ export const Modal: React.FC<ModalProps> = ({
       aria-labelledby={modalTitleId}
       aria-describedby={descriptionId}
       data-testid="modal-wrapper"
+      {...rest}
     >
       <StyledMain>
         {title && (

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
@@ -659,4 +659,24 @@ describe('NumberInput', () => {
       assertInputValue('')
     })
   })
+
+  describe('when arbitrary props are specified', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <NumberInput
+          data-arbitrary="arbitrary"
+          name="number-input"
+          onChange={onChangeSpy}
+        />
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('number-input-input')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
+
 })

--- a/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
@@ -370,4 +370,19 @@ describe('Pagination', () => {
       expect(page).toHaveStyleRule('color', color('neutral', 'white'))
     })
   })
+
+  describe('when passing arbitrary props', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Pagination data-arbitrary="arbitrary" pageSize={10} total={45} />
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('pagination')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Pagination/Pagination.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.tsx
@@ -18,6 +18,7 @@ export const Pagination: React.FC<PaginationProps> = ({
   onChange,
   pageSize,
   total,
+  ...rest
 }) => {
   const totalPages = Math.ceil(total / pageSize)
 
@@ -28,7 +29,7 @@ export const Pagination: React.FC<PaginationProps> = ({
   )
 
   return (
-    <StyledList>
+    <StyledList data-testid="pagination" {...rest}>
       <StyledListItem key={getKey('pagination-item', 'previous')}>
         <PaginationButton
           aria-label="Previous page"

--- a/packages/react-component-library/src/components/Panel/Panel.test.tsx
+++ b/packages/react-component-library/src/components/Panel/Panel.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { render, RenderResult } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
 
 import { Panel } from './index'
 
@@ -8,11 +9,18 @@ describe('Panel', () => {
 
   beforeEach(() => {
     wrapper = render(
-      <Panel>Content</Panel>
+      <Panel data-arbitrary="arbitrary">Content</Panel>
     )
   })
 
   it('should render the content', () => {
     expect(wrapper.getByText('Content')).toBeTruthy()
+  })
+
+  it('should spread arbitrary props', () => {
+    expect(wrapper.getByTestId('panel')).toHaveAttribute(
+      'data-arbitrary',
+      'arbitrary'
+    )
   })
 })

--- a/packages/react-component-library/src/components/Panel/Panel.tsx
+++ b/packages/react-component-library/src/components/Panel/Panel.tsx
@@ -13,9 +13,6 @@ const StyledPanel = styled.div`
   border-radius: 3px;
 `
 
-export const Panel: React.FC<ComponentWithClass> = ({
-  children,
-  className,
-}) => {
-  return <StyledPanel className={className}>{children}</StyledPanel>
-}
+export const Panel: React.FC<ComponentWithClass> = (props) => (
+  <StyledPanel data-testid="panel" {...props} />
+)

--- a/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.test.tsx
+++ b/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.test.tsx
@@ -17,12 +17,21 @@ describe('PhaseBanner', () => {
         </p>
       )
 
-      wrapper = render(<PhaseBanner>{content}</PhaseBanner>)
+      wrapper = render(
+        <PhaseBanner data-arbitrary="arbitrary">{content}</PhaseBanner>
+      )
     })
 
     it('renders the custom content', () => {
       expect(wrapper.getByTestId('phase-banner-content').innerHTML).toContain(
         renderToStaticMarkup(content)
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('phase-banner')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
       )
     })
   })

--- a/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.tsx
+++ b/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.tsx
@@ -18,9 +18,9 @@ export const PhaseBanner: React.FC<PhaseBannerProps> = ({
   isFullWidth = false,
   link = '/feedback',
   phase = 'alpha',
-  className,
+  ...rest
 }) => (
-  <StyledPhaseBanner className={className}>
+  <StyledPhaseBanner data-testid="phase-banner" {...rest}>
     <StyledWrapper
       $isFullWidth={isFullWidth}
       data-testid="phase-banner-wrapper"

--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -54,7 +54,7 @@ describe('Popover', () => {
         .getByTestId('floating-box-content')
         .getAttribute('id')
 
-      expect(wrapper.getByTestId('floating-box')).toHaveAttribute(
+      expect(wrapper.getByTestId('popover')).toHaveAttribute(
         'aria-describedby',
         contentId
       )
@@ -70,7 +70,7 @@ describe('Popover', () => {
       })
 
       it('to be visible to the end user', () => {
-        expect(wrapper.getByTestId('floating-box')).toHaveStyleRule(
+        expect(wrapper.getByTestId('popover')).toHaveStyleRule(
           'opacity',
           '1'
         )
@@ -93,7 +93,7 @@ describe('Popover', () => {
 
         it('to not be visible to the end user', () => {
           return waitFor(() => {
-            expect(wrapper.getByTestId('floating-box')).toHaveStyleRule(
+            expect(wrapper.getByTestId('popover')).toHaveStyleRule(
               'opacity',
               '0'
             )
@@ -128,7 +128,7 @@ describe('Popover', () => {
       })
 
       it('to be visible to the end user', () => {
-        expect(wrapper.getByTestId('floating-box')).toHaveStyleRule(
+        expect(wrapper.getByTestId('popover')).toHaveStyleRule(
           'opacity',
           '1'
         )
@@ -147,7 +147,7 @@ describe('Popover', () => {
 
         it('to not be visible to the end user', () => {
           return waitFor(() => {
-            expect(wrapper.getByTestId('floating-box')).toHaveStyleRule(
+            expect(wrapper.getByTestId('popover')).toHaveStyleRule(
               'opacity',
               '0'
             )
@@ -168,7 +168,7 @@ describe('Popover', () => {
 
         it('to not be visible to the end user', () => {
           return waitFor(() => {
-            expect(wrapper.getByTestId('floating-box')).toHaveStyleRule(
+            expect(wrapper.getByTestId('popover')).toHaveStyleRule(
               'opacity',
               '0'
             )
@@ -203,4 +203,22 @@ describe('Popover', () => {
       })
     })
   })
+
+  describe('when passing arbitrary props', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Popover content={content} data-arbitrary="arbitrary">
+          <div>{HOVER_ON_ME}</div>
+        </Popover>
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('popover')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
+
 })

--- a/packages/react-component-library/src/components/Popover/Popover.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.tsx
@@ -69,6 +69,7 @@ export const Popover: React.FC<PopoverProps> = ({
         scheme={scheme}
         aria-describedby={contentId}
         contentId={contentId}
+        data-testid="popover"
         {...rest}
       >
         {React.cloneElement(content, {

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.test.tsx
@@ -34,4 +34,19 @@ describe('ProgressIndicator', () => {
       )
     })
   })
+
+  describe('with arbitrary props', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <ProgressIndicator data-arbitrary="arbitrary" />
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('progress-indicator')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -4,14 +4,9 @@ import { IconLoader } from '@royalnavy/icon-library'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { StyledProgressIndicator } from './partials/StyledProgressIndicator'
 
-export const ProgressIndicator: React.FC<ComponentWithClass> = ({
-  className,
-}) => {
+export const ProgressIndicator: React.FC<ComponentWithClass> = (props) => {
   return (
-    <StyledProgressIndicator
-      className={className}
-      data-testid="progress-indicator"
-    >
+    <StyledProgressIndicator data-testid="progress-indicator" {...props}>
       <IconLoader size={40} data-testid="loader" />
       <span>Loading...</span>
     </StyledProgressIndicator>

--- a/packages/react-component-library/src/components/Radio/Radio.test.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.test.tsx
@@ -107,7 +107,7 @@ describe('Radio', () => {
     })
   })
 
-  describe('when an additional class it provided', () => {
+  describe('when an additional class is provided', () => {
     beforeEach(() => {
       radio = render(
         <Radio
@@ -144,6 +144,27 @@ describe('Radio', () => {
 
     it('should associate the label to the field with the custom id', () => {
       expect(radio.queryByTestId('label')).toHaveAttribute('for', 'test')
+    })
+  })
+
+  describe('when arbitrary props are provided', () => {
+    beforeEach(() => {
+      radio = render(
+        <Radio
+          data-arbitrary="arbitrary"
+          name={field.name}
+          value={field.value}
+          onChange={field.onChange}
+          label={label}
+        />
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(radio.getByTestId('radio')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
     })
   })
 })

--- a/packages/react-component-library/src/components/Radio/Radio.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.tsx
@@ -59,8 +59,8 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
               onChange={onChange}
               onBlur={onBlur}
               disabled={isDisabled}
-              {...rest}
               data-testid="radio"
+              {...rest}
             />
             <StyledCheckmark />
             {label}

--- a/packages/react-component-library/src/components/RadioEnhanced/RadioEnhanced.test.tsx
+++ b/packages/react-component-library/src/components/RadioEnhanced/RadioEnhanced.test.tsx
@@ -147,7 +147,7 @@ describe('RadioEnhanced', () => {
     })
   })
 
-  describe('when an additional class it provided', () => {
+  describe('when an additional class is provided', () => {
     beforeEach(() => {
       radio = render(
         <RadioEnhanced
@@ -204,6 +204,27 @@ describe('RadioEnhanced', () => {
     it('should output the description', () => {
       expect(radio.getByTestId('radioenhanced-description').innerHTML).toEqual(
         'Hello, World!'
+      )
+    })
+  })
+
+  describe('when arbitrary props are provided', () => {
+    beforeEach(() => {
+      radio = render(
+        <RadioEnhanced
+          data-arbitrary="arbitrary"
+          name={field.name}
+          value={field.value}
+          onChange={field.onChange}
+          title={label}
+        />
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(radio.getByTestId('radio')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
       )
     })
   })

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
@@ -306,6 +306,30 @@ describe('RangeSlider', () => {
     })
   })
 
+  describe('when arbitrary props are provided', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <RangeSlider
+          data-arbitrary="arbitrary"
+          domain={[0, 40]}
+          mode={1}
+          values={[20]}
+          tracksLeft
+          tickCount={4}
+          thresholds={[40, 60]}
+        />
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('rangeslider')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
+
+
   describe('without the `onUpdate` callback', () => {
     beforeEach(() => {
       wrapper = render(

--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -113,7 +113,6 @@ const StyledIconRight = styled.div`
 `
 
 export const RangeSlider: React.FC<RangeSliderProps> = ({
-  className,
   domain,
   step,
   hasLabels,
@@ -125,6 +124,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
   isReversed,
   isDisabled,
   values,
+  onChange,
   onUpdate,
   thresholds,
   hasPercentage,
@@ -152,11 +152,11 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
 
   return (
     <StyledRangeSlider
-      className={className}
       $isReversed={isReversed}
       $isDisabled={isDisabled}
       $hasPercentage={hasPercentage}
       data-testid="rangeslider"
+      {...rest}
     >
       {IconLeft && (
         <StyledIconLeft aria-hidden data-testid="rangeslider-icon-left">
@@ -169,8 +169,8 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
         disabled={isDisabled}
         values={values}
         step={step}
+        onChange={onChange}
         onUpdate={onUpdateHandler}
-        {...rest}
       >
         <Rail>
           {({ getRailProps }) => (

--- a/packages/react-component-library/src/components/Switch/Switch.test.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.test.tsx
@@ -15,6 +15,7 @@ describe('Switch', () => {
       wrapper = render(
         <Switch
           className="custom-class"
+          data-arbitrary="arbitrary"
           label="Switch label"
           name="switch-name"
           onChange={onChangeSpy}
@@ -26,6 +27,13 @@ describe('Switch', () => {
           ]}
           value="3"
         />
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('switch-wrapper')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
       )
     })
 

--- a/packages/react-component-library/src/components/Switch/Switch.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.tsx
@@ -39,23 +39,19 @@ export interface SwitchProps extends ComponentWithClass, InputValidationProps {
 }
 
 export const Switch: React.FC<SwitchProps> = ({
-  className,
   label,
   name,
   onChange,
   options = [],
   size = SWITCH_SIZE.REGULAR,
   value,
+  ...rest
 }) => {
   const [active, setActive] = useState(getActiveOption(options, value))
   const id = uuidv4()
 
   return (
-    <StyledSwitch
-      className={className}
-      data-testid="switch-wrapper"
-      $size={size}
-    >
+    <StyledSwitch data-testid="switch-wrapper" $size={size} {...rest}>
       {label && (
         <StyledLegend data-testid="switch-legend">{label}</StyledLegend>
       )}

--- a/packages/react-component-library/src/components/TabSet/TabContent.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabContent.tsx
@@ -13,6 +13,7 @@ export const TabContent: React.FC<TabContentProps> = ({
   tabId,
   isActive,
   children,
+  ...rest
 }) => {
   const classes = classNames('rn-tab-set__content', { 'is-active': isActive })
 
@@ -25,6 +26,7 @@ export const TabContent: React.FC<TabContentProps> = ({
       id={tabId}
       tabIndex={0}
       data-testid="tab-set-content"
+      {...rest}
     >
       {children}
     </div>

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -24,6 +24,7 @@ describe('TabSet', () => {
       beforeEach(() => {
         const props = {
           className: 'rn-tab-set--modifier',
+          'data-arbitrary': 'arbitrary',
           onChange: () => {
             return true
           },
@@ -33,9 +34,23 @@ describe('TabSet', () => {
 
         wrapper = render(
           <TabSet {...props}>
-            <Tab title="Title 1">Content 1</Tab>
+            <Tab data-arbitrary="arbitrary-tab" title="Title 1">Content 1</Tab>
             <Tab title="Title 2">Content 2</Tab>
           </TabSet>
+        )
+      })
+
+      it('should spread arbitrary props on the tab set', () => {
+        expect(wrapper.getByTestId('tab-set')).toHaveAttribute(
+          'data-arbitrary',
+          'arbitrary'
+        )
+      })
+
+      it('should spread arbitrary props on the tab', () => {
+        expect(wrapper.getAllByTestId('tab-set-content')[0]).toHaveAttribute(
+          'data-arbitrary',
+          'arbitrary-tab'
         )
       })
 

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -1,7 +1,7 @@
 import React, { Children, useState, KeyboardEvent } from 'react'
 import classNames from 'classnames'
 
-import { TabContent, TabItem, TabProps } from '.'
+import { Tab, TabContent, TabItem, TabProps } from '.'
 import { ScrollButton } from './ScrollButton'
 import { useScrollableTabSet } from './useScrollableTabSet'
 import { SCROLL_DIRECTION } from './constants'
@@ -22,6 +22,7 @@ export const TabSet: React.FC<TabSetProps> = ({
   children,
   onChange,
   isScrollable,
+  ...rest
 }) => {
   const [tabIds] = useState(
     Array.from({ length: children.length }).map(() => getId('tab-content'))
@@ -61,7 +62,7 @@ export const TabSet: React.FC<TabSetProps> = ({
   })
 
   return (
-    <article className={articleClasses} data-testid="tab-set">
+    <article className={articleClasses} data-testid="tab-set" {...rest}>
       <header className="rn-tab-set__head">
         {isScrollable && (
           <ScrollButton
@@ -107,11 +108,19 @@ export const TabSet: React.FC<TabSetProps> = ({
       <div className="rn-tab-set__body">
         {Children.map(
           children,
-          (child: React.ReactElement<TabProps>, index: number) => (
-            <TabContent tabId={tabIds[index]} isActive={index === activeTab}>
-              {child}
-            </TabContent>
-          )
+          (child: React.ReactElement<TabProps>, index: number) => {
+            const { children: tabChildren, title, ...tabRest } = child.props
+
+            return (
+              <TabContent
+                tabId={tabIds[index]}
+                isActive={index === activeTab}
+                {...tabRest}
+              >
+                <Tab title={title}>{tabChildren}</Tab>
+              </TabContent>
+            )
+          }
         )}
       </div>
     </article>

--- a/packages/react-component-library/src/components/Table/Table.test.tsx
+++ b/packages/react-component-library/src/components/Table/Table.test.tsx
@@ -367,4 +367,51 @@ describe('Table', () => {
       )
     })
   })
+
+  describe('when arbitrary props are provided', () => {
+    beforeEach(() => {
+      const tableDataMock = [
+        {
+          id: 'a',
+          first: 'a1',
+          second: 'a2',
+          third: 'a3',
+        },
+        {
+          id: 'b',
+          first: 'b1',
+          second: 'b2',
+          third: 'b3',
+        },
+        {
+          id: 'c',
+          first: 'c1',
+          second: 'c2',
+          third: 'c3',
+        },
+      ]
+
+      wrapper = render(
+        <Table data={tableDataMock} data-arbitrary="arbitrary">
+          <TableColumn data-arbitrary="arbitrary-column" field="first">First</TableColumn>
+          <TableColumn field="second">Second</TableColumn>
+          <TableColumn field="third">Third</TableColumn>
+        </Table>
+      )
+    })
+
+    it('should spread arbitrary props on the table', () => {
+      expect(wrapper.getByTestId('table')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+
+    it('should spread arbitrary props on the table column', () => {
+      expect(wrapper.getAllByTestId('table-header')[0]).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-column'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Table/Table.tsx
+++ b/packages/react-component-library/src/components/Table/Table.tsx
@@ -25,9 +25,10 @@ function getKey(prefix: string, id: string) {
 
 export const Table: React.FC<TableProps> = ({
   data,
-  children,
   caption,
+  children,
   className,
+  ...rest
 }) => {
   const { tableData, sortTableData, sortField, sortOrder } = useTableData(data)
 
@@ -43,7 +44,7 @@ export const Table: React.FC<TableProps> = ({
 
   return (
     <StyledTableWrapper className={className} data-testid="table-wrapper">
-      <StyledTable data-testid="table" role="grid">
+      <StyledTable data-testid="table" role="grid" {...rest}>
         {caption && <caption data-testid="table-caption">{caption}</caption>}
         <StyledTableHead>
           <StyledTableRow>{childrenWithSort}</StyledTableRow>

--- a/packages/react-component-library/src/components/Table/TableColumn.tsx
+++ b/packages/react-component-library/src/components/Table/TableColumn.tsx
@@ -66,6 +66,7 @@ export const TableColumn: React.FC<TableColumnProps> = ({
   onSortClick,
   sortOrder,
   children,
+  ...rest
 }) => {
   const icon = getIcon(isSortable, sortOrder)
 
@@ -81,6 +82,7 @@ export const TableColumn: React.FC<TableColumnProps> = ({
       $isSortable={isSortable}
       onClick={onClick}
       data-testid="table-header"
+      {...rest}
     >
       {children}
       {icon}

--- a/packages/react-component-library/src/components/TextInput/TextInput.test.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.test.tsx
@@ -22,6 +22,7 @@ describe('TextInput', () => {
           <TextInput
             autoFocus
             className="rn-textinput--custom"
+            data-arbitrary="arbitrary"
             endAdornment={<span>end</span>}
             value="value"
             name="name"
@@ -54,6 +55,13 @@ describe('TextInput', () => {
     it('should set the custom class', () => {
       expect(wrapper.getByTestId('container').classList).toContain(
         'rn-textinput--custom'
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('input')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
       )
     })
 

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -145,6 +145,7 @@ export const Timeline: React.FC<TimelineProps> = ({
   today,
   range,
   unitWidth,
+  ...rest
 }) => {
   const hoursBlockSize = getHoursBlockSize(children)
   const options: TimelineOptions = {
@@ -192,6 +193,7 @@ export const Timeline: React.FC<TimelineProps> = ({
         className={classNames('timeline', className)}
         data-testid="timeline"
         role="grid"
+        {...rest}
       >
         <StyledInner
           className="timeline__inner"

--- a/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
@@ -22,7 +22,10 @@ const StyledTimelineDays = styled.div`
   white-space: nowrap;
 `
 
-export const TimelineDays: React.FC<TimelineDaysProps> = ({ render }) => {
+export const TimelineDays: React.FC<TimelineDaysProps> = ({
+  render,
+  ...rest
+}) => {
   return (
     <TimelineContext.Consumer>
       {({
@@ -37,6 +40,7 @@ export const TimelineDays: React.FC<TimelineDaysProps> = ({ render }) => {
           isShort
           name="Days"
           data-testid="timeline-days"
+          {...rest}
         >
           <StyledTimelineDays>
             {days.map(({ date }, index) => (

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -182,6 +182,7 @@ export const TimelineEvent: React.FC<TimelineEventProps> = ({
   endDate,
   render,
   startDate,
+  ...rest
 }) => {
   const {
     startsBeforeStart,
@@ -216,6 +217,7 @@ export const TimelineEvent: React.FC<TimelineEventProps> = ({
         title,
         'aria-label': title,
         role: 'cell',
+        ...rest,
       })}
     </div>
   )

--- a/packages/react-component-library/src/components/Timeline/TimelineEvents.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvents.tsx
@@ -9,10 +9,14 @@ export interface TimelineEventsProps extends ComponentWithClass {
     | React.ReactElement<TimelineEventProps>[]
 }
 
-export const TimelineEvents: React.FC<TimelineEventsProps> = props => {
+export const TimelineEvents: React.FC<TimelineEventsProps> = (props) => {
   const { children, ...rest } = props
 
-  return <div {...rest}>{children}</div>
+  return (
+    <div data-testid="timeline-events" {...rest}>
+      {children}
+    </div>
+  )
 }
 
 TimelineEvents.displayName = 'TimelineEvents'

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -56,7 +56,10 @@ const StyledTimelineMonths = styled.div`
   white-space: nowrap;
 `
 
-export const TimelineMonths: React.FC<TimelineMonthsProps> = ({ render }) => (
+export const TimelineMonths: React.FC<TimelineMonthsProps> = ({
+  render,
+  ...rest
+}) => (
   <TimelineContext.Consumer>
     {({
       dispatch,
@@ -93,6 +96,7 @@ export const TimelineMonths: React.FC<TimelineMonthsProps> = ({ render }) => (
             </StyledNavigation>
           </>
         )}
+        {...rest}
       >
         <StyledTimelineMonths>
           {months.map(({ startDate }, index) => (

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -39,7 +39,7 @@ const StyledTimelineRowWeek = styled.div<StyledTimelineRowWeekProps>`
   display: inline-block;
   height: 100vh;
   background-color: ${({ isOddNumber }) =>
-    isOddNumber ?  TIMELINE_ALT_BG_COLOR : TIMELINE_BG_COLOR};
+    isOddNumber ? TIMELINE_ALT_BG_COLOR : TIMELINE_BG_COLOR};
   margin-left: ${({ marginLeft }) => marginLeft};
   width: ${({ width }) => width};
 `
@@ -88,6 +88,7 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
   children,
   className,
   renderColumns,
+  ...rest
 }) => {
   const hasChildren = React.Children.count(children) > 0
   const mainClasses = classNames('timeline__main', className)
@@ -151,6 +152,7 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
         defaultStyles={!renderColumns}
         role="rowgroup"
         data-testid="timeline-rows"
+        {...rest}
       >
         {hasChildren ? children : <TimelineNoData />}
       </StyledTimelineMain>

--- a/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
@@ -55,6 +55,7 @@ function renderDefault({ offset }: { offset: string }) {
 
 export const TimelineTodayMarker: React.FC<TimelineTodayMarkerProps> = ({
   render,
+  ...rest
 }) => {
   const {
     state: { today },
@@ -71,6 +72,7 @@ export const TimelineTodayMarker: React.FC<TimelineTodayMarkerProps> = ({
     <StyledTimelineTodayMarkerWrapper
       data-testid="timeline-today-marker-wrapper"
       role="presentation"
+      {...rest}
     >
       {render ? render(today, offset) : renderDefault({ offset })}
     </StyledTimelineTodayMarkerWrapper>

--- a/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
@@ -32,7 +32,10 @@ const StyledTimelineWeeks = styled.div`
   white-space: nowrap;
 `
 
-export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({ render }) => {
+export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({
+  render,
+  ...rest
+}) => {
   return (
     <TimelineContext.Consumer>
       {({
@@ -47,6 +50,7 @@ export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({ render }) => {
           isShort
           name="Weeks"
           data-testid="timeline-weeks"
+          {...rest}
         >
           <StyledTimelineWeeks>
             {weeks.map(({ startDate }, index) => (

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -545,6 +545,99 @@ describe('Timeline', () => {
     })
   })
 
+  describe('when arbitrary props are specified', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Timeline
+          data-arbitrary="arbitrary-timeline"
+          startDate={new Date(2020, 3, 1)}
+          today={new Date(2020, 3, 15)}
+        >
+          <TimelineTodayMarker data-arbitrary="arbitrary-today-marker" />
+          <TimelineMonths data-arbitrary="arbitrary-months" />
+          <TimelineWeeks data-arbitrary="arbitrary-weeks" />
+          <TimelineDays data-arbitrary="arbitrary-days" />
+          <TimelineRows data-arbitrary="arbitrary-rows">
+            <TimelineRow name="Row 1" data-arbitrary="arbitrary-row">
+              <TimelineEvents data-arbitrary="arbitrary-events">
+                <TimelineEvent
+                  data-arbitrary="arbitrary-event"
+                  startDate={new Date(2020, 3, 4)}
+                  endDate={new Date(2020, 3, 6)}
+                >
+                  Event
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('should spread arbitrary props on the timeline', () => {
+      expect(wrapper.getByTestId('timeline')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-timeline'
+      )
+    })
+
+    it('should spread arbitrary props on the timeline today marker', () => {
+      expect(wrapper.getByTestId('timeline-today-marker-wrapper')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-today-marker'
+      )
+    })
+
+    it('should spread arbitrary props on the timeline months', () => {
+      expect(wrapper.getByTestId('timeline-months')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-months'
+      )
+    })
+
+    it('should spread arbitrary props on the timeline weeks', () => {
+      expect(wrapper.getByTestId('timeline-weeks')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-weeks'
+      )
+    })
+
+    it('should spread arbitrary props on the timeline days', () => {
+      expect(wrapper.getByTestId('timeline-days')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-days'
+      )
+    })
+
+    it('should spread arbitrary props on the timeline rows', () => {
+      expect(wrapper.getByTestId('timeline-rows')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-rows'
+      )
+    })
+
+    it('should spread arbitrary props on the timeline row', () => {
+      expect(wrapper.getByTestId('timeline-row')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-row'
+      )
+    })
+
+    it('should spread arbitrary props on the timeline events', () => {
+      expect(wrapper.getByTestId('timeline-events')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-events'
+      )
+    })
+
+    it('should spread arbitrary props on the timeline event', () => {
+      expect(wrapper.getByTestId('timeline-event')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-event'
+      )
+    })
+  })
+
   describe('when an event is outside the range', () => {
     beforeEach(() => {
       const EventWithinRange: React.FC = () => (

--- a/packages/react-component-library/src/components/Toast/Toast.test.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.test.tsx
@@ -23,6 +23,7 @@ describe('Toast', () => {
           appearance="info"
           autoDismiss={false}
           autoDismissTimeout={300}
+          data-arbitrary="arbitrary"
           label={LABEL}
           isRunning={false}
           onDismiss={onDismissSpy}
@@ -34,6 +35,13 @@ describe('Toast', () => {
         >
           {DESCRIPTION}
         </Toast>
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('toast-wrapper')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
       )
     })
 

--- a/packages/react-component-library/src/components/Toast/Toast.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.tsx
@@ -67,7 +67,7 @@ export const Toast: React.FC<ToastProps> = ({
   transitionDuration,
   transitionState,
   dateTime,
-  className,
+  ...rest
 }) => {
   const [time] = useState<string>(
     (dateTime || new Date()).toLocaleTimeString('en-GB', {
@@ -82,7 +82,6 @@ export const Toast: React.FC<ToastProps> = ({
 
   return (
     <StyledToast
-      className={className}
       $appearance={appearance}
       style={{
         transition: `
@@ -95,6 +94,7 @@ export const Toast: React.FC<ToastProps> = ({
       aria-labelledby={titleId}
       aria-describedby={descriptionId}
       data-testid="toast-wrapper"
+      {...rest}
     >
       <StyledToastHeader>
         <StyledToastTitle id={titleId} data-testid="toast-title">

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.test.tsx
@@ -51,6 +51,7 @@ describe('Tooltip', () => {
       wrapper = render(
         <Tooltip
           bottom={1}
+          data-arbitrary="arbitrary"
           id="123"
           left={2}
           position={TOOLTIP_POSITION.BELOW}
@@ -61,6 +62,13 @@ describe('Tooltip', () => {
         >
           Content
         </Tooltip>
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('tooltip')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
       )
     })
 

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
@@ -152,13 +152,13 @@ const StyledTooltipMessage = styled.div`
 export const Tooltip: React.FC<TooltipProps> = ({
   bottom,
   children,
-  id,
   left,
   position = TOOLTIP_POSITION.ABOVE,
   right,
   title,
   top,
   width,
+  ...rest
 }) => {
   const style = {
     bottom,
@@ -176,9 +176,9 @@ export const Tooltip: React.FC<TooltipProps> = ({
       aria-describedby={contentId}
       aria-labelledby={titleId}
       data-testid="tooltip"
-      id={id}
       role="tooltip"
       style={style}
+      {...rest}
     >
       <StyledTooltipContent position={position}>
         {title && <StyledTooltipTitle id={titleId}>{title}</StyledTooltipTitle>}

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
@@ -21,6 +21,10 @@ import { Notification, Notifications } from '../NotificationPanel'
 describe('Masthead', () => {
   let wrapper: RenderResult
 
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('minimal props', () => {
     beforeEach(() => {
       wrapper = render(<Masthead title="title" />)
@@ -80,6 +84,7 @@ describe('Masthead', () => {
 
       const notification = (
         <Notification
+          data-arbitrary="arbitrary-notification"
           link={<Link href="notifications/1" />}
           name="Thomas Stephens"
           action="added a new comment to your"
@@ -90,17 +95,30 @@ describe('Masthead', () => {
       )
 
       const props = {
+        'data-arbitrary': 'arbitrary-masthead',
         hasUnreadNotification: true,
-        homeLink: <Link href="/" />,
+        homeLink: (
+          <Link
+            data-arbitrary="arbitrary-home-link"
+            data-testid="masthead-home-link"
+            href="/"
+          />
+        ),
         Logo: ({ role }) => <svg data-testid="custom-logo" role={role} />,
         nav: (
-          <MastheadNav>
-            <MastheadNavItem link={<Link href="/first">First</Link>} />
+          <MastheadNav data-arbitrary="arbitrary-nav">
+            <MastheadNavItem
+              data-arbitrary="arbitrary-nav-item"
+              link={<Link href="/first">First</Link>}
+            />
             <MastheadNavItem link={<Link href="/second">Second</Link>} />
           </MastheadNav>
         ),
         notifications: (
-          <Notifications link={<Link href="notifications" />}>
+          <Notifications
+            data-arbitrary="arbitrary-notifications"
+            link={<Link href="notifications" />}
+          >
             {notification}
             {notification}
           </Notifications>
@@ -109,13 +127,53 @@ describe('Masthead', () => {
         searchPlaceholder: 2,
         title: 'title',
         user: (
-          <MastheadUser initials="AB" link={<Link href="/user-profile" />} />
+          <MastheadUser
+            data-arbitrary="arbitrary-user"
+            data-testid="masthead-user"
+            initials="AB"
+            link={<Link href="/user-profile" />}
+          />
         ),
       }
 
       onSearchSpy = jest.spyOn(props, 'onSearch')
 
       wrapper = render(<Masthead {...props} />)
+    })
+
+    it('should spread arbitrary props on the masthead', () => {
+      expect(wrapper.getByTestId('masthead')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-masthead'
+      )
+    })
+
+    it('should spread arbitrary props on the home link', () => {
+      expect(wrapper.getByTestId('masthead-home-link')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-home-link'
+      )
+    })
+
+    it('should spread arbitrary props on the nav', () => {
+      expect(wrapper.getByTestId('masthead-nav')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-nav'
+      )
+    })
+
+    it('should spread arbitrary props on the nav item', () => {
+      expect(wrapper.getAllByTestId('masthead-nav-item')[0]).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-nav-item'
+      )
+    })
+
+    it('should spread arbitrary props on the user', () => {
+      expect(wrapper.getByTestId('masthead-user')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-user'
+      )
     })
 
     it('should warn the consumer for using the deprecated `link` prop', () => {
@@ -314,6 +372,20 @@ describe('Masthead', () => {
         wrapper.queryByTestId('notification-button').click()
       })
 
+      it('should spread arbitrary props on the notifications', () => {
+        expect(wrapper.getByTestId('notifications-sheet')).toHaveAttribute(
+          'data-arbitrary',
+          'arbitrary-notifications'
+        )
+      })
+
+      it('should spread arbitrary props on the notifications item', () => {
+        expect(wrapper.getAllByTestId('notification')[0]).toHaveAttribute(
+          'data-arbitrary',
+          'arbitrary-notification'
+        )
+      })
+
       it('should set the `aria-expanded` attribute on the notification button to `true`', () => {
         expect(wrapper.queryByTestId('notification-button')).toHaveAttribute(
           'aria-expanded',
@@ -356,7 +428,10 @@ describe('Masthead', () => {
             title="title"
             user={(
               <MastheadUser initials="AB">
-                <MastheadUserItem link={<Link href="/profile">Profile</Link>} />
+                <MastheadUserItem
+                  data-arbitrary="arbitrary-user-item"
+                  link={<Link href="/profile">Profile</Link>}
+                />
                 <MastheadUserItem
                   link={<Link href="/settings">Settings</Link>}
                 />
@@ -398,6 +473,13 @@ describe('Masthead', () => {
         expect(wrapper.getByText('Settings')).toBeInTheDocument()
         expect(wrapper.getByText('Support')).toBeInTheDocument()
         expect(wrapper.getByText('Logout')).toBeInTheDocument()
+      })
+
+      it('should spread arbitrary props on the user item', () => {
+        expect(wrapper.getAllByTestId('masthead-user-item')[0]).toHaveAttribute(
+          'data-arbitrary',
+          'arbitrary-user-item'
+        )
       })
 
       describe('and the avatar is clicked again', () => {

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadNavItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadNavItem.tsx
@@ -4,12 +4,17 @@ import { NavItem } from '../../../common/Nav'
 import { getKey } from '../../../helpers'
 import { StyledScrollableNavItem } from './partials/StyledScrollableNavItem'
 
-export const MastheadNavItem: React.FC<NavItem> = ({ isActive, link }) => (
+export const MastheadNavItem: React.FC<NavItem> = ({
+  isActive,
+  link,
+  ...rest
+}) => (
   <StyledScrollableNavItem
     $isActive={isActive}
     key={getKey('masthead-nav-item', link.toString())}
     data-testid="masthead-nav-item"
     role="none"
+    {...rest}
   >
     {React.cloneElement(link as React.ReactElement, {
       role: 'menuitem',

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
@@ -33,11 +33,12 @@ export type MastheadUserProps =
 const MastheadUserWithLink: React.FC<MastheadUserWithLinkProps> = ({
   link,
   initials,
+  ...rest
 }) =>
   React.cloneElement(link as ReactElement, {
     ...link.props,
     children: (
-      <StyledOption>
+      <StyledOption {...rest}>
         <Avatar
           data-testid="masthead-avatar"
           initials={initials}
@@ -75,19 +76,15 @@ const MastheadUserWithItems: React.FC<MastheadUserWithItemsProps> = ({
 
 export const MastheadUser: React.FC<MastheadUserProps> = ({
   children,
-  initials,
   link,
+  ...rest
 }) => {
   if (link) {
     logger.warn('The `link` prop is deprecated')
-    return <MastheadUserWithLink initials={initials} link={link} />
+    return <MastheadUserWithLink link={link} {...rest} />
   }
 
-  return (
-    <MastheadUserWithItems initials={initials}>
-      {children}
-    </MastheadUserWithItems>
-  )
+  return <MastheadUserWithItems {...rest}>{children}</MastheadUserWithItems>
 }
 
 MastheadUser.displayName = 'MastheadUser'

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUserItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUserItem.tsx
@@ -13,6 +13,7 @@ export interface MastheadUserItemProps extends NavItem {
 export const MastheadUserItem: React.FC<MastheadUserItemProps> = ({
   icon,
   link,
+  ...rest
 }) => {
   const linkElement = link as React.ReactElement
 
@@ -27,7 +28,7 @@ export const MastheadUserItem: React.FC<MastheadUserItemProps> = ({
   })
 
   return (
-    <li>
+    <li data-testid="masthead-user-item" {...rest}>
       <StyledUserItemWrapper>{item}</StyledUserItemWrapper>
     </li>
   )

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.tsx
@@ -47,11 +47,12 @@ export const Notification: React.FC<NotificationProps> = ({
   on,
   when,
   description,
+  ...rest
 }) => {
   const contentId = getId('content')
 
   return (
-    <li data-testid="notification">
+    <li data-testid="notification" {...rest}>
       <div className="rn-notifications-item-wrapper">
         {React.cloneElement(link as ReactElement, {
           ...link.props,

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.test.tsx
@@ -7,6 +7,7 @@ import { Link } from '../../Link'
 
 const MOCK_NOTIFICATION = (
   <Notification
+    data-arbitrary="arbitrary-notification"
     link={<Link href="notifications/1" />}
     name="Thomas Stephens"
     action="added a new comment to your"
@@ -22,11 +23,27 @@ describe('Notifications', () => {
 
     beforeEach(() => {
       wrapper = render(
-        <Notifications link={<Link href="notifications" />}>
+        <Notifications
+          data-arbitrary="arbitrary-notifications"
+          link={<Link href="notifications" />}
+        >
           {MOCK_NOTIFICATION}
           {MOCK_NOTIFICATION}
         </Notifications>
       )
+    })
+
+    it('should spread arbitrary props on the notifications', () => {
+      expect(wrapper.getByTestId('notifications-sheet')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-notifications'
+      )
+    })
+
+    it('should spread arbitrary props on the notifications item', () => {
+      expect(
+        wrapper.getAllByTestId('notification')[0]
+      ).toHaveAttribute('data-arbitrary', 'arbitrary-notification')
     })
 
     it('should set the `role` attribute on the notification sheet to `grid`', () => {

--- a/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.test.tsx
@@ -144,4 +144,31 @@ describe('Searchbar', () => {
       })
     })
   })
+
+  describe('when arbitrary props are specified', () => {
+    beforeEach(() => {
+      const searchButton = {
+        current: {
+          contains: jest.fn().mockReturnValue(false),
+        },
+      }
+
+      wrapper = render(
+        <SearchBar
+          data-arbitrary="arbitrary"
+          onSearch={onSearchSpy}
+          searchButton={searchButton}
+          searchPlaceholder="placeholder"
+          setShowSearch={setShowSearchSpy}
+        />
+      )
+    })
+
+    it('should spread arbitrary props', () => {
+      expect(wrapper.getByTestId('searchbar')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.tsx
@@ -17,7 +17,6 @@ export interface SearchbarProps {
 }
 
 export const SearchBar: React.FC<SearchbarProps> = ({
-  className = '',
   onSearch,
   searchButton,
   searchPlaceholder,
@@ -41,9 +40,8 @@ export const SearchBar: React.FC<SearchbarProps> = ({
   return (
     <StyledSearchBar
       ref={searchBoxRef}
-      className={className}
-      {...rest}
       data-testid="searchbar"
+      {...rest}
     >
       <StyledForm data-testid="searchbar-form" onSubmit={onSubmit}>
         <TextInput

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.test.tsx
@@ -36,10 +36,15 @@ describe('Sidebar', () => {
     beforeEach(() => {
       wrapper = render(
         <Sidebar
+          data-arbitrary="arbitrary-sidebar"
           hasUnreadNotification
           nav={(
-            <SidebarNav>
-              <SidebarNavItem Image={House} link={<Link href="/">Home</Link>} />
+            <SidebarNav data-arbitrary="arbitrary-nav">
+              <SidebarNavItem
+                data-arbitrary="arbitrary-nav-item"
+                Image={House}
+                link={<Link href="/">Home</Link>}
+              />
               <SidebarNavItem
                 Image={Graph}
                 link={<Link href="/stats">Stats</Link>}
@@ -52,8 +57,12 @@ describe('Sidebar', () => {
             </SidebarNav>
           )}
           notifications={(
-            <Notifications link={<Link href="notifications" />}>
+            <Notifications
+              data-arbitrary="arbitrary-notifications"
+              link={<Link href="notifications" />}
+            >
               <Notification
+                data-arbitrary="arbitrary-notification"
                 link={<Link href="notifications/1" />}
                 name="Thomas Stephens"
                 action="added a new comment to your"
@@ -71,10 +80,42 @@ describe('Sidebar', () => {
               />
             </Notifications>
           )}
-          user={
-            <SidebarUser initials="XT" link={<Link href="/user-profile" />} />
-          }
+          user={(
+            <SidebarUser
+              data-arbitrary="arbitrary-user"
+              initials="XT"
+              link={<Link href="/user-profile" />}
+            />
+          )}
         />
+      )
+    })
+
+    it('should spread arbitrary props on the sidebar', () => {
+      expect(wrapper.getByTestId('sidebar')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-sidebar'
+      )
+    })
+
+    it('should spread arbitrary props on the nav', () => {
+      expect(wrapper.getByTestId('sidebar-nav')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-nav'
+      )
+    })
+
+    it('should spread arbitrary props on the nav item', () => {
+      expect(wrapper.getAllByTestId('sidebar-nav-item')[0]).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-nav-item'
+      )
+    })
+
+    it('should spread arbitrary props on the user', () => {
+      expect(wrapper.getByTestId('sidebar-user')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-user'
       )
     })
 
@@ -84,10 +125,6 @@ describe('Sidebar', () => {
       images.forEach((image) => {
         expect(image).toHaveAttribute('aria-hidden', 'true')
       })
-    })
-
-    it('should render the notifications', () => {
-      expect(wrapper.getByTestId('notification-button')).toBeInTheDocument()
     })
 
     it('should set the `aria-expanded` attribute on the notification button to `false`', () => {
@@ -113,6 +150,25 @@ describe('Sidebar', () => {
 
     it('should render the user', () => {
       expect(wrapper.getByTestId('sidebar-user')).toBeInTheDocument()
+    })
+
+    describe('when the user opens the notifications', () => {
+      beforeEach(() => {
+        wrapper.queryByTestId('notification-button').click()
+      })
+
+      it('should spread arbitrary props on the notifications', () => {
+        expect(wrapper.getByTestId('notifications-sheet')).toHaveAttribute(
+          'data-arbitrary',
+          'arbitrary-notifications'
+        )
+      })
+
+      it('should spread arbitrary props on the notifications item', () => {
+        expect(
+          wrapper.getAllByTestId('notification')[0]
+        ).toHaveAttribute('data-arbitrary', 'arbitrary-notification')
+      })
     })
   })
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.tsx
@@ -23,6 +23,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   notifications,
   hasUnreadNotification,
   user,
+  ...rest
 }) => {
   const { open, setOpen } = useOpenClose(false)
   const classes = classNames('rn-sidebar', {
@@ -30,7 +31,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   })
 
   return (
-    <div className={classes} data-testid="sidebar">
+    <div className={classes} data-testid="sidebar" {...rest}>
       {nav &&
         React.cloneElement(nav, {
           ...nav.props,

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNav.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNav.tsx
@@ -26,20 +26,10 @@ function mapNavItem(
 
 export const SidebarNav: React.FC<SidebarNavProps> = ({
   children,
-  onBlur,
-  onFocus,
   onItemClick,
-  onMouseOut,
-  onMouseOver,
+  ...rest
 }) => (
-  <nav
-    className="rn-sidebar__top"
-    data-testid="sidebar-nav"
-    onBlur={onBlur}
-    onFocus={onFocus}
-    onMouseOut={onMouseOut}
-    onMouseOver={onMouseOver}
-  >
+  <nav className="rn-sidebar__top" data-testid="sidebar-nav" {...rest}>
     {React.Children.map(
       children,
       (child: React.ReactElement<SidebarNavItemProps>) => {

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNavItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNavItem.tsx
@@ -12,7 +12,7 @@ export const SidebarNavItem: React.FC<SidebarNavItemProps> = ({
   Image,
   isActive,
   link,
-  onClick,
+  ...rest
 }) => {
   const linkElement = link as React.ReactElement
   const classes = classNames('rn-sidebar__nav-link', { 'is-active': isActive })
@@ -31,6 +31,6 @@ export const SidebarNavItem: React.FC<SidebarNavItemProps> = ({
     ),
     className: classes,
     'data-testid': 'sidebar-nav-item',
-    onClick,
+    ...rest,
   })
 }

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
@@ -14,6 +14,7 @@ export const SidebarUser: React.FC<SidebarUserProps> = ({
   className,
   initials,
   link,
+  ...rest
 }) => {
   const classes = classNames('rn-sidebar__nav-link', className)
 
@@ -27,6 +28,7 @@ export const SidebarUser: React.FC<SidebarUserProps> = ({
     ),
     className: classes,
     'data-testid': 'sidebar-user',
+    ...rest
   })
 }
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/Sidebar.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/Sidebar.test.tsx
@@ -550,4 +550,59 @@ describe('Sidebar', () => {
       })
     })
   })
+
+  describe('when composed with arbitrary props', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <SidebarWrapperE data-arbitrary="arbitrary-wrapper">
+          <SidebarE data-arbitrary="arbitrary-sidebar" notifications={notifications}>
+            <SidebarNavE data-arbitrary="arbitrary-nav">
+              <SidebarNavItemE
+                data-arbitrary="arbitrary-nav-item"
+                icon={<IconHome />}
+                link={<Link href="/dashboard">Dashboard</Link>}
+              >
+                <SidebarNavItemE
+                  link={<Link href="/sub-nav-item-1">Sub-nav-item 1</Link>}
+                />
+                <SidebarNavItemE
+                  link={<Link href="/sub-nav-item-2">Sub-nav-item 2</Link>}
+                />
+              </SidebarNavItemE>
+              <SidebarNavItemE link={<Link href="/reports">Reports</Link>} />
+            </SidebarNavE>
+          </SidebarE>
+          <main>Hello, World!</main>
+        </SidebarWrapperE>
+      )
+    })
+
+    it('should spread arbitrary props on the sidebar wrapper', () => {
+      expect(wrapper.getByTestId('sidebar-wrapper')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-wrapper'
+      )
+    })
+
+    it('should spread arbitrary props on the sidebar', () => {
+      expect(wrapper.getByTestId('sidebar')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-sidebar'
+      )
+    })
+
+    it('should spread arbitrary props on the sidebar nav', () => {
+      expect(wrapper.getByTestId('sidebar-nav')).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-nav'
+      )
+    })
+
+    it('should spread arbitrary props on the sidebar nav item', () => {
+      expect(wrapper.getAllByTestId('sidebar-nav-item')[0]).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-nav-item'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/Sidebar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/Sidebar.tsx
@@ -28,15 +28,18 @@ export const SidebarE: React.FC<SidebarEProps> = ({
   user,
   hasUnreadNotification,
   notifications,
+  ...rest
 }) => {
   return (
     <SidebarProvider>
       <SidebarContext.Consumer>
         {({ isOpen, hasMouseOver, setHasMouseOver }) => (
           <StyledSidebar
+            data-testid="sidebar"
             isOpen={isOpen}
             onMouseEnter={(_) => setHasMouseOver(true)}
             onMouseLeave={(_) => setHasMouseOver(false)}
+            {...rest}
           >
             <Transition in={hasMouseOver} timeout={0} unmountOnExit>
               {(state) => (

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarNav.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarNav.tsx
@@ -32,6 +32,7 @@ export const SidebarNavE: React.FC<SidebarNavEProps> = ({
   onItemClick,
   onMouseOut,
   onMouseOver,
+  ...rest
 }) => (
   <StyledNav
     onBlur={onBlur}
@@ -39,6 +40,7 @@ export const SidebarNavE: React.FC<SidebarNavEProps> = ({
     onMouseOut={onMouseOut}
     onMouseOver={onMouseOver}
     data-testid="sidebar-nav"
+    {...rest}
   >
     {React.Children.map(
       children,

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarNavItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarNavItem.tsx
@@ -23,6 +23,7 @@ export const SidebarNavItemE: React.FC<SidebarNavItemEProps> = ({
   icon,
   onClick,
   children,
+  ...rest
 }) => {
   const [hasMouseOver, setHasMouseOver] = useState(false)
   const { isOpen } = useContext(SidebarContext)
@@ -54,6 +55,7 @@ export const SidebarNavItemE: React.FC<SidebarNavItemEProps> = ({
     onClick,
     'aria-label': linkElement.props.children,
     'data-testid': 'sidebar-nav-item',
+    ...rest,
   })
 
   return (

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarWrapper.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarWrapper.tsx
@@ -3,11 +3,8 @@ import React from 'react'
 import { ComponentWithClass } from '../../../common/ComponentWithClass'
 import { StyledWrapper } from './partials/StyledWrapper'
 
-export const SidebarWrapperE: React.FC<ComponentWithClass> = ({
-  className,
-  children,
-}) => {
-  return <StyledWrapper className={className}>{children}</StyledWrapper>
+export const SidebarWrapperE: React.FC<ComponentWithClass> = (props) => {
+  return <StyledWrapper data-testid="sidebar-wrapper" {...props} />
 }
 
 SidebarWrapperE.displayName = 'SidebarWrapper'


### PR DESCRIPTION
## Related issue
Closes #1834 

## Overview
Adds ability to drill props to all components.

## Reason
Useful for drill arbitrary props such as `data-testid`.

## Work carried out
- [x] Add to all components
- [x] Backfill tests

## Developer notes
❤️ 
