### PR TITLE
Add ability to set TabSet tabs to full width

### DIFF
--- a/packages/docs-site/src/library/pages/components/tab-set.md
+++ b/packages/docs-site/src/library/pages/components/tab-set.md
@@ -124,6 +124,13 @@ The TabSet (and companion Tab) component allows the user to switch between diffe
     Description: 'Called when a tab is clicked.',
   },
   {
+    Name: 'isFullWidth',
+    Type: 'boolean',
+    Required: 'False',
+    Default: 'False',
+    Description: 'Sets the TabSet and tabs to fill the full width',
+  },
+  {
     Name: 'isScrollable',
     Type: 'boolean',
     Required: 'False',

--- a/packages/react-component-library/src/components/TabSet/TabItem.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabItem.tsx
@@ -10,36 +10,46 @@ interface TabItemProps {
   isActive: boolean
   onClick: () => void
   onKeyDown: (event: KeyboardEvent<HTMLLIElement>) => void
+  isFullWidth?: boolean
   isScrollable?: boolean
 }
 
-export const TabItem = forwardRef<HTMLLIElement, TabItemProps>(
-  ({ tabId, children, isActive, isScrollable, onClick, onKeyDown }, ref) => {
-    function handleClick(e: MouseEvent<HTMLButtonElement>) {
-      e.preventDefault()
-      onClick()
-    }
+export const TabItem = forwardRef<HTMLLIElement, TabItemProps>((props, ref) => {
+  const {
+    tabId,
+    children,
+    isActive,
+    isFullWidth,
+    isScrollable,
+    onClick,
+    onKeyDown,
+  } = props
 
-    return (
-      <StyledTabItem
-        $isScrollable={isScrollable}
-        ref={ref}
-        role="tab"
-        aria-controls={tabId}
-        aria-selected={!!isActive}
-        tabIndex={!isActive ? -1 : 0}
-        data-testid="tab-set-tab"
-        aria-label={children.toString()}
-        onKeyDown={onKeyDown}
-      >
-        <StyledTab
-          $isActive={isActive}
-          $isScrollable={isScrollable}
-          onClick={handleClick}
-        >
-          <div>{children}</div>
-        </StyledTab>
-      </StyledTabItem>
-    )
+  function handleClick(e: MouseEvent<HTMLButtonElement>) {
+    e.preventDefault()
+    onClick()
   }
-)
+
+  return (
+    <StyledTabItem
+      $isFullWidth={isFullWidth}
+      $isScrollable={isScrollable}
+      ref={ref}
+      role="tab"
+      aria-controls={tabId}
+      aria-selected={!!isActive}
+      tabIndex={!isActive ? -1 : 0}
+      data-testid="tab-set-tab"
+      aria-label={children.toString()}
+      onKeyDown={onKeyDown}
+    >
+      <StyledTab
+        $isActive={isActive}
+        $isScrollable={isScrollable}
+        onClick={handleClick}
+      >
+        <div>{children}</div>
+      </StyledTab>
+    </StyledTabItem>
+  )
+})

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -1,6 +1,6 @@
+import React from 'react'
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
-import React from 'react'
 
 import { Tab, TabSet } from '.'
 
@@ -19,6 +19,17 @@ stories.add('Default', () => (
     </Tab>
     <Tab title="Example Tab 4">
       <p>This is some example tab 4 content</p>
+    </Tab>
+  </TabSet>
+))
+
+stories.add('Default full width', () => (
+  <TabSet isFullWidth onChange={action('onChange')}>
+    <Tab title="Example Tab 1">
+      <p>This is some example tab 1 content</p>
+    </Tab>
+    <Tab title="Example Tab 2">
+      <p>This is some example tab 2 content</p>
     </Tab>
   </TabSet>
 ))

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -34,6 +34,29 @@ stories.add('Default full width', () => (
   </TabSet>
 ))
 
+stories.add('Default scrollable body', () => (
+  <div style={{ height: '200px' }}>
+    <TabSet onChange={action('onChange')}>
+      <Tab title="Example Tab 1">
+        <>
+          <p>This is some example tab 1 content</p>
+          <p>This is some example tab 1 content</p>
+          <p>This is some example tab 1 content</p>
+          <p>This is some example tab 1 content</p>
+          <p>This is some example tab 1 content</p>
+          <p>This is some example tab 1 content</p>
+          <p>This is some example tab 1 content</p>
+          <p>This is some example tab 1 content</p>
+          <p>This is some example tab 1 content</p>
+        </>
+      </Tab>
+      <Tab title="Example Tab 2">
+        <p>This is some example tab 2 content</p>
+      </Tab>
+    </TabSet>
+  </div>
+))
+
 interface TabTitleProps {
   children: string
   year: number

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -1,9 +1,7 @@
-import React, { Children, useState, KeyboardEvent } from 'react'
-import {
-  IconKeyboardArrowLeft,
-  IconKeyboardArrowRight,
-} from '@royalnavy/icon-library'
+import React, { Children, KeyboardEvent, useState } from 'react'
+import { IconKeyboardArrowLeft, IconKeyboardArrowRight } from '@royalnavy/icon-library'
 
+import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { Tab, TabContent, TabItem, TabProps } from '.'
 import { useScrollableTabSet } from './useScrollableTabSet'
 import { SCROLL_DIRECTION } from './constants'
@@ -16,20 +14,28 @@ import { StyledBody } from './partials/StyledBody'
 import { StyledScrollRight } from './partials/StyledScrollRight'
 import { StyledScrollLeft } from './partials/StyledScrollLeft'
 
-interface TabSetProps {
-  className?: string
+interface TabSetProps extends ComponentWithClass {
   children: React.ReactElement<TabProps>[]
   onChange?: (id: number) => void
+  isFullWidth?: boolean
+  isScrollable?: never
+}
+
+interface ScrollableTabSetProps extends ComponentWithClass {
+  children: React.ReactElement<TabProps>[]
+  onChange?: (id: number) => void
+  isFullWidth?: never
   isScrollable?: boolean
 }
 
 const LEFT_ARROW = 37
 const RIGHT_ARROW = 39
 
-export const TabSet: React.FC<TabSetProps> = ({
+export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
   className,
   children,
   onChange,
+  isFullWidth,
   isScrollable,
   ...rest
 }) => {
@@ -67,12 +73,7 @@ export const TabSet: React.FC<TabSetProps> = ({
   }
 
   return (
-    <StyledTabSet
-      $isScrollable={isScrollable}
-      className={className}
-      data-testid="tab-set"
-      {...rest}
-    >
+    <StyledTabSet className={className} data-testid="tab-set" {...rest}>
       <StyledHeader $isScrollable={isScrollable}>
         {isScrollable && (
           <StyledScrollLeft
@@ -96,6 +97,7 @@ export const TabSet: React.FC<TabSetProps> = ({
                 onKeyDown={handleKeyDown}
                 isActive={index === activeTab}
                 index={index}
+                isFullWidth={isFullWidth}
                 isScrollable={isScrollable}
                 ref={(el) => {
                   itemsRef.current[index] = el

--- a/packages/react-component-library/src/components/TabSet/partials/StyledBody.tsx
+++ b/packages/react-component-library/src/components/TabSet/partials/StyledBody.tsx
@@ -7,6 +7,7 @@ const { color, spacing } = selectors
 
 export const StyledBody = styled.div<StyledTabSetProps>`
   padding: ${spacing('12')} 0;
+  overflow-y: auto;
 
   ${({ $isScrollable }) =>
     $isScrollable &&

--- a/packages/react-component-library/src/components/TabSet/partials/StyledTab.tsx
+++ b/packages/react-component-library/src/components/TabSet/partials/StyledTab.tsx
@@ -11,6 +11,7 @@ interface StyledTabProps extends StyledTabSetProps {
 
 function getDefaultTab($isActive: boolean) {
   return css`
+    width: 100%;
     display: flex;
     align-items: center;
     text-align: center;
@@ -39,7 +40,6 @@ function getDefaultTab($isActive: boolean) {
 
 function getScrollableTab($isActive: boolean) {
   return css`
-    width: 100%;
     padding: ${spacing('5')} ${spacing('10')};
     border-radius: 4px 4px 0 0;
     border: 1px solid ${color('neutral', $isActive ? '200' : '100')};

--- a/packages/react-component-library/src/components/TabSet/partials/StyledTabItem.tsx
+++ b/packages/react-component-library/src/components/TabSet/partials/StyledTabItem.tsx
@@ -5,13 +5,22 @@ import { StyledTabSetProps } from './StyledTabSet'
 
 const { mq, spacing } = selectors
 
-export const StyledTabItem = styled.li<StyledTabSetProps>`
+interface StyledTabItemProps extends StyledTabSetProps {
+  $isFullWidth: boolean
+}
+
+export const StyledTabItem = styled.li<StyledTabItemProps>`
   display: inline-block;
+
+  ${({ $isFullWidth }) =>
+    $isFullWidth &&
+    css`
+      flex: 1;
+    `}
 
   ${({ $isScrollable }) =>
     $isScrollable &&
     css`
-      width: 100%;
       padding-left: ${spacing('2')};
 
       &:last-child {

--- a/packages/react-component-library/src/components/TabSet/partials/StyledTabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/partials/StyledTabSet.tsx
@@ -11,4 +11,5 @@ export const StyledTabSet = styled.article`
   display: flex;
   flex-flow: column;
   background-color: ${color('neutral', 'white')};
+  height: 100%;
 `

--- a/packages/react-component-library/src/components/TabSet/partials/StyledTabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/partials/StyledTabSet.tsx
@@ -7,7 +7,7 @@ export interface StyledTabSetProps {
   $isScrollable: boolean
 }
 
-export const StyledTabSet = styled.article<StyledTabSetProps>`
+export const StyledTabSet = styled.article`
   display: flex;
   flex-flow: column;
   background-color: ${color('neutral', 'white')};

--- a/packages/react-component-library/src/components/TabSet/partials/StyledTabs.tsx
+++ b/packages/react-component-library/src/components/TabSet/partials/StyledTabs.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components'
 
 export const StyledTabs = styled.ol`
+  display: flex;
+  flex-direction: row;
   list-style-type: none;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
## Related issue
Closes #1907 

## Overview
Adds capability to `TabSet`:
- use `isFullWidth` on `TabSet` so that tabs use full available width
- will overflow the y axis when the content is bigger than the parent

## Reason
This was [requested](https://github.com/Royal-Navy/design-system/issues/1907) by a downstream consumer.

## Work carried out
- [x] Add `isFullWidth`
- [x] Add scrolling on y axis 

## Screenshot
<img width="1148" alt="Screenshot 2021-02-08 at 15 06 38" src="https://user-images.githubusercontent.com/56078793/107237997-417a5a00-6a1f-11eb-8d35-b78b6ec55efa.png">

## Developer notes
Some comments have been added to the original request.
