### PR TITLE
Expose `useTimelineFrame` and `useTimelineZoom`

### DIFF
--- a/packages/react-component-library/src/components/Timeline/TimelineToolbar.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineToolbar.tsx
@@ -10,7 +10,8 @@ import { Button, BUTTON_SIZE, BUTTON_VARIANT } from '../Button'
 import { StyledToolbar } from './partials/StyledToolbar'
 import { StyledToolbarButtons } from './partials/StyledToolbarButtons'
 import { StyledToolbarSeparator } from './partials/StyledToolbarSeparator'
-import { useTimelineScale } from './hooks/useTimelineScale'
+import { useTimelineFrame } from './hooks/useTimelineFrame'
+import { useTimelineZoom } from './hooks/useTimelineZoom'
 
 interface TimelineToolbarProps {
   hideScaling: boolean
@@ -19,14 +20,8 @@ interface TimelineToolbarProps {
 export const TimelineToolbar: React.FC<TimelineToolbarProps> = ({
   hideScaling,
 }) => {
-  const {
-    canZoomIn,
-    canZoomOut,
-    moveNext,
-    movePrevious,
-    zoomIn,
-    zoomOut,
-  } = useTimelineScale()
+  const { canZoomIn, canZoomOut, zoomIn, zoomOut } = useTimelineZoom()
+  const { moveNext, movePrevious } = useTimelineFrame()
 
   return (
     <StyledToolbar data-testid="timeline-toolbar">

--- a/packages/react-component-library/src/components/Timeline/hooks/index.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/index.ts
@@ -1,1 +1,3 @@
+export * from './useTimelineFrame'
 export * from './useTimelinePosition'
+export * from './useTimelineZoom'

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineFrame.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineFrame.ts
@@ -1,47 +1,17 @@
-import { useContext, useEffect, useState } from 'react'
-import { isNil } from 'lodash'
+import { useContext } from 'react'
 
-import { TIMELINE_ACTIONS, TimelineScaleOption } from '../context/types'
-import { TimelineContext } from '../context'
 import { initialiseScaleOptions } from '../context/timeline_scales'
+import { TimelineContext } from '../context'
+import { TIMELINE_ACTIONS, TimelineScaleOption } from '../context/types'
 
-export function useTimelineScale() {
+export function useTimelineFrame(): {
+  moveNext: () => void
+  movePrevious: () => void
+} {
   const {
     dispatch,
-    state: {
-      currentScaleIndex,
-      currentScaleOption,
-      options,
-      scaleOptions,
-      width,
-    },
+    state: { currentScaleOption, options, width },
   } = useContext(TimelineContext)
-  const [timelineScaleOptions, setTimelineScaleOptions] = useState(scaleOptions)
-  const canZoomIn = isNil(currentScaleIndex) || currentScaleIndex > 0
-  const canZoomOut = currentScaleIndex < timelineScaleOptions.length - 1
-
-  useEffect(() => {
-    const newScaleOptions = initialiseScaleOptions(options, width)
-    setTimelineScaleOptions(newScaleOptions)
-  }, [width])
-
-  useEffect(() => {
-    setTimelineScaleOptions(scaleOptions)
-  }, [scaleOptions])
-
-  function zoomIn() {
-    dispatch({
-      scaleIndex: currentScaleIndex - 1,
-      type: TIMELINE_ACTIONS.SCALE,
-    })
-  }
-
-  function zoomOut() {
-    dispatch({
-      scaleIndex: currentScaleIndex + 1,
-      type: TIMELINE_ACTIONS.SCALE,
-    })
-  }
 
   function move(
     type: typeof TIMELINE_ACTIONS.GET_NEXT | typeof TIMELINE_ACTIONS.GET_PREV
@@ -90,11 +60,7 @@ export function useTimelineScale() {
   }
 
   return {
-    canZoomIn,
-    canZoomOut,
     moveNext,
     movePrevious,
-    zoomIn,
-    zoomOut,
   }
 }

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
@@ -26,15 +26,15 @@ export function useTimelinePosition(
   startDate: Date,
   endDate: Date
 ): {
-  width: string
-  offset: string
-  maxWidth: string
-  isBeforeStart: boolean
-  isAfterEnd: boolean
-  startsBeforeStart: boolean
-  startsAfterEnd: boolean
-  endsBeforeStart: boolean
   endsAfterEnd: boolean
+  endsBeforeStart: boolean
+  isAfterEnd: boolean
+  isBeforeStart: boolean
+  maxWidth: string
+  offset: string
+  startsAfterEnd: boolean
+  startsBeforeStart: boolean
+  width: string
 } {
   const {
     state: { currentScaleOption, days },

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineZoom.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineZoom.ts
@@ -1,0 +1,51 @@
+import { useContext, useEffect, useState } from 'react'
+import { isNil } from 'lodash'
+
+import { initialiseScaleOptions } from '../context/timeline_scales'
+import { TIMELINE_ACTIONS } from '../context/types'
+import { TimelineContext } from '../context'
+
+export function useTimelineZoom(): {
+  canZoomIn: boolean
+  canZoomOut: boolean
+  zoomIn: () => void
+  zoomOut: () => void
+} {
+  const {
+    dispatch,
+    state: { currentScaleIndex, options, scaleOptions, width },
+  } = useContext(TimelineContext)
+  const [timelineScaleOptions, setTimelineScaleOptions] = useState(scaleOptions)
+  const canZoomIn = isNil(currentScaleIndex) || currentScaleIndex > 0
+  const canZoomOut = currentScaleIndex < timelineScaleOptions.length - 1
+
+  useEffect(() => {
+    const newScaleOptions = initialiseScaleOptions(options, width)
+    setTimelineScaleOptions(newScaleOptions)
+  }, [width])
+
+  useEffect(() => {
+    setTimelineScaleOptions(scaleOptions)
+  }, [scaleOptions])
+
+  function zoomIn() {
+    dispatch({
+      scaleIndex: currentScaleIndex - 1,
+      type: TIMELINE_ACTIONS.SCALE,
+    })
+  }
+
+  function zoomOut() {
+    dispatch({
+      scaleIndex: currentScaleIndex + 1,
+      type: TIMELINE_ACTIONS.SCALE,
+    })
+  }
+
+  return {
+    canZoomIn,
+    canZoomOut,
+    zoomIn,
+    zoomOut,
+  }
+}


### PR DESCRIPTION
## Related issue
Closes #2347 

## Overview
Exposes `useTimelineFrame` and `useTimelineZoom` for downstream consumers.

## Reason
> would be useful to expose the useTimelineScale hook so we have access to moveNext, movePrev etc

## Work carried out
- [x] Split out hook
- [x] Expose hooks

## Developer notes
[Documentation to follow.](https://github.com/Royal-Navy/docs.royalnavy.io/issues/125)