### PR TITLE
ci(GHA): Update action version to master

### DIFF
--- a/.github/workflows/project_issues.yml
+++ b/.github/workflows/project_issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Move small/med labeled issues to Candidates column
-      uses: Royal-Navy/move-labeled-or-milestoned-issue@v2.0
+      uses: Royal-Navy/move-labeled-or-milestoned-issue@master
       with:
         action-token: "${{ secrets.GHA_ISSUES_TOKEN }}"
         project-url: "https://github.com/Royal-Navy/design-system/projects/6"


### PR DESCRIPTION
## Related issue

#2159 

## Overview

Update project automation workflow to 'master' action version 

## Work carried out

- [x] Update project_issues workflow
