### PR TITLE
Add `isFullWidth` to `Timeline` to present at full width

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -898,3 +898,40 @@ export const HiddenScaling: Story<TimelineProps> = (props) => (
 HiddenScaling.parameters = disableScrollableRegionFocusableRule
 
 HiddenScaling.storyName = 'Hidden scaling'
+
+export const FullWidth = () => (
+  <Timeline
+    isFullWidth
+    startDate={new Date(2020, 9, 1)}
+    today={new Date(2020, 9, 15, 12)}
+  >
+    <TimelineTodayMarker />
+    <TimelineMonths />
+    <TimelineWeeks />
+    <TimelineDays />
+    <TimelineRows>
+      <TimelineRow name="Row 1">
+        <TimelineEvents>
+          <TimelineEvent
+            startDate={new Date(2020, 9, 14, 12)}
+            endDate={new Date(2020, 9, 18, 12)}
+          >
+            Event 1
+          </TimelineEvent>
+        </TimelineEvents>
+      </TimelineRow>
+      <TimelineRow name="Row 2">
+        <TimelineEvents>
+          <TimelineEvent
+            startDate={new Date(2020, 9, 3)}
+            endDate={new Date(2020, 9, 8)}
+          >
+            Event 2
+          </TimelineEvent>
+        </TimelineEvents>
+      </TimelineRow>
+    </TimelineRows>
+  </Timeline>
+)
+FullWidth.parameters = disableScrollableRegionFocusableRule
+FullWidth.storyName = 'Full width'

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -33,6 +33,10 @@ export interface TimelineProps extends ComponentWithClass {
    */
   hideToolbar?: boolean
   /**
+   * Specify whether the `Timeline` should fill the full width.
+   */
+  isFullWidth?: boolean
+  /**
    * A month will display either side of this start date.
    */
   startDate?: Date
@@ -89,6 +93,7 @@ export const Timeline: React.FC<TimelineProps> = ({
   hasSide,
   hideScaling = false,
   hideToolbar = false,
+  isFullWidth = false,
   startDate,
   endDate,
   today,
@@ -117,6 +122,7 @@ export const Timeline: React.FC<TimelineProps> = ({
         hasSide={hasSide || hasTimelineSide}
         hideScaling={hideScaling}
         hideToolbar={hideToolbar}
+        isFullWidth={isFullWidth}
         {...rest}
       >
         {children}

--- a/packages/react-component-library/src/components/Timeline/TimelineGrid.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineGrid.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import classNames from 'classnames'
+
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { extractChildren, timelineChildrenType } from './helpers/children'
+import { StyledHeader } from './partials/StyledHeader'
+import { StyledInner } from './partials/StyledInner'
+import { StyledTimeline } from './partials/StyledTimeline'
+import { TimelineDays } from './TimelineDays'
+import { TimelineHours } from './TimelineHours'
+import { TimelineMonths } from './TimelineMonths'
+import { TimelineRows, TimelineRowsProps } from './TimelineRows'
+import { TimelineSide } from './TimelineSide'
+import { TimelineTodayMarker } from './TimelineTodayMarker'
+import { TimelineToolbar } from './TimelineToolbar'
+import { TimelineWeekColumns } from './TimelineWeekColumns'
+import { TimelineWeeks } from './TimelineWeeks'
+
+export interface ComponentNameProps extends ComponentWithClass {
+  children: timelineChildrenType | timelineChildrenType[]
+  hasSide: boolean
+  hideScaling: boolean
+  hideToolbar: boolean
+}
+
+function getRenderColumns(
+  children: timelineChildrenType | timelineChildrenType[]
+) {
+  const rowsChildren = extractChildren(children, [TimelineRows])
+
+  return (rowsChildren[0] as React.ReactElement<TimelineRowsProps>).props
+    .renderColumns
+}
+
+export const TimelineGrid: React.FC<ComponentNameProps> = ({
+  children,
+  className,
+  hasSide,
+  hideScaling,
+  hideToolbar,
+  ...rest
+}) => {
+  const renderColumns = getRenderColumns(children)
+
+  const rootChildren = extractChildren(
+    children,
+    [
+      TimelineDays,
+      TimelineHours,
+      TimelineMonths,
+      TimelineRows,
+      TimelineSide,
+      TimelineTodayMarker,
+      TimelineWeeks,
+    ],
+    true
+  )
+
+  const headChildren = extractChildren(children, [
+    TimelineDays,
+    TimelineHours,
+    TimelineWeeks,
+    TimelineMonths,
+    TimelineTodayMarker,
+  ])
+
+  const bodyChildren = extractChildren(children, [TimelineRows])
+
+  return (
+    <>
+      {!hideToolbar && <TimelineToolbar hideScaling={hideScaling} />}
+      <StyledTimeline
+        className={classNames('timeline', className)}
+        data-testid="timeline"
+        role="grid"
+        {...rest}
+      >
+        <StyledInner className="timeline__inner" hasSide={hasSide}>
+          {
+            <>
+              <TimelineWeekColumns renderColumns={renderColumns} />
+              {rootChildren}
+              <StyledHeader
+                className="timeline__header"
+                data-testid="timeline-header"
+                role="rowgroup"
+              >
+                {headChildren}
+              </StyledHeader>
+              {bodyChildren}
+            </>
+          }
+        </StyledInner>
+      </StyledTimeline>
+    </>
+  )
+}
+
+TimelineGrid.displayName = 'TimelineGrid'

--- a/packages/react-component-library/src/components/Timeline/TimelineGrid.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineGrid.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import classNames from 'classnames'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
@@ -6,6 +6,7 @@ import { extractChildren, timelineChildrenType } from './helpers/children'
 import { StyledHeader } from './partials/StyledHeader'
 import { StyledInner } from './partials/StyledInner'
 import { StyledTimeline } from './partials/StyledTimeline'
+import { TimelineContext } from './context'
 import { TimelineDays } from './TimelineDays'
 import { TimelineHours } from './TimelineHours'
 import { TimelineMonths } from './TimelineMonths'
@@ -15,12 +16,14 @@ import { TimelineTodayMarker } from './TimelineTodayMarker'
 import { TimelineToolbar } from './TimelineToolbar'
 import { TimelineWeekColumns } from './TimelineWeekColumns'
 import { TimelineWeeks } from './TimelineWeeks'
+import { useTimelineWidth } from './hooks/useTimelineWidth'
 
 export interface ComponentNameProps extends ComponentWithClass {
   children: timelineChildrenType | timelineChildrenType[]
   hasSide: boolean
   hideScaling: boolean
   hideToolbar: boolean
+  isFullWidth: boolean
 }
 
 function getRenderColumns(
@@ -38,8 +41,14 @@ export const TimelineGrid: React.FC<ComponentNameProps> = ({
   hasSide,
   hideScaling,
   hideToolbar,
+  isFullWidth,
   ...rest
 }) => {
+  const {
+    state: { currentScaleOption },
+  } = useContext(TimelineContext)
+  const { timelineRef } = useTimelineWidth(hasSide, isFullWidth)
+
   const renderColumns = getRenderColumns(children)
 
   const rootChildren = extractChildren(
@@ -68,15 +77,18 @@ export const TimelineGrid: React.FC<ComponentNameProps> = ({
 
   return (
     <>
-      {!hideToolbar && <TimelineToolbar hideScaling={hideScaling} />}
+      {currentScaleOption && !hideToolbar && (
+        <TimelineToolbar hideScaling={hideScaling} />
+      )}
       <StyledTimeline
         className={classNames('timeline', className)}
         data-testid="timeline"
+        ref={timelineRef}
         role="grid"
         {...rest}
       >
-        <StyledInner className="timeline__inner" hasSide={hasSide}>
-          {
+        {currentScaleOption && (
+          <StyledInner className="timeline__inner" $hasSide={hasSide}>
             <>
               <TimelineWeekColumns renderColumns={renderColumns} />
               {rootChildren}
@@ -89,8 +101,8 @@ export const TimelineGrid: React.FC<ComponentNameProps> = ({
               </StyledHeader>
               {bodyChildren}
             </>
-          }
-        </StyledInner>
+          </StyledInner>
+        )}
       </StyledTimeline>
     </>
   )

--- a/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
@@ -11,11 +11,21 @@ import { StyledMonthTitleSmall } from './partials/StyledMonthTitleSmall'
 import { TimelineDay } from './context/types'
 
 const DECEMBER_INDEX = 11
-const MONTH_SMALL_THRESHOLD = 30
-const MONTH_MEDIUM_THRESHOLD = 100
+
+export const MONTH_SIZE = {
+  SMALL: 'small',
+  MEDIUM: 'medium',
+  LARGE: 'large',
+} as const
+
+export type TimelineMonthSizeType =
+  | typeof MONTH_SIZE.SMALL
+  | typeof MONTH_SIZE.MEDIUM
+  | typeof MONTH_SIZE.LARGE
 
 interface TimelineMonthProps {
   days: TimelineDay[]
+  daysTotal: number
   dayWidth: number
   index: number
   render: (
@@ -24,72 +34,68 @@ interface TimelineMonthProps {
     daysTotal: number,
     startDate: Date
   ) => React.ReactElement
+  size: TimelineMonthSizeType
   startDate: Date
 }
 
-function renderDefault({
-  dayWidth,
-  daysTotal,
-  startDate,
-}: {
-  dayWidth: number
-  daysTotal: number
-  startDate: Date
-}): React.ReactElement {
-  const width = dayWidth * daysTotal
-
-  if (width < MONTH_SMALL_THRESHOLD) {
-    return (
-      <StyledMonthSmall
-        $hasThickBorder={startDate.getMonth() === DECEMBER_INDEX}
-        $width={width}
-        data-testid="timeline-month"
-      >
-        <StyledMonthTitleSmall>
-          {format(startDate, 'MMM')} {format(startDate, 'yyyy')}
-        </StyledMonthTitleSmall>
-      </StyledMonthSmall>
-    )
-  }
-
-  if (width < MONTH_MEDIUM_THRESHOLD) {
-    return (
-      <StyledMonthMedium $width={width} data-testid="timeline-month">
-        <StyledMonthTitleMedium>
-          <span>{format(startDate, 'MMM')}</span>
-          <span>{format(startDate, 'yyyy')}</span>
-        </StyledMonthTitleMedium>
-      </StyledMonthMedium>
-    )
-  }
-
-  return (
+const MONTHS_BY_SIZE = {
+  [MONTH_SIZE.SMALL]: (startDate: Date, width: number) => (
+    <StyledMonthSmall
+      $hasThickBorder={startDate.getMonth() === DECEMBER_INDEX}
+      $width={width}
+      data-testid="timeline-month"
+    >
+      <StyledMonthTitleSmall>
+        {format(startDate, 'MMM')} {format(startDate, 'yyyy')}
+      </StyledMonthTitleSmall>
+    </StyledMonthSmall>
+  ),
+  [MONTH_SIZE.MEDIUM]: (startDate: Date, width: number) => (
+    <StyledMonthMedium $width={width} data-testid="timeline-month">
+      <StyledMonthTitleMedium>
+        <span>{format(startDate, 'MMM')}</span>
+        <span>{format(startDate, 'yyyy')}</span>
+      </StyledMonthTitleMedium>
+    </StyledMonthMedium>
+  ),
+  [MONTH_SIZE.LARGE]: (startDate: Date, width: number) => (
     <StyledMonth $width={width} data-testid="timeline-month">
       <StyledMonthTitle>
         {format(startDate, DATE_MONTH_FORMAT)}
       </StyledMonthTitle>
     </StyledMonth>
-  )
+  ),
+}
+
+function renderDefault({
+  dayWidth,
+  daysTotal,
+  size,
+  startDate,
+}: {
+  dayWidth: number
+  daysTotal: number
+  size: TimelineMonthSizeType
+  startDate: Date
+}): React.ReactElement {
+  const width = dayWidth * daysTotal
+
+  return MONTHS_BY_SIZE[size](startDate, width)
 }
 
 export const TimelineMonth: React.FC<TimelineMonthProps> = ({
   days,
+  daysTotal,
   dayWidth,
   index,
   render,
+  size,
   startDate,
   ...rest
 }) => {
-  const firstDateDisplayed = max([startDate, days[0].date])
-  const lastDateDisplayed = min([
-    endOfMonth(startDate),
-    days[days.length - 1].date,
-  ])
-  const daysTotal = differenceInDays(lastDateDisplayed, firstDateDisplayed) + 1
-
   const child = render
     ? render(index, dayWidth, daysTotal, startDate)
-    : renderDefault({ dayWidth, daysTotal, startDate })
+    : renderDefault({ dayWidth, daysTotal, size, startDate })
 
   return React.cloneElement(child, {
     role: 'columnheader',

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -1,10 +1,12 @@
 import React, { useContext } from 'react'
+import { differenceInDays, endOfMonth, min as minDate, max } from 'date-fns'
+import { min as minNumber } from 'lodash'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { getKey } from '../../helpers'
 import { TimelineContext } from './context'
 import { TimelineHeaderRow } from './TimelineHeaderRow'
-import { TimelineMonth } from './TimelineMonth'
+import { MONTH_SIZE, TimelineMonth } from './TimelineMonth'
 import { StyledMonths } from './partials/StyledMonths'
 
 export interface TimelineMonthsWithRenderContentProps
@@ -28,6 +30,23 @@ export type TimelineMonthsProps =
   | TimelineMonthsWithRenderContentProps
   | TimelineMonthsWithChildrenProps
 
+const MONTH_SMALL_THRESHOLD = 30
+const MONTH_MEDIUM_THRESHOLD = 160
+
+function getSize(monthWidths: { daysTotal: number; monthWidth: number }[]) {
+  const smallest = minNumber(monthWidths.map(({ monthWidth }) => monthWidth))
+
+  if (smallest < MONTH_SMALL_THRESHOLD) {
+    return MONTH_SIZE.SMALL
+  }
+
+  if (smallest < MONTH_MEDIUM_THRESHOLD) {
+    return MONTH_SIZE.MEDIUM
+  }
+
+  return MONTH_SIZE.LARGE
+}
+
 export const TimelineMonths: React.FC<TimelineMonthsProps> = ({
   render,
   ...rest
@@ -35,6 +54,25 @@ export const TimelineMonths: React.FC<TimelineMonthsProps> = ({
   const {
     state: { currentScaleOption, days, months },
   } = useContext(TimelineContext)
+
+  const monthWidths = months.map(({ startDate }) => {
+    const firstDateDisplayed = max([startDate, days[0].date])
+    const lastDateDisplayed = minDate([
+      endOfMonth(startDate),
+      days[days.length - 1].date,
+    ])
+    const daysTotal =
+      differenceInDays(lastDateDisplayed, firstDateDisplayed) + 1
+
+    const monthWidth = currentScaleOption.widths.day * daysTotal
+
+    return {
+      daysTotal,
+      monthWidth,
+    }
+  })
+
+  const size = getSize(monthWidths)
 
   return (
     <TimelineHeaderRow
@@ -48,9 +86,11 @@ export const TimelineMonths: React.FC<TimelineMonthsProps> = ({
           <TimelineMonth
             days={days}
             dayWidth={currentScaleOption.widths.day}
+            daysTotal={monthWidths[index].daysTotal}
             index={index}
             key={getKey('timeline-month', startDate.toString())}
             render={render}
+            size={size}
             startDate={startDate}
           />
         ))}

--- a/packages/react-component-library/src/components/Timeline/constants.ts
+++ b/packages/react-component-library/src/components/Timeline/constants.ts
@@ -27,7 +27,7 @@ const { color } = selectors
 const TIMELINE_BORDER_COLOR = color('neutral', '100')
 const TIMELINE_BG_COLOR = color('neutral', '000')
 const TIMELINE_ALT_BG_COLOR = color('neutral', 'white')
-const TIMELINE_ROW_HEADER_WIDTH = '16rem'
+const TIMELINE_ROW_HEADER_WIDTH = 270
 
 export {
   ACCESSIBLE_DATE_FORMAT,
@@ -41,5 +41,5 @@ export {
   TIMELINE_BORDER_COLOR,
   TIMELINE_BG_COLOR,
   TIMELINE_ALT_BG_COLOR,
-  TIMELINE_ROW_HEADER_WIDTH
+  TIMELINE_ROW_HEADER_WIDTH,
 }

--- a/packages/react-component-library/src/components/Timeline/context/index.tsx
+++ b/packages/react-component-library/src/components/Timeline/context/index.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useReducer } from 'react'
 
-import { initialState, initialiseState } from './state'
+import { initialState } from './state'
 import { reducer } from './reducer'
 import { TimelineContextDefault, TimelineProviderProps } from './types'
 
@@ -18,9 +18,11 @@ export const TimelineProvider: React.FC<TimelineProviderProps> = ({
   options,
   today,
 }) => {
-  const [state, dispatch] = useReducer(reducer, initialState, () =>
-    initialiseState(today, options)
-  )
+  const [state, dispatch] = useReducer(reducer, {
+    ...initialState,
+    options,
+    today,
+  })
 
   return (
     <TimelineContext.Provider value={{ hasSide, state, dispatch }}>

--- a/packages/react-component-library/src/components/Timeline/context/state.ts
+++ b/packages/react-component-library/src/components/Timeline/context/state.ts
@@ -1,39 +1,16 @@
-import { find } from 'lodash'
-
-import { buildCalendar } from './reducer'
-import { TimelineOptions, TimelineState } from './types'
-import { initialiseScaleOptions } from './timeline_scales'
+import { TimelineState } from './types'
 
 const initialState: TimelineState = {
+  currentScaleIndex: null,
+  currentScaleOption: null,
   days: [],
   hours: [],
   months: [],
   options: null,
   scaleOptions: [],
-  currentScaleOption: null,
   today: new Date(),
   weeks: [],
+  width: null,
 }
 
-function initialiseState(
-  today: Date = new Date(),
-  options: TimelineOptions
-): TimelineState {
-  const state = {
-    ...initialState,
-    today,
-    options,
-  }
-
-  const scaleOptions = initialiseScaleOptions(options)
-  const defaultScaleOption = find(scaleOptions, ({ isDefault }) => isDefault)
-
-  return {
-    ...state,
-    ...buildCalendar(defaultScaleOption),
-    scaleOptions,
-    currentScaleOption: defaultScaleOption,
-  }
-}
-
-export { initialState, initialiseState }
+export { initialState }

--- a/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
+++ b/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
@@ -50,20 +50,17 @@ function getScaleConfig(
 ): ScaleConfigType {
   return {
     hour: {
-      calculateDate: addWeeks,
+      calculateDate: addDays,
       hoursBlockSize: TIMELINE_BLOCK_SIZE.SINGLE_HOUR,
-      intervalSize: DEFAULT_INTERVAL_SIZE,
-      scale: 8,
+      intervalSize: 1,
     },
     quarter_day: {
-      calculateDate: addWeeks,
-      intervalSize: DEFAULT_INTERVAL_SIZE,
-      scale: 4,
+      calculateDate: addDays,
+      intervalSize: 3,
     },
     day: {
-      calculateDate: addWeeks,
-      intervalSize: DEFAULT_INTERVAL_SIZE,
-      scale: 2,
+      calculateDate: addDays,
+      intervalSize: 5,
     },
     week: {
       calculateDate: addWeeks,
@@ -114,13 +111,24 @@ function mapScaleOption(
   }
 }
 
-function initialiseScaleOptions({
-  endDate,
-  hoursBlockSize,
-  range,
-  startDate,
-  unitWidth,
-}: TimelineOptions): TimelineScaleOption[] {
+function getMaxWidth(
+  timelineWidth: number,
+  unitWidth: number,
+  numberOfDays: number
+) {
+  const unitWidthTotal = unitWidth * numberOfDays
+
+  if (timelineWidth && timelineWidth > unitWidthTotal) {
+    return timelineWidth
+  }
+
+  return unitWidthTotal
+}
+
+function initialiseScaleOptions(
+  { endDate, hoursBlockSize, range, startDate, unitWidth }: TimelineOptions,
+  timelineWidth?: number
+): TimelineScaleOption[] {
   const scaleConfig = getScaleConfig(startDate, endDate, range)
   const defaultConfig = find(scaleConfig, ({ isDefault }) => isDefault)
   const numberOfDays = endDate
@@ -129,7 +137,7 @@ function initialiseScaleOptions({
         defaultConfig.calculateDate(startDate, defaultConfig.intervalSize),
         startDate
       )
-  const maxWidth = unitWidth * numberOfDays
+  const maxWidth = getMaxWidth(timelineWidth, unitWidth, numberOfDays)
 
   return Object.keys(scaleConfig).map((scaleConfigKey) => {
     return mapScaleOption(

--- a/packages/react-component-library/src/components/Timeline/context/types.ts
+++ b/packages/react-component-library/src/components/Timeline/context/types.ts
@@ -1,6 +1,12 @@
-import { Dispatch } from 'react'
+import React, { Dispatch } from 'react'
 
 import { BlockSizeType } from '../TimelineHours'
+import { TimelineSideProps } from '../TimelineSide'
+import { TimelineTodayMarkerProps } from '../TimelineTodayMarker'
+import { TimelineMonthsProps } from '../TimelineMonths'
+import { TimelineWeeksProps } from '../TimelineWeeks'
+import { TimelineDaysProps } from '../TimelineDays'
+import { TimelineRowsProps } from '../TimelineRows'
 
 export type TimelineScaleOption = {
   calculateDate: (d: Date, n: number) => Date
@@ -44,26 +50,39 @@ export type TimelineMonth = {
 }
 
 export type TimelineState = {
-  today: Date
-  months: TimelineMonth[]
-  weeks: TimelineWeek[]
+  currentScaleIndex: number
+  currentScaleOption: TimelineScaleOption
   days: TimelineDay[]
   hours: TimelineHour[]
+  months: TimelineMonth[]
   options: TimelineOptions
   scaleOptions: TimelineScaleOption[]
-  currentScaleOption: TimelineScaleOption
+  today: Date
+  weeks: TimelineWeek[]
+  width: number
 }
 
 export const TIMELINE_ACTIONS = {
+  CHANGE_WIDTH: 'CHANGE_WIDTH',
   GET_NEXT: 'GET_NEXT',
   GET_PREV: 'GET_PREV',
   SCALE: 'SCALE',
 } as const
 
 export type TimelineAction =
-  | { type: typeof TIMELINE_ACTIONS.GET_NEXT; scale: TimelineScaleOption }
-  | { type: typeof TIMELINE_ACTIONS.GET_PREV; scale: TimelineScaleOption }
-  | { type: typeof TIMELINE_ACTIONS.SCALE; scale: TimelineScaleOption }
+  | {
+      type: typeof TIMELINE_ACTIONS.CHANGE_WIDTH
+      width: number
+    }
+  | {
+      type: typeof TIMELINE_ACTIONS.GET_NEXT
+      scaleOptions: TimelineScaleOption[]
+    }
+  | {
+      type: typeof TIMELINE_ACTIONS.GET_PREV
+      scaleOptions: TimelineScaleOption[]
+    }
+  | { type: typeof TIMELINE_ACTIONS.SCALE; scaleIndex: number }
 
 export interface TimelineContextDefault {
   hasSide: boolean

--- a/packages/react-component-library/src/components/Timeline/helpers/children.ts
+++ b/packages/react-component-library/src/components/Timeline/helpers/children.ts
@@ -7,20 +7,20 @@ import { TimelineSideProps } from '../TimelineSide'
 import { TimelineTodayMarkerProps } from '../TimelineTodayMarker'
 import { TimelineWeeksProps } from '../TimelineWeeks'
 
-export type timelineRootChildrenType = React.ReactElement<TimelineSideProps>
+type TimelineRootChildrenType = React.ReactElement<TimelineSideProps>
 
-export type timelineHeadChildrenType =
+type TimelineHeadChildrenType =
   | React.ReactElement<TimelineTodayMarkerProps>
   | React.ReactElement<TimelineMonthsProps>
   | React.ReactElement<TimelineWeeksProps>
   | React.ReactElement<TimelineDaysProps>
 
-export type timelineBodyChildrenType = React.ReactElement<TimelineRowsProps>
+type TimelineBodyChildrenType = React.ReactElement<TimelineRowsProps>
 
 export type timelineChildrenType =
-  | timelineRootChildrenType
-  | timelineHeadChildrenType
-  | timelineBodyChildrenType
+  | TimelineRootChildrenType
+  | TimelineHeadChildrenType
+  | TimelineBodyChildrenType
 
 export function extractChildren(
   children: timelineChildrenType | timelineChildrenType[],

--- a/packages/react-component-library/src/components/Timeline/helpers/children.ts
+++ b/packages/react-component-library/src/components/Timeline/helpers/children.ts
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import { TimelineDaysProps } from '../TimelineDays'
+import { TimelineMonthsProps } from '../TimelineMonths'
+import { TimelineRowsProps } from '../TimelineRows'
+import { TimelineSideProps } from '../TimelineSide'
+import { TimelineTodayMarkerProps } from '../TimelineTodayMarker'
+import { TimelineWeeksProps } from '../TimelineWeeks'
+
+export type timelineRootChildrenType = React.ReactElement<TimelineSideProps>
+
+export type timelineHeadChildrenType =
+  | React.ReactElement<TimelineTodayMarkerProps>
+  | React.ReactElement<TimelineMonthsProps>
+  | React.ReactElement<TimelineWeeksProps>
+  | React.ReactElement<TimelineDaysProps>
+
+export type timelineBodyChildrenType = React.ReactElement<TimelineRowsProps>
+
+export type timelineChildrenType =
+  | timelineRootChildrenType
+  | timelineHeadChildrenType
+  | timelineBodyChildrenType
+
+export function extractChildren(
+  children: timelineChildrenType | timelineChildrenType[],
+  types: React.ReactElement['type'][],
+  inverse?: boolean
+) {
+  return React.Children.toArray(children).filter((child: React.ReactNode) => {
+    const type = (child as React.ReactElement)?.type
+
+    return inverse ? !types.includes(type) : types.includes(type)
+  })
+}

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineWidth.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineWidth.ts
@@ -1,0 +1,45 @@
+import { MutableRefObject, useContext, useEffect, useRef } from 'react'
+import { debounce } from 'lodash'
+
+import { TimelineContext } from '../context'
+import { TIMELINE_ACTIONS } from '../context/types'
+import { TIMELINE_ROW_HEADER_WIDTH } from '../constants'
+
+export function useTimelineWidth(
+  hasSide: boolean,
+  isFullWidth: boolean
+): {
+  timelineRef: MutableRefObject<HTMLDivElement>
+} {
+  const timelineRef = useRef<HTMLDivElement>()
+  const { dispatch } = useContext(TimelineContext)
+
+  function getWidth() {
+    const timelineWidth = timelineRef.current.getBoundingClientRect().width
+    const sideWidth = hasSide ? TIMELINE_ROW_HEADER_WIDTH : 0
+    return timelineWidth - 1 - sideWidth
+  }
+
+  function dispatchWidthChange() {
+    dispatch({
+      type: TIMELINE_ACTIONS.CHANGE_WIDTH,
+      width: isFullWidth ? getWidth() : null,
+    })
+  }
+
+  /* eslint-disable consistent-return */
+  useEffect(() => {
+    dispatchWidthChange()
+
+    if (isFullWidth) {
+      window.addEventListener('resize', debounce(dispatchWidthChange, 250))
+      return () => {
+        window.removeEventListener('resize', debounce(dispatchWidthChange, 250))
+      }
+    }
+  }, [])
+
+  return {
+    timelineRef,
+  }
+}

--- a/packages/react-component-library/src/components/Timeline/partials/StyledInner.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledInner.tsx
@@ -14,5 +14,5 @@ export const StyledInner = styled.div<StyledInnerProps>`
   border-right: ${spacing('px')} solid ${TIMELINE_BORDER_COLOR};
   border-bottom: ${spacing('px')} solid ${TIMELINE_BORDER_COLOR};
   margin-left: ${({ $hasSide }) =>
-    $hasSide ? TIMELINE_ROW_HEADER_WIDTH : 'initial'};
+    $hasSide ? `${TIMELINE_ROW_HEADER_WIDTH}px` : 'initial'};
 `

--- a/packages/react-component-library/src/components/Timeline/partials/StyledMonth.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledMonth.tsx
@@ -22,9 +22,9 @@ export const StyledMonth = styled.div<StyledMonthProps>`
     border-right: none;
   }
 
-  &::after {
+  &:not(:last-of-type)::after {
     position: absolute;
-    right: -1px;
+    right: 0;
     top: 0;
     content: '';
     display: inline-block;
@@ -32,9 +32,7 @@ export const StyledMonth = styled.div<StyledMonthProps>`
     height: 100vh;
     border-right: ${({ $hasThickBorder }) =>
       $hasThickBorder
-        ? css`
-            2px solid ${color('neutral', '200')}
-          `
+        ? css`2px solid ${color('neutral', '200')}`
         : css`
             ${spacing('px')} dashed ${color('neutral', '200')}
           `};

--- a/packages/react-component-library/src/components/Timeline/partials/StyledRowHeader.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledRowHeader.tsx
@@ -11,7 +11,7 @@ interface StyledRowHeaderProps extends StyledSubComponentProps {
 }
 
 export const StyledRowHeader = styled.div<StyledRowHeaderProps>`
-  min-width: ${TIMELINE_ROW_HEADER_WIDTH};
+  min-width: ${TIMELINE_ROW_HEADER_WIDTH}px;
   position: absolute;
   left: 0;
   height: inherit;


### PR DESCRIPTION
## Related issue
Closes #2120 

## Overview
With an `isFullWidth` prop the `Timeline` will expand to the full width of the viewport or parent.

## Reason
The `range` prop is being used to fill the full width with unexpected results.

## Work carried out
- [x] Refactor to use a `TimelineGrid`
- [x] Implement change

## Screenshot
![2021-05-06 10 35 45](https://user-images.githubusercontent.com/56078793/117276602-f70a4d00-ae56-11eb-9ebd-6edf36ab8af0.gif)

## Developer notes
- Full test coverage of window resizing is not in this PR. A [separate issue](https://github.com/Royal-Navy/design-system/issues/2335) has been created.
- The rendering of months needed to change as we need to know what is the biggest month that can be presented and then render all months the same. Because the window is being resized and unit sizes are constantly changing, it meant that some months were being rendered differently
- The initial load of the calendar feels magical as it is now [hidden in `useTimelineWidth`](https://github.com/Royal-Navy/design-system/pull/2332/files#diff-0bf12df71e7ff0b7533a25b059fce664d6fc508ac76b098d718252a02ae73b87R32). A thought was to abstract out a `initialLoad` `function` which is called in `TimelineGrid`.