### PR TITLE
ci(GHA): Add skip ci to release workflows

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -47,7 +47,7 @@ jobs:
           GIT_COMMITTER_NAME: ${{ secrets.GH_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.GH_EMAIL }}
         if: contains(steps.changes.outputs.changed, 'ready to publish')
-        run: "yarn lerna:run-version --yes --create-release github -m \"chore(Release): %v\" --conventional-commits"
+        run: "yarn lerna:run-version --yes --create-release github -m \"chore(Release): %v [skip ci]\" --conventional-commits"
 
       - name: Get version from package.json after release step
         id: extractver

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           GIT_COMMITTER_NAME: ${{ secrets.GH_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.GH_EMAIL }}
         if: contains(steps.changes.outputs.changed, 'ready to publish')
-        run: "yarn lerna:run-version --yes --create-release github -m \"chore(Release): %v\" --conventional-commits"
+        run: "yarn lerna:run-version --yes --create-release github -m \"chore(Release): %v [skip ci]\" --conventional-commits"
 
       - name: Get version from package.json after release step
         id: extractver


### PR DESCRIPTION
## Related issue

fixes #2092 

## Overview

Add 'skip ci' to release workflows to prevent CI workflows triggering following a release commit

## Reason
GitHub Actions now supports 'skip ci' - https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/

So we can now use this in the release commit message to prevent CI & NPM Smoketest workflows from running post release.  This also resolves the problem experienced with intermittent smoketest workflow failures following a release.

