### PR TITLE
Fix setting of startDate in Timeline

### DIFF
--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { ColorNeutral100, ColorNeutral200 } from '@royalnavy/design-tokens'
 import { css, CSSProp } from 'styled-components'
-import { render, RenderResult, fireEvent } from '@testing-library/react'
+import { render, RenderResult } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import userEvent from '@testing-library/user-event'
 
 import { NO_DATA_MESSAGE, TIMELINE_BLOCK_SIZE } from '../constants'
 import { SubcomponentProps } from '../../../common/SubcomponentProps'
@@ -422,13 +423,7 @@ describe('Timeline', () => {
 
       describe('and when the left button is clicked', () => {
         beforeEach(() => {
-          fireEvent(
-            wrapper.getByTestId('timeline-side-button-left'),
-            new MouseEvent('click', {
-              bubbles: true,
-              cancelable: true,
-            })
-          )
+          userEvent.click(wrapper.getByTestId('timeline-side-button-left'))
         })
 
         it('should move to the previous month', () => {
@@ -440,13 +435,7 @@ describe('Timeline', () => {
 
       describe('and when the right button is clicked', () => {
         beforeEach(() => {
-          fireEvent(
-            wrapper.getByTestId('timeline-side-button-right'),
-            new MouseEvent('click', {
-              bubbles: true,
-              cancelable: true,
-            })
-          )
+          userEvent.click(wrapper.getByTestId('timeline-side-button-right'))
         })
 
         it('should move to the next month', () => {
@@ -1307,13 +1296,7 @@ describe('Timeline', () => {
 
     describe('when navigating right', () => {
       beforeEach(() => {
-        fireEvent(
-          wrapper.getByTestId('timeline-side-button-right'),
-          new MouseEvent('click', {
-            bubbles: true,
-            cancelable: true,
-          })
-        )
+        userEvent.click(wrapper.getByTestId('timeline-side-button-right'))
       })
 
       it('renders the correct number of days', () => {

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { ColorNeutral100, ColorNeutral200 } from '@royalnavy/design-tokens'
 import { css, CSSProp } from 'styled-components'
@@ -10,7 +10,9 @@ import { NO_DATA_MESSAGE, TIMELINE_BLOCK_SIZE } from '../constants'
 import { SubcomponentProps } from '../../../common/SubcomponentProps'
 import {
   Timeline,
+  TimelineContext,
   TimelineDays,
+  TimelineDaysProps,
   TimelineHours,
   TimelineEvent,
   TimelineEvents,
@@ -21,6 +23,23 @@ import {
   TimelineTodayMarker,
   TimelineWeeks,
 } from '..'
+
+const TimelineDates: React.FC<TimelineDaysProps> = () => {
+  const {
+    state: {
+      options: { startDate, endDate },
+    },
+  } = useContext(TimelineContext)
+
+  return (
+    <>
+      <span data-testid="timeline-start-date">{startDate.toISOString()}</span>
+      {endDate && (
+        <span data-testid="timeline-end-date">{endDate.toISOString()}</span>
+      )}
+    </>
+  )
+}
 
 describe('Timeline', () => {
   let wrapper: RenderResult
@@ -363,6 +382,7 @@ describe('Timeline', () => {
             startDate={new Date(2020, 3, 1)}
             today={new Date(2020, 3, 15)}
           >
+            <TimelineDates />
             <TimelineTodayMarker />
             <TimelineMonths />
             <TimelineWeeks />
@@ -431,6 +451,12 @@ describe('Timeline', () => {
 
           expect(months[0]).toHaveTextContent('March 2020')
         })
+
+        it('should update the `startDate`', () => {
+          expect(wrapper.getByTestId('timeline-start-date')).toHaveTextContent(
+            '2020-03-01T00:00:00.000Z'
+          )
+        })
       })
 
       describe('and when the right button is clicked', () => {
@@ -442,6 +468,12 @@ describe('Timeline', () => {
           const months = wrapper.getAllByTestId('timeline-month')
 
           expect(months[0]).toHaveTextContent('May 2020')
+        })
+
+        it('should update the `startDate`', () => {
+          expect(wrapper.getByTestId('timeline-start-date')).toHaveTextContent(
+            '2020-05-01T00:00:00.000Z'
+          )
         })
       })
     })
@@ -1240,7 +1272,7 @@ describe('Timeline', () => {
     })
   })
 
-  describe('when Timeline is initialized with a fixed endDate', () => {
+  describe('when Timeline is initialised with a fixed `endDate`', () => {
     beforeEach(() => {
       wrapper = render(
         <Timeline
@@ -1248,6 +1280,7 @@ describe('Timeline', () => {
           endDate={new Date(2020, 2, 17, 0, 0, 0)}
           today={new Date(2020, 4, 1, 0, 0, 0)}
         >
+          <TimelineDates />
           <TimelineTodayMarker />
           <TimelineMonths />
           <TimelineWeeks />
@@ -1304,6 +1337,18 @@ describe('Timeline', () => {
         expect(days).toHaveLength(41)
         expect(days[0]).toHaveTextContent('18')
         expect(days[days.length - 1]).toHaveTextContent('27')
+      })
+
+      it('should update the `startDate`', () => {
+        expect(wrapper.getByTestId('timeline-start-date')).toHaveTextContent(
+          '2020-03-18T00:00:00.000Z'
+        )
+      })
+
+      it('should update the `endDate`', () => {
+        expect(wrapper.getByTestId('timeline-end-date')).toHaveTextContent(
+          '2020-04-27T00:00:00.000Z'
+        )
       })
     })
   })

--- a/packages/react-component-library/src/components/Timeline/context/reducer.ts
+++ b/packages/react-component-library/src/components/Timeline/context/reducer.ts
@@ -99,5 +99,10 @@ export function reducer(
     ...state,
     ...buildCalendar(scale),
     currentScaleOption: scale,
+    options: {
+      ...state.options,
+      startDate: scale.from,
+      endDate: scale.to,
+    },
   }
 }


### PR DESCRIPTION
## Related issue
Closes #2117 

## Overview
Fixes the setting of `startDate` and `endDate` if the buttons to navigate left or right are pressed.

## Reason
When navigating, a calculation happens with the scales but the `startDate` and `endDate` are not updated but this is being used by downstream applications.

## Work carried out
- [x] Refactor tests
- [x] Set field