### PR TITLE
ci(GHA): Remove codecov upload from workflows

### DIFF
--- a/.github/workflows/build_and_test_feature.yml
+++ b/.github/workflows/build_and_test_feature.yml
@@ -184,9 +184,6 @@ jobs:
             JEST_JUNIT_OUTPUT_NAME: docs-site-results.xml
           run: yarn --cwd packages/docs-site jest --ci --coverage --silent --no-cache --reporters=default --reporters=jest-junit --runInBand
 
-        - name: Upload test reports to CodeCov
-          run: bash <(curl -s https://codecov.io/bash)
-
         - name: Persist artifacts
           uses: actions/upload-artifact@v2
           with:

--- a/.github/workflows/build_and_test_master.yml
+++ b/.github/workflows/build_and_test_master.yml
@@ -160,9 +160,6 @@ jobs:
             JEST_JUNIT_OUTPUT_NAME: docs-site-results.xml
           run: yarn --cwd packages/docs-site jest --ci --coverage --silent --no-cache --reporters=default --reporters=jest-junit --runInBand
 
-        - name: Upload test reports to CodeCov
-          run: bash <(curl -s https://codecov.io/bash)
-
         - name: Persist artifacts
           uses: actions/upload-artifact@v2
           with:


### PR DESCRIPTION
## Related issue

closes #2272 

## Overview

Remove Codecov upload from CI workflows

## Reason

Codecov no longer required

