### PR TITLE
fix(Timeline): Increase threshold to display day

### DIFF
--- a/packages/react-component-library/src/components/Timeline/TimelineDay.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDay.tsx
@@ -5,7 +5,7 @@ import { DATE_DAY_FORMAT } from './constants'
 import { StyledDay } from './partials/StyledDay'
 import { StyledDayTitle } from './partials/StyledDayTitle'
 
-const DAY_DISPLAY_THRESHOLD = 29
+const DAY_DISPLAY_THRESHOLD = 20
 
 interface TimelineDayProps {
   date: Date

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -523,37 +523,105 @@ describe('Timeline', () => {
     })
   })
 
-  describe('when `dayWidth` is specified', () => {
-    beforeEach(() => {
-      wrapper = render(
-        <Timeline
-          dayWidth={100}
-          startDate={new Date(2020, 3, 1)}
-          today={new Date(2020, 3, 15)}
-        >
-          <TimelineTodayMarker />
-          <TimelineMonths />
-          <TimelineWeeks />
-          <TimelineDays />
-          <TimelineRows>
-            <TimelineRow name="Row 1">
-              <TimelineEvents>
-                <TimelineEvent
-                  startDate={new Date(2020, 3, 4)}
-                  endDate={new Date(2020, 3, 6)}
-                >
-                  Event
-                </TimelineEvent>
-              </TimelineEvents>
-            </TimelineRow>
-          </TimelineRows>
-        </Timeline>
-      )
+  describe('when `unitWidth` is specified', () => {
+    describe('when the width is 100', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <Timeline
+            unitWidth={100}
+            startDate={new Date(2020, 3, 1)}
+            today={new Date(2020, 3, 15)}
+          >
+            <TimelineTodayMarker />
+            <TimelineMonths />
+            <TimelineWeeks />
+            <TimelineDays />
+            <TimelineRows>
+              <TimelineRow name="Row 1">
+                <TimelineEvents>
+                  <TimelineEvent
+                    startDate={new Date(2020, 3, 4)}
+                    endDate={new Date(2020, 3, 6)}
+                  >
+                    Event
+                  </TimelineEvent>
+                </TimelineEvents>
+              </TimelineRow>
+            </TimelineRows>
+          </Timeline>
+        )
+      })
+
+      it('positions the event correctly', () => {
+        expect(wrapper.getByTestId('timeline-event')).toHaveStyle({
+          left: '300px',
+        })
+      })
     })
 
-    it('positions the event correctly', () => {
-      expect(wrapper.getByTestId('timeline-event')).toHaveStyle({
-        left: '300px',
+    describe('when the width is 20', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <Timeline
+            startDate={new Date(2020, 3, 1)}
+            today={new Date(2020, 3, 15)}
+            unitWidth={20}
+          >
+            <TimelineTodayMarker />
+            <TimelineMonths />
+            <TimelineWeeks />
+            <TimelineDays />
+            <TimelineRows>
+              <TimelineRow name="Row 1">
+                <TimelineEvents>
+                  <TimelineEvent
+                    startDate={new Date(2020, 3, 4)}
+                    endDate={new Date(2020, 3, 6)}
+                  >
+                    Event
+                  </TimelineEvent>
+                </TimelineEvents>
+              </TimelineRow>
+            </TimelineRows>
+          </Timeline>
+        )
+      })
+
+      it('should render the days', () => {
+        expect(wrapper.getAllByTestId('timeline-day')).toHaveLength(30)
+      })
+    })
+
+    describe('when the width is 19', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <Timeline
+            startDate={new Date(2020, 3, 1)}
+            today={new Date(2020, 3, 15)}
+            unitWidth={19}
+          >
+            <TimelineTodayMarker />
+            <TimelineMonths />
+            <TimelineWeeks />
+            <TimelineDays />
+            <TimelineRows>
+              <TimelineRow name="Row 1">
+                <TimelineEvents>
+                  <TimelineEvent
+                    startDate={new Date(2020, 3, 4)}
+                    endDate={new Date(2020, 3, 6)}
+                  >
+                    Event
+                  </TimelineEvent>
+                </TimelineEvents>
+              </TimelineRow>
+            </TimelineRows>
+          </Timeline>
+        )
+      })
+
+      it('should not render the days', () => {
+        expect(wrapper.queryAllByTestId('timeline-day')).toHaveLength(0)
       })
     })
   })


### PR DESCRIPTION
## Related issue
Closes #2181 

## Overview
Increases the width threshold for displaying days.

## Reason
A downstream app is using `unitWidth` of `22` and they would like to see days.

## Work carried out
- [x] Add fix

## Screenshot
![Screenshot 2021-04-26 at 12 19 17](https://user-images.githubusercontent.com/56078793/116074554-d5a4a680-a689-11eb-8646-ad7944e76a73.png)
