### PR TITLE
Update month presentation in Timeline at 5 year level scale

### DIFF
--- a/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
@@ -10,6 +10,7 @@ import { StyledMonthTitleMedium } from './partials/StyledMonthTitleMedium'
 import { StyledMonthTitleSmall } from './partials/StyledMonthTitleSmall'
 import { TimelineDay } from './context/types'
 
+const DECEMBER_INDEX = 11
 const MONTH_SMALL_THRESHOLD = 30
 const MONTH_MEDIUM_THRESHOLD = 100
 
@@ -39,7 +40,11 @@ function renderDefault({
 
   if (width < MONTH_SMALL_THRESHOLD) {
     return (
-      <StyledMonthSmall $width={width} data-testid="timeline-month">
+      <StyledMonthSmall
+        $hasThickBorder={startDate.getMonth() === DECEMBER_INDEX}
+        $width={width}
+        data-testid="timeline-month"
+      >
         <StyledMonthTitleSmall>
           {format(startDate, 'MMM')} {format(startDate, 'yyyy')}
         </StyledMonthTitleSmall>

--- a/packages/react-component-library/src/components/Timeline/partials/StyledMonth.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledMonth.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
 
 import { TIMELINE_BORDER_COLOR } from '../constants'
@@ -6,6 +6,7 @@ import { TIMELINE_BORDER_COLOR } from '../constants'
 const { color, spacing, zIndex } = selectors
 
 export interface StyledMonthProps {
+  $hasThickBorder?: boolean
   $width: number
 }
 
@@ -23,13 +24,20 @@ export const StyledMonth = styled.div<StyledMonthProps>`
 
   &::after {
     position: absolute;
-    right: 0;
+    right: -1px;
     top: 0;
     content: '';
     display: inline-block;
     width: 1rem;
     height: 100vh;
-    border-right: ${spacing('px')} dashed ${color('neutral', '200')};
+    border-right: ${({ $hasThickBorder }) =>
+      $hasThickBorder
+        ? css`
+            2px solid ${color('neutral', '200')}
+          `
+        : css`
+            ${spacing('px')} dashed ${color('neutral', '200')}
+          `};
     z-index: ${zIndex('body', 1)};
   }
 `

--- a/packages/react-component-library/src/components/Timeline/partials/StyledMonthTitleSmall.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledMonthTitleSmall.tsx
@@ -4,9 +4,12 @@ import { selectors } from '@royalnavy/design-tokens'
 const { color, fontSize } = selectors
 
 export const StyledMonthTitleSmall = styled.span`
-  font-size: ${fontSize('xs')};
+  font-size: ${fontSize('xxs')};
   font-weight: 600;
   color: ${color('neutral', '600')};
   text-transform: uppercase;
   transform: rotate(-90deg);
+  width: 4rem;
+  position: absolute;
+  bottom: 40px;
 `

--- a/packages/react-component-library/src/components/Timeline/partials/StyledTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledTodayMarker.tsx
@@ -16,7 +16,8 @@ export const StyledTodayMarker = styled.div`
     content: 'Today';
     display: inline-block;
     color: ${color('danger', '500')};
-    font-size: ${fontSize('s')};
-    transform: translate(-50%, -175%);
+    background-color: ${color('neutral', 'white')};
+    font-size: ${fontSize('xxs')};
+    transform: translate(-50%, -200%);
   }
 `


### PR DESCRIPTION
## Related issue
Closes #2042 

## Overview
Updates the presentation of months when scaled to the five year view.

## Reason
These changes were part of the designs.

## Work carried out
- [x] Add thick border
- [x] Update title positioning

## Screenshot
<img width="1159" alt="Screenshot 2021-02-23 at 11 39 13" src="https://user-images.githubusercontent.com/56078793/108838591-c2af2080-75cb-11eb-9c53-62dd4bbed0b8.png">
