### PR TITLE
Fix select box shadow when hovering over menu

### DIFF
--- a/packages/react-component-library/src/components/Select/partials/StyledControl.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledControl.tsx
@@ -10,17 +10,12 @@ export const StyledControl = styled(components.Control)`
   padding: 0;
   margin: 0;
 
-  .rn-select__control--is-focused,
+  &.rn-select__control--is-focused,
+  &.rn-select__control--menu-is-open,
   &:hover {
     border-color: ${color('action', '600')};
     box-shadow: 0 0 0 1px ${color('action', '600')},
       0 0 0 4px ${color('action', '100')};
-  }
-
-  .rn-select__control--menu-is-open {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-    border-bottom-color: transparent;
   }
 
   &.rn-select__control--is-focused ${StyledLabel} {

--- a/packages/react-component-library/src/components/Select/partials/StyledValueContainer.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledValueContainer.tsx
@@ -8,8 +8,11 @@ const { spacing } = selectors
 
 export const StyledValueContainer = styled(components.ValueContainer)`
   position: initial;
-  padding: 0 0 0 ${spacing('6')};
   height: inherit;
+
+  &&& {
+    padding: 0 0 0 ${spacing('6')};
+  }
 
   &.rn-select__value-container--has-value ${StyledLabel} {
     transform: translate(${spacing('6')}, ${spacing('2')}) scale(0.8);


### PR DESCRIPTION
## Related issue
Fixes #2091

## Overview
Fixes the select box shadow when hovering over the menu. The issue was a small syntax error.

## Reason
This is a bug and not consistent with intended design.

## Work carried out
- [x] Fix box shadow

## Screenshot
![2021-03-23 14 36 43](https://user-images.githubusercontent.com/56078793/112163873-56810600-8be5-11eb-93b4-a931e26e9436.gif)

## Developer notes
Tried adding a test but this fits into the `toHaveStyleRule` issues we have been seeing.
