### PR TITLE
ci(Security): Add yarn audit wrapper script

### DIFF
--- a/.github/workflows/build_and_test_feature.yml
+++ b/.github/workflows/build_and_test_feature.yml
@@ -47,7 +47,7 @@ jobs:
           uses: actions/checkout@v2
 
         - name: Run audit
-          run: yarn audit
+          run: yarn run audit
 
 
      Check_commits:

--- a/.github/workflows/build_and_test_master.yml
+++ b/.github/workflows/build_and_test_master.yml
@@ -46,7 +46,7 @@ jobs:
           uses: actions/checkout@v2
 
         - name: Run audit
-          run: yarn audit
+          run: yarn run audit
 
 
      Lint_css-framework:

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "storybook:static": "lerna run --parallel storybook:static",
     "lerna:prerelease": "yarn lerna:run-version --conventional-prerelease=* --no-changelog -m \"chore(Prerelease): %v [skip ci]\"",
     "lerna:version": "yarn lerna:run-version --conventional-graduate --create-release github -m \"chore(Release): %v\"",
-    "lerna:run-version": "lerna version --force-publish=* --tag-version-prefix=''"
+    "lerna:run-version": "lerna version --force-publish=* --tag-version-prefix=''",
+    "audit": "./scripts/audit/audit.sh"
   },
   "husky": {
     "hooks": {

--- a/scripts/audit/audit.sh
+++ b/scripts/audit/audit.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# workaround for missing feature
+# https://github.com/yarnpkg/yarn/issues/6669
+
+set -u
+
+set +e
+output=$(yarn audit --json)
+result=$?
+set -e
+
+if [ $result -eq 0 ]; then
+	# everything is fine
+	exit 0
+fi
+
+if [ -f yarn-audit-known-issues ] && echo "$output" | grep auditAdvisory | diff -q yarn-audit-known-issues - > /dev/null 2>&1; then
+	echo
+	echo Ignorning known vulnerabilities
+	exit 0
+fi
+
+echo
+echo Security vulnerabilities were found that were not ignored
+echo
+echo Check to see if these vulnerabilities apply to production
+echo and/or if they have fixes available. If they do not have
+echo fixes and they do not apply to production, you may ignore them
+echo
+echo To ignore these vulnerabilities, run:
+echo
+echo "yarn audit --json | grep auditAdvisory > yarn-audit-known-issues"
+echo
+echo and commit the yarn-audit-known-issues file
+echo
+exit "$result"


### PR DESCRIPTION
## Related issue

closes #2346 

## Overview

Add yarn audit wrapper script

## Reason
Add ability to ignore dependencies from yarn audit

## Work carried out

- [x] Add yarn audit wrapper script
- [x] Changed workflows to run audit script instead of yarn audit

