### PR TITLE
feat(TabSet): Add ability to set initial active tab

### DIFF
--- a/packages/react-component-library/src/components/TabSet/Tab.tsx
+++ b/packages/react-component-library/src/components/TabSet/Tab.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 export interface TabProps {
   title: React.ReactElement | string
   children: React.ReactElement | string
+  isActive?: boolean
 }
 
 export const Tab: React.FC<TabProps> = ({ children }) => {

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -23,6 +23,23 @@ stories.add('Default', () => (
   </TabSet>
 ))
 
+stories.add('Initial active tab', () => (
+  <TabSet onChange={action('onChange')}>
+    <Tab title="Example Tab 1">
+      <p>This is some example tab 1 content</p>
+    </Tab>
+    <Tab title="Example Tab 2" isActive>
+      <p>This is some example tab 2 content</p>
+    </Tab>
+    <Tab title="Example Tab 3">
+      <p>This is some example tab 3 content</p>
+    </Tab>
+    <Tab title="Example Tab 4">
+      <p>This is some example tab 4 content</p>
+    </Tab>
+  </TabSet>
+))
+
 stories.add('Default full width', () => (
   <TabSet isFullWidth onChange={action('onChange')}>
     <Tab title="Example Tab 1">

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -235,9 +235,42 @@ describe('TabSet', () => {
           wrapper.getByText('Title 2').click()
         })
 
-        it('should apply the `is-active` class to the appropriate tab', () => {
+        it('should make the appropriate tab active', () => {
           const tab = wrapper.getByText('Title 2').parentElement
           expect(tab).toHaveStyleRule('color', color('neutral', '500'))
+        })
+      })
+    })
+
+    describe('when the initialActiveTab is set', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <TabSet>
+            <Tab title="Title 1">Content 1</Tab>
+            <Tab title="Title 2" isActive>
+              Content 2
+            </Tab>
+          </TabSet>
+        )
+      })
+
+      it('should make the appropriate tab active', () => {
+        const tab1 = wrapper.getByText('Title 1').parentElement
+        const tab2 = wrapper.getByText('Title 2').parentElement
+        expect(tab1).not.toHaveStyleRule('color', color('neutral', '500'))
+        expect(tab2).toHaveStyleRule('color', color('neutral', '500'))
+      })
+
+      describe('when the user clicks on a tab', () => {
+        beforeEach(() => {
+          wrapper.getByText('Title 1').click()
+        })
+
+        it('should make the appropriate tab active', () => {
+          const tab1 = wrapper.getByText('Title 1').parentElement
+          const tab2 = wrapper.getByText('Title 2').parentElement
+          expect(tab1).toHaveStyleRule('color', color('neutral', '500'))
+          expect(tab2).not.toHaveStyleRule('color', color('neutral', '500'))
         })
       })
     })

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -22,6 +22,7 @@ interface TabSetProps extends ComponentWithClass {
   onChange?: (id: number) => void
   isFullWidth?: boolean
   isScrollable?: never
+  initialActiveTab?: number
 }
 
 interface ScrollableTabSetProps extends ComponentWithClass {
@@ -42,11 +43,24 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
   isScrollable,
   ...rest
 }) => {
+  function getActiveIndex(tabs: React.ReactNode | React.ReactNode[]): number {
+    const activeIndex = Children.toArray(tabs).findIndex(
+      (item: React.ReactNode) => {
+        if (React.isValidElement(item)) {
+          return item.props.isActive
+        }
+
+        return false
+      }
+    )
+
+    return activeIndex === -1 ? 0 : activeIndex
+  }
+
   const [tabIds] = useState(
     Array.from({ length: children.length }).map(() => getId('tab-content'))
   )
-
-  const [activeTab, setActiveTab] = useState(0)
+  const [activeTab, setActiveTab] = useState(getActiveIndex(children))
   const { scrollToNextTab, tabsRef, itemsRef } = useScrollableTabSet(children)
 
   function handleClick(index: number) {
@@ -126,7 +140,12 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
         {Children.map(
           children,
           (child: React.ReactElement<TabProps>, index: number) => {
-            const { children: tabChildren, title, ...tabRest } = child.props
+            const {
+              children: tabChildren,
+              title,
+              isActive,
+              ...tabRest
+            } = child.props
 
             return (
               <TabContent


### PR DESCRIPTION
## Related issue

Closes #2147

## Overview

Add ability to set the initial active tab for a TabSet.

## Reason

There was no way to programmatically set the initially active tab.

## Work carried out

- [x] Interrogate `isActive` prop from Tab sub-component