### PR TITLE
fix(Timeline): Show all days if `endDate` supplied

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import classNames from 'classnames'
-import { find } from 'lodash'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TimelineProvider } from './context'
@@ -29,7 +28,6 @@ import { StyledTimeline } from './partials/StyledTimeline'
 import { StyledInner } from './partials/StyledInner'
 import { StyledHeader } from './partials/StyledHeader'
 import { TimelineToolbar } from './TimelineToolbar'
-import { initialiseScaleOptions } from './context/timeline_scales'
 import { TimelineWeekColumns } from './TimelineWeekColumns'
 
 type timelineRootChildrenType = React.ReactElement<TimelineSideProps>
@@ -125,7 +123,9 @@ export const Timeline: React.FC<TimelineProps> = ({
 }) => {
   const renderColumns = getRenderColumns(children)
   const options: TimelineOptions = {
+    endDate,
     range,
+    startDate,
     hoursBlockSize: getHoursBlockSize(children),
     unitWidth: dayWidth || unitWidth || DEFAULTS.UNIT_WIDTH,
   }
@@ -158,10 +158,8 @@ export const Timeline: React.FC<TimelineProps> = ({
 
   return (
     <TimelineProvider
-      endDate={endDate}
       hasSide={hasSide || hasTimelineSide}
       options={options}
-      startDate={startDate}
       today={today}
     >
       <TimelineToolbar />

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -1253,7 +1253,7 @@ describe('Timeline', () => {
       wrapper = render(
         <Timeline
           startDate={new Date(2020, 1, 6, 0, 0, 0)}
-          endDate={new Date(2020, 1, 22, 0, 0, 0)}
+          endDate={new Date(2020, 2, 17, 0, 0, 0)}
           today={new Date(2020, 4, 1, 0, 0, 0)}
         >
           <TimelineTodayMarker />
@@ -1278,15 +1278,18 @@ describe('Timeline', () => {
     })
 
     it('renders the correct number of months', () => {
-      expect(wrapper.queryAllByTestId('timeline-month')).toHaveLength(1)
+      expect(wrapper.queryAllByTestId('timeline-month')).toHaveLength(2)
     })
 
     it('renders the correct number of weeks', () => {
-      expect(wrapper.queryAllByTestId('timeline-week')).toHaveLength(3)
+      expect(wrapper.queryAllByTestId('timeline-week')).toHaveLength(7)
     })
 
     it('renders the correct number of days', () => {
-      expect(wrapper.queryAllByTestId('timeline-day-title')).toHaveLength(17)
+      const days = wrapper.queryAllByTestId('timeline-day-title')
+      expect(days).toHaveLength(41)
+      expect(days[0]).toHaveTextContent('06')
+      expect(days[days.length - 1]).toHaveTextContent('17')
     })
 
     it('does not render hours', () => {
@@ -1295,7 +1298,26 @@ describe('Timeline', () => {
 
     it('positions the event correctly', () => {
       expect(wrapper.getByTestId('timeline-event')).toHaveStyle({
-        left: `30px`,
+        left: `30.75px`,
+      })
+    })
+
+    describe('when navigating right', () => {
+      beforeEach(() => {
+        fireEvent(
+          wrapper.getByTestId('timeline-side-button-right'),
+          new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      })
+
+      it('renders the correct number of days', () => {
+        const days = wrapper.queryAllByTestId('timeline-day-title')
+        expect(days).toHaveLength(41)
+        expect(days[0]).toHaveTextContent('18')
+        expect(days[days.length - 1]).toHaveTextContent('27')
       })
     })
   })

--- a/packages/react-component-library/src/components/Timeline/context/index.tsx
+++ b/packages/react-component-library/src/components/Timeline/context/index.tsx
@@ -14,14 +14,12 @@ export const TimelineContext = createContext(timelineContextDefaults)
 
 export const TimelineProvider: React.FC<TimelineProviderProps> = ({
   children,
-  endDate,
   hasSide,
   options,
-  startDate,
   today,
 }) => {
   const [state, dispatch] = useReducer(reducer, initialState, () =>
-    initialiseState(startDate, endDate, today, options)
+    initialiseState(today, options)
   )
 
   return (

--- a/packages/react-component-library/src/components/Timeline/context/state.ts
+++ b/packages/react-component-library/src/components/Timeline/context/state.ts
@@ -16,20 +16,16 @@ const initialState: TimelineState = {
 }
 
 function initialiseState(
-  startDate: Date = new Date(),
-  endDate: Date,
   today: Date = new Date(),
   options: TimelineOptions
 ): TimelineState {
   const state = {
     ...initialState,
     today,
-    startDate,
-    endDate,
     options,
   }
 
-  const scaleOptions = initialiseScaleOptions(startDate, endDate, options)
+  const scaleOptions = initialiseScaleOptions(options)
   const defaultScaleOption = find(scaleOptions, ({ isDefault }) => isDefault)
 
   return {

--- a/packages/react-component-library/src/components/Timeline/context/types.ts
+++ b/packages/react-component-library/src/components/Timeline/context/types.ts
@@ -16,8 +16,10 @@ export type TimelineScaleOption = {
 }
 
 export type TimelineOptions = {
+  endDate: Date
   hoursBlockSize: BlockSizeType
   range: number
+  startDate: Date
   unitWidth: number
 }
 
@@ -72,8 +74,6 @@ export interface TimelineContextDefault {
 export interface TimelineProviderProps {
   children?: React.ReactNode
   hasSide?: boolean
-  startDate?: Date
-  endDate?: Date
   today?: Date
   options?: TimelineOptions
 }

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineScale.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineScale.ts
@@ -1,7 +1,7 @@
 import { useContext, useState } from 'react'
 import { findIndex, isNil } from 'lodash'
 
-import { TIMELINE_ACTIONS } from '../context/types'
+import { TIMELINE_ACTIONS, TimelineScaleOption } from '../context/types'
 import { TimelineContext } from '../context'
 import { initialiseScaleOptions } from '../context/timeline_scales'
 
@@ -39,19 +39,33 @@ export function useTimelineScale() {
   function move(
     type: typeof TIMELINE_ACTIONS.GET_NEXT | typeof TIMELINE_ACTIONS.GET_PREV
   ) {
-    const intervalMultiplier = type === TIMELINE_ACTIONS.GET_NEXT ? 1 : -1
     const currentScaleOption = timelineScaleOptions[scaleIndex]
-    const newScaleOptions = initialiseScaleOptions(
-      currentScaleOption.calculateDate(
-        currentScaleOption.from,
-        currentScaleOption.intervalSize * intervalMultiplier
-      ),
-      null,
-      {
-        ...options,
-        hoursBlockSize: currentScaleOption.hoursBlockSize,
-      }
+    const intervalMultiplier = type === TIMELINE_ACTIONS.GET_NEXT ? 1 : -1
+
+    const getIntervalSize = ({ intervalSize }: TimelineScaleOption) =>
+      intervalSize * intervalMultiplier
+    const newStartDate = currentScaleOption.calculateDate(
+      currentScaleOption.from,
+      getIntervalSize(currentScaleOption)
     )
+    const getNewEndDate = (): Date => {
+      if (options.endDate && currentScaleOption.isDefault) {
+        return currentScaleOption.calculateDate(
+          currentScaleOption.to,
+          getIntervalSize(currentScaleOption)
+        )
+      }
+
+      return null
+    }
+
+    const newScaleOptions = initialiseScaleOptions({
+      ...options,
+      startDate: newStartDate,
+      endDate: getNewEndDate(),
+      hoursBlockSize: currentScaleOption.hoursBlockSize,
+    })
+
     const newScaleOption = newScaleOptions[scaleIndex]
     setTimelineScaleOptions(newScaleOptions)
 


### PR DESCRIPTION
## Related issue
Fixes #2061 

## Overview
If an `endDate` is supplied then it uses that at the default zoom level.

## Reason
The default zoom level was only showing one month but it needs to show all days if the `endDate` is supplied.

## Work carried out
- [x] Use `endDate`

## Screenshot
<img width="1078" alt="Screenshot 2021-03-05 at 08 23 54" src="https://user-images.githubusercontent.com/56078793/110087895-2257b980-7d8c-11eb-864c-dfd0725f66a5.png">