### PR TITLE
chore(Sonar): Exclude stories from coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.projectName=design-system
 # Path to sources
 sonar.sources=packages/react-component-library/src
 sonar.exclusions=**/*.test.ts,**/*.test.tsx*
-sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx*
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx*,**/*.stories.tsx*
 
 
 # Path to tests


### PR DESCRIPTION
## Related issue
#2118 

## Overview
Exclude `*.stories.tsx` from coverage.

## Reason
`*.stories.tsx` are being included.

## Work carried out
- [x] Exclude