### PR TITLE
feat(Timeline): Set `width` of rows

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -438,6 +438,7 @@ export const WithCustomRowCss = () => {
     <Timeline
       hasSide
       startDate={new Date(2020, 3, 1)}
+      endDate={new Date(2020, 4, 30)}
       today={new Date(2020, 3, 15)}
     >
       <TimelineTodayMarker />

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import classNames from 'classnames'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { StyledRows } from './partials/StyledRows'
 import { TimelineNoData } from './TimelineNoData'
-import { TimelineRowProps } from '.'
+import { TimelineContext, TimelineRowProps } from '.'
+import { StyledRow } from './partials/StyledRow'
 
 type TimelineRowsChildrenType =
   | React.ReactElement<TimelineRowProps>
@@ -28,9 +29,13 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
 }) => {
   const hasChildren = React.Children.count(children) > 0
   const mainClasses = classNames('timeline__main', className)
+  const {
+    state: { currentScaleOption, days },
+  } = useContext(TimelineContext)
 
   return (
     <StyledRows
+      $width={currentScaleOption.widths.day * days.length}
       className={mainClasses}
       defaultStyles={!renderColumns}
       role="rowgroup"

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -294,6 +294,13 @@ describe('Timeline', () => {
       expect(wrapper.queryByTestId('timeline-no-data')).not.toBeInTheDocument()
     })
 
+    it('should set the width of the rows', () => {
+      expect(wrapper.getByTestId('timeline-rows')).toHaveStyleRule(
+        'width',
+        '900px'
+      )
+    })
+
     it('should set the `role` attribute to `rowgroup` on the rows group', () => {
       expect(wrapper.queryByTestId('timeline-rows')).toHaveAttribute(
         'role',
@@ -1928,6 +1935,13 @@ describe('Timeline', () => {
       expect(wrapper.getAllByTestId('timeline-day')[0]).toHaveStyleRule(
         'width',
         '53px'
+      )
+    })
+
+    it('should set the width of the rows', () => {
+      expect(wrapper.getByTestId('timeline-rows')).toHaveStyleRule(
+        'width',
+        '6360px'
       )
     })
   })

--- a/packages/react-component-library/src/components/Timeline/partials/StyledRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledRows.tsx
@@ -1,14 +1,19 @@
 import styled, { css } from 'styled-components'
 
 interface StyledRowsProps {
+  $width: number
   defaultStyles: boolean
 }
 
 export const StyledRows = styled.div<StyledRowsProps>`
+  width: ${({ $width }) =>
+    css`
+      ${$width}px
+    `};
+
   ${({ defaultStyles }) =>
     defaultStyles &&
     css`
-      width: auto;
       height: auto;
       min-height: 4rem;
     `}


### PR DESCRIPTION
## Related issue
Fixes #2121 

## Overview
Fixes the rows so that they are 100% of `Timeline` width.

## Reason
Required so that each row fills 100% of parent rather than just 100% of view width. Useful for setting custom row styles.

## Work carried out
- [x] Add fix for width

## Screenshot
![2021-04-08 14 16 51](https://user-images.githubusercontent.com/56078793/114033538-46b82180-9875-11eb-9fe2-b9295a2bcce8.gif)
