### PR TITLE
fix(Modal): Set `max-height` and `overflow-y`

### DIFF
--- a/packages/react-component-library/src/components/Modal/Modal.test.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.test.tsx
@@ -79,6 +79,17 @@ describe('Modal', () => {
         )
       })
 
+      it('should scroll on lower resolution screens', () => {
+        expect(wrapper.getByTestId('modal-main')).toHaveStyleRule(
+          'max-height',
+          '95vh'
+        )
+        expect(wrapper.getByTestId('modal-main')).toHaveStyleRule(
+          'overflow-y',
+          'scroll'
+        )
+      })
+
       it('should not render the Header component', () => {
         expect(wrapper.queryByTestId('modal-header')).toBeNull()
       })

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -95,7 +95,7 @@ export const Modal: React.FC<ModalProps> = ({
       data-testid="modal-wrapper"
       {...rest}
     >
-      <StyledMain>
+      <StyledMain data-testid="modal-main">
         {title && (
           <Header
             titleId={modalTitleId}

--- a/packages/react-component-library/src/components/Modal/partials/StyledMain.tsx
+++ b/packages/react-component-library/src/components/Modal/partials/StyledMain.tsx
@@ -13,6 +13,8 @@ export const StyledMain = styled.article`
   right: 0;
   bottom: 0;
   border-radius: 8px 8px 0 0;
+  max-height: 95vh;
+  overflow-y: scroll;
 
   ${mq({ gte: 'xs' })`
     border-radius: 5px;


### PR DESCRIPTION
## Related issue
Fixes #2269 

## Overview
Adds a `max-height` and `overflow-y: scroll` to `Modal`.

## Reason
> When users have a low screen resolution, or if dialogues contain a lot of content a dialogue's size can often exceed that of the available space.

## Work carried out
- [x] Apply fix

## Screenshot
![2021-05-21 14 13 57](https://user-images.githubusercontent.com/56078793/119143035-13091380-ba3f-11eb-9a55-68978048aedf.gif)
