### PR TITLE
ci(GHA): Skip cypress binary install

### DIFF
--- a/.github/workflows/build_and_test_feature.yml
+++ b/.github/workflows/build_and_test_feature.yml
@@ -250,6 +250,7 @@ jobs:
           uses: cypress-io/github-action@v2
           env:
             CHOKIDAR_USEPOLLING: 1
+            CYPRESS_INSTALL_BINARY: 0
           with:
             project: ./packages/react-component-library
             start: yarn --cwd packages/react-component-library storybook:test

--- a/.github/workflows/build_and_test_master.yml
+++ b/.github/workflows/build_and_test_master.yml
@@ -226,6 +226,7 @@ jobs:
           uses: cypress-io/github-action@v2
           env:
             CHOKIDAR_USEPOLLING: 1
+            CYPRESS_INSTALL_BINARY: 0
           with:
             project: ./packages/react-component-library
             start: yarn --cwd packages/react-component-library storybook:test


### PR DESCRIPTION
## Related issue

closes #2387 

## Overview

Skip cypress binary install in Ci workflows

