### PR TITLE
fix(Timeline): Correctly set width of days

### DIFF
--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -1301,7 +1301,7 @@ describe('Timeline', () => {
 
     it('positions the event correctly', () => {
       expect(wrapper.getByTestId('timeline-event')).toHaveStyle({
-        left: `30.75px`,
+        left: `30px`,
       })
     })
 

--- a/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
+++ b/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
@@ -95,10 +95,9 @@ function mapScaleOption(
     ...rest
   }: ScaleConfigOptionType): TimelineScaleOption => {
     const to = addDays(calculateDate(startDate, intervalSize), -1)
-    const numberOfHours = differenceInHours(to, startDate)
+    const numberOfHours = differenceInHours(to, startDate) + HOURS_IN_DAY
     const optionHoursBlockSize =
       configHoursBlockSize || hoursBlockSize || TIMELINE_BLOCK_SIZE.QUARTER_DAY
-
     const hourWidth = (maxWidth / numberOfHours) * (scale || 1)
 
     return {
@@ -130,7 +129,7 @@ function initialiseScaleOptions({
     : differenceInDays(
         defaultConfig.calculateDate(startDate, defaultConfig.intervalSize),
         startDate
-      ) - 1
+      )
   const maxWidth = unitWidth * numberOfDays
 
   return Object.keys(scaleConfig).map((scaleConfigKey) => {


### PR DESCRIPTION
## Related issue
Closes #2100

## Overview
Account for `endDate` needing to be included in calculating number of hours.

## Reason
Downstream applications need the width to be precise.

## Work carried out
- [x] Add hours