### PR TITLE
fix(DocsSite): Prevent bleeding `TabSet`

### DIFF
--- a/packages/docs-site/src/components/presenters/post-article/index.js
+++ b/packages/docs-site/src/components/presenters/post-article/index.js
@@ -11,7 +11,9 @@ const PostArticle = ({ mdx, className, title, description, header }) => {
           <p className="post-article__lede">{description}</p>
         </div>
       )}
-      <MDXRenderer>{mdx}</MDXRenderer>
+      <div>
+        <MDXRenderer>{mdx}</MDXRenderer>
+      </div>
     </article>
   )
 }


### PR DESCRIPTION
## Related issue
Fixes #2014 

## Overview
Prevents the `TabSet` bleeding into the footer.

## Reason
`TabSet` was recently updated to fill 100% of height.

## Work carried out
- [x] Fix
