### PR TITLE
feat(Timeline): Add ability to customise row CSS

### DIFF
--- a/packages/docs-site/src/library/pages/timeline/index.md
+++ b/packages/docs-site/src/library/pages/timeline/index.md
@@ -1080,6 +1080,49 @@ Here you will find comprehensive API documentation for the Timeline Components.
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
     <h1 className="rn-fw-api-title">
+      children
+      <Badge className="rn_ml-4" color="danger" colorVariant="faded" variant="pill" size="small">Required</Badge>
+    </h1>
+    <Badge color="supa" colorVariant="faded" size="small">React.ReactNode &#124; React.ReactNode[]</Badge>
+  </div>
+  <div className="rn-fw-api-body">
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Default Value</div>
+      <div className="rn-fw-api-value">
+        <code>Function</code>
+      </div>
+    </div>
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Description</div>
+      <p className="rn-fw-api-value">Supply children to be rendered.</p>
+    </div>
+  </div>
+</div>
+
+<div className="rn-fw-api">
+  <div className="rn-fw-api-header">
+    <h1 className="rn-fw-api-title">
+      css
+    </h1>
+    <Badge color="supa" colorVariant="faded" size="small">CSSProp</Badge>
+  </div>
+  <div className="rn-fw-api-body">
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Default Value</div>
+      <div className="rn-fw-api-value">
+        <code>-</code>
+      </div>
+    </div>
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Description</div>
+      <p className="rn-fw-api-value">Pass a styled-components css`` value to modify the CSS.</p>
+    </div>
+  </div>
+</div>
+
+<div className="rn-fw-api">
+  <div className="rn-fw-api-header">
+    <h1 className="rn-fw-api-title">
       name
       <Badge className="rn_ml-4" color="danger" colorVariant="faded" variant="pill" size="small">Required</Badge>
     </h1>
@@ -1102,21 +1145,41 @@ Here you will find comprehensive API documentation for the Timeline Components.
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
     <h1 className="rn-fw-api-title">
-      children
-      <Badge className="rn_ml-4" color="danger" colorVariant="faded" variant="pill" size="small">Required</Badge>
+      contentProps
     </h1>
-    <Badge color="supa" colorVariant="faded" size="small">React.ReactNode &#124; React.ReactNode[]</Badge>
+    <Badge color="supa" colorVariant="faded" size="small">&#123; css:? CSSProp, 'data-testid'?: string &#125;</Badge>
   </div>
   <div className="rn-fw-api-body">
     <div className="rn-fw-api-row">
       <div className="rn-fw-api-item">Default Value</div>
       <div className="rn-fw-api-value">
-        <code>Function</code>
+        <code>-</code>
       </div>
     </div>
     <div className="rn-fw-api-row">
       <div className="rn-fw-api-item">Description</div>
-      <p className="rn-fw-api-value">Supply children to be rendered.</p>
+      <p className="rn-fw-api-value">Ability to pass props to the content div of the row.</p>
+    </div>
+  </div>
+</div>
+
+<div className="rn-fw-api">
+  <div className="rn-fw-api-header">
+    <h1 className="rn-fw-api-title">
+      headerProps
+    </h1>
+    <Badge color="supa" colorVariant="faded" size="small">&#123; css:? CSSProp, 'data-testid'?: string &#125;</Badge>
+  </div>
+  <div className="rn-fw-api-body">
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Default Value</div>
+      <div className="rn-fw-api-value">
+        <code>-</code>
+      </div>
+    </div>
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Description</div>
+      <p className="rn-fw-api-value">Ability to pass props to the header div of the row.</p>
     </div>
   </div>
 </div>

--- a/packages/react-component-library/src/common/SubcomponentProps.ts
+++ b/packages/react-component-library/src/common/SubcomponentProps.ts
@@ -1,0 +1,7 @@
+import { CSSProp } from 'styled-components'
+import 'styled-components/cssprop'
+
+export interface SubcomponentProps {
+  css?: CSSProp
+  'data-testid'?: string
+}

--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
+import { css, CSSProp } from 'styled-components'
 import { format } from 'date-fns'
 import { Meta } from '@storybook/react/types-6-0'
