### PR TITLE
fix(CRATemplateRoyalNavy): Add missing type

### DIFF
--- a/packages/cra-template-royalnavy/template/src/pages/Home/Home.tsx
+++ b/packages/cra-template-royalnavy/template/src/pages/Home/Home.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Main } from '../../layouts'
 
-export const Home = () => (
+export const Home: React.FC<unknown> = () => (
   <Main>
     <h1>Hello, World!</h1>
   </Main>


### PR DESCRIPTION
## Overview

Fix missing return type compiler warning in CRATemplateRoyalNavy boilerplate.