### PR TITLE
docs(Storybook): Display Docs tab on initial load

### DIFF
--- a/packages/react-component-library/.storybook/preview.js
+++ b/packages/react-component-library/.storybook/preview.js
@@ -1,6 +1,33 @@
 import '@royalnavy/css-framework/index.scss'
 import '@royalnavy/fonts'
 
+/**
+ * Hacky way of clicking on Docs button on first load of page.
+ * https://github.com/storybookjs/storybook/issues/13128
+ *
+ */
+function clickDocsButtonOnFirstLoad() {
+  window.removeEventListener('load', clickDocsButtonOnFirstLoad)
+
+  try {
+    const docsButtonSelector = window.parent.document.evaluate(
+      "//button[contains(., 'Docs')]",
+      window.parent.document,
+      null,
+      XPathResult.ANY_TYPE,
+      null
+    )
+
+    const button = docsButtonSelector.iterateNext()
+
+    button.click()
+  } catch (error) {
+    console.warn('Failed to set default Storybook tab', error)
+  }
+}
+
+window.addEventListener('load', clickDocsButtonOnFirstLoad)
+
 export const parameters = {
   layout: 'fullscreen',
   docs: {


### PR DESCRIPTION
## Related issue

Closes #2274

## Overview

Display the Docs tab on initial load of Storybook.