### PR TITLE
fix(RangeSlider): Drill missing `mode` prop

### DIFF
--- a/packages/react-component-library/src/components/RangeSlider/Slider.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/Slider.tsx
@@ -130,6 +130,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
   hasPercentage,
   displayUnit = '',
   formatValue,
+  mode,
   ...rest
 }) => {
   const [sliderValues, setSliderValues] = useState(values)
@@ -169,6 +170,7 @@ export const RangeSlider: React.FC<RangeSliderProps> = ({
         disabled={isDisabled}
         values={values}
         step={step}
+        mode={mode}
         onChange={onChange}
         onUpdate={onUpdateHandler}
       >


### PR DESCRIPTION
## Related issue

Closes #2007

## Overview

This was a regression introduced by the recent arbitrary prop drilling change.

## Reason

>This was causing the multiple handle story to break.

## Work carried out

- [x] Explicitly drill missing `mode` prop