### PR TITLE
Add ability to hide Timeline toolbar

### DIFF
--- a/packages/docs-site/src/library/pages/timeline/index.md
+++ b/packages/docs-site/src/library/pages/timeline/index.md
@@ -83,28 +83,6 @@ yarn add @royalnavy/css-framework @royalnavy/react-component-library
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
     <h1 className="rn-fw-api-title">
-      startDate
-      <Badge className="rn_ml-4" color="danger" colorVariant="faded" variant="pill" size="small">Required</Badge>
-    </h1>
-    <Badge color="supa" colorVariant="faded" size="small">Date</Badge>
-  </div>
-  <div className="rn-fw-api-body">
-    <div className="rn-fw-api-row">
-      <div className="rn-fw-api-item">Default Value</div>
-      <div className="rn-fw-api-value">
-        <code>-</code>
-      </div>
-    </div>
-    <div className="rn-fw-api-row">
-      <div className="rn-fw-api-item">Description</div>
-      <p className="rn-fw-api-value">A month will display either side of this start date.</p>
-    </div>
-  </div>
-</div>
-
-<div className="rn-fw-api">
-  <div className="rn-fw-api-header">
-    <h1 className="rn-fw-api-title">
       endDate
     </h1>
     <Badge color="supa" colorVariant="faded" size="small">Date</Badge>
@@ -125,19 +103,19 @@ yarn add @royalnavy/css-framework @royalnavy/react-component-library
 
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
-    <h1 className="rn-fw-api-title">today</h1>
-    <Badge color="supa" colorVariant="faded" size="small">Date</Badge>
+    <h1 className="rn-fw-api-title">hasSide</h1>
+    <Badge color="supa" colorVariant="faded" size="small">Boolean</Badge>
   </div>
   <div className="rn-fw-api-body">
     <div className="rn-fw-api-row">
       <div className="rn-fw-api-item">Default Value</div>
       <div className="rn-fw-api-value">
-        <code>new Date()</code>
+        <code>-</code>
       </div>
     </div>
     <div className="rn-fw-api-row">
       <div className="rn-fw-api-item">Description</div>
-      <p className="rn-fw-api-value">Today's current date - default is system date time.</p>
+      <p className="rn-fw-api-value">Specify whether or not to output sidebar headings.</p>
     </div>
   </div>
 </div>
@@ -163,6 +141,47 @@ yarn add @royalnavy/css-framework @royalnavy/react-component-library
 
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
+    <h1 className="rn-fw-api-title">
+      startDate
+      <Badge className="rn_ml-4" color="danger" colorVariant="faded" variant="pill" size="small">Required</Badge>
+    </h1>
+    <Badge color="supa" colorVariant="faded" size="small">Date</Badge>
+  </div>
+  <div className="rn-fw-api-body">
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Default Value</div>
+      <div className="rn-fw-api-value">
+        <code>-</code>
+      </div>
+    </div>
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Description</div>
+      <p className="rn-fw-api-value">A month will display either side of this start date.</p>
+    </div>
+  </div>
+</div>
+
+<div className="rn-fw-api">
+  <div className="rn-fw-api-header">
+    <h1 className="rn-fw-api-title">today</h1>
+    <Badge color="supa" colorVariant="faded" size="small">Date</Badge>
+  </div>
+  <div className="rn-fw-api-body">
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Default Value</div>
+      <div className="rn-fw-api-value">
+        <code>new Date()</code>
+      </div>
+    </div>
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Description</div>
+      <p className="rn-fw-api-value">Today's current date - default is system date time.</p>
+    </div>
+  </div>
+</div>
+
+<div className="rn-fw-api">
+  <div className="rn-fw-api-header">
     <h1 className="rn-fw-api-title">unitWidth</h1>
     <Badge color="supa" colorVariant="faded" size="small">Number</Badge>
   </div>
@@ -176,25 +195,6 @@ yarn add @royalnavy/css-framework @royalnavy/react-component-library
     <div className="rn-fw-api-row">
       <div className="rn-fw-api-item">Description</div>
       <p className="rn-fw-api-value">The fixed width value of a single day or hour (in pixels).</p>
-    </div>
-  </div>
-</div>
-
-<div className="rn-fw-api">
-  <div className="rn-fw-api-header">
-    <h1 className="rn-fw-api-title">hasSide</h1>
-    <Badge color="supa" colorVariant="faded" size="small">Boolean</Badge>
-  </div>
-  <div className="rn-fw-api-body">
-    <div className="rn-fw-api-row">
-      <div className="rn-fw-api-item">Default Value</div>
-      <div className="rn-fw-api-value">
-        <code>-</code>
-      </div>
-    </div>
-    <div className="rn-fw-api-row">
-      <div className="rn-fw-api-item">Description</div>
-      <p className="rn-fw-api-value">Specify whether or not to output sidebar headings.</p>
     </div>
   </div>
 </div>

