### PR TITLE
fix(SidebarE): Resolve `Sheet` positioning issues

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
@@ -49,7 +49,7 @@ export const Sheet: React.FC<SheetProps> = ({
   className,
   onShow,
   onHide,
-  placement = SHEET_PLACEMENT.RIGHT_BOTTOM,
+  placement,
   width,
   enterTiming = 300,
   exitTiming = 300,

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sheet/useSheet.ts
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sheet/useSheet.ts
@@ -30,7 +30,9 @@ export function useSheet(
     const element: any = event.currentTarget
     element.blur()
 
-    setPosition(calculate[placement](element, width))
+    if (placement) {
+      setPosition(calculate[placement](element, width))
+    }
 
     toggle(event)
   }

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarNotifications.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarNotifications.tsx
@@ -63,7 +63,6 @@ export const SidebarNotifications: React.FC<SidebarNotificationsProps> = ({
               </Transition>
             </StyledNotificationsSheetButton>
           }
-          placement={SHEET_PLACEMENT.RIGHT_BOTTOM}
           width={NOTIFICATION_CONTAINER_WIDTH}
         >
           {notifications}

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarSubNav.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarSubNav.tsx
@@ -21,7 +21,6 @@ export const SidebarSubNav: React.FC<Nav<SidebarNavItemEProps>> = ({
           icon={<IconMoreVert />}
         />
       }
-      placement={SHEET_PLACEMENT.RIGHT_TOP}
       width={SHEET_WIDTH}
       exitTiming={0}
       data-testid="sidebar-sub-nav"

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarUserE.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarUserE.tsx
@@ -27,6 +27,9 @@ export interface SidebarUserEProps extends ComponentWithClass {
    * Link component to apply to the exit icon.
    */
   exitLink?: React.ReactElement<LinkTypes>
+  /**
+   * Full name of the end user (e.g. Joe Bloggs).
+   */
   name?: string
 }
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarUserE.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarUserE.tsx
@@ -6,7 +6,6 @@ import { ComponentWithClass } from '../../../common/ComponentWithClass'
 import { LinkTypes } from '../../../common/Link'
 import { SidebarContext } from './context'
 import { SidebarUserItemE } from './SidebarUserItemE'
-import { SHEET_PLACEMENT } from '../Sheet/constants'
 import { TRANSITION_STYLES, TRANSITION_TIMEOUT } from './constants'
 import { StyledUserAvatar } from './partials/StyledUserAvatar'
 import { StyledUserSheet } from './partials/StyledUserSheet'
@@ -50,7 +49,6 @@ const SidebarAvatarWithItems: React.FC<SidebarAvatarWithItemsProps> = ({
         }
       />
     }
-    placement={SHEET_PLACEMENT.RIGHT_BOTTOM}
     width={SHEET_WIDTH}
   >
     <ol>

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledNotificationsSheet.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledNotificationsSheet.tsx
@@ -1,8 +1,13 @@
 import styled from 'styled-components'
 
 import { Sheet } from '../../Sheet/Sheet'
+import { StyledFloatingBox } from '../../../../primitives/FloatingBox/partials/StyledFloatingBox'
 
 export const StyledNotificationsSheet = styled(Sheet)`
   display: flex;
   justify-content: center;
+
+  ${StyledFloatingBox} {
+    transform: translate(10px, calc(-100% + 30px));
+  }
 `

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledSubNavSheet.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledSubNavSheet.tsx
@@ -11,7 +11,7 @@ export const StyledSubNavSheet = styled(Sheet)`
   display: flex;
 
   ${StyledFloatingBox} {
-    margin-left: ${spacing('3')};
+    transform: translateX(20px);
 
     ol {
       list-style-type: none;

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledUserSheet.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/partials/StyledUserSheet.tsx
@@ -8,7 +8,7 @@ const { color } = selectors
 
 export const StyledUserSheet = styled(Sheet)`
   ${StyledFloatingBox} {
-    margin-left: 1px;
+    transform: translate(55px, calc(-100% + 10px));
 
     ol {
       list-style-type: none;


### PR DESCRIPTION
## Related issue

Closes #2260

## Overview

Change the way `Sheet` is positioned for `SidebarE`.

## Reason

>`SidebarE` `Sheet` would not display in Storybook stories because of the way position is calculated. 
>
>The sheets were also positioned inconsistently.

## Work carried out

- [x] Change `SidebarE` `Sheet` positioning

## Screenshot

<img width="595" alt="Screenshot 2021-05-27 at 12 19 47" src="https://user-images.githubusercontent.com/48086589/119818305-f198a380-bee6-11eb-964e-abbd0ead1f09.png">
<img width="261" alt="Screenshot 2021-05-27 at 12 20 03" src="https://user-images.githubusercontent.com/48086589/119818312-f2c9d080-bee6-11eb-9050-4b7d36f6edef.png">
<img width="437" alt="Screenshot 2021-05-27 at 12 20 11" src="https://user-images.githubusercontent.com/48086589/119818314-f2c9d080-bee6-11eb-83d4-9d08da45477f.png">

## Developer notes

The codebase currently contains multiple ways to position 'floating' elements relative to a target.

We are using both a library called `react-tether` (see `DatePicker` and others) and also a separate implementation in the form of the `Sheet` component (see `SidebarE`, `Masthead`). I've identified shortcomings in both of these implementations. 

I suggest we refactor into a single implementation and expose a hook that both our components and downstream consumers can rely upon. There is a ticket for this.
