### PR TITLE
fix(Timeline): Use `range` at default zoom level

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -125,6 +125,7 @@ export const Timeline: React.FC<TimelineProps> = ({
 }) => {
   const renderColumns = getRenderColumns(children)
   const options: TimelineOptions = {
+    range,
     hoursBlockSize: getHoursBlockSize(children),
     unitWidth: dayWidth || unitWidth || DEFAULTS.UNIT_WIDTH,
   }

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -47,10 +47,7 @@ describe('Timeline', () => {
   describe('when no data is provided', () => {
     beforeEach(() => {
       wrapper = render(
-        <Timeline
-          startDate={new Date(2020, 3, 1)}
-          today={new Date(2020, 3, 6)}
-        >
+        <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 6)}>
           <TimelineTodayMarker />
           <TimelineMonths />
           <TimelineWeeks />
@@ -1247,7 +1244,7 @@ describe('Timeline', () => {
     })
 
     it('renders the correct number of months', () => {
-      expect(wrapper.queryAllByTestId('timeline-month')).toHaveLength(1)
+      expect(wrapper.queryAllByTestId('timeline-month')).toHaveLength(6)
     })
   })
 

--- a/packages/react-component-library/src/components/Timeline/context/state.ts
+++ b/packages/react-component-library/src/components/Timeline/context/state.ts
@@ -29,12 +29,7 @@ function initialiseState(
     options,
   }
 
-  const scaleOptions = initialiseScaleOptions(
-    startDate,
-    endDate,
-    options.hoursBlockSize,
-    options.unitWidth
-  )
+  const scaleOptions = initialiseScaleOptions(startDate, endDate, options)
   const defaultScaleOption = find(scaleOptions, ({ isDefault }) => isDefault)
 
   return {

--- a/packages/react-component-library/src/components/Timeline/context/types.ts
+++ b/packages/react-component-library/src/components/Timeline/context/types.ts
@@ -17,6 +17,7 @@ export type TimelineScaleOption = {
 
 export type TimelineOptions = {
   hoursBlockSize: BlockSizeType
+  range: number
   unitWidth: number
 }
 

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineScale.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineScale.ts
@@ -47,8 +47,10 @@ export function useTimelineScale() {
         (currentScaleOption.intervalSize || 1) * intervalMultiplier
       ),
       null,
-      currentScaleOption.hoursBlockSize,
-      options.unitWidth
+      {
+        ...options,
+        hoursBlockSize: currentScaleOption.hoursBlockSize,
+      }
     )
     const newScaleOption = newScaleOptions[scaleIndex]
     setTimelineScaleOptions(newScaleOptions)


### PR DESCRIPTION
## Related issue
Fixes #2062 

## Overview
Considers the `range` prop when displaying the default view.

## Reason
`range` prop was being disregarding and displaying just one month.

## Work carried out
- [x] Fix `range`