### PR TITLE
fix(Select): Allow clear from outside component

### DIFF
--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -1,9 +1,15 @@
-import React from 'react'
+import React, { useState } from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import { fireEvent, render, RenderResult } from '@testing-library/react'
+import {
+  fireEvent,
+  render,
+  RenderResult,
+  waitFor,
+} from '@testing-library/react'
 import { IconAnchor } from '@royalnavy/icon-library'
 
 import { Select } from '.'
+import { Button } from '../Button'
 
 const options = [
   {
@@ -79,6 +85,14 @@ describe('Select', () => {
           wrapper.getByText('Option 1').click()
         })
 
+        it('should render the select with the selected value', () => {
+          return waitFor(() => {
+            expect(
+              wrapper.getByTestId('select-single-value-label')
+            ).toHaveTextContent('Option 1')
+          })
+        })
+
         it('should call the `onChange` spy once', () => {
           expect(onChangeSpy).toHaveBeenCalledTimes(1)
           expect(onChangeSpy).toHaveBeenCalledWith({
@@ -126,6 +140,59 @@ describe('Select', () => {
 
     it('should render the icons', () => {
       expect(wrapper.getAllByTestId('select-option-icon')).toHaveLength(2)
+    })
+  })
+
+  describe('when there is a clear button outside', () => {
+    beforeEach(() => {
+      const SelectWithOutsideClearButton: React.FC = () => {
+        const [value, setValue] = useState<string>()
+        const onChange = (event: any) => setValue(event.target.value)
+        const onClick = () => setValue(null)
+
+        return (
+          <>
+            <Select
+              options={options}
+              value={value}
+              onChange={onChange}
+              label="test"
+            />
+            <Button data-testid="clear-button" onClick={onClick}>
+              Clear
+            </Button>
+          </>
+        )
+      }
+
+      wrapper = render(<SelectWithOutsideClearButton />)
+    })
+
+    describe('and an option is selected', () => {
+      beforeEach(async () => {
+        const input = wrapper.getByTestId('react-select-vendor-input')
+        fireEvent.focus(input)
+        fireEvent.keyDown(input, {
+          key: 'ArrowDown',
+          code: 40,
+        })
+
+        wrapper.getByText('Option 1').click()
+      })
+
+      describe('and the `Clear` button is clicked', () => {
+        beforeEach(() => {
+          wrapper.getByTestId('clear-button').click()
+        })
+
+        it('should clear the select label', () => {
+          return waitFor(() => {
+            expect(
+              wrapper.queryAllByTestId('select-single-value-label')
+            ).toHaveLength(0)
+          })
+        })
+      })
     })
   })
 })

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import ReactSelect, { Props as ReactSelectProps } from 'react-select'
 
 import { DropdownIndicator } from '../Dropdown/DropdownIndicator'
@@ -12,6 +12,7 @@ import { StyledMenu } from './partials/StyledMenu'
 import { StyledValueContainer } from './partials/StyledValueContainer'
 import { StyledIndicatorSeparator } from './partials/StyledIndicatorSeparator'
 import { StyledControl } from './partials/StyledControl'
+import { useSelectedOption } from './useSelectedOption'
 
 export interface SelectProps
   extends ReactSelectProps<any>,
@@ -48,9 +49,12 @@ export const Select: React.FC<SelectProps> = ({
   defaultMenuIsOpen,
   ...rest
 }) => {
+  const { selectedOption, setSelectedValue } = useSelectedOption(options, value)
+
   const onSelectChange = (option: any) => {
     const selectedValue =
       option && option.value !== undefined ? option.value : null
+    setSelectedValue(selectedValue)
 
     onChange({
       target: {
@@ -59,8 +63,6 @@ export const Select: React.FC<SelectProps> = ({
       },
     })
   }
-
-  const selectedOption = options.find((option) => option.value === value)
 
   return (
     <ReactSelect

--- a/packages/react-component-library/src/components/Select/useSelectedOption.ts
+++ b/packages/react-component-library/src/components/Select/useSelectedOption.ts
@@ -1,0 +1,32 @@
+import { Dispatch, SetStateAction, useEffect, useState } from 'react'
+
+import { SelectOptionWithBadgeType } from './Option'
+
+export function useSelectedOption(
+  options: SelectOptionWithBadgeType[],
+  value: string
+): {
+  selectedOption: SelectOptionWithBadgeType
+  setSelectedValue: Dispatch<SetStateAction<string>>
+} {
+  const [selectedOption, setSelectedOption] =
+    useState<SelectOptionWithBadgeType>(
+      options.find((option) => option.value === value)
+    )
+  const [selectedValue, setSelectedValue] = useState<string>(value)
+
+  useEffect(() => {
+    setSelectedValue(value)
+  }, [value])
+
+  useEffect(() => {
+    setSelectedOption(
+      options.find((option) => option.value === selectedValue) || null
+    )
+  }, [selectedValue])
+
+  return {
+    selectedOption,
+    setSelectedValue,
+  }
+}


### PR DESCRIPTION
## Related issue
Closes #2372 

## Overview
Needs to handle the side effect of the value changing.

## Reason
> The field value changes and inspecting the select component shows it's value is not undefined or '' but the field still displays the previously selected value

## Work carried out
- [x] Fix

## Screenshot
![2021-06-02 14 40 53](https://user-images.githubusercontent.com/56078793/120491078-da5b2980-c3b0-11eb-9f00-c52177bd9218.gif)