### PR TITLE
fix(Timeline): Set `endDate` if bound by dates

### DIFF
--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -1278,6 +1278,21 @@ describe('Timeline', () => {
     it('renders the correct number of months', () => {
       expect(wrapper.queryAllByTestId('timeline-month')).toHaveLength(6)
     })
+
+    describe('when moving left four times', () => {
+      beforeEach(() => {
+        userEvent.click(wrapper.getByTestId('timeline-side-button-left'))
+        userEvent.click(wrapper.getByTestId('timeline-side-button-left'))
+        userEvent.click(wrapper.getByTestId('timeline-side-button-left'))
+        userEvent.click(wrapper.getByTestId('timeline-side-button-left'))
+      })
+
+      it('the first day should be 01', () => {
+        expect(wrapper.getAllByTestId('timeline-day')[0]).toHaveTextContent(
+          '01'
+        )
+      })
+    })
   })
 
   describe('when Timeline is initialised with a fixed `endDate`', () => {

--- a/packages/react-component-library/src/components/Timeline/context/reducer.ts
+++ b/packages/react-component-library/src/components/Timeline/context/reducer.ts
@@ -102,7 +102,7 @@ export function reducer(
     options: {
       ...state.options,
       startDate: scale.from,
-      endDate: scale.to,
+      endDate: state.options.endDate ? scale.to : null,
     },
   }
 }


### PR DESCRIPTION
## Related issue
Fixes #2190 

## Overview
`range` and `endDate` need to be treated differently so `endDate` should not be set if it was not originally specified.

## Reason
Has a knock on effect when navigating left and right as the `endDate` is being used to calculate where the next time frame should be.

## Work carried out
- [x] Set `endDate` if it was originally supplied
