### PR TITLE
build(Storybook): Resolve `typescript` to `4.2.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "**/**/postcss": "^8.2.15",
     "**/**/postcss-scss": "^3.0.5",
     "**/**/browserslist": "4.16.5",
-    "**/**/dns-packet": "^5.2.2"
+    "**/**/dns-packet": "^5.2.2",
+    "**/**/typescript": "4.2.2"
   },
   "prettier": {
     "bracketSpacing": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -23323,10 +23323,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.3, typescript@^4.1.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@4.2.2, typescript@^4.0.3, typescript@^4.1.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
+  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
 
 uglify-js@^3.1.4:
   version "3.13.8"


### PR DESCRIPTION
## Overview

https://github.com/storybookjs/storybook/issues/15067

https://github.com/styleguidist/react-docgen-typescript/issues/356#issuecomment-849406193

Storybook builds fail with the latest TypeScript release `4.3.2`.

Resolving to an earlier stable release for now.