### PR TITLE
ci(GHA): Remove check commits job from b&tm

### DIFF
--- a/.github/workflows/build_and_test_master.yml
+++ b/.github/workflows/build_and_test_master.yml
@@ -49,29 +49,6 @@ jobs:
           run: yarn audit
 
 
-     Check_commits:
-      runs-on: ubuntu-latest
-      needs: Build_icon_library
-      env:
-        GIT_URL: "https://github.com/Royal-Navy/design-system/pulls/"
-      steps:
-        - name: Git clone repository
-          uses: actions/checkout@v2
-
-        - name: Cache Node modules
-          uses: actions/cache@v2
-          with:
-            path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
-        - name: check commits
-          run: |
-            PR_NUM=$(curl -s  -H "Accept: application/vnd.github.groot-preview+json" \
-            https://api.github.com/repos/Royal-Navy/design-system/commits/${{ github.sha }}/pulls | jq -r '.[].number')
-            node ./scripts/commitlint "$GIT_URL$PR_NUM"
-            node ./scripts/check-fixup "$GIT_URL$PR_NUM"
-
-
      Lint_css-framework:
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
## Related issue

fixes #2098 

## Overview

Remove check commits job from build & test master workflow

## Reason
Check commits will not complete following an automated release as there is no associated pull request with the release commit. Team discussed & decided check commits step not required in this workflow.

## Work carried out

- [x] Edited build_and_test_master.yml

