### PR TITLE
ci(GHA): Fix caching issue in NPM smoketest

### DIFF
--- a/.github/workflows/npmsmoketest.yml
+++ b/.github/workflows/npmsmoketest.yml
@@ -47,6 +47,7 @@ jobs:
 
         - name: Create boilerplate app
           run: |
+           if [ -d "my-app" ]; then rm -Rf my-app ; fi
            npx create-react-app my-app --template file:../design-system/packages/cra-template-royalnavy
 
         - name: Build boilerlate app


### PR DESCRIPTION
## Related issue

closes #2113 

## Overview
Fix caching issue in NPM smoketest for pull request triggered jobs


## Reason
We are experiencing intermittent NPM smoketest failures due to the test-app directory sometimes being cached and causing the create boilerplate app step to fail


## Work carried out

- [x] Edited npmsmoketest.yml

