### PR TITLE
Fix Timeline presentation if range prop is provided

### DIFF
--- a/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
+++ b/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
@@ -109,7 +109,10 @@ function initialiseScaleOptions(
   const scaleConfig = getScaleConfig(range)
   const defaultConfig = find(scaleConfig, ({ isDefault }) => isDefault)
   const numberOfDays =
-    differenceInDays(defaultConfig.calculateDate(startDate, 1), startDate) - 1
+    differenceInDays(
+      defaultConfig.calculateDate(startDate, defaultConfig.intervalSize),
+      startDate
+    ) - 1
   const maxWidth = unitWidth * numberOfDays
 
   return Object.keys(scaleConfig).map((scaleConfigKey) => {

--- a/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
+++ b/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
@@ -22,7 +22,7 @@ function getEarliest(endDate: Date, to: Date) {
 type ScaleConfigOptionType = {
   calculateDate: (date: Date, intervalSize: number) => Date
   hoursBlockSize?: BlockSizeType
-  intervalSize?: number
+  intervalSize: number
   isDefault?: boolean
   scale?: number
 }
@@ -33,26 +33,31 @@ function getScaleConfig(monthIntervalSize: number): ScaleConfigType {
     hour: {
       calculateDate: addWeeks,
       hoursBlockSize: TIMELINE_BLOCK_SIZE.SINGLE_HOUR,
+      intervalSize: DEFAULT_INTERVAL_SIZE,
       scale: 8,
     },
     quarter_day: {
       calculateDate: addWeeks,
+      intervalSize: DEFAULT_INTERVAL_SIZE,
       scale: 4,
     },
     day: {
       calculateDate: addWeeks,
+      intervalSize: DEFAULT_INTERVAL_SIZE,
       scale: 2,
     },
     week: {
       calculateDate: addWeeks,
+      intervalSize: DEFAULT_INTERVAL_SIZE,
     },
     month: {
       calculateDate: addMonths,
-      intervalSize: monthIntervalSize || 1,
+      intervalSize: monthIntervalSize || DEFAULT_INTERVAL_SIZE,
       isDefault: true,
     },
     year: {
       calculateDate: addYears,
+      intervalSize: DEFAULT_INTERVAL_SIZE,
     },
     five_year: {
       calculateDate: addYears,
@@ -74,10 +79,7 @@ function mapScaleOption(
     hoursBlockSize: configHoursBlockSize,
     ...rest
   }: ScaleConfigOptionType): TimelineScaleOption => {
-    const to = addDays(
-      calculateDate(startDate, intervalSize || DEFAULT_INTERVAL_SIZE),
-      -1
-    )
+    const to = addDays(calculateDate(startDate, intervalSize), -1)
     const numberOfHours = differenceInHours(to, startDate)
     const optionHoursBlockSize =
       configHoursBlockSize || hoursBlockSize || TIMELINE_BLOCK_SIZE.QUARTER_DAY

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineScale.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineScale.ts
@@ -44,7 +44,7 @@ export function useTimelineScale() {
     const newScaleOptions = initialiseScaleOptions(
       currentScaleOption.calculateDate(
         currentScaleOption.from,
-        (currentScaleOption.intervalSize || 1) * intervalMultiplier
+        currentScaleOption.intervalSize * intervalMultiplier
       ),
       null,
       {


### PR DESCRIPTION
## Related issue
Fixes #2067 

## Overview
The default interval size of `1` was being used to calculate the `maxWidth` but if a `range` is set then it should use that.

## Reason
Downstream consumers expect six months to be wider.

## Work carried out
- [x] Use range rather than default 1

## Screenshot
<img width="1211" alt="Screenshot 2021-03-05 at 08 18 48" src="https://user-images.githubusercontent.com/56078793/110087454-96459200-7d8b-11eb-9471-7957fe76334f.png">