### PR TITLE
fix(NumberInput): Make number unit unselectable

### DIFF
--- a/packages/react-component-library/src/components/NumberInput/ClearButton.tsx
+++ b/packages/react-component-library/src/components/NumberInput/ClearButton.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { IconCancel } from '@royalnavy/icon-library'
-import { selectors } from '@royalnavy/design-tokens'
-import styled, { css } from 'styled-components'
 
-const { color } = selectors
+import { StyledClearButton } from './partials/StyledClearButton'
 
 interface ClearButtonProps {
   isCondensed: boolean
@@ -11,42 +9,13 @@ interface ClearButtonProps {
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-interface StyledButtonProps {
-  $isCondensed: boolean
-}
-
-const StyledButton = styled.button<StyledButtonProps>`
-  background-color: ${color('neutral', 'white')};
-  border: none;
-  color: ${color('neutral', '300')};
-  cursor: pointer;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  height: 1rem;
-  right: 54px;
-  padding: unset;
-  display: flex;
-  align-items: center;
-
-  ${({ $isCondensed }) =>
-    $isCondensed &&
-    css`
-      right: 44px;
-
-      & > svg {
-        transform: scale(0.8);
-      }
-    `}
-`
-
 export const ClearButton: React.FC<ClearButtonProps> = ({
   isCondensed,
   isDisabled,
   onClick,
 }) => {
   return (
-    <StyledButton
+    <StyledClearButton
       $isCondensed={isCondensed}
       aria-label="Clear the input value"
       data-testid="number-input-clear"
@@ -55,7 +24,7 @@ export const ClearButton: React.FC<ClearButtonProps> = ({
       type="button"
     >
       <IconCancel />
-    </StyledButton>
+    </StyledClearButton>
   )
 }
 

--- a/packages/react-component-library/src/components/NumberInput/EndAdornment.tsx
+++ b/packages/react-component-library/src/components/NumberInput/EndAdornment.tsx
@@ -1,11 +1,8 @@
 import React from 'react'
-import { selectors } from '@royalnavy/design-tokens'
-import styled from 'styled-components'
 
 import { EndAdornmentButton } from './EndAdornmentButton'
 import { END_ADORNMENT_TYPE } from './constants'
-
-const { color } = selectors
+import { StyledNumberInputControls } from './partials/StyledNumberInputControls'
 
 interface EndAdornmentProps {
   isCondensed: boolean
@@ -20,14 +17,6 @@ interface EndAdornmentProps {
   step?: number
   value: number
 }
-
-const StyledNumberInputControls = styled.div`
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  text-align: center;
-  border-left: 1px solid ${color('neutral', '100')};
-`
 
 export const EndAdornment: React.FC<EndAdornmentProps> = ({
   isCondensed,

--- a/packages/react-component-library/src/components/NumberInput/EndAdornmentButton.tsx
+++ b/packages/react-component-library/src/components/NumberInput/EndAdornmentButton.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
 import capitalize from 'lodash/capitalize'
-import { selectors } from '@royalnavy/design-tokens'
-import styled, { css } from 'styled-components'
 
 import { END_ADORNMENT_TYPE } from './constants'
-
-const { color } = selectors
+import { StyledIncreaseButton } from './partials/StyledIncreaseButton'
+import { StyledDecreaseButton } from './partials/StyledDecreaseButton'
 
 type EndAdornmentType =
   | typeof END_ADORNMENT_TYPE.DECREASE
@@ -17,72 +15,6 @@ interface EndAdornmentButtonProps {
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
   type: EndAdornmentType
 }
-
-interface StyledButtonProps {
-  $isCondensed: boolean
-}
-
-const StyledButton = styled.button<StyledButtonProps>`
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  width: 42px;
-  align-items: center;
-
-  background: transparent;
-  margin: 0;
-  padding: 0;
-  outline: 0;
-  border: 0;
-
-  flex-grow: 1;
-
-  &:focus {
-    border-radius: 4px;
-    box-shadow: 2px 2px 0 0 ${color('action', '600')},
-      -2px -2px 0 0 ${color('action', '600')},
-      2px -2px 0 0 ${color('action', '600')},
-      -2px 2px 0 0 ${color('action', '600')};
-  }
-`
-
-const StyledDecreaseButton = styled(StyledButton)`
-  border-top: 1px solid ${color('neutral', '100')};
-
-  &:focus {
-    border-color: transparent;
-  }
-
-  ${({ $isCondensed }) =>
-    $isCondensed &&
-    css`
-      width: 36px;
-
-      & > svg {
-        transform: scale(0.7);
-      }
-    `}
-`
-
-const StyledIncreaseButton = styled(StyledButton)`
-  & > svg {
-    transform: rotate(180deg);
-  }
-
-  ${({ $isCondensed }) =>
-    $isCondensed &&
-    css`
-      width: 36px;
-
-      & > svg {
-        transform: rotate(180deg) scale(0.7);
-      }
-    `}
-
-  &:focus + ${StyledDecreaseButton} {
-    border-color: transparent;
-  }
-`
 
 export const EndAdornmentButton: React.FC<EndAdornmentButtonProps> = ({
   isCondensed,

--- a/packages/react-component-library/src/components/NumberInput/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInput/Input.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { isFinite, isNil } from 'lodash'
 import { selectors } from '@royalnavy/design-tokens'
-import styled, { css } from 'styled-components'
 
 import { NumberInputUnit } from './NumberInputUnit'
 import { UnitPosition } from './NumberInput'
 import { useInputText } from './useInputText'
 import { InputValidationProps } from '../../common/InputValidationProps'
-
-const { color, fontSize, spacing } = selectors
+import { StyledInput } from './partials/StyledInput'
+import { StyledLabel } from './partials/StyledLabel'
+import { StyledInputWrapper } from './partials/StyledInputWrapper'
 
 interface InputProps extends InputValidationProps {
   hasFocus: boolean
@@ -26,69 +26,7 @@ interface InputProps extends InputValidationProps {
   value?: number
 }
 
-interface StyledInputProps {
-  $hasLabel: boolean
-  $isCondensed: boolean
-  $offset: number
-}
-
-interface StyledLabelProps {
-  $hasContent: boolean
-  $hasFocus: boolean
-  $hasUnit: boolean
-}
-
-const StyledInputWrapper = styled.div`
-  position: relative;
-  flex-grow: 1;
-`
-
-const StyledLabel = styled.label<StyledLabelProps>`
-  display: block;
-  z-index: 1;
-  position: absolute;
-  top: 0;
-  left: 0;
-  transform-origin: top left;
-  transform: translate(${spacing('6')}, ${spacing('6')}) scale(1);
-  transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
-    transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
-  pointer-events: none;
-  color: ${color('neutral', '400')};
-  font-size: ${fontSize('base')};
-
-  ${({ $hasContent, $hasFocus, $hasUnit }) =>
-    ($hasContent || $hasFocus || $hasUnit) &&
-    css`
-      transform: translate(${spacing('6')}, 6px) scale(0.8);
-    `}
-`
-
-const StyledInput = styled.input<StyledInputProps>`
-  display: block;
-  box-sizing: border-box;
-  width: 100%;
-  margin: 0 0 0 ${({ $offset }) => `${$offset}px`};
-  padding: ${({ $hasLabel, $isCondensed }) => {
-    if ($isCondensed) {
-      return spacing('3')
-    }
-
-    if ($hasLabel) {
-      return `${spacing('10')} ${spacing('6')} ${spacing('2')}`
-    }
-
-    return spacing('6')
-  }};
-  border: 0;
-  background: none;
-  -webkit-tap-highlight-color: transparent;
-  font-size: ${fontSize('base')};
-
-  &:focus {
-    outline: 0;
-  }
-`
+const { spacing } = selectors
 
 export const Input: React.FC<InputProps> = ({
   hasFocus,

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import { isFinite, isNil } from 'lodash'
-import { selectors } from '@royalnavy/design-tokens'
-import styled, { css } from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
 
 import { ClearButton } from './ClearButton'
@@ -15,12 +13,8 @@ import { StartAdornment } from './StartAdornment'
 import { useFocus } from '../../hooks/useFocus'
 import { useValue } from './useValue'
 import { UNIT_POSITION } from './constants'
-import {
-  getOuterWrapperBorder,
-  StyledOuterWrapperProps,
-} from '../../styled-components/input'
-
-const { color, spacing } = selectors
+import { StyledNumberInput } from './partials/StyledNumberInput'
+import { StyledNumberInputOuterWrapper } from './partials/StyledNumberInputOuterWrapper'
 
 export type UnitPosition =
   | typeof UNIT_POSITION.AFTER
@@ -48,25 +42,6 @@ export interface NumberInputProps
   unitPosition?: UnitPosition
   value?: number
 }
-
-const StyledNumberInput = styled.div`
-  display: inline-flex;
-  flex-direction: column;
-  position: relative;
-  margin: ${spacing('6')} 0;
-  padding: 0;
-  border: 0;
-  vertical-align: top;
-  width: 100%;
-`
-
-const StyledNumberInputOuterWrapper = styled.div<StyledOuterWrapperProps>`
-  display: inline-flex;
-  flex-direction: row;
-  background-color: ${color('neutral', 'white')};
-
-  ${(props) => getOuterWrapperBorder(props)}
-`
 
 function formatValue(
   displayValue: number,

--- a/packages/react-component-library/src/components/NumberInput/NumberInputUnit.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInputUnit.tsx
@@ -1,29 +1,12 @@
 import React from 'react'
-import { selectors } from '@royalnavy/design-tokens'
-import styled from 'styled-components'
 
-const { fontSize } = selectors
+import { StyledNumberInputUnit } from './partials/StyledNumberInputUnit'
 
 interface NumberInputUnitProps {
   children: string
   left: string
   top: string
 }
-
-interface StyledNumberInputUnitProps {
-  $left: string
-  $top: string
-}
-
-const StyledNumberInputUnit = styled.span<StyledNumberInputUnitProps>`
-  align-items: center;
-  display: flex;
-  height: 100%;
-  position: absolute;
-  font-size: ${fontSize('base')};
-  left: ${({ $left }) => $left};
-  top: ${({ $top }) => $top};
-`
 
 export const NumberInputUnit: React.FC<NumberInputUnitProps> = ({
   children,

--- a/packages/react-component-library/src/components/NumberInput/StartAdornment.tsx
+++ b/packages/react-component-library/src/components/NumberInput/StartAdornment.tsx
@@ -1,33 +1,10 @@
 import React from 'react'
-import { selectors } from '@royalnavy/design-tokens'
-import styled from 'styled-components'
 
-const { spacing, color, fontSize } = selectors
+import { StyledStartAdornment } from './partials/StyledStartAdornment'
 
 interface StartAdornmentProps {
   children: React.ReactNode | string
 }
-
-const StyledStartAdornment = styled.div`
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  text-align: center;
-  padding: ${spacing('6')};
-  order: 0;
-  background-color: ${color('neutral', '000')};
-  border-right: 1px solid ${color('neutral', '200')};
-  border-top-left-radius: 3px;
-  border-bottom-left-radius: 3px;
-  color: ${color('neutral', '400')};
-  font-weight: 600;
-  line-height: 1;
-  font-size: ${fontSize('base')};
-
-  > svg {
-    color: ${color('neutral', '300')};
-  }
-`
 
 export const StartAdornment: React.FC<StartAdornmentProps> = ({ children }) => {
   if (!children) {

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledButton.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledButton.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+export interface StyledButtonProps {
+  $isCondensed: boolean
+}
+
+const { color } = selectors
+
+export const StyledButton = styled.button<StyledButtonProps>`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  width: 42px;
+  align-items: center;
+
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  outline: 0;
+  border: 0;
+
+  flex-grow: 1;
+
+  &:focus {
+    border-radius: 4px;
+    box-shadow: 2px 2px 0 0 ${color('action', '600')},
+      -2px -2px 0 0 ${color('action', '600')},
+      2px -2px 0 0 ${color('action', '600')},
+      -2px 2px 0 0 ${color('action', '600')};
+  }
+`

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledClearButton.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledClearButton.tsx
@@ -1,0 +1,33 @@
+import styled, { css } from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+interface StyledClearButtonProps {
+  $isCondensed: boolean
+}
+
+const { color } = selectors
+
+export const StyledClearButton = styled.button<StyledClearButtonProps>`
+  background-color: ${color('neutral', 'white')};
+  border: none;
+  color: ${color('neutral', '300')};
+  cursor: pointer;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 1rem;
+  right: 54px;
+  padding: unset;
+  display: flex;
+  align-items: center;
+
+  ${({ $isCondensed }) =>
+    $isCondensed &&
+    css`
+      right: 44px;
+
+      & > svg {
+        transform: scale(0.8);
+      }
+    `}
+`

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledDecreaseButton.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledDecreaseButton.tsx
@@ -1,0 +1,24 @@
+import styled, { css } from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+import { StyledButton, StyledButtonProps } from './StyledButton'
+
+const { color } = selectors
+
+export const StyledDecreaseButton = styled(StyledButton)`
+  border-top: 1px solid ${color('neutral', '100')};
+
+  &:focus {
+    border-color: transparent;
+  }
+
+  ${({ $isCondensed }) =>
+    $isCondensed &&
+    css`
+      width: 36px;
+
+      & > svg {
+        transform: scale(0.7);
+      }
+    `}
+`

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledIncreaseButton.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledIncreaseButton.tsx
@@ -1,0 +1,24 @@
+import styled, { css } from 'styled-components'
+
+import { StyledButton, StyledButtonProps } from './StyledButton'
+import { StyledDecreaseButton } from './StyledDecreaseButton'
+
+export const StyledIncreaseButton = styled(StyledButton)`
+  & > svg {
+    transform: rotate(180deg);
+  }
+
+  ${({ $isCondensed }) =>
+    $isCondensed &&
+    css`
+      width: 36px;
+
+      & > svg {
+        transform: rotate(180deg) scale(0.7);
+      }
+    `}
+
+  &:focus + ${StyledDecreaseButton} {
+    border-color: transparent;
+  }
+`

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledInput.tsx
@@ -1,0 +1,36 @@
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { fontSize, spacing } = selectors
+
+interface StyledInputProps {
+  $hasLabel: boolean
+  $isCondensed: boolean
+  $offset: number
+}
+
+export const StyledInput = styled.input<StyledInputProps>`
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  margin: 0 0 0 ${({ $offset }) => `${$offset}px`};
+  padding: ${({ $hasLabel, $isCondensed }) => {
+    if ($isCondensed) {
+      return spacing('3')
+    }
+
+    if ($hasLabel) {
+      return `${spacing('10')} ${spacing('6')} ${spacing('2')}`
+    }
+
+    return spacing('6')
+  }};
+  border: 0;
+  background: none;
+  -webkit-tap-highlight-color: transparent;
+  font-size: ${fontSize('base')};
+
+  &:focus {
+    outline: 0;
+  }
+`

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledInputWrapper.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledInputWrapper.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components'
+
+export const StyledInputWrapper = styled.div`
+  position: relative;
+  flex-grow: 1;
+`

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledLabel.tsx
@@ -1,0 +1,31 @@
+import { selectors } from '@royalnavy/design-tokens'
+import styled, { css } from 'styled-components'
+
+interface StyledLabelProps {
+  $hasContent: boolean
+  $hasFocus: boolean
+  $hasUnit: boolean
+}
+
+const { color, spacing, fontSize } = selectors
+
+export const StyledLabel = styled.label<StyledLabelProps>`
+  display: block;
+  z-index: 1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: top left;
+  transform: translate(${spacing('6')}, ${spacing('6')}) scale(1);
+  transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
+    transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+  pointer-events: none;
+  color: ${color('neutral', '400')};
+  font-size: ${fontSize('base')};
+
+  ${({ $hasContent, $hasFocus, $hasUnit }) =>
+    ($hasContent || $hasFocus || $hasUnit) &&
+    css`
+      transform: translate(${spacing('6')}, 6px) scale(0.8);
+    `}
+`

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledLabel.tsx
@@ -20,6 +20,7 @@ export const StyledLabel = styled.label<StyledLabelProps>`
   transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
     transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
   pointer-events: none;
+  user-select: none;
   color: ${color('neutral', '400')};
   font-size: ${fontSize('base')};
 

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledNumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledNumberInput.tsx
@@ -1,0 +1,15 @@
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { spacing } = selectors
+
+export const StyledNumberInput = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+  position: relative;
+  margin: ${spacing('6')} 0;
+  padding: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+`

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledNumberInputControls.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledNumberInputControls.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color } = selectors
+
+export const StyledNumberInputControls = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  text-align: center;
+  border-left: 1px solid ${color('neutral', '100')};
+`

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledNumberInputOuterWrapper.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledNumberInputOuterWrapper.tsx
@@ -1,0 +1,17 @@
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+import {
+  getOuterWrapperBorder,
+  StyledOuterWrapperProps,
+} from '../../../styled-components/input'
+
+const { color } = selectors
+
+export const StyledNumberInputOuterWrapper = styled.div<StyledOuterWrapperProps>`
+  display: inline-flex;
+  flex-direction: row;
+  background-color: ${color('neutral', 'white')};
+
+  ${(props) => getOuterWrapperBorder(props)}
+`

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledNumberInputUnit.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledNumberInputUnit.tsx
@@ -16,4 +16,6 @@ export const StyledNumberInputUnit = styled.span<StyledNumberInputUnitProps>`
   font-size: ${fontSize('base')};
   left: ${({ $left }) => $left};
   top: ${({ $top }) => $top};
+  pointer-events: none;
+  user-select: none;
 `

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledNumberInputUnit.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledNumberInputUnit.tsx
@@ -1,0 +1,19 @@
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { fontSize } = selectors
+
+interface StyledNumberInputUnitProps {
+  $left: string
+  $top: string
+}
+
+export const StyledNumberInputUnit = styled.span<StyledNumberInputUnitProps>`
+  align-items: center;
+  display: flex;
+  height: 100%;
+  position: absolute;
+  font-size: ${fontSize('base')};
+  left: ${({ $left }) => $left};
+  top: ${({ $top }) => $top};
+`

--- a/packages/react-component-library/src/components/NumberInput/partials/StyledStartAdornment.tsx
+++ b/packages/react-component-library/src/components/NumberInput/partials/StyledStartAdornment.tsx
@@ -1,0 +1,25 @@
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { spacing, color, fontSize } = selectors
+
+export const StyledStartAdornment = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  text-align: center;
+  padding: ${spacing('6')};
+  order: 0;
+  background-color: ${color('neutral', '000')};
+  border-right: 1px solid ${color('neutral', '200')};
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+  color: ${color('neutral', '400')};
+  font-weight: 600;
+  line-height: 1;
+  font-size: ${fontSize('base')};
+
+  > svg {
+    color: ${color('neutral', '300')};
+  }
+`


### PR DESCRIPTION
## Related issue

Closes #2087

## Overview

Make unit unselectable and refactor to use partials pattern.

## Reason

>When the NumberInput is used with a unit and label the unit is selectable as text.
>
>This makes it difficult to interact with and focus the input with a mouse. Same applies for the label.

## Work carried out

- [x] Make unit element unselectable
- [x] Refactor to use partials pattern

## Screenshot

![2021-03-25 11 43 52](https://user-images.githubusercontent.com/48086589/112467970-9e2b9d00-8d5f-11eb-81d6-03c6b34b9c40.gif)
