### PR TITLE
fix(SidebarE): Adjust expanded state icon positioning

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.stories.tsx
@@ -23,6 +23,19 @@ import {
 import { Link } from '../../Link'
 import { Notification, Notifications } from '../NotificationPanel'
 
+const disableColorContrastRule = {
+  a11y: {
+    config: {
+      rules: [
+        {
+          id: 'color-contrast',
+          enabled: false,
+        },
+      ],
+    },
+  },
+}
+
 export default {
   component: SidebarE,
   subcomponents: {
@@ -99,6 +112,63 @@ export const Default: Story<SidebarEProps> = (props) => {
 }
 
 Default.args = {}
+
+export const InitiallyOpen: Story<SidebarEProps> = (props) => {
+  const sidebarNav = (
+    <SidebarNavE>
+      <SidebarNavItemE
+        icon={<IconHome />}
+        link={<Link href="#">Dashboard</Link>}
+      />
+      <SidebarNavItemE
+        icon={<IconVerifiedUser />}
+        link={<Link href="#">Reports</Link>}
+      />
+      <SidebarNavItemE
+        icon={<IconLocalShipping />}
+        link={<Link href="#">Platforms</Link>}
+      />
+      <SidebarNavItemE
+        icon={<IconFeedback />}
+        link={<Link href="#">Data&nbsp;Feed</Link>}
+      />
+      <SidebarNavItemE
+        isActive
+        icon={<IconMessage />}
+        link={<Link href="#">Messages</Link>}
+      />
+      <SidebarNavItemE
+        icon={<IconSettings />}
+        link={<Link href="#">Settings</Link>}
+      />
+    </SidebarNavE>
+  )
+
+  return (
+    <SidebarWrapperE>
+      <div style={{ maxHeight: '30rem' }}>
+        <StyledSidebarE {...props} initialIsOpen>
+          {sidebarNav}
+        </StyledSidebarE>
+      </div>
+      <main
+        style={{
+          padding: '2rem',
+          backgroundColor: '#c9c9c9',
+          width: '100%',
+        }}
+      >
+        Hello, World!
+      </main>
+    </SidebarWrapperE>
+  )
+}
+
+InitiallyOpen.args = {}
+
+InitiallyOpen.parameters = disableColorContrastRule
+
+InitiallyOpen.storyName = 'Initially open'
 
 export const WithSubNavigation: Story<SidebarEProps> = (props) => {
   const sidebarNavWithSub = (

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.test.tsx
@@ -53,6 +53,30 @@ const notifications = (
 describe('SidebarE', () => {
   let wrapper: RenderResult
 
+  describe('when `initialIsOpen` is set', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <SidebarWrapperE>
+          <SidebarE initialIsOpen icon={<IconGrain />} title="Application Name">
+            <SidebarNavE>
+              <SidebarNavItemE
+                icon={<IconHome />}
+                link={<Link href="/dashboard">Dashboard</Link>}
+              />
+              <SidebarNavItemE link={<Link href="/reports">Reports</Link>} />
+            </SidebarNavE>
+          </SidebarE>
+          <main>Hello, World!</main>
+        </SidebarWrapperE>
+      )
+      fireEvent.mouseEnter(wrapper.getAllByTestId('sidebar-nav-item')[0])
+    })
+
+    it('should display the text titles for navigation items', () => {
+      expect(wrapper.queryByText('Dashboard')).toBeInTheDocument()
+    })
+  })
+
   describe('when rendered in React strict mode', () => {
     it('should not throw deprecation warning about findDOMNode', () => {
       expect(() => {

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.tsx
@@ -34,6 +34,10 @@ export interface SidebarEProps extends ComponentWithClass {
    * Optional JSX to render a collection of notifications.
    */
   notifications?: React.ReactElement<NotificationsProps>
+  /**
+   * Initial `isOpen` state on first render.
+   */
+  initialIsOpen?: boolean
 }
 
 export const SidebarE: React.FC<SidebarEProps> = ({
@@ -43,12 +47,13 @@ export const SidebarE: React.FC<SidebarEProps> = ({
   user,
   hasUnreadNotification,
   notifications,
+  initialIsOpen = false,
   ...rest
 }) => {
   const nodeRef = useRef(null)
 
   return (
-    <SidebarProvider>
+    <SidebarProvider initialIsOpen={initialIsOpen}>
       <SidebarContext.Consumer>
         {({ isOpen, hasMouseOver, setHasMouseOver }) => (
           <StyledSidebar

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/context.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/context.tsx
@@ -9,6 +9,7 @@ interface SidebarContextDefaults {
 
 interface SidebarProviderProps {
   children?: React.ReactNode
+  initialIsOpen?: boolean
 }
 
 const sidebarContextDefaults: SidebarContextDefaults = {
@@ -22,8 +23,9 @@ export const SidebarContext = createContext(sidebarContextDefaults)
 
 export const SidebarProvider: React.FC<SidebarProviderProps> = ({
   children,
+  initialIsOpen = false,
 }) => {
-  const [isOpen, setIsOpen] = useState<boolean>(false)
+  const [isOpen, setIsOpen] = useState<boolean>(initialIsOpen)
   const [hasMouseOver, setHasMouseOver] = useState<boolean>(false)
 
   return (

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledNavItemIcon.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledNavItemIcon.tsx
@@ -14,7 +14,7 @@ export const StyledNavItemIcon = styled.div<StyledNavItemIconProps>`
   align-items: center;
   width: 100%;
   padding: 0.55rem 0;
-  justify-content: center;
+  justify-content: space-evenly;
 
   svg {
     width: 18px;
@@ -30,5 +30,6 @@ export const StyledNavItemIcon = styled.div<StyledNavItemIconProps>`
     isOpen &&
     css`
       width: auto;
+      padding: 0.55rem;
     `}
 `


### PR DESCRIPTION
## Related issue

#2312

## Overview

Resolve styling issue in expanded state introduced by recent fix.

## Reason

>Icons were no longer positioned correctly in the expanded state.

## Work carried out

- [x] Adjust styling

## Screenshot

<img width="309" alt="Screenshot 2021-05-18 at 11 15 25" src="https://user-images.githubusercontent.com/48086589/118635109-20b66300-b7cb-11eb-82ee-406cc187b02c.png">
<img width="310" alt="Screenshot 2021-05-18 at 11 21 50" src="https://user-images.githubusercontent.com/48086589/118635252-46dc0300-b7cb-11eb-8711-ec28481b5815.png">
