### PR TITLE
chore(Security): Limit open Dependabot PRs to 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5
   reviewers:
   - m7kvqbe1
   - thyhjwb6


### PR DESCRIPTION
## Overview

Limit open Dependabot PRs to 5