### PR TITLE
Refactor timeline to use transient props

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -174,8 +174,8 @@ export const Timeline: React.FC<TimelineProps> = ({
         {...rest}
       >
         <StyledInner
+          $hasSide={hasSide || hasTimelineSide}
           className="timeline__inner"
-          hasSide={hasSide || hasTimelineSide}
         >
           <TimelineWeekColumns renderColumns={renderColumns} />
           {rootChildren}

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -61,11 +61,11 @@ function renderDefault({
   return (
     <StyledEvent $leftPx={offsetPx} data-testid="timeline-event">
       <StyledEventBar
-        barColor={barColor}
-        width={widthPx}
-        maxWidth={maxWidthPx}
-        startsBeforeStart={startsBeforeStart}
-        endsAfterEnd={endsAfterEnd}
+        $barColor={barColor}
+        $width={widthPx}
+        $maxWidth={maxWidthPx}
+        $startsBeforeStart={startsBeforeStart}
+        $endsAfterEnd={endsAfterEnd}
         data-testid="timeline-event-bar"
       />
       <StyledEventTitle data-testid="timeline-event-title">

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -59,7 +59,7 @@ function renderDefault({
   endsAfterEnd: boolean
 }) {
   return (
-    <StyledEvent style={{ left: offsetPx }} data-testid="timeline-event">
+    <StyledEvent $leftPx={offsetPx} data-testid="timeline-event">
       <StyledEventBar
         barColor={barColor}
         width={widthPx}

--- a/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
@@ -54,7 +54,7 @@ export const TimelineRow: React.FC<TimelineRowProps> = ({
           {hasSide && (
             <StyledRowHeader
               $css={headerCss}
-              isHeader={isHeader}
+              $isHeader={isHeader}
               data-testid="timeline-row-header"
               role="rowheader"
               aria-label={ariaLabel || name}

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -35,9 +35,9 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
 
   return (
     <StyledRows
+      $hasDefaultStyles={!renderColumns}
       $width={currentScaleOption.widths.day * days.length}
       className={mainClasses}
-      defaultStyles={!renderColumns}
       role="rowgroup"
       data-testid="timeline-rows"
       {...rest}

--- a/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
@@ -22,10 +22,7 @@ export type TimelineTodayMarkerProps =
 
 function renderDefault({ offset }: { offset: string }) {
   return (
-    <StyledTodayMarker
-      data-testid="timeline-today-marker"
-      style={{ left: offset }}
-    />
+    <StyledTodayMarker $leftPx={offset} data-testid="timeline-today-marker" />
   )
 }
 

--- a/packages/react-component-library/src/components/Timeline/TimelineWeek.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeek.tsx
@@ -42,9 +42,9 @@ function renderDefault({
 }) {
   return (
     <StyledWeek
-      isOddNumber={isOddNumber}
-      marginLeft={offsetPx}
-      width={widthPx}
+      $isOddNumber={isOddNumber}
+      $marginLeftPx={offsetPx}
+      $widthPx={widthPx}
       data-testid="timeline-week"
     >
       <StyledWeekTitle>{format(startDate, DATE_WEEK_FORMAT)}</StyledWeekTitle>

--- a/packages/react-component-library/src/components/Timeline/TimelineWeekColumns.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeekColumns.tsx
@@ -17,9 +17,9 @@ function renderDefaultColumns(
 ) {
   return (
     <StyledWeekColumn
-      isOddNumber={isOddNumber}
-      marginLeft={offsetPx}
-      width={widthPx}
+      $isOddNumber={isOddNumber}
+      $marginLeftPx={offsetPx}
+      $widthPx={widthPx}
     />
   )
 }

--- a/packages/react-component-library/src/components/Timeline/partials/StyledEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledEvent.tsx
@@ -3,10 +3,14 @@ import { selectors } from '@royalnavy/design-tokens'
 
 const { spacing, zIndex } = selectors
 
-export const StyledEvent = styled.div`
+interface StyledEventProps {
+  $leftPx: string
+}
+
+export const StyledEvent = styled.div<StyledEventProps>`
   position: absolute;
   top: 50%;
-  left: 0;
+  left: ${({ $leftPx }) => $leftPx || 0};
   width: 4.5rem;
   transform: translateY(-50%);
   display: inline-flex;

--- a/packages/react-component-library/src/components/Timeline/partials/StyledEventBar.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledEventBar.tsx
@@ -6,11 +6,11 @@ import { StyledEventTitle } from './StyledEventTitle'
 const { color } = selectors
 
 interface StyledEventBarProps {
-  width: string
-  maxWidth?: string
-  barColor: string
-  startsBeforeStart?: boolean
-  endsAfterEnd?: boolean
+  $width: string
+  $maxWidth?: string
+  $barColor: string
+  $startsBeforeStart?: boolean
+  $endsAfterEnd?: boolean
 }
 
 export const StyledEventBar = styled.div<StyledEventBarProps>`
@@ -18,19 +18,19 @@ export const StyledEventBar = styled.div<StyledEventBarProps>`
   position: relative;
   display: inline-block;
   border-radius: 4px;
-  background-color: ${({ barColor = color('success', '500') }) => barColor};
+  background-color: ${({ $barColor = color('success', '500') }) => $barColor};
   height: 16px;
   min-width: 1rem;
-  width: ${({ width }) => width};
-  max-width: ${({ maxWidth }) => maxWidth};
+  width: ${({ $width }) => $width};
+  max-width: ${({ $maxWidth }) => $maxWidth};
 
-  ${({ startsBeforeStart, width, barColor = color('success', '500') }) =>
-    startsBeforeStart &&
+  ${({ $startsBeforeStart, $width, $barColor = color('success', '500') }) =>
+    $startsBeforeStart &&
     css`
       border-top-left-radius: unset;
       border-bottom-left-radius: unset;
       margin-left: 14px;
-      width: calc(${width} - 14px);
+      width: calc(${$width} - 14px);
 
       &::before {
         content: '';
@@ -40,7 +40,7 @@ export const StyledEventBar = styled.div<StyledEventBarProps>`
         height: 0;
         border-style: solid;
         border-width: 8px 14px 8px 0;
-        border-color: transparent ${barColor} transparent transparent;
+        border-color: transparent ${$barColor} transparent transparent;
       }
 
       + ${StyledEventTitle} {
@@ -48,12 +48,12 @@ export const StyledEventBar = styled.div<StyledEventBarProps>`
       }
     `}
 
-  ${({ endsAfterEnd, maxWidth, barColor = color('success', '500') }) =>
-    endsAfterEnd &&
+  ${({ $endsAfterEnd, $maxWidth, $barColor = color('success', '500') }) =>
+    $endsAfterEnd &&
     css`
       border-top-right-radius: unset;
       border-bottom-right-radius: unset;
-      max-width: calc(${maxWidth} - 14px);
+      max-width: calc(${$maxWidth} - 14px);
 
       &::after {
         content: '';
@@ -63,14 +63,14 @@ export const StyledEventBar = styled.div<StyledEventBarProps>`
         height: 0;
         border-style: solid;
         border-width: 8px 0 8px 14px;
-        border-color: transparent transparent transparent ${barColor};
+        border-color: transparent transparent transparent ${$barColor};
       }
     `}
 
-    ${({ startsBeforeStart, endsAfterEnd, maxWidth }) =>
-    startsBeforeStart &&
-    endsAfterEnd &&
+    ${({ $startsBeforeStart, $endsAfterEnd, $maxWidth }) =>
+    $startsBeforeStart &&
+    $endsAfterEnd &&
     css`
-      max-width: calc(${maxWidth} - 28px);
+      max-width: calc(${$maxWidth} - 28px);
     `}
 `

--- a/packages/react-component-library/src/components/Timeline/partials/StyledHours.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledHours.tsx
@@ -1,7 +1,5 @@
 import styled from 'styled-components'
 
-import { TIMELINE_BG_COLOR } from '../constants'
-
 export const StyledHours = styled.div`
   white-space: nowrap;
   width: 100%;

--- a/packages/react-component-library/src/components/Timeline/partials/StyledInner.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledInner.tsx
@@ -6,13 +6,13 @@ import { TIMELINE_BORDER_COLOR, TIMELINE_ROW_HEADER_WIDTH } from '../constants'
 const { spacing } = selectors
 
 interface StyledInnerProps {
-  hasSide: boolean
+  $hasSide: boolean
 }
 
 export const StyledInner = styled.div<StyledInnerProps>`
   overflow-y: hidden;
   border-right: ${spacing('px')} solid ${TIMELINE_BORDER_COLOR};
   border-bottom: ${spacing('px')} solid ${TIMELINE_BORDER_COLOR};
-  margin-left: ${({ hasSide }) =>
-    hasSide ? TIMELINE_ROW_HEADER_WIDTH : 'initial'};
+  margin-left: ${({ $hasSide }) =>
+    $hasSide ? TIMELINE_ROW_HEADER_WIDTH : 'initial'};
 `

--- a/packages/react-component-library/src/components/Timeline/partials/StyledRowHeader.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledRowHeader.tsx
@@ -7,7 +7,7 @@ import { TIMELINE_BORDER_COLOR, TIMELINE_ROW_HEADER_WIDTH } from '../constants'
 const { color, fontSize, spacing, zIndex } = selectors
 
 interface StyledRowHeaderProps extends StyledSubComponentProps {
-  isHeader?: boolean
+  $isHeader?: boolean
 }
 
 export const StyledRowHeader = styled.div<StyledRowHeaderProps>`
@@ -25,8 +25,8 @@ export const StyledRowHeader = styled.div<StyledRowHeaderProps>`
   font-weight: 600;
   color: ${color('neutral', '600')};
   padding-right: ${spacing('8')};
-  ${({ isHeader }) =>
-    isHeader &&
+  ${({ $isHeader }) =>
+    $isHeader &&
     css`
       font-size: ${fontSize('s')};
       font-weight: normal;

--- a/packages/react-component-library/src/components/Timeline/partials/StyledRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledRows.tsx
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components'
 
 interface StyledRowsProps {
   $width: number
-  defaultStyles: boolean
+  $hasDefaultStyles: boolean
 }
 
 export const StyledRows = styled.div<StyledRowsProps>`
@@ -11,8 +11,8 @@ export const StyledRows = styled.div<StyledRowsProps>`
       ${$width}px
     `};
 
-  ${({ defaultStyles }) =>
-    defaultStyles &&
+  ${({ $hasDefaultStyles }) =>
+    $hasDefaultStyles &&
     css`
       height: auto;
       min-height: 4rem;

--- a/packages/react-component-library/src/components/Timeline/partials/StyledTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledTodayMarker.tsx
@@ -3,9 +3,14 @@ import { selectors } from '@royalnavy/design-tokens'
 
 const { color, fontSize, spacing, zIndex } = selectors
 
-export const StyledTodayMarker = styled.div`
+interface StyledTodayMarkerProps {
+  $leftPx: string
+}
+
+export const StyledTodayMarker = styled.div<StyledTodayMarkerProps>`
   position: absolute;
   top: 4rem;
+  left: ${({ $leftPx }) => $leftPx || 0};
   display: inline-block;
   width: ${spacing('px')};
   height: 100vh;

--- a/packages/react-component-library/src/components/Timeline/partials/StyledWeek.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledWeek.tsx
@@ -10,19 +10,19 @@ import {
 const { spacing } = selectors
 
 interface StyledWeekProps {
-  isOddNumber: boolean
-  marginLeft: string
-  width: string
+  $isOddNumber: boolean
+  $marginLeftPx: string
+  $widthPx: string
 }
 
 export const StyledWeek = styled.div<StyledWeekProps>`
   display: inline-flex;
   align-items: center;
   height: 2.5rem;
-  background-color: ${({ isOddNumber }) =>
-    isOddNumber ? TIMELINE_ALT_BG_COLOR : TIMELINE_BG_COLOR};
+  background-color: ${({ $isOddNumber }) =>
+    $isOddNumber ? TIMELINE_ALT_BG_COLOR : TIMELINE_BG_COLOR};
   border-bottom: ${spacing('px')} solid ${TIMELINE_BORDER_COLOR};
   justify-content: unset;
-  margin-left: ${({ marginLeft }) => marginLeft};
-  width: ${({ width }) => width};
+  margin-left: ${({ $marginLeftPx }) => $marginLeftPx};
+  width: ${({ $widthPx }) => $widthPx};
 `

--- a/packages/react-component-library/src/components/Timeline/partials/StyledWeekColumn.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledWeekColumn.tsx
@@ -3,16 +3,16 @@ import styled from 'styled-components'
 import { TIMELINE_ALT_BG_COLOR, TIMELINE_BG_COLOR } from '../constants'
 
 interface StyledWeekColumnProps {
-  isOddNumber: boolean
-  marginLeft: string
-  width: string
+  $isOddNumber: boolean
+  $marginLeftPx: string
+  $widthPx: string
 }
 
 export const StyledWeekColumn = styled.div<StyledWeekColumnProps>`
   display: inline-block;
   height: 100vh;
-  background-color: ${({ isOddNumber }) =>
-    isOddNumber ? TIMELINE_ALT_BG_COLOR : TIMELINE_BG_COLOR};
-  margin-left: ${({ marginLeft }) => marginLeft};
-  width: ${({ width }) => width};
+  background-color: ${({ $isOddNumber }) =>
+    $isOddNumber ? TIMELINE_ALT_BG_COLOR : TIMELINE_BG_COLOR};
+  margin-left: ${({ $marginLeftPx }) => $marginLeftPx};
+  width: ${({ $widthPx }) => $widthPx};
 `


### PR DESCRIPTION
## Related issue
Closes #2175 

## Overview
Use transient props in partials.

## Reason
This is the pattern for our styled-components implementation.

## Work carried out
- [x] Refactor