### PR TITLE
Add ability to open `ContextMenu` on the left

### DIFF
--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
@@ -7,7 +7,10 @@ import userEvent from '@testing-library/user-event'
 
 import { ContextMenu, ContextMenuItem, ContextMenuDivider } from '.'
 import { Link } from '../Link'
-import { CLICK_MENU_POSITION } from '../../hooks/useClickMenu'
+import {
+  CLICK_MENU_POSITION,
+  ClickMenuPositionType,
+} from '../../hooks/useClickMenu'
 
 const CustomLink = ({ children, onClick }: any) => {
   return (
@@ -124,47 +127,151 @@ describe('ContextMenu', () => {
     })
   })
 
-  describe('with a position of above', () => {
-    beforeEach(() => {
-      const ContextExample = () => {
-        const ref = useRef()
+  describe('when setting different positions', () => {
+    const ContextExample = ({
+      position,
+    }: {
+      position: ClickMenuPositionType
+    }) => {
+      const ref = useRef()
 
-        return (
-          <>
-            <div ref={ref}>Right click me!</div>
-            <ContextMenu
-              attachedToRef={ref}
-              position={CLICK_MENU_POSITION.ABOVE}
-            >
-              <ContextMenuItem
-                link={<Link href="/hello-foo">Hello, Foo!</Link>}
-              />
-              <ContextMenuItem
-                link={<Link href="/hello-bar">Hello, Bar!</Link>}
-              />
-            </ContextMenu>
-          </>
+      return (
+        <>
+          <div ref={ref}>Right click me!</div>
+          <ContextMenu attachedToRef={ref} position={position}>
+            <ContextMenuItem
+              link={<Link href="/hello-foo">Hello, Foo!</Link>}
+            />
+            <ContextMenuItem
+              link={<Link href="/hello-bar">Hello, Bar!</Link>}
+            />
+          </ContextMenu>
+        </>
+      )
+    }
+
+    describe('with a position of `ABOVE`', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <ContextExample position={CLICK_MENU_POSITION.ABOVE} />
         )
-      }
 
-      wrapper = render(<ContextExample />)
+        // @ts-ignore
+        wrapper.getByTestId('context-menu').getBoundingClientRect = () => ({
+          height: 100,
+          width: 50,
+        })
+      })
 
-      // @ts-ignore
-      wrapper.getByTestId('context-menu').getBoundingClientRect = () => ({
-        height: 100,
+      describe('and the user right clicks on the target area', () => {
+        beforeEach(() => {
+          fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+        })
+
+        it('is is rendered above the mouse pointer', () => {
+          expect(wrapper.queryByTestId('context-menu')).toHaveStyleRule(
+            'top',
+            '-100px'
+          )
+          expect(wrapper.queryByTestId('context-menu')).toHaveStyleRule(
+            'left',
+            '0px'
+          )
+        })
       })
     })
 
-    describe('and the user right clicks on the target area', () => {
+    describe('with a position of `RIGHT_ABOVE`', () => {
       beforeEach(() => {
-        fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+        wrapper = render(
+          <ContextExample position={CLICK_MENU_POSITION.RIGHT_ABOVE} />
+        )
+
+        // @ts-ignore
+        wrapper.getByTestId('context-menu').getBoundingClientRect = () => ({
+          height: 100,
+          width: 50,
+        })
       })
 
-      it('is is rendered above the mouse pointer', () => {
-        expect(wrapper.queryByTestId('context-menu')).toHaveStyleRule(
-          'top',
-          '-100px'
+      describe('and the user right clicks on the target area', () => {
+        beforeEach(() => {
+          fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+        })
+
+        it('is is rendered above the mouse pointer', () => {
+          expect(wrapper.queryByTestId('context-menu')).toHaveStyleRule(
+            'top',
+            '-100px'
+          )
+          expect(wrapper.queryByTestId('context-menu')).toHaveStyleRule(
+            'left',
+            '0px'
+          )
+        })
+      })
+    })
+
+    describe('with a position of `LEFT_ABOVE`', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <ContextExample position={CLICK_MENU_POSITION.LEFT_ABOVE} />
         )
+
+        // @ts-ignore
+        wrapper.getByTestId('context-menu').getBoundingClientRect = () => ({
+          height: 100,
+          width: 50,
+        })
+      })
+
+      describe('and the user right clicks on the target area', () => {
+        beforeEach(() => {
+          fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+        })
+
+        it('is is rendered above the mouse pointer on the left', () => {
+          expect(wrapper.queryByTestId('context-menu')).toHaveStyleRule(
+            'top',
+            '-100px'
+          )
+
+          expect(wrapper.queryByTestId('context-menu')).toHaveStyleRule(
+            'left',
+            '-50px'
+          )
+        })
+      })
+    })
+
+    describe('with a position of `LEFT_BELOW`', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <ContextExample position={CLICK_MENU_POSITION.LEFT_BELOW} />
+        )
+
+        // @ts-ignore
+        wrapper.getByTestId('context-menu').getBoundingClientRect = () => ({
+          height: 100,
+          width: 50,
+        })
+      })
+
+      describe('and the user right clicks on the target area', () => {
+        beforeEach(() => {
+          fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+        })
+
+        it('is is rendered below the mouse pointer on the left', () => {
+          expect(wrapper.queryByTestId('context-menu')).toHaveStyleRule(
+            'top',
+            '0px'
+          )
+          expect(wrapper.queryByTestId('context-menu')).toHaveStyleRule(
+            'left',
+            '-50px'
+          )
+        })
       })
     })
   })

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
@@ -38,7 +38,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   clickType = 'right',
   onHide,
   onShow,
-  position = CLICK_MENU_POSITION.BELOW,
+  position = CLICK_MENU_POSITION.RIGHT_BELOW,
   ...rest
 }) => {
   const { coordinates, isOpen, menuRef } = useClickMenu<HTMLOListElement>({

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
@@ -5,6 +5,7 @@ import {
   useClickMenu,
   ClickType,
   ClickMenuPositionType,
+  CLICK_BUTTON,
   CLICK_MENU_POSITION,
 } from '../../hooks/useClickMenu'
 import { StyledContextMenu } from './partials/StyledContextMenu'
@@ -33,9 +34,9 @@ export interface ContextMenuProps extends ComponentWithClass {
 }
 
 export const ContextMenu: React.FC<ContextMenuProps> = ({
-  children,
   attachedToRef,
-  clickType = 'right',
+  children,
+  clickType = CLICK_BUTTON.RIGHT,
   onHide,
   onShow,
   position = CLICK_MENU_POSITION.RIGHT_BELOW,


### PR DESCRIPTION
## Related issue
Closes #2122 

## Overview
Adds the ability to open the `ContextMenu` on the left.

## Reason
Downstream applications would like to open the menu on the left.

## Work carried out
- [x] Add feature
- [x] Tidy up code

## Screenshot
![2021-04-29 10 55 39](https://user-images.githubusercontent.com/56078793/116533631-848af180-a8d9-11eb-9976-49f6d416f80d.gif)