-import { ColorDanger500 } from '@royalnavy/design-tokens'
+import {
+  ColorDanger500,
+  ColorNeutral100,
+  ColorNeutral200,
+} from '@royalnavy/design-tokens'
 
 import {
   Timeline,
@@ -413,6 +418,55 @@ export const WithCustomColumns = () => {
 }
 WithCustomColumns.parameters = disableScrollableRegionFocusableRule
 WithCustomColumns.storyName = 'With custom columns'
+
+export const WithCustomRowCss = () => {
+  const rowCss: CSSProp = css`
+    height: 40px;
+  `
+  const rowContentProps = {
+    css: css`
+      background-color: ${ColorNeutral100};
+    `,
+  }
+  const rowHeaderProps = {
+    css: css`
+      background-color: ${ColorNeutral200};
+    `,
+  }
+
+  return (
+    <Timeline
+      hasSide
+      startDate={new Date(2020, 3, 1)}
+      today={new Date(2020, 3, 15)}
+    >
+      <TimelineTodayMarker />
+      <TimelineMonths />
+      <TimelineWeeks />
+      <TimelineDays />
+      <TimelineRows>
+        <TimelineRow
+          css={rowCss}
+          contentProps={rowContentProps}
+          headerProps={rowHeaderProps}
+          name="Row 1"
+          renderRowHeader={() => <span>Row with custom style</span>}
+        >
+          <TimelineEvents>
+            <TimelineEvent
+              startDate={new Date(2020, 2, 14)}
+              endDate={new Date(2020, 3, 18)}
+            >
+              Event 1
+            </TimelineEvent>
+          </TimelineEvents>
+        </TimelineRow>
+      </TimelineRows>
+    </Timeline>
+  )
+}
+WithCustomRowCss.parameters = disableScrollableRegionFocusableRule
+WithCustomRowCss.storyName = 'With custom row CSS'
 
 export const WithCustomEventBarColor = () => {
   return (

--- a/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
@@ -1,26 +1,34 @@
 import React from 'react'
 import classNames from 'classnames'
-import { useTimelineRowContent } from './hooks/useTimelineRowContent'
+import { CSSProp } from 'styled-components'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { StyledNoEvents } from './partials/StyledNoEvents'
 import { StyledRow } from './partials/StyledRow'
 import { StyledRowContent } from './partials/StyledRowContent'
 import { StyledRowHeader } from './partials/StyledRowHeader'
+import { SubcomponentProps } from '../../common/SubcomponentProps'
 import { TimelineContext, TimelineEventsProps } from '.'
+import { useTimelineRowContent } from './hooks/useTimelineRowContent'
 
 export interface TimelineRowProps extends ComponentWithClass {
   children:
     | React.ReactElement<TimelineEventsProps>
     | React.ReactElement<TimelineEventsProps>[]
+  css?: CSSProp
   name?: string
   ariaLabel?: string
+  contentProps?: SubcomponentProps
+  headerProps?: SubcomponentProps
   renderRowHeader?: (name: string) => React.ReactElement
   isHeader?: boolean
 }
 
 export const TimelineRow: React.FC<TimelineRowProps> = ({
   children,
+  contentProps = {},
+  css,
+  headerProps = {},
   name,
   ariaLabel,
   renderRowHeader,
@@ -30,11 +38,14 @@ export const TimelineRow: React.FC<TimelineRowProps> = ({
 }) => {
   const classes = classNames('timeline__row', className)
   const { noCells, rowContentRef } = useTimelineRowContent(isHeader, [children])
+  const { css: contentCss, ...restContentProps } = contentProps
+  const { css: headerCss, ...restHeaderProps } = headerProps
 
   return (
     <TimelineContext.Consumer>
       {({ hasSide }) => (
         <StyledRow
+          $css={css}
           className={classes}
           data-testid="timeline-row"
           role="row"
@@ -42,15 +53,21 @@ export const TimelineRow: React.FC<TimelineRowProps> = ({
         >
           {hasSide && (
             <StyledRowHeader
+              $css={headerCss}
               isHeader={isHeader}
               data-testid="timeline-row-header"
               role="rowheader"
               aria-label={ariaLabel || name}
+              {...restHeaderProps}
             >
               {renderRowHeader ? renderRowHeader(name) : name}
             </StyledRowHeader>
           )}
-          <StyledRowContent ref={rowContentRef}>
+          <StyledRowContent
+            $css={contentCss}
+            ref={rowContentRef}
+            {...restContentProps}
+          >
             {noCells && <StyledNoEvents role="cell">No events</StyledNoEvents>}
             {children}
           </StyledRowContent>

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
+import { ColorNeutral100, ColorNeutral200 } from '@royalnavy/design-tokens'
+import { css, CSSProp } from 'styled-components'
 import { render, RenderResult, fireEvent } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
 import { NO_DATA_MESSAGE, TIMELINE_BLOCK_SIZE } from '../constants'
+import { SubcomponentProps } from '../../../common/SubcomponentProps'
 import {
   Timeline,
   TimelineDays,
@@ -1750,6 +1753,75 @@ describe('Timeline', () => {
 
     it('should not render the toolbar', () => {
       expect(wrapper.queryAllByTestId('timeline-toolbar')).toHaveLength(0)
+    })
+  })
+
+  describe('when using custom row CSS', () => {
+    beforeEach(() => {
+      const rowCss: CSSProp = css`
+        height: 40px;
+      `
+      const rowContentProps: SubcomponentProps = {
+        css: css`
+          background-color: ${ColorNeutral100};
+        `,
+        'data-testid': `content-1`,
+      }
+      const rowHeaderProps: SubcomponentProps = {
+        css: css`
+          background-color: ${ColorNeutral200};
+        `,
+        'data-testid': `header-1`,
+      }
+
+      wrapper = render(
+        <Timeline
+          hasSide
+          startDate={new Date(2020, 3, 1)}
+          today={new Date(2020, 3, 15)}
+        >
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineWeeks />
+          <TimelineDays />
+          <TimelineRows>
+            <TimelineRow
+              css={rowCss}
+              contentProps={rowContentProps}
+              headerProps={rowHeaderProps}
+              name="Row 1"
+              renderRowHeader={() => <span>Row with custom style</span>}
+            >
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={new Date(2020, 2, 14)}
+                  endDate={new Date(2020, 3, 18)}
+                >
+                  Event 1
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('should render the custom CSS on the row', () => {
+      const row = wrapper.getByTestId('timeline-row')
+
+      expect(row).toHaveStyleRule('height', '40px')
+    })
+
+    it('should render the custom CSS on the row header', () => {
+      const content = wrapper.getByTestId('header-1')
+
+      expect(content).toHaveStyleRule('background-color', ColorNeutral200)
+    })
+
+    it('should render the custom CSS on the row content', () => {
+      const content = wrapper.getByTestId('content-1')
+
+      expect(content).toHaveStyleRule('background-color', ColorNeutral100)
     })
   })
 })

--- a/packages/react-component-library/src/components/Timeline/partials/StyledRow.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledRow.tsx
@@ -1,6 +1,10 @@
 import styled from 'styled-components'
 
-export const StyledRow = styled.div`
+import { StyledSubComponentProps } from './StyledSubComponent'
+
+export const StyledRow = styled.div<StyledSubComponentProps>`
   display: flex;
   height: 4rem;
+
+  ${({ $css }) => $css}
 `

--- a/packages/react-component-library/src/components/Timeline/partials/StyledRowContent.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledRowContent.tsx
@@ -1,6 +1,10 @@
 import styled from 'styled-components'
 
-export const StyledRowContent = styled.div`
+import { StyledSubComponentProps } from './StyledSubComponent'
+
+export const StyledRowContent = styled.div<StyledSubComponentProps>`
   position: relative;
   width: 100%;
+
+  ${({ $css }) => $css}
 `

--- a/packages/react-component-library/src/components/Timeline/partials/StyledRowHeader.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledRowHeader.tsx
@@ -1,11 +1,12 @@
 import styled, { css } from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
 
+import { StyledSubComponentProps } from './StyledSubComponent'
 import { TIMELINE_BORDER_COLOR, TIMELINE_ROW_HEADER_WIDTH } from '../constants'
 
 const { color, fontSize, spacing, zIndex } = selectors
 
-interface StyledRowHeaderProps {
+interface StyledRowHeaderProps extends StyledSubComponentProps {
   isHeader?: boolean
 }
 
@@ -31,4 +32,6 @@ export const StyledRowHeader = styled.div<StyledRowHeaderProps>`
       font-weight: normal;
       color: ${color('neutral', '400')};
     `}
+
+  ${({ $css }) => $css}
 `

--- a/packages/react-component-library/src/components/Timeline/partials/StyledSubComponent.ts
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledSubComponent.ts
@@ -1,0 +1,5 @@
+import { CSSProp } from 'styled-components'
+
+export interface StyledSubComponentProps {
+  $css: CSSProp
+}

--- a/packages/react-component-library/src/cssprop.d.ts
+++ b/packages/react-component-library/src/cssprop.d.ts
@@ -1,0 +1,16 @@
+import { CSSProp } from 'styled-components'
+import 'styled-components/cssprop'
+
+declare module 'react' {
+  interface DOMAttributes<T> {
+    css?: CSSProp
+  }
+}
+
+declare global {
+  namespace JSX {
+    interface IntrinsicAttributes {
+      css?: CSSProp
+    }
+  }
+}


### PR DESCRIPTION
## Related issue
Closes #1998 

## Overview
Adds the ability to customise the CSS of a `TimelineRow`, including header and content.

## Reason
Required by downstream applications as `Timeline` is a framework.

## Work carried out
- [x] Add customisation

## Screenshot
![Screenshot 2021-03-11 at 13 07 51](https://user-images.githubusercontent.com/56078793/110792040-d2389580-826a-11eb-9be1-ffdc2344f009.png)
