### PR TITLE
docs(Timeline): Fix dead link

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -44,7 +44,7 @@ export default {
     docs: {
       description: {
         component:
-          'A collection of composable and presentation agnostic Compound Components, Hooks and a Context Provider, to help aid in the creation of scheduling based user-interfaces. Visit the [Compound Timeline microsite](https://docs.royalnavy.io/timeline) for more comprehensive documentation.',
+          'A collection of composable and presentation agnostic Compound Components, Hooks and a Context Provider, to help aid in the creation of scheduling based user-interfaces. Visit the [Compound Timeline microsite](https://timeline.royalnavy.io/) for more comprehensive documentation.',
       },
     },
   },


### PR DESCRIPTION
## Related issue

Closes #2353 

## Overview

Fix dead link in Storybook Timeline docs.