### PR TITLE
fix(Timeline): Reduce day display threshold

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -62,7 +62,7 @@ BoundByFixedDates.parameters = disableScrollableRegionFocusableRule
 BoundByFixedDates.storyName = 'Bound by fixed dates'
 
 export const WithData = () => (
-  <Timeline startDate={new Date(2020, 3, 1)} today={new Date(2020, 3, 15, 12)}>
+  <Timeline startDate={new Date(2020, 9, 1)} today={new Date(2020, 9, 15, 12)}>
     <TimelineTodayMarker />
     <TimelineMonths />
     <TimelineWeeks />
@@ -71,8 +71,8 @@ export const WithData = () => (
       <TimelineRow name="Row 1">
         <TimelineEvents>
           <TimelineEvent
-            startDate={new Date(2020, 3, 14, 12)}
-            endDate={new Date(2020, 3, 18, 12)}
+            startDate={new Date(2020, 9, 14, 12)}
+            endDate={new Date(2020, 9, 18, 12)}
           >
             Event 1
           </TimelineEvent>
@@ -81,8 +81,8 @@ export const WithData = () => (
       <TimelineRow name="Row 2">
         <TimelineEvents>
           <TimelineEvent
-            startDate={new Date(2020, 3, 3)}
-            endDate={new Date(2020, 3, 8)}
+            startDate={new Date(2020, 9, 3)}
+            endDate={new Date(2020, 9, 8)}
           >
             Event 2
           </TimelineEvent>

--- a/packages/react-component-library/src/components/Timeline/TimelineDay.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDay.tsx
@@ -5,7 +5,7 @@ import { DATE_DAY_FORMAT } from './constants'
 import { StyledDay } from './partials/StyledDay'
 import { StyledDayTitle } from './partials/StyledDayTitle'
 
-const DAY_DISPLAY_THRESHOLD = 30
+const DAY_DISPLAY_THRESHOLD = 29
 
 interface TimelineDayProps {
   date: Date


### PR DESCRIPTION
## Related issue
Fixes #2059 

## Overview
Reduces the day display threshold to `29`.

## Reason
Because of daylight saving in October, there was an hour extra which was causing the `widths.day` to be calculated as `29.x`. The quick solution is to change the day display threshold from `30` to `29`. This is only an issue for October is any year.

## Work carried out
- [x] Change threshold