### PR TITLE
chore(Security): Change w3 url references to https

### DIFF
--- a/packages/react-component-library/src/components/NumberInput/EndAdornmentButton.tsx
+++ b/packages/react-component-library/src/components/NumberInput/EndAdornmentButton.tsx
@@ -104,7 +104,7 @@ export const EndAdornmentButton: React.FC<EndAdornmentButtonProps> = ({
       disabled={isDisabled}
       onClick={onClick}
     >
-      <svg xmlns="http://www.w3.org/2000/svg" width="11" height="7">
+      <svg xmlns="https://www.w3.org/2000/svg" width="11" height="7">
         <path
           fill="#6F798A"
           fillRule="evenodd"

--- a/packages/react-component-library/src/icons/Right-Arrow.tsx
+++ b/packages/react-component-library/src/icons/Right-Arrow.tsx
@@ -7,8 +7,8 @@ export const RightArrow: React.FC = ({ children, ...rest }) => (
     height="10px"
     viewBox="0 0 11 10"
     version="1.1"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlnsXlink="http://www.w3.org/1999/xlink"
+    xmlns="https://www.w3.org/2000/svg"
+    xmlnsXlink="https://www.w3.org/1999/xlink"
     {...rest}
   >
     <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">

--- a/packages/react-component-library/src/icons/Search.tsx
+++ b/packages/react-component-library/src/icons/Search.tsx
@@ -6,7 +6,7 @@ export const Search: React.FC = () => (
     height="15px"
     viewBox="0 0 15 15"
     version="1.1"
-    xmlns="http://www.w3.org/2000/svg"
+    xmlns="https://www.w3.org/2000/svg"
   >
     <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
       <g


### PR DESCRIPTION
## Related issue

closes #2114 

## Overview
Change w3 url references to https

## Reason

Flagged by Sonarcloud analysis

## Work carried out

- [x] Changed w3.org references from http to https in react-component-library files
     
