### PR TITLE
fix(SidebarE): Tweak icon positioning

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledNavItemIcon.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledNavItemIcon.tsx
@@ -13,7 +13,8 @@ export const StyledNavItemIcon = styled.div<StyledNavItemIconProps>`
   display: inline-flex;
   align-items: center;
   width: 100%;
-  padding: 0.55rem;
+  padding: 0.55rem 0;
+  justify-content: center;
 
   svg {
     width: 18px;


### PR DESCRIPTION
## Related issue

Closes #2312

## Overview

Tweak icon positioning (use flexbox).

## Reason

Positioning was out very slightly due to use of explicit padding instead of flexbox.

## Work carried out

- [x] Position using flexbox

## Screenshot

<img width="52" alt="Screenshot 2021-05-14 at 11 57 46" src="https://user-images.githubusercontent.com/48086589/118261892-108d4380-b4ac-11eb-8ece-04ca375c0668.png">
