### PR TITLE
fix(CheckboxEnhanced): Resolve unclickable label

### DIFF
--- a/packages/react-component-library/src/components/CheckboxEnhanced/partials/StyledCheckboxEnhanced.tsx
+++ b/packages/react-component-library/src/components/CheckboxEnhanced/partials/StyledCheckboxEnhanced.tsx
@@ -1,6 +1,5 @@
-import React from 'react'
 import { selectors } from '@royalnavy/design-tokens'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import { StyledCheckmark } from '../../Checkbox/partials/StyledCheckmark'
 import { StyledInput } from '../../Checkbox/partials/StyledInput'
@@ -36,5 +35,6 @@ export const StyledCheckboxEnhanced = styled.div`
   ${StyledLabel} {
     font-size: ${fontSize('m')};
     color: ${color('neutral', '500')};
+    pointer-events: none;
   }
 `


### PR DESCRIPTION
## Related issue

Closes #1955

## Overview

Clicking the label in the `CheckboxEnhanced` variant would not toggle the checked state.

## Screenshot

![2021-02-01 12 23 30](https://user-images.githubusercontent.com/48086589/106458508-66535800-6488-11eb-830f-d92c05930a6e.gif)
