### PR TITLE
feat(Timeline): Move navigation to toolbar

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -138,6 +138,7 @@ export const WithSidebar = () => (
     </TimelineRows>
   </Timeline>
 )
+WithSidebar.parameters = disableScrollableRegionFocusableRule
 WithSidebar.storyName = 'With sidebar'
 
 export const WithHours = () => (
@@ -175,6 +176,7 @@ export const WithHours = () => (
     </TimelineRows>
   </Timeline>
 )
+WithHours.parameters = disableScrollableRegionFocusableRule
 WithHours.storyName = 'With hours'
 
 export const WithCustomMonths = () => {
@@ -212,6 +214,7 @@ export const WithCustomMonths = () => {
     </Timeline>
   )
 }
+WithCustomMonths.parameters = disableScrollableRegionFocusableRule
 WithCustomMonths.storyName = 'With custom months'
 
 export const WithCustomWeeks = () => {
@@ -254,6 +257,7 @@ export const WithCustomWeeks = () => {
     </Timeline>
   )
 }
+WithCustomWeeks.parameters = disableScrollableRegionFocusableRule
 WithCustomWeeks.storyName = 'With custom weeks'
 
 export const WithCustomDays = () => {
@@ -284,6 +288,7 @@ export const WithCustomDays = () => {
     </Timeline>
   )
 }
+WithCustomDays.parameters = disableScrollableRegionFocusableRule
 WithCustomDays.storyName = 'With custom days'
 
 export const WithCustomHours = () => {
@@ -315,6 +320,7 @@ export const WithCustomHours = () => {
     </Timeline>
   )
 }
+WithCustomHours.parameters = disableScrollableRegionFocusableRule
 WithCustomHours.storyName = 'With custom hours'
 
 export const WithCustomTodayMarker = () => {
@@ -350,6 +356,7 @@ export const WithCustomTodayMarker = () => {
     </Timeline>
   )
 }
+WithCustomTodayMarker.parameters = disableScrollableRegionFocusableRule
 WithCustomTodayMarker.storyName = 'With custom today marker'
 
 export const WithCustomColumns = () => {
@@ -404,6 +411,7 @@ export const WithCustomColumns = () => {
     </Timeline>
   )
 }
+WithCustomColumns.parameters = disableScrollableRegionFocusableRule
 WithCustomColumns.storyName = 'With custom columns'
 
 export const WithCustomEventBarColor = () => {
@@ -430,6 +438,7 @@ export const WithCustomEventBarColor = () => {
     </Timeline>
   )
 }
+WithCustomEventBarColor.parameters = disableScrollableRegionFocusableRule
 WithCustomEventBarColor.storyName = 'With custom event bar color'
 
 export const WithCustomEventContent = () => {
@@ -539,6 +548,7 @@ export const WithCustomEventContent = () => {
     </Timeline>
   )
 }
+WithCustomEventContent.parameters = disableScrollableRegionFocusableRule
 WithCustomEventContent.storyName = 'With custom event content'
 
 export const WithCustomDayWidth = () => {
@@ -578,6 +588,7 @@ export const WithCustomDayWidth = () => {
     </Timeline>
   )
 }
+WithCustomDayWidth.parameters = disableScrollableRegionFocusableRule
 WithCustomDayWidth.storyName = 'With custom day width'
 
 export const WithCustomRange = () => {
@@ -617,6 +628,7 @@ export const WithCustomRange = () => {
     </Timeline>
   )
 }
+WithCustomRange.parameters = disableScrollableRegionFocusableRule
 WithCustomRange.storyName = 'With custom range'
 
 export const NoVisibleCells = () => (

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -27,6 +27,7 @@ import { DEFAULTS } from './constants'
 import { StyledTimeline } from './partials/StyledTimeline'
 import { StyledInner } from './partials/StyledInner'
 import { StyledHeader } from './partials/StyledHeader'
+import { TimelineToolbar } from './TimelineToolbar'
 
 type timelineRootChildrenType = React.ReactElement<TimelineSideProps>
 
@@ -162,6 +163,7 @@ export const Timeline: React.FC<TimelineProps> = ({
       startDate={startDate}
       today={today}
     >
+      <TimelineToolbar />
       <StyledTimeline
         className={classNames('timeline', className)}
         data-testid="timeline"

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -1,15 +1,11 @@
 import React from 'react'
-import { IconChevronRight, IconChevronLeft } from '@royalnavy/icon-library'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { getKey } from '../../helpers'
 import { TimelineContext } from './context'
 import { TimelineHeaderRow } from './TimelineHeaderRow'
 import { TimelineMonth } from './TimelineMonth'
-import { Button } from '../Button'
-import { TIMELINE_ACTIONS } from './context/types'
 import { StyledMonths } from './partials/StyledMonths'
-import { StyledNavigation } from './partials/StyledNavigation'
 
 export interface TimelineMonthsWithRenderContentProps
   extends ComponentWithClass {
@@ -46,29 +42,6 @@ export const TimelineMonths: React.FC<TimelineMonthsProps> = ({
         className="timeline__months"
         data-testid="timeline-months"
         name="Months"
-        renderRowHeader={() => (
-          <>
-            <StyledNavigation
-              className="timeline__navigation"
-              data-testid="timeline-navigation"
-            >
-              <Button
-                aria-label="Navigate left"
-                variant="secondary"
-                icon={<IconChevronLeft />}
-                onClick={(_) => dispatch({ type: TIMELINE_ACTIONS.GET_PREV })}
-                data-testid="timeline-side-button-left"
-              />
-              <Button
-                aria-label="Navigate right"
-                variant="secondary"
-                icon={<IconChevronRight />}
-                onClick={(_) => dispatch({ type: TIMELINE_ACTIONS.GET_NEXT })}
-                data-testid="timeline-side-button-right"
-              />
-            </StyledNavigation>
-          </>
-        )}
         {...rest}
       >
         <StyledMonths>

--- a/packages/react-component-library/src/components/Timeline/TimelineToolbar.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineToolbar.tsx
@@ -1,0 +1,37 @@
+import React, { useContext } from 'react'
+import { IconChevronRight, IconChevronLeft } from '@royalnavy/icon-library'
+
+import { Button, BUTTON_SIZE, BUTTON_VARIANT } from '../Button'
+import { StyledToolbar } from './partials/StyledToolbar'
+import { TIMELINE_ACTIONS } from './context/types'
+import { TimelineContext } from './context'
+import { StyledToolbarButtons } from './partials/StyledToolbarButtons'
+
+export const TimelineToolbar: React.FC = () => {
+  const { dispatch } = useContext(TimelineContext)
+
+  return (
+    <StyledToolbar>
+      <StyledToolbarButtons>
+        <Button
+          aria-label="Navigate left"
+          size={BUTTON_SIZE.SMALL}
+          variant={BUTTON_VARIANT.SECONDARY}
+          icon={<IconChevronLeft />}
+          onClick={(_) => dispatch({ type: TIMELINE_ACTIONS.GET_PREV })}
+          data-testid="timeline-side-button-left"
+        />
+        <Button
+          aria-label="Navigate right"
+          size={BUTTON_SIZE.SMALL}
+          variant={BUTTON_VARIANT.SECONDARY}
+          icon={<IconChevronRight />}
+          onClick={(_) => dispatch({ type: TIMELINE_ACTIONS.GET_NEXT })}
+          data-testid="timeline-side-button-right"
+        />
+      </StyledToolbarButtons>
+    </StyledToolbar>
+  )
+}
+
+TimelineToolbar.displayName = 'TimelineToolbar'

--- a/packages/react-component-library/src/components/Timeline/partials/StyledToolbar.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledToolbar.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, spacing } = selectors
+
+export const StyledToolbar = styled.div`
+  display: flex;
+  align-items: center;
+  border-bottom: ${spacing('px')} solid ${color('neutral', '100')};
+`

--- a/packages/react-component-library/src/components/Timeline/partials/StyledToolbarButtons.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledToolbarButtons.tsx
@@ -1,22 +1,17 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
 
 import { StyledIcon } from '../../Button/partials/StyledIcon'
 
 const { spacing } = selectors
 
-export const StyledNavigation = styled.div`
-  position: absolute;
-  top: 1rem;
-  left: 1rem;
-
+export const StyledToolbarButtons = styled.div`
+  display: inline-block;
+  margin: ${spacing('4')} ${spacing('6')};
+  
   button {
     &:first-of-type {
       margin-right: ${spacing('4')};
-    }
-
-    span:first-of-type {
-      display: none;
     }
 
     ${StyledIcon} {


### PR DESCRIPTION
## Related issue
Closes #2016 

## Overview
Moves to the `Timeline` navigation buttons to a toolbar.

## Reason
A new toolbar will facilitate changes required for scaling.

## Work carried out
- [x] Move navigation to toolbar

## Screenshot
![Screenshot 2021-02-17 at 09 47 28](https://user-images.githubusercontent.com/56078793/108186365-31d8d080-7105-11eb-99d0-79c4ee354f47.png)