### PR TITLE
Fix pagination error hiding input

### DIFF
--- a/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
@@ -169,6 +169,13 @@ describe('Pagination', () => {
             expect(wrapper.getByText('Check page number')).toBeVisible()
           })
 
+          it('should display the error in the correct position', () => {
+            const error = wrapper.getByTestId('tooltip')
+            expect(error).toHaveStyleRule('bottom', '39px')
+            expect(error).toHaveStyleRule('right', '3px')
+            expect(error).toHaveStyleRule('width', '155px')
+          })
+
           it('should not call the onChange callback', () => {
             expect(onChangeSpy).not.toHaveBeenCalled()
           })

--- a/packages/react-component-library/src/components/Pagination/PaginationErrorMessage.tsx
+++ b/packages/react-component-library/src/components/Pagination/PaginationErrorMessage.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Tooltip } from '../Tooltip'
 
 export const PaginationErrorMessage: React.FC = () => (
-  <Tooltip top={-35} right={3} width={155}>
+  <Tooltip bottom={39} right={3} width={155}>
     Check page number
   </Tooltip>
 )

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.test.tsx
@@ -101,10 +101,11 @@ describe('Tooltip', () => {
     })
 
     it('should render the tooltip with extra style', () => {
-      expect(wrapper.getByTestId('tooltip')).toHaveAttribute(
-        'style',
-        'bottom: 1px; left: 2px; right: 3px; top: 4px; width: 100px;'
-      )
+      expect(wrapper.getByTestId('tooltip')).toHaveStyleRule('bottom', '1px')
+      expect(wrapper.getByTestId('tooltip')).toHaveStyleRule('left', '2px')
+      expect(wrapper.getByTestId('tooltip')).toHaveStyleRule('right', '3px')
+      expect(wrapper.getByTestId('tooltip')).toHaveStyleRule('top', '4px')
+      expect(wrapper.getByTestId('tooltip')).toHaveStyleRule('width', '100px')
     })
 
     it('should render the title', () => {

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
@@ -46,24 +46,20 @@ export const Tooltip: React.FC<TooltipProps> = ({
   width,
   ...rest
 }) => {
-  const style = {
-    bottom,
-    left,
-    right,
-    top,
-    width,
-  }
-
   const contentId = getId('tooltip-content')
   const titleId = title ? getId('tooltip-title') : null
 
   return (
     <StyledTooltip
+      $bottom={bottom}
+      $left={left}
+      $right={right}
+      $top={top}
+      $width={width}
       aria-describedby={contentId}
       aria-labelledby={titleId}
       data-testid="tooltip"
       role="tooltip"
-      style={style}
       {...rest}
     >
       <StyledContent $position={position}>

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
-import styled from 'styled-components'
-import { selectors } from '@royalnavy/design-tokens'
 
 import { getId } from '../../helpers'
 import { PositionType } from '../../common/Position'
 import { TOOLTIP_POSITION } from '.'
+import { StyledTooltip } from './partials/StyledTooltip'
+import { StyledContent } from './partials/StyledContent'
+import { StyledTitle } from './partials/StyledTitle'
+import { StyledMessage } from './partials/StyledMessage'
 
 export interface TooltipProps extends PositionType {
   /**
@@ -32,140 +34,6 @@ export interface TooltipProps extends PositionType {
    */
   width?: number
 }
-
-interface StyledTooltipContentProps {
-  /**
-   * Where to position the tooltip relative to the target element.
-   */
-  position?: string
-}
-
-const { zIndex, color, spacing, fontSize } = selectors
-
-const TOOLTIP_BORDER_THICK = 1
-const TOOLTIP_INNER = 4
-const TOOLTIP_OUTER = TOOLTIP_INNER - 4
-const TOOLTIP_OFFSET = TOOLTIP_OUTER + TOOLTIP_BORDER_THICK
-const TOOLTIP_DARK_BG = color('neutral', '700')
-const TOOLTIP_DARK_BORDER = TOOLTIP_DARK_BG
-
-function getPositionStyles(position: string): string {
-  const styles = {
-    above: `
-      &::before {
-        border-color: ${TOOLTIP_DARK_BORDER} transparent;
-        border-width: ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px 0;
-        margin-left: -${TOOLTIP_OUTER}px;
-        bottom: -${TOOLTIP_INNER}px;
-        left: 50%;
-      }
-      &::after {
-        border-color: ${TOOLTIP_DARK_BG} transparent;
-        border-width: ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px 0;
-        margin-left: -${TOOLTIP_OUTER}px;
-        bottom: -${TOOLTIP_OUTER}px;
-        left: 50%;
-      }
-    `,
-    right: `
-      &::before {
-        border-color: transparent ${TOOLTIP_DARK_BORDER};
-        border-width: ${TOOLTIP_OUTER}px ${TOOLTIP_OUTER}px ${TOOLTIP_OUTER}px 0;
-        margin-top: -${TOOLTIP_OUTER}px;
-        left: -${TOOLTIP_OFFSET}px;
-        top: 50%;
-      }
-      &::after {
-        border-color: transparent ${TOOLTIP_DARK_BG};
-        border-width: ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px 0;
-        margin-top: -${TOOLTIP_INNER}px;
-        left: -${TOOLTIP_INNER}px;
-        top: 50%;
-      }
-    `,
-    below: `
-      &::before {
-        border-color: ${TOOLTIP_DARK_BORDER} transparent;
-        border-width: 0 ${TOOLTIP_OUTER}px ${TOOLTIP_OUTER}px;
-        margin-left: -${TOOLTIP_OUTER}px;
-        top: -${TOOLTIP_OFFSET}px;
-        left: 50%;
-      }
-      &::after {
-        border-color: ${TOOLTIP_DARK_BG} transparent;
-        border-width: 0 ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px;
-        margin-left: -${TOOLTIP_INNER}px;
-        top: -${TOOLTIP_INNER}px;
-        left: 50%;
-      }
-    `,
-    left: `
-      &::before {
-        border-color: transparent ${TOOLTIP_DARK_BORDER};
-        border-width: ${TOOLTIP_OUTER}px 0 ${TOOLTIP_OUTER}px ${TOOLTIP_OUTER}px;
-        margin-top: -${TOOLTIP_OUTER}px;
-        right: -${TOOLTIP_OFFSET}px;
-        top: 50%;
-      }
-      &::after {
-        border-color: transparent ${TOOLTIP_DARK_BG};
-        border-width: ${TOOLTIP_INNER}px 0 ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px;
-        margin-top: -${TOOLTIP_INNER}px;
-        right: -${TOOLTIP_INNER}px;
-        top: 50%;
-      }
-    `,
-  }
-
-  return styles[position]
-}
-
-const StyledTooltip = styled.div`
-  position: absolute;
-`
-
-const StyledTooltipContent = styled.div<StyledTooltipContentProps>`
-  z-index: ${zIndex('modal', 1)};
-  background: ${TOOLTIP_DARK_BG};
-  color: ${color('neutral', 'white')};
-  border: ${TOOLTIP_DARK_BORDER} solid ${TOOLTIP_BORDER_THICK};
-  border-radius: 5px;
-  padding: ${spacing('6')} ${spacing('8')};
-  position: relative;
-  top: auto;
-  left: auto;
-  height: auto;
-  width: auto;
-
-  &::before {
-    border-style: solid;
-    content: '';
-    display: block;
-    position: absolute;
-    width: 0;
-    z-index: 0;
-  }
-
-  &::after {
-    border-style: solid;
-    content: '';
-    display: block;
-    position: absolute;
-    width: 0;
-    z-index: 1;
-  }
-
-  ${({ position }) => getPositionStyles(position)}
-`
-
-const StyledTooltipTitle = styled.div`
-  padding-bottom: ${spacing('1')};
-`
-
-const StyledTooltipMessage = styled.div`
-  font-size: ${fontSize('base')};
-  color: ${color('neutral', '100')};
-`
 
 export const Tooltip: React.FC<TooltipProps> = ({
   bottom,
@@ -198,14 +66,14 @@ export const Tooltip: React.FC<TooltipProps> = ({
       style={style}
       {...rest}
     >
-      <StyledTooltipContent position={position}>
-        {title && <StyledTooltipTitle id={titleId}>{title}</StyledTooltipTitle>}
+      <StyledContent $position={position}>
+        {title && <StyledTitle id={titleId}>{title}</StyledTitle>}
         {children && (
-          <StyledTooltipMessage data-testid="tooltip-content" id={contentId}>
+          <StyledMessage data-testid="tooltip-content" id={contentId}>
             {children}
-          </StyledTooltipMessage>
+          </StyledMessage>
         )}
-      </StyledTooltipContent>
+      </StyledContent>
     </StyledTooltip>
   )
 }

--- a/packages/react-component-library/src/components/Tooltip/partials/StyledContent.tsx
+++ b/packages/react-component-library/src/components/Tooltip/partials/StyledContent.tsx
@@ -1,0 +1,123 @@
+import styled, { css } from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, spacing, zIndex } = selectors
+
+const TOOLTIP_BORDER_THICK = 1
+const TOOLTIP_INNER = 4
+const TOOLTIP_OUTER = TOOLTIP_INNER - 4
+const TOOLTIP_OFFSET = TOOLTIP_OUTER + TOOLTIP_BORDER_THICK
+const TOOLTIP_DARK_BG = color('neutral', '700')
+const TOOLTIP_DARK_BORDER = TOOLTIP_DARK_BG
+
+interface StyledContentProps {
+  /**
+   * Where to position the tooltip relative to the target element.
+   */
+  $position?: string
+}
+
+function getPositionStyles(position: string): string {
+  const styles = {
+    above: css`
+      &::before {
+        border-color: ${TOOLTIP_DARK_BORDER} transparent;
+        border-width: ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px 0;
+        margin-left: -${TOOLTIP_OUTER}px;
+        bottom: -${TOOLTIP_INNER}px;
+        left: 50%;
+      }
+      &::after {
+        border-color: ${TOOLTIP_DARK_BG} transparent;
+        border-width: ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px 0;
+        margin-left: -${TOOLTIP_OUTER}px;
+        bottom: -${TOOLTIP_OUTER}px;
+        left: 50%;
+      }
+    `,
+    right: css`
+      &::before {
+        border-color: transparent ${TOOLTIP_DARK_BORDER};
+        border-width: ${TOOLTIP_OUTER}px ${TOOLTIP_OUTER}px ${TOOLTIP_OUTER}px 0;
+        margin-top: -${TOOLTIP_OUTER}px;
+        left: -${TOOLTIP_OFFSET}px;
+        top: 50%;
+      }
+      &::after {
+        border-color: transparent ${TOOLTIP_DARK_BG};
+        border-width: ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px 0;
+        margin-top: -${TOOLTIP_INNER}px;
+        left: -${TOOLTIP_INNER}px;
+        top: 50%;
+      }
+    `,
+    below: css`
+      &::before {
+        border-color: ${TOOLTIP_DARK_BORDER} transparent;
+        border-width: 0 ${TOOLTIP_OUTER}px ${TOOLTIP_OUTER}px;
+        margin-left: -${TOOLTIP_OUTER}px;
+        top: -${TOOLTIP_OFFSET}px;
+        left: 50%;
+      }
+      &::after {
+        border-color: ${TOOLTIP_DARK_BG} transparent;
+        border-width: 0 ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px;
+        margin-left: -${TOOLTIP_INNER}px;
+        top: -${TOOLTIP_INNER}px;
+        left: 50%;
+      }
+    `,
+    left: css`
+      &::before {
+        border-color: transparent ${TOOLTIP_DARK_BORDER};
+        border-width: ${TOOLTIP_OUTER}px 0 ${TOOLTIP_OUTER}px ${TOOLTIP_OUTER}px;
+        margin-top: -${TOOLTIP_OUTER}px;
+        right: -${TOOLTIP_OFFSET}px;
+        top: 50%;
+      }
+      &::after {
+        border-color: transparent ${TOOLTIP_DARK_BG};
+        border-width: ${TOOLTIP_INNER}px 0 ${TOOLTIP_INNER}px ${TOOLTIP_INNER}px;
+        margin-top: -${TOOLTIP_INNER}px;
+        right: -${TOOLTIP_INNER}px;
+        top: 50%;
+      }
+    `,
+  }
+
+  return styles[position]
+}
+
+export const StyledContent = styled.div<StyledContentProps>`
+  z-index: ${zIndex('modal', 1)};
+  background: ${TOOLTIP_DARK_BG};
+  color: ${color('neutral', 'white')};
+  border: ${TOOLTIP_DARK_BORDER} solid ${TOOLTIP_BORDER_THICK};
+  border-radius: 5px;
+  padding: ${spacing('6')} ${spacing('8')};
+  position: relative;
+  top: auto;
+  left: auto;
+  height: auto;
+  width: auto;
+
+  &::before {
+    border-style: solid;
+    content: '';
+    display: block;
+    position: absolute;
+    width: 0;
+    z-index: 0;
+  }
+
+  &::after {
+    border-style: solid;
+    content: '';
+    display: block;
+    position: absolute;
+    width: 0;
+    z-index: 1;
+  }
+
+  ${({ $position }) => getPositionStyles($position)}
+`

--- a/packages/react-component-library/src/components/Tooltip/partials/StyledMessage.tsx
+++ b/packages/react-component-library/src/components/Tooltip/partials/StyledMessage.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, fontSize } = selectors
+
+export const StyledMessage = styled.div`
+  font-size: ${fontSize('base')};
+  color: ${color('neutral', '100')};
+`

--- a/packages/react-component-library/src/components/Tooltip/partials/StyledTitle.tsx
+++ b/packages/react-component-library/src/components/Tooltip/partials/StyledTitle.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { spacing } = selectors
+
+export const StyledTitle = styled.div`
+  padding-bottom: ${spacing('1')};
+`

--- a/packages/react-component-library/src/components/Tooltip/partials/StyledTooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/partials/StyledTooltip.tsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components'
+
+export const StyledTooltip = styled.div`
+  position: absolute;
+`

--- a/packages/react-component-library/src/components/Tooltip/partials/StyledTooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/partials/StyledTooltip.tsx
@@ -1,5 +1,25 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
-export const StyledTooltip = styled.div`
+interface StyledTooltipProps {
+  $bottom: number
+  $left: number
+  $right: number
+  $top: number
+  $width: number
+}
+
+function getUnitAsPx($unit: number) {
+  return $unit ? `${$unit}px` : 'auto'
+}
+
+export const StyledTooltip = styled.div<StyledTooltipProps>`
   position: absolute;
+
+  ${({ $bottom, $left, $right, $top, $width }) => css`
+    bottom: ${getUnitAsPx($bottom)};
+    left: ${getUnitAsPx($left)};
+    right: ${getUnitAsPx($right)};
+    top: ${getUnitAsPx($top)};
+    width: ${getUnitAsPx($width)};
+  `}
 `


### PR DESCRIPTION
## Related issue
Fixes #2189 

## Overview
Pagination error hides the input in some circumstances. This change positions the error from the `bottom` rather than the `top`.

## Reason
Use cannot type into the input.

## Work carried out
- [x] Refactor existing code
- [x] Fix issue

## Screenshot
![Screenshot 2021-04-23 at 15 26 08](https://user-images.githubusercontent.com/56078793/115886088-7dcb2d00-a448-11eb-9d51-5d909cc14ca7.png)