--- a/packages/docs-site/src/library/pages/timeline/index.md
+++ b/packages/docs-site/src/library/pages/timeline/index.md
@@ -122,6 +122,25 @@ yarn add @royalnavy/css-framework @royalnavy/react-component-library
 
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
+    <h1 className="rn-fw-api-title">hideToolbar</h1>
+    <Badge color="supa" colorVariant="faded" size="small">Boolean</Badge>
+  </div>
+  <div className="rn-fw-api-body">
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Default Value</div>
+      <div className="rn-fw-api-value">
+        <code>false</code>
+      </div>
+    </div>
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Description</div>
+      <p className="rn-fw-api-value">Specify whether to hide the toolbar.</p>
+    </div>
+  </div>
+</div>
+
+<div className="rn-fw-api">
+  <div className="rn-fw-api-header">
     <h1 className="rn-fw-api-title">range</h1>
     <Badge color="supa" colorVariant="faded" size="small">Number</Badge>
   </div>

--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -653,3 +653,40 @@ export const NoVisibleCells = () => (
 )
 NoVisibleCells.parameters = disableScrollableRegionFocusableRule
 NoVisibleCells.storyName = 'No visible cells'
+
+export const HiddenToolbar = () => (
+  <Timeline
+    hideToolbar
+    startDate={new Date(2020, 9, 1)}
+    today={new Date(2020, 9, 15, 12)}
+  >
+    <TimelineTodayMarker />
+    <TimelineMonths />
+    <TimelineWeeks />
+    <TimelineDays />
+    <TimelineRows>
+      <TimelineRow name="Row 1">
+        <TimelineEvents>
+          <TimelineEvent
+            startDate={new Date(2020, 9, 14, 12)}
+            endDate={new Date(2020, 9, 18, 12)}
+          >
+            Event 1
+          </TimelineEvent>
+        </TimelineEvents>
+      </TimelineRow>
+      <TimelineRow name="Row 2">
+        <TimelineEvents>
+          <TimelineEvent
+            startDate={new Date(2020, 9, 3)}
+            endDate={new Date(2020, 9, 8)}
+          >
+            Event 2
+          </TimelineEvent>
+        </TimelineEvents>
+      </TimelineRow>
+    </TimelineRows>
+  </Timeline>
+)
+HiddenToolbar.parameters = disableScrollableRegionFocusableRule
+HiddenToolbar.storyName = 'Hidden toolbar'

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -49,6 +49,7 @@ export interface TimelineProps extends ComponentWithClass {
   children: timelineChildrenType | timelineChildrenType[]
   dayWidth?: number
   hasSide?: boolean
+  hideToolbar?: boolean
   startDate?: Date
   endDate?: Date
   today?: Date
@@ -114,6 +115,7 @@ export const Timeline: React.FC<TimelineProps> = ({
   className,
   dayWidth,
   hasSide,
+  hideToolbar = false,
   startDate,
   endDate,
   today,
@@ -162,7 +164,7 @@ export const Timeline: React.FC<TimelineProps> = ({
       options={options}
       today={today}
     >
-      <TimelineToolbar />
+      {!hideToolbar && <TimelineToolbar />}
       <StyledTimeline
         className={classNames('timeline', className)}
         data-testid="timeline"

--- a/packages/react-component-library/src/components/Timeline/TimelineToolbar.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineToolbar.tsx
@@ -23,7 +23,7 @@ export const TimelineToolbar: React.FC = () => {
   } = useTimelineScale()
 
   return (
-    <StyledToolbar>
+    <StyledToolbar data-testid="timeline-toolbar">
       <StyledToolbarButtons>
         <Button
           aria-label="Navigate left"

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -1713,4 +1713,43 @@ describe('Timeline', () => {
       })
     })
   })
+
+  describe('when the toolbar is to be hidden', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Timeline
+          hideToolbar
+          startDate={new Date(2020, 3, 1)}
+          today={new Date(2020, 3, 15)}
+        >
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineWeeks />
+          <TimelineDays />
+          <TimelineRows>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={new Date(2020, 3, 13)}
+                  endDate={new Date(2020, 3, 18)}
+                >
+                  Event 1
+                </TimelineEvent>
+                <TimelineEvent
+                  startDate={new Date(2020, 3, 20)}
+                  endDate={new Date(2020, 3, 22)}
+                >
+                  Event 2
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('should not render the toolbar', () => {
+      expect(wrapper.queryAllByTestId('timeline-toolbar')).toHaveLength(0)
+    })
+  })
 })


### PR DESCRIPTION
## Related issue
Closes #2044 

## Overview
Adds the ability to hide the toolbar with `hideToolbar`.

## Reason
Some consumers do not want to see the toolbar.

## Work carried out
- [x] Hide toolbar
- [x] Tidy docs

## Screenshot
![Screenshot 2021-03-09 at 12 08 56](https://user-images.githubusercontent.com/56078793/110495831-ce7f0480-80ec-11eb-901c-411bfee5aa76.png)