### PR TITLE
docs(Timeline): Add note about hour visibility

### DIFF
--- a/packages/docs-site/src/library/pages/timeline/index.md
+++ b/packages/docs-site/src/library/pages/timeline/index.md
@@ -925,6 +925,8 @@ Here you will find comprehensive API documentation for the Timeline Components.
 
 ## TimelineHours
 
+<p>Hour blocks will not be visible at the default scale level and will be visible when scaling in from the week level.</p>
+
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
     <h1 className="rn-fw-api-title">blockSize</h1>


### PR DESCRIPTION
## Related issue
Closes #2041 

## Overview
Adds note to docs for `TimelineHours` visibility with scaling.

## Reason
It is not immediately obvious how `TimelineHours` is visible when the default scale is presented.

## Work carried out
- [x] Add note

## Screenshot
![Screenshot 2021-02-25 at 11 39 55](https://user-images.githubusercontent.com/56078793/109168998-46f1d700-7777-11eb-9b5b-082d959ca69a.png)
