### PR TITLE
ci(GHA): Add exemption for v3 labelled issues

### DIFF
--- a/.github/workflows/project_stale_issues.yml
+++ b/.github/workflows/project_stale_issues.yml
@@ -15,3 +15,4 @@ jobs:
           days-before-stale: 60
           days-before-close: -1
           stale-issue-label: 'Status: Stale'
+          exempt-issue-labels: 'Release: v3'


### PR DESCRIPTION
## Related issue

closes #2388 

## Overview

Ignore 'Release: v3' labelled issues when marking issues as stale

## Work carried out

- [x] Changed Project Automation - stale issues workflow


