### PR TITLE
feat(Timeline): Add `hideScaling` prop

### DIFF
--- a/packages/docs-site/src/library/pages/timeline/index.md
+++ b/packages/docs-site/src/library/pages/timeline/index.md
@@ -122,6 +122,25 @@ yarn add @royalnavy/css-framework @royalnavy/react-component-library
 
 <div className="rn-fw-api">
   <div className="rn-fw-api-header">
+    <h1 className="rn-fw-api-title">hideScaling</h1>
+    <Badge color="supa" colorVariant="faded" size="small">Boolean</Badge>
+  </div>
+  <div className="rn-fw-api-body">
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Default Value</div>
+      <div className="rn-fw-api-value">
+        <code>false</code>
+      </div>
+    </div>
+    <div className="rn-fw-api-row">
+      <div className="rn-fw-api-item">Description</div>
+      <p className="rn-fw-api-value">Specify whether to hide the scaling buttons.</p>
+    </div>
+  </div>
+</div>
+
+<div className="rn-fw-api">
+  <div className="rn-fw-api-header">
     <h1 className="rn-fw-api-title">hideToolbar</h1>
     <Badge color="supa" colorVariant="faded" size="small">Boolean</Badge>
   </div>

--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -744,3 +744,40 @@ export const HiddenToolbar = () => (
 )
 HiddenToolbar.parameters = disableScrollableRegionFocusableRule
 HiddenToolbar.storyName = 'Hidden toolbar'
