### PR TITLE
ci(GHA): Update triage url

### DIFF
--- a/.github/workflows/project_notify.yml
+++ b/.github/workflows/project_notify.yml
@@ -12,7 +12,7 @@ jobs:
       steps:
         - name: Send slack message for triage issues
           env:
-             TRIAGE_URL: https://github.com/Royal-Navy/design-system/issues?q=is%3Aissue+is%3Aopen+label%3A%22%E2%8F%B1+Awaiting+triage%22
+             TRIAGE_URL: https://github.com/Royal-Navy/design-system/issues?q=is%3Aissue+is%3Aopen+label%3A%22Status%3A+Awaiting+triage%22
           run: |
 
             result=$(( gh issue list --repo Royal-Navy/design-system -l 'Status: Awaiting triage' ) 2>&1)


### PR DESCRIPTION
## Related issue

closes #2428 

## Overview

Update url in notify workflow


