### PR TITLE
fix(DatePicker): Fix end date outside of days

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -90,6 +90,8 @@ examples.add('Disabled days', () => {
 examples.add('Range', () => {
   return (
     <DatePicker
+      endDate={new Date(2021, 3, 2)}
+      startDate={new Date(2021, 2, 15)}
       onBlur={action('onBlur')}
       onChange={action('onChange')}
       isRange

--- a/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
@@ -4,28 +4,34 @@ import styled, { css } from 'styled-components'
 
 const { color } = selectors
 
-export const StyledDayPicker = styled<any>(DayPicker)`
+interface StyledDayPickerProps {
+  $isRange: boolean
+}
+
+export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
   ${({ $isRange }) =>
     $isRange &&
     css`
-      .DayPicker-Day {
-        border-radius: 0;
-      }
+      &&&& {
+        .DayPicker-Day {
+          border-radius: 0;
+        }
 
-      .DayPicker-Day--start,
-      .DayPicker-Day--end {
-        background-color: ${color('action', '500')} !important;
-        color: ${color('neutral', 'white')};
-      }
+        .DayPicker-Day--start,
+        .DayPicker-Day--end:not(.DayPicker-Day--outside) {
+          background-color: ${color('action', '500')};
+          color: ${color('neutral', 'white')};
+        }
 
-      .DayPicker-Day--start {
-        border-top-left-radius: 50%;
-        border-bottom-left-radius: 50%;
-      }
+        .DayPicker-Day--start {
+          border-top-left-radius: 50%;
+          border-bottom-left-radius: 50%;
+        }
 
-      .DayPicker-Day--end {
-        border-top-right-radius: 50%;
-        border-bottom-right-radius: 50%;
+        .DayPicker-Day--end {
+          border-top-right-radius: 50%;
+          border-bottom-right-radius: 50%;
+        }
       }
     `}
 `


### PR DESCRIPTION
## Related issue
Closes #2083 

## Overview
Fixes the end date selection showing twice when a range is being selected.

## Reason
This is broken and does not provide a good user experience.

## Work carried out
- [x] Fix

## Screenshot
![Screenshot 2021-03-24 at 09 18 15](https://user-images.githubusercontent.com/56078793/112285123-dfe61600-8c81-11eb-8c49-90d2df631b40.png)