### PR TITLE
Fix ESLint config clashing with Prettier multilines

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -45,6 +45,7 @@ module.exports = {
     ],
     'react/jsx-one-expression-per-line': 0,
     'react/jsx-props-no-spreading': 0,
+    'react/jsx-wrap-multilines': 0,
     'react/prop-types': 0,
     '@typescript-eslint/ban-ts-ignore': 0,
     '@typescript-eslint/ban-ts-comment': 0,

--- a/packages/react-component-library/src/components/Badge/Badge.stories.tsx
+++ b/packages/react-component-library/src/components/Badge/Badge.stories.tsx
@@ -43,7 +43,7 @@ const badgeSizeTextMap = {
 
 stories.add('Default', () => <Badge>{text('Children', 'Badge')}</Badge>)
 
-Object.keys(badgeColorTextMap).forEach(key => {
+Object.keys(badgeColorTextMap).forEach((key) => {
   fadedExamples.add(badgeColorTextMap[key], () => (
     <Badge
       color={key as BadgeColorType}
@@ -55,7 +55,7 @@ Object.keys(badgeColorTextMap).forEach(key => {
   ))
 })
 
-Object.keys(badgeColorTextMap).forEach(key => {
+Object.keys(badgeColorTextMap).forEach((key) => {
   solidExamples.add(badgeColorTextMap[key], () => (
     <Badge
       color={key as BadgeColorType}
@@ -67,7 +67,7 @@ Object.keys(badgeColorTextMap).forEach(key => {
   ))
 })
 
-Object.keys(badgeSizeTextMap).forEach(key => {
+Object.keys(badgeSizeTextMap).forEach((key) => {
   sizesExamples.add(badgeSizeTextMap[key], () => (
     <Badge
       color={BADGE_COLOR.NEUTRAL}
@@ -79,7 +79,7 @@ Object.keys(badgeSizeTextMap).forEach(key => {
   ))
 })
 
-Object.keys(badgeColorTextMap).forEach(key => {
+Object.keys(badgeColorTextMap).forEach((key) => {
   pillsExamples.add(badgeColorTextMap[key], () => (
     <Badge
       color={key as BadgeColorType}

--- a/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.test.tsx
@@ -103,7 +103,12 @@ describe('ButtonGroup', () => {
     beforeEach(() => {
       wrapper = render(
         <ButtonGroup data-arbitrary="arbitrary-buttongroup">
-          <ButtonGroupItem data-arbitrary="arbitrary-button" onClick={oneClickSpy}>One</ButtonGroupItem>
+          <ButtonGroupItem
+            data-arbitrary="arbitrary-button"
+            onClick={oneClickSpy}
+          >
+            One
+          </ButtonGroupItem>
           <ButtonGroupItem onClick={twoClickSpy}>Two</ButtonGroupItem>
           <ButtonGroupItem onClick={threeClickSpy} isDisabled>
             Three

--- a/packages/react-component-library/src/components/CardFrame/partials/StyledCardFrame.tsx
+++ b/packages/react-component-library/src/components/CardFrame/partials/StyledCardFrame.tsx
@@ -5,7 +5,7 @@ const { color, shadow } = selectors
 
 export const StyledCardFrame = styled.div`
   border-radius: 3px;
-  background-color: ${color("neutral", "white")};
-  border: 1px solid ${color("neutral", "100")};
-  box-shadow: ${shadow("1")};
+  background-color: ${color('neutral', 'white')};
+  border: 1px solid ${color('neutral', '100')};
+  box-shadow: ${shadow('1')};
 `

--- a/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmark.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { selectors } from '@royalnavy/design-tokens'
-import styled  from 'styled-components'
+import styled from 'styled-components'
 
 const { color } = selectors
 

--- a/packages/react-component-library/src/components/Checkbox/partials/StyledOuterWrapper.tsx
+++ b/packages/react-component-library/src/components/Checkbox/partials/StyledOuterWrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled  from 'styled-components'
+import styled from 'styled-components'
 
 export const StyledOuterWrapper = styled.div`
   display: inline-flex;

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -115,11 +115,11 @@ const ContextMenuExample: React.FC<ContentMenuExampleProps> = ({
         />
         <ContextMenuDivider />
         <ContextMenuItem
-          link={(
+          link={
             <Link href="/something-else">
               This is too much text to put into a context menu item
             </Link>
-          )}
+          }
         />
       </ContextMenu>
     </>

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
@@ -259,9 +259,7 @@ describe('ContextMenu', () => {
     })
 
     it('renders the icons', () => {
-      expect(
-        wrapper.queryByTestId('context-menu-item-icon')
-      ).toBeVisible()
+      expect(wrapper.queryByTestId('context-menu-item-icon')).toBeVisible()
     })
   })
 
@@ -309,7 +307,9 @@ describe('ContextMenu', () => {
         return (
           <>
             <div>Click elsewhere</div>
-            <div ref={ref}><p>Click me!</p></div>
+            <div ref={ref}>
+              <p>Click me!</p>
+            </div>
             <ContextMenu
               attachedToRef={ref}
               clickType="left"
@@ -359,7 +359,9 @@ describe('ContextMenu', () => {
         return (
           <>
             <div>Click elsewhere</div>
-            <div ref={ref}><p>Click me!</p></div>
+            <div ref={ref}>
+              <p>Click me!</p>
+            </div>
             <ContextMenu
               attachedToRef={ref}
               clickType="left"

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenu.tsx
@@ -25,8 +25,8 @@ export const StyledContextMenu = styled.ol<StyledContextMenuProps>`
   border: 1px solid ${color('neutral', '200')};
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.12), 0 1px 3px 0 rgba(0, 0, 0, 0.04);
   z-index: ${zIndex('context', 1)};
-  visibility: ${({ $isOpen }) => $isOpen ? 'visible' : 'hidden'};
-  
+  visibility: ${({ $isOpen }) => ($isOpen ? 'visible' : 'hidden')};
+
   ${({ $hasIcons }) =>
     !$hasIcons &&
     css`

--- a/packages/react-component-library/src/components/DataList/DataList.test.tsx
+++ b/packages/react-component-library/src/components/DataList/DataList.test.tsx
@@ -11,7 +11,9 @@ describe('DataList', () => {
     beforeEach(() => {
       wrapper = render(
         <DataList data-arbitrary="arbitrary" title="title">
-          <DataListItem data-arbitrary="arbitrary-item" description="One">1</DataListItem>
+          <DataListItem data-arbitrary="arbitrary-item" description="One">
+            1
+          </DataListItem>
           <DataListItem description="Two">2</DataListItem>
           <DataListItem description="Three">3</DataListItem>
         </DataList>

--- a/packages/react-component-library/src/components/DataList/partials/StyledHeader.tsx
+++ b/packages/react-component-library/src/components/DataList/partials/StyledHeader.tsx
@@ -28,7 +28,7 @@ export const StyledHeader = styled.button<StyledDataListProps>`
 
       &:hover {
         background-color: ${color('neutral', '000')};
-        
+
         ${StyledAction} {
           background-color: ${color('neutral', '200')};
         }

--- a/packages/react-component-library/src/components/DatePicker/partials/StyledDatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/partials/StyledDatePicker.tsx
@@ -1,3 +1,3 @@
-import styled  from 'styled-components'
+import styled from 'styled-components'
 
 export const StyledDatePicker = styled.div``

--- a/packages/react-component-library/src/components/DatePicker/partials/StyledTetherComponent.tsx
+++ b/packages/react-component-library/src/components/DatePicker/partials/StyledTetherComponent.tsx
@@ -9,8 +9,8 @@ export const StyledTetherComponent = styled<any>(TetherComponent)`
   pointer-events: none;
 
   ${({ $isVisible }) =>
-  $isVisible &&
-  css`
+    $isVisible &&
+    css`
       pointer-events: all;
     `}
 

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
@@ -8,7 +8,6 @@ import { Dropdown } from './Dropdown'
 const stories = storiesOf('Dropdown', module)
 const examples = storiesOf('Dropdown/Examples', module)
 
-
 const options = [
   { value: 'chocolate', label: 'Chocolate' },
   { value: 'chozbun', label: 'Chozo Bun', isHidden: true },
@@ -29,7 +28,7 @@ const scrollOptions = [
   { value: 'Zombie', label: 'Zombie' },
 ]
 
-const iconOptions = options.map(option => ({
+const iconOptions = options.map((option) => ({
   ...option,
   icon: <IconAnchor />,
 }))

--- a/packages/react-component-library/src/components/Dropdown/DropdownLabel.tsx
+++ b/packages/react-component-library/src/components/Dropdown/DropdownLabel.tsx
@@ -57,11 +57,7 @@ export const DropdownLabel: React.FC<DropdownOption> = ({
   isVisible,
 }) => (
   <StyledLabel isDisabled={isDisabled}>
-    {icon && (
-      <StyledIcon data-testid="dropdown-label-icon">
-        {icon}
-      </StyledIcon>
-    )}
+    {icon && <StyledIcon data-testid="dropdown-label-icon">{icon}</StyledIcon>}
     <StyledStartAdornment data-testid="dropdown-label-label">
       {label}
     </StyledStartAdornment>

--- a/packages/react-component-library/src/components/FormikGroup/FormikGroup.test.tsx
+++ b/packages/react-component-library/src/components/FormikGroup/FormikGroup.test.tsx
@@ -61,7 +61,10 @@ describe('FormikGroup', () => {
     })
 
     it('should add the role attribute', () => {
-      expect(wrapper.getByTestId('formik-group')).toHaveAttribute('role', 'group')
+      expect(wrapper.getByTestId('formik-group')).toHaveAttribute(
+        'role',
+        'group'
+      )
     })
 
     it('should add the legend', () => {

--- a/packages/react-component-library/src/components/Nav/Nav.stories.tsx
+++ b/packages/react-component-library/src/components/Nav/Nav.stories.tsx
@@ -1,4 +1,4 @@
-import React  from 'react'
+import React from 'react'
 import { IconArrowDropDown, IconArrowDropUp } from '@royalnavy/icon-library'
 import { storiesOf } from '@storybook/react'
 import { withKnobs } from '@storybook/addon-knobs'

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
@@ -678,5 +678,4 @@ describe('NumberInput', () => {
       )
     })
   })
-
 })

--- a/packages/react-component-library/src/components/Panel/Panel.test.tsx
+++ b/packages/react-component-library/src/components/Panel/Panel.test.tsx
@@ -8,9 +8,7 @@ describe('Panel', () => {
   let wrapper: RenderResult
 
   beforeEach(() => {
-    wrapper = render(
-      <Panel data-arbitrary="arbitrary">Content</Panel>
-    )
+    wrapper = render(<Panel data-arbitrary="arbitrary">Content</Panel>)
   })
 
   it('should render the content', () => {

--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -70,10 +70,7 @@ describe('Popover', () => {
       })
 
       it('to be visible to the end user', () => {
-        expect(wrapper.getByTestId('popover')).toHaveStyleRule(
-          'opacity',
-          '1'
-        )
+        expect(wrapper.getByTestId('popover')).toHaveStyleRule('opacity', '1')
       })
 
       it('renders the provided arbitrary JSX', () => {
@@ -128,10 +125,7 @@ describe('Popover', () => {
       })
 
       it('to be visible to the end user', () => {
-        expect(wrapper.getByTestId('popover')).toHaveStyleRule(
-          'opacity',
-          '1'
-        )
+        expect(wrapper.getByTestId('popover')).toHaveStyleRule('opacity', '1')
       })
 
       describe('and the user clicks on the target again', () => {
@@ -220,5 +214,4 @@ describe('Popover', () => {
       )
     })
   })
-
 })

--- a/packages/react-component-library/src/components/Popover/Popover.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import TetherComponent from 'react-tether'
 
-import { POPOVER_CLOSE_DELAY, POPOVER_PLACEMENT, POPOVER_PLACEMENTS } from './constants'
+import {
+  POPOVER_CLOSE_DELAY,
+  POPOVER_PLACEMENT,
+  POPOVER_PLACEMENTS,
+} from './constants'
 
 import {
   FLOATING_BOX_SCHEME,
@@ -17,7 +21,7 @@ import { useHideShow } from './useHideShow'
 interface PopoverProps
   extends Omit<FloatingBoxProps, 'onMouseEnter' | 'onMouseLeave'> {
   children: React.ReactElement
-  closeDelay?: number,
+  closeDelay?: number
   content: React.ReactElement
   isClick?: boolean
   placement:

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.test.tsx
@@ -37,9 +37,7 @@ describe('ProgressIndicator', () => {
 
   describe('with arbitrary props', () => {
     beforeEach(() => {
-      wrapper = render(
-        <ProgressIndicator data-arbitrary="arbitrary" />
-      )
+      wrapper = render(<ProgressIndicator data-arbitrary="arbitrary" />)
     })
 
     it('should spread arbitrary props', () => {

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.test.tsx
@@ -349,7 +349,6 @@ describe('RangeSlider', () => {
     })
   })
 
-
   describe('without the `onUpdate` callback', () => {
     beforeEach(() => {
       wrapper = render(

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -37,7 +37,9 @@ describe('TabSet', () => {
 
         wrapper = render(
           <TabSet {...props}>
-            <Tab data-arbitrary="arbitrary-tab" title="Title 1">Content 1</Tab>
+            <Tab data-arbitrary="arbitrary-tab" title="Title 1">
+              Content 1
+            </Tab>
             <Tab title="Title 2">Content 2</Tab>
           </TabSet>
         )

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -1,5 +1,8 @@
 import React, { Children, KeyboardEvent, useState } from 'react'
-import { IconKeyboardArrowLeft, IconKeyboardArrowRight } from '@royalnavy/icon-library'
+import {
+  IconKeyboardArrowLeft,
+  IconKeyboardArrowRight,
+} from '@royalnavy/icon-library'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { Tab, TabContent, TabItem, TabProps } from '.'

--- a/packages/react-component-library/src/components/Table/Table.test.tsx
+++ b/packages/react-component-library/src/components/Table/Table.test.tsx
@@ -393,7 +393,9 @@ describe('Table', () => {
 
       wrapper = render(
         <Table data={tableDataMock} data-arbitrary="arbitrary">
-          <TableColumn data-arbitrary="arbitrary-column" field="first">First</TableColumn>
+          <TableColumn data-arbitrary="arbitrary-column" field="first">
+            First
+          </TableColumn>
           <TableColumn field="second">Second</TableColumn>
           <TableColumn field="third">Third</TableColumn>
         </Table>

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -59,10 +59,7 @@ function renderDefault({
   endsAfterEnd: boolean
 }) {
   return (
-    <StyledEvent
-      style={{ left: offsetPx }}
-      data-testid="timeline-event"
-    >
+    <StyledEvent style={{ left: offsetPx }} data-testid="timeline-event">
       <StyledEventBar
         barColor={barColor}
         width={widthPx}

--- a/packages/react-component-library/src/components/Timeline/partials/StyledTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledTodayMarker.tsx
@@ -1,4 +1,4 @@
-import styled  from 'styled-components'
+import styled from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
 
 const { color, fontSize, spacing, zIndex } = selectors

--- a/packages/react-component-library/src/components/Timeline/partials/StyledToolbarSeparator.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledToolbarSeparator.tsx
@@ -1,4 +1,4 @@
-import styled  from 'styled-components'
+import styled from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
 
 const { color, spacing } = selectors

--- a/packages/react-component-library/src/components/Timeline/partials/StyledWeekColumn.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledWeekColumn.tsx
@@ -12,7 +12,7 @@ export const StyledWeekColumn = styled.div<StyledWeekColumnProps>`
   display: inline-block;
   height: 100vh;
   background-color: ${({ isOddNumber }) =>
-  isOddNumber ? TIMELINE_ALT_BG_COLOR : TIMELINE_BG_COLOR};
+    isOddNumber ? TIMELINE_ALT_BG_COLOR : TIMELINE_BG_COLOR};
   margin-left: ${({ marginLeft }) => marginLeft};
   width: ${({ width }) => width};
 `

--- a/packages/react-component-library/src/components/Timeline/partials/StyledWeekTitle.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledWeekTitle.tsx
@@ -1,4 +1,4 @@
-import styled  from 'styled-components'
+import styled from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
 
 const { color, fontSize, spacing, zIndex } = selectors

--- a/packages/react-component-library/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.stories.tsx
@@ -25,7 +25,7 @@ const ToastButton: React.FC<Options> = ({
 
   return (
     <button
-      onClick={_ => {
+      onClick={(_) => {
         addToast(text('Description', DESCRIPTION), {
           label: text('Label', LABEL),
           appearance,

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -75,14 +75,14 @@ const user = (
 stories.add('Default', () => (
   <Masthead
     homeLink={<Link href="#" />}
-    nav={(
+    nav={
       <MastheadNav>
         <MastheadNavItem link={<Link href="#">Get started</Link>} isActive />
         <MastheadNavItem link={<Link href="#">Styles</Link>} />
         <MastheadNavItem link={<Link href="#">Components</Link>} />
         <MastheadNavItem link={<Link href="#">About</Link>} />
       </MastheadNav>
-    )}
+    }
     notifications={notifications}
     onSearch={action('onSearch')}
     searchPlaceholder="Search"
@@ -120,27 +120,27 @@ examples.add('With navigation', () => (
   <Masthead
     homeLink={<Link href="#" />}
     title="Royal Navy Design System"
-    nav={(
+    nav={
       <MastheadNav>
         <MastheadNavItem link={<Link href="#">Get started</Link>} isActive />
         <MastheadNavItem link={<Link href="#">Styles</Link>} />
         <MastheadNavItem link={<Link href="#">Components</Link>} />
         <MastheadNavItem link={<Link href="#">About</Link>} />
       </MastheadNav>
-    )}
+    }
   />
 ))
 
 examples.add('With navigation', () => (
   <Masthead
-    nav={(
+    nav={
       <MastheadNav>
         <MastheadNavItem link={<Link href="#">Get started</Link>} isActive />
         <MastheadNavItem link={<Link href="#">Styles</Link>} />
         <MastheadNavItem link={<Link href="#">Components</Link>} />
         <MastheadNavItem link={<Link href="#">About</Link>} />
       </MastheadNav>
-    )}
+    }
     title="Royal Navy Design System"
   />
 ))

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
@@ -426,7 +426,7 @@ describe('Masthead', () => {
         <>
           <Masthead
             title="title"
-            user={(
+            user={
               <MastheadUser initials="AB">
                 <MastheadUserItem
                   data-arbitrary="arbitrary-user-item"
@@ -438,7 +438,7 @@ describe('Masthead', () => {
                 <MastheadUserItem link={<Link href="/support">Support</Link>} />
                 <MastheadUserItem link={<Link href="/logout">Logout</Link>} />
               </MastheadUser>
-            )}
+            }
           />
           <div>Other content</div>
         </>

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
@@ -126,7 +126,7 @@ export const Masthead: React.FC<MastheadProps> = ({
 
           {notifications && (
             <Sheet
-              button={(
+              button={
                 <StyledOption
                   aria-label="Show notifications"
                   as={SheetButton}
@@ -137,7 +137,7 @@ export const Masthead: React.FC<MastheadProps> = ({
                     <StyledNotRead data-testid="not-read" />
                   )}
                 </StyledOption>
-              )}
+              }
               placement={SHEET_PLACEMENT.BELOW}
               width={NOTIFICATION_CONTAINER_WIDTH}
               onHide={() => setShowNotifications(false)}

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
@@ -53,20 +53,20 @@ const MastheadUserWithItems: React.FC<MastheadUserWithItemsProps> = ({
   initials,
 }) => (
   <Sheet
-    button={(
+    button={
       <StyledOption
         aria-label="Show user options"
         as={SheetButton}
         data-testid="user-button"
-        icon={(
+        icon={
           <Avatar
             data-testid="masthead-avatar"
             initials={initials}
             variant={AVATAR_VARIANT.DARK}
           />
-        )}
+        }
       />
-    )}
+    }
     placement={SHEET_PLACEMENT.BELOW}
     width={SHEET_WIDTH}
   >

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.test.tsx
@@ -41,9 +41,10 @@ describe('Notifications', () => {
     })
 
     it('should spread arbitrary props on the notifications item', () => {
-      expect(
-        wrapper.getAllByTestId('notification')[0]
-      ).toHaveAttribute('data-arbitrary', 'arbitrary-notification')
+      expect(wrapper.getAllByTestId('notification')[0]).toHaveAttribute(
+        'data-arbitrary',
+        'arbitrary-notification'
+      )
     })
 
     it('should set the `role` attribute on the notification sheet to `grid`', () => {

--- a/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.tsx
@@ -38,11 +38,7 @@ export const SearchBar: React.FC<SearchbarProps> = ({
   }
 
   return (
-    <StyledSearchBar
-      ref={searchBoxRef}
-      data-testid="searchbar"
-      {...rest}
-    >
+    <StyledSearchBar ref={searchBoxRef} data-testid="searchbar" {...rest}>
       <StyledForm data-testid="searchbar-form" onSubmit={onSubmit}>
         <TextInput
           autoFocus

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
@@ -22,7 +22,7 @@ const user = <SidebarUser initials="XT" link={<Link href="#" />} />
 stories.add('With notifications', () => (
   <Sidebar
     nav={nav}
-    notifications={(
+    notifications={
       <Notifications link={<Link href="#" />}>
         <Notification
           link={<Link href="#" />}
@@ -49,7 +49,7 @@ stories.add('With notifications', () => (
           description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
         />
       </Notifications>
-    )}
+    }
     hasUnreadNotification
     user={user}
   />
@@ -60,7 +60,7 @@ stories.add('Without notifications', () => <Sidebar nav={nav} user={user} />)
 stories.add('With custom Link component', () => (
   <Sidebar
     nav={nav}
-    notifications={(
+    notifications={
       <Notifications link={<CustomLink to="notifications" />}>
         <Notification
           link={<CustomLink to="notifications/1" />}
@@ -87,7 +87,7 @@ stories.add('With custom Link component', () => (
           description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
         />
       </Notifications>
-    )}
+    }
     hasUnreadNotification
     user={user}
   />

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.test.tsx
@@ -38,7 +38,7 @@ describe('Sidebar', () => {
         <Sidebar
           data-arbitrary="arbitrary-sidebar"
           hasUnreadNotification
-          nav={(
+          nav={
             <SidebarNav data-arbitrary="arbitrary-nav">
               <SidebarNavItem
                 data-arbitrary="arbitrary-nav-item"
@@ -55,8 +55,8 @@ describe('Sidebar', () => {
                 link={<Link href="/tools">Tools</Link>}
               />
             </SidebarNav>
-          )}
-          notifications={(
+          }
+          notifications={
             <Notifications
               data-arbitrary="arbitrary-notifications"
               link={<Link href="notifications" />}
@@ -79,14 +79,14 @@ describe('Sidebar', () => {
                 description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
               />
             </Notifications>
-          )}
-          user={(
+          }
+          user={
             <SidebarUser
               data-arbitrary="arbitrary-user"
               initials="XT"
               link={<Link href="/user-profile" />}
             />
-          )}
+          }
         />
       )
     })
@@ -165,9 +165,10 @@ describe('Sidebar', () => {
       })
 
       it('should spread arbitrary props on the notifications item', () => {
-        expect(
-          wrapper.getAllByTestId('notification')[0]
-        ).toHaveAttribute('data-arbitrary', 'arbitrary-notification')
+        expect(wrapper.getAllByTestId('notification')[0]).toHaveAttribute(
+          'data-arbitrary',
+          'arbitrary-notification'
+        )
       })
     })
   })
@@ -176,7 +177,7 @@ describe('Sidebar', () => {
     beforeEach(() => {
       wrapper = render(
         <Sidebar
-          nav={(
+          nav={
             <SidebarNav>
               <SidebarNavItem link={<Link href="/">Home</Link>} />
               <SidebarNavItem
@@ -185,7 +186,7 @@ describe('Sidebar', () => {
               />
               <SidebarNavItem link={<Link href="/tools">Tools</Link>} />
             </SidebarNav>
-          )}
+          }
         />
       )
     })
@@ -221,11 +222,11 @@ describe('Sidebar', () => {
     beforeEach(() => {
       wrapper = render(
         <Sidebar
-          nav={(
+          nav={
             <SidebarNav>
               <SidebarNavItem link={<Link href="/">Home</Link>} />
             </SidebarNav>
-          )}
+          }
         />
       )
     })
@@ -261,11 +262,11 @@ describe('Sidebar', () => {
     beforeEach(() => {
       wrapper = render(
         <Sidebar
-          nav={(
+          nav={
             <SidebarNav>
               <SidebarNavItem link={<Link href="/">Home</Link>} />
             </SidebarNav>
-          )}
+          }
         />
       )
     })
@@ -305,14 +306,14 @@ describe('Sidebar', () => {
 
       wrapper = render(
         <Sidebar
-          nav={(
+          nav={
             <SidebarNav>
               <SidebarNavItem
                 link={<Link href="/">Home</Link>}
                 onClick={() => undefined}
               />
             </SidebarNav>
-          )}
+          }
         />
       )
     })

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.tsx
@@ -46,7 +46,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
       <div className="rn-sidebar__bottom">
         {notifications && (
           <Sheet
-            button={(
+            button={
               <SheetButton
                 aria-label="Show notifications"
                 data-testid="notification-button"
@@ -56,7 +56,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   <StyledNotRead data-testid="not-read" />
                 )}
               </SheetButton>
-            )}
+            }
             width={NOTIFICATION_CONTAINER_WIDTH}
           >
             {notifications}

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
@@ -28,7 +28,7 @@ export const SidebarUser: React.FC<SidebarUserProps> = ({
     ),
     className: classes,
     'data-testid': 'sidebar-user',
-    ...rest
+    ...rest,
   })
 }
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/Sidebar.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/Sidebar.test.tsx
@@ -555,7 +555,10 @@ describe('Sidebar', () => {
     beforeEach(() => {
       wrapper = render(
         <SidebarWrapperE data-arbitrary="arbitrary-wrapper">
-          <SidebarE data-arbitrary="arbitrary-sidebar" notifications={notifications}>
+          <SidebarE
+            data-arbitrary="arbitrary-sidebar"
+            notifications={notifications}
+          >
             <SidebarNavE data-arbitrary="arbitrary-nav">
               <SidebarNavItemE
                 data-arbitrary="arbitrary-nav-item"

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarNotifications.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarNotifications.tsx
@@ -30,7 +30,7 @@ export const SidebarNotifications: React.FC<SidebarNotificationsProps> = ({
     <>
       {notifications && (
         <StyledNotificationsSheet
-          button={(
+          button={
             <StyledNotificationsSheetButton
               aria-label="Show notifications"
               data-testid="notification-button"
@@ -56,7 +56,7 @@ export const SidebarNotifications: React.FC<SidebarNotificationsProps> = ({
                 )}
               </Transition>
             </StyledNotificationsSheetButton>
-          )}
+          }
           placement={SHEET_PLACEMENT.RIGHT_BOTTOM}
           width={NOTIFICATION_CONTAINER_WIDTH}
         >

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarSubNav.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarSubNav.tsx
@@ -14,13 +14,13 @@ export const SidebarSubNav: React.FC<Nav<SidebarNavItemEProps>> = ({
 }) => {
   return (
     <StyledSubNavSheet
-      button={(
+      button={
         <StyledSubNavSheetButton
           aria-label="Expand sub-menu"
           data-testid="sub-menu-expand-button"
           icon={<IconMoreVert />}
         />
-      )}
+      }
       placement={SHEET_PLACEMENT.RIGHT_TOP}
       width={SHEET_WIDTH}
       exitTiming={0}

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarUser.tsx
@@ -32,7 +32,7 @@ const SidebarAvatarWithItems: React.FC<SidebarAvatarWithItemsProps> = ({
   exitLink,
 }) => (
   <StyledUserSheet
-    button={(
+    button={
       <StyledUserSheetButton
         aria-label="Show user options"
         data-testid="user-button"
@@ -40,7 +40,7 @@ const SidebarAvatarWithItems: React.FC<SidebarAvatarWithItemsProps> = ({
           <StyledUserAvatar initials={initials} data-testid="sidebar-avatar" />
         }
       />
-    )}
+    }
     placement={SHEET_PLACEMENT.RIGHT_BOTTOM}
     width={SHEET_WIDTH}
   >

--- a/packages/react-component-library/src/icons/Logo.tsx
+++ b/packages/react-component-library/src/icons/Logo.tsx
@@ -2,7 +2,10 @@ import React from 'react'
 
 import { ComponentWithClass } from '../common/ComponentWithClass'
 
-export const Logo: React.FC<ComponentWithClass> = ({ className = '', ...rest }) => (
+export const Logo: React.FC<ComponentWithClass> = ({
+  className = '',
+  ...rest
+}) => (
   <svg
     className={className}
     width="21"


### PR DESCRIPTION
## Related issue
Fixes #2123 

## Overview
Fixes the ESLint config that is clashing with Prettier which removes the brackets from multiline JSX.

## Reason
We are happy with the Prettier formatting.

## Work carried out
- [x] Update rule
- [x] Run Prettier across component library codebase
