### PR TITLE
ci(GHA): Fix check commits job

### DIFF
--- a/.github/workflows/build_and_test_feature.yml
+++ b/.github/workflows/build_and_test_feature.yml
@@ -65,14 +65,8 @@ jobs:
             path: '**/node_modules'
             key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-        - name: Attach workspace
-          uses: actions/download-artifact@v2
-          with:
-            name: dist
-
         - name: check commits
           run: |
-            tar -xzf dist.tar.gz && mv distil packages/icon-library/dist && mv distdt packages/design-tokens/dist
             PR_NUM=$(curl -s  -H "Accept: application/vnd.github.groot-preview+json" \
             https://api.github.com/repos/Royal-Navy/design-system/commits/${{ github.sha }}/pulls | jq -r '.[].number')
             node ./scripts/commitlint "$GIT_URL$PR_NUM"

--- a/.github/workflows/build_and_test_feature.yml
+++ b/.github/workflows/build_and_test_feature.yml
@@ -53,6 +53,8 @@ jobs:
      Check_commits:
       runs-on: ubuntu-latest
       needs: Build_icon_library
+      env:
+        GIT_URL: "https://github.com/Royal-Navy/design-system/pulls/"
       steps:
         - name: Git clone repository
           uses: actions/checkout@v2
@@ -71,8 +73,10 @@ jobs:
         - name: check commits
           run: |
             tar -xzf dist.tar.gz && mv distil packages/icon-library/dist && mv distdt packages/design-tokens/dist
-            node ./scripts/commitlint ${{ github.event.pull_request._links.html.href }}
-            node ./scripts/check-fixup ${{ github.event.pull_request._links.html.href }}
+            PR_NUM=$(curl -s  -H "Accept: application/vnd.github.groot-preview+json" \
+            https://api.github.com/repos/Royal-Navy/design-system/commits/${{ github.sha }}/pulls | jq -r '.[].number')
+            node ./scripts/commitlint "$GIT_URL$PR_NUM"
+            node ./scripts/check-fixup "$GIT_URL$PR_NUM"
 
 
      Lint_css-framework:

--- a/.github/workflows/build_and_test_master.yml
+++ b/.github/workflows/build_and_test_master.yml
@@ -64,14 +64,8 @@ jobs:
             path: '**/node_modules'
             key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-        - name: Attach workspace
-          uses: actions/download-artifact@v2
-          with:
-            name: dist
-
         - name: check commits
           run: |
-            tar -xzf dist.tar.gz && mv distil packages/icon-library/dist && mv distdt packages/design-tokens/dist
             PR_NUM=$(curl -s  -H "Accept: application/vnd.github.groot-preview+json" \
             https://api.github.com/repos/Royal-Navy/design-system/commits/${{ github.sha }}/pulls | jq -r '.[].number')
             node ./scripts/commitlint "$GIT_URL$PR_NUM"

--- a/.github/workflows/build_and_test_master.yml
+++ b/.github/workflows/build_and_test_master.yml
@@ -52,6 +52,8 @@ jobs:
      Check_commits:
       runs-on: ubuntu-latest
       needs: Build_icon_library
+      env:
+        GIT_URL: "https://github.com/Royal-Navy/design-system/pulls/"
       steps:
         - name: Git clone repository
           uses: actions/checkout@v2
@@ -70,8 +72,10 @@ jobs:
         - name: check commits
           run: |
             tar -xzf dist.tar.gz && mv distil packages/icon-library/dist && mv distdt packages/design-tokens/dist
-            node ./scripts/commitlint ${{ github.event.pull_request._links.html.href }}
-            node ./scripts/check-fixup ${{ github.event.pull_request._links.html.href }}
+            PR_NUM=$(curl -s  -H "Accept: application/vnd.github.groot-preview+json" \
+            https://api.github.com/repos/Royal-Navy/design-system/commits/${{ github.sha }}/pulls | jq -r '.[].number')
+            node ./scripts/commitlint "$GIT_URL$PR_NUM"
+            node ./scripts/check-fixup "$GIT_URL$PR_NUM"
 
 
      Lint_css-framework:


### PR DESCRIPTION
## Related issue

closes #1710 

## Overview

Fix check commits job which runs the commintlint & check-fixup scripts.

## Work carried out
Added new method to the check commits job to pass in the pull request URL to the commintlint & check-fixup scripts.  The previous method used was passing an empty string as we are no longer using the 'pull request' trigger and therefore unable to access the 'github.event.pull_request._links.html.href' context variable.

- [x] Edited build_and_test_feature.yml 
- [x] Edited build_and_test_master.yml

