### PR TITLE
fix(Timeline): Add bg colour to toolbar

### DIFF
--- a/packages/react-component-library/src/components/Timeline/partials/StyledToolbar.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledToolbar.tsx
@@ -7,4 +7,5 @@ export const StyledToolbar = styled.div`
   display: flex;
   align-items: center;
   border-bottom: ${spacing('px')} solid ${color('neutral', '100')};
+  background-color: ${color('neutral', 'white')};
 `


### PR DESCRIPTION
## Related issue
Fixes #2026 

## Overview
Adds a background colour to the `Timeline` toolbar.

## Reason
Required when integrating with application.

## Work carried out
- [x] Add background colour

## Screenshot
### Before
<img width="352" alt="Screenshot 2021-02-19 at 10 14 54" src="https://user-images.githubusercontent.com/56078793/108508500-d436b680-72b3-11eb-95ed-a8cc2307b6bd.png">

### After
<img width="551" alt="Screenshot 2021-02-19 at 13 10 47" src="https://user-images.githubusercontent.com/56078793/108508541-e31d6900-72b3-11eb-81ed-c015ac75e99e.png">