+
+export const HiddenScaling = () => (
+  <Timeline
+    hideScaling
+    startDate={new Date(2020, 9, 1)}
+    today={new Date(2020, 9, 15, 12)}
+  >
+    <TimelineTodayMarker />
+    <TimelineMonths />
+    <TimelineWeeks />
+    <TimelineDays />
+    <TimelineRows>
+      <TimelineRow name="Row 1">
+        <TimelineEvents>
+          <TimelineEvent
+            startDate={new Date(2020, 9, 14, 12)}
+            endDate={new Date(2020, 9, 18, 12)}
+          >
+            Event 1
+          </TimelineEvent>
+        </TimelineEvents>
+      </TimelineRow>
+      <TimelineRow name="Row 2">
+        <TimelineEvents>
+          <TimelineEvent
+            startDate={new Date(2020, 9, 3)}
+            endDate={new Date(2020, 9, 8)}
+          >
+            Event 2
+          </TimelineEvent>
+        </TimelineEvents>
+      </TimelineRow>
+    </TimelineRows>
+  </Timeline>
+)
+HiddenScaling.parameters = disableScrollableRegionFocusableRule
+HiddenScaling.storyName = 'Hidden scaling'

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -49,6 +49,7 @@ export interface TimelineProps extends ComponentWithClass {
   children: timelineChildrenType | timelineChildrenType[]
   dayWidth?: number
   hasSide?: boolean
+  hideScaling?: boolean
   hideToolbar?: boolean
   startDate?: Date
   endDate?: Date
@@ -115,6 +116,7 @@ export const Timeline: React.FC<TimelineProps> = ({
   className,
   dayWidth,
   hasSide,
+  hideScaling = false,
   hideToolbar = false,
   startDate,
   endDate,
@@ -164,7 +166,7 @@ export const Timeline: React.FC<TimelineProps> = ({
       options={options}
       today={today}
     >
-      {!hideToolbar && <TimelineToolbar />}
+      {!hideToolbar && <TimelineToolbar hideScaling={hideScaling} />}
       <StyledTimeline
         className={classNames('timeline', className)}
         data-testid="timeline"

--- a/packages/react-component-library/src/components/Timeline/TimelineToolbar.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineToolbar.tsx
@@ -12,7 +12,13 @@ import { StyledToolbarButtons } from './partials/StyledToolbarButtons'
 import { StyledToolbarSeparator } from './partials/StyledToolbarSeparator'
 import { useTimelineScale } from './hooks/useTimelineScale'
 
-export const TimelineToolbar: React.FC = () => {
+interface TimelineToolbarProps {
+  hideScaling: boolean
+}
+
+export const TimelineToolbar: React.FC<TimelineToolbarProps> = ({
+  hideScaling,
+}) => {
   const {
     canZoomIn,
     canZoomOut,
@@ -42,27 +48,31 @@ export const TimelineToolbar: React.FC = () => {
           data-testid="timeline-side-button-right"
         />
       </StyledToolbarButtons>
-      <StyledToolbarSeparator />
-      <StyledToolbarButtons>
-        <Button
-          aria-label="Zoom out"
-          isDisabled={!canZoomOut}
-          size={BUTTON_SIZE.SMALL}
-          variant={BUTTON_VARIANT.SECONDARY}
-          icon={<IconZoomOut />}
-          onClick={zoomOut}
-          data-testid="timeline-toolbar-zoom-out"
-        />
-        <Button
-          aria-label="Zoom in"
-          isDisabled={!canZoomIn}
-          size={BUTTON_SIZE.SMALL}
-          variant={BUTTON_VARIANT.SECONDARY}
-          icon={<IconZoomIn />}
-          onClick={zoomIn}
-          data-testid="timeline-toolbar-zoom-in"
-        />
-      </StyledToolbarButtons>
+      {!hideScaling && (
+        <>
+          <StyledToolbarSeparator />
+          <StyledToolbarButtons>
+            <Button
+              aria-label="Zoom out"
+              isDisabled={!canZoomOut}
+              size={BUTTON_SIZE.SMALL}
+              variant={BUTTON_VARIANT.SECONDARY}
+              icon={<IconZoomOut />}
+              onClick={zoomOut}
+              data-testid="timeline-toolbar-zoom-out"
+            />
+            <Button
+              aria-label="Zoom in"
+              isDisabled={!canZoomIn}
+              size={BUTTON_SIZE.SMALL}
+              variant={BUTTON_VARIANT.SECONDARY}
+              icon={<IconZoomIn />}
+              onClick={zoomIn}
+              data-testid="timeline-toolbar-zoom-in"
+            />
+          </StyledToolbarButtons>
+        </>
+      )}
     </StyledToolbar>
   )
 }

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -1784,6 +1784,51 @@ describe('Timeline', () => {
     })
   })
 
+  describe('when the scaling buttons are to be hidden', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Timeline
+          hideScaling
+          startDate={new Date(2020, 3, 1)}
+          today={new Date(2020, 3, 15)}
+        >
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineWeeks />
+          <TimelineDays />
+          <TimelineRows>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={new Date(2020, 3, 13)}
+                  endDate={new Date(2020, 3, 18)}
+                >
+                  Event 1
+                </TimelineEvent>
+                <TimelineEvent
+                  startDate={new Date(2020, 3, 20)}
+                  endDate={new Date(2020, 3, 22)}
+                >
+                  Event 2
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('should not render the scaling buttons', () => {
+      expect(
+        wrapper.queryAllByTestId('timeline-toolbar-zoom-out')
+      ).toHaveLength(0)
+
+      expect(wrapper.queryAllByTestId('timeline-toolbar-zoom-in')).toHaveLength(
+        0
+      )
+    })
+  })
+
   describe('when using custom row CSS', () => {
     beforeEach(() => {
       const rowCss: CSSProp = css`

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.projectName=design-system
 
 # Path to sources
 sonar.sources=packages/react-component-library/src
-sonar.exclusions=**/*.test.ts,**/*.test.tsx*
+sonar.exclusions=**/*.test.ts,**/*.test.tsx*,**/*.stories.tsx*
 sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx*,**/*.stories.tsx*
 
 


### PR DESCRIPTION
## Related issue
Closes #2133 

## Overview
Adds ability to hide the scaling buttons.

## Reason
Some downstream applications want to be able to hide scaling.

## Work carried out
- [x] Add prop

## Screenshot
![Screenshot 2021-03-22 at 14 04 06](https://user-images.githubusercontent.com/56078793/112002301-a5606a00-8b17-11eb-84c2-dc9fe746af4b.png)