### PR TITLE
fix(DatePicker): Do not style `--outside` days

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
@@ -17,7 +17,7 @@ export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
           border-radius: 0;
         }
 
-        .DayPicker-Day--start,
+        .DayPicker-Day--start:not(.DayPicker-Day--outside),
         .DayPicker-Day--end:not(.DayPicker-Day--outside) {
           background-color: ${color('action', '500')};
           color: ${color('neutral', 'white')};


### PR DESCRIPTION
## Related issue

Closes #2253

## Overview

Add missing qualifier to CSS selector to handle edge case.

## Reason

Outside days would sometimes be styled in a month block.

## Work carried out

- [x] Fix broken CSS selector

## Screenshot

<img width="520" alt="Screenshot 2021-05-14 at 11 13 28" src="https://user-images.githubusercontent.com/48086589/118256826-d1f48a80-b4a5-11eb-90b7-6b3d855a7fa9.png">
<img width="508" alt="Screenshot 2021-05-14 at 11 12 44" src="https://user-images.githubusercontent.com/48086589/118256834-d325b780-b4a5-11eb-80c4-7e2fb7f92c7a.png">

## Developer notes

I'd add a test to cover this but it's tricky because we're overriding internal library styles using CSS selectors.
