### PR TITLE
ci(GHA): Add stale issues workflow

### DIFF
--- a/.github/workflows/project_stale_issues.yml
+++ b/.github/workflows/project_stale_issues.yml
@@ -1,0 +1,17 @@
+name: Project Automation - stale issues
+
+on:
+  schedule:
+    - cron: '0 1 * * 1'
+
+jobs:
+  Update_stale_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label & comment to stale issues
+        uses: actions/stale@v3
+        with:
+          stale-issue-message: 'This issue has been marked as stale because it has been open for 60 days with no activity'
+          days-before-stale: 60
+          days-before-close: -1
+          stale-issue-label: 'Status: Stale'


### PR DESCRIPTION
## Related issue

closes #2149

## Overview

Add workflow to identify & mark stale issues

## Reason

[Why did you do what you did? - feel free to copy from the ticket if the reason is there]

## Work carried out

- [x] Add project automation stale issues workflow -
        will run every Monday @ 0100 adding a comment and 'stale' label to any issue aged > 60 days 
        without any activity.


