### PR TITLE
feat(Select): Add ability to remove clear button

### DIFF
--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -49,6 +49,18 @@ export const Disabled: Story<SelectProps> = (props) => (
 
 Disabled.storyName = 'Disabled'
 
+export const NotClearable: Story<SelectProps> = (props) => (
+  <Select
+    {...props}
+    options={options}
+    label="Example label"
+    name="select-disabled"
+    isClearable={false}
+  />
+)
+
+NotClearable.storyName = 'Not clearable'
+
 export const WithIcons: Story<SelectProps> = (props) => {
   const iconOptions = options.map((option) => ({
     ...option,

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -85,6 +85,16 @@ describe('Select', () => {
           wrapper.getByText('Option 1').click()
         })
 
+        it('should render a clear button', () => {
+          const control = wrapper.container.children[0].children[1]
+          const indicators = control.children[1]
+          const firstIndicator = indicators.children[0]
+
+          expect(firstIndicator.classList).toContain(
+            'rn-select__clear-indicator'
+          )
+        })
+
         it('should render the select with the selected value', () => {
           return waitFor(() => {
             expect(
@@ -191,6 +201,43 @@ describe('Select', () => {
               wrapper.queryAllByTestId('select-single-value-label')
             ).toHaveLength(0)
           })
+        })
+      })
+    })
+  })
+
+  describe('when `isClearable` is `false`', () => {
+    beforeEach(() => {
+      onChangeSpy = jest.fn()
+
+      wrapper = render(
+        <Select isClearable={false} onChange={onChangeSpy} options={options} />
+      )
+    })
+
+    describe('when the select is clicked', () => {
+      beforeEach(() => {
+        const input = wrapper.getByTestId('react-select-vendor-input')
+        fireEvent.focus(input)
+        fireEvent.keyDown(input, {
+          key: 'ArrowDown',
+          code: 40,
+        })
+      })
+
+      describe('when the first option is clicked', () => {
+        beforeEach(() => {
+          wrapper.getByText('Option 1').click()
+        })
+
+        it('should not render a clear button', () => {
+          const control = wrapper.container.children[0].children[1]
+          const indicators = control.children[1]
+          const firstIndicator = indicators.children[0]
+
+          expect(firstIndicator.classList).not.toContain(
+            'rn-select__clear-indicator'
+          )
         })
       })
     })

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -19,6 +19,10 @@ export interface SelectProps
     ComponentWithClass,
     InputValidationProps {
   /**
+   * Specify whether or not to have a clear button.
+   */
+  isClearable?: boolean
+  /**
    * Optional text label to display within the component.
    */
   label?: string
@@ -41,6 +45,7 @@ export interface SelectProps
 }
 
 export const Select: React.FC<SelectProps> = ({
+  isClearable = true,
   label,
   name,
   onChange,
@@ -79,7 +84,7 @@ export const Select: React.FC<SelectProps> = ({
         MenuList: StyledMenuList,
         ValueContainer: StyledValueContainer,
       }}
-      isClearable
+      isClearable={isClearable}
       name={name}
       onChange={onSelectChange}
       options={options}


### PR DESCRIPTION
## Related issue
Closes #2386 

## Overview
Allows `isClearable` to be passed as a parameter.

## Reason
> The 'x' button that clears the select should be optional, we would like a way to turn it off

## Work carried out
- [x] Allow `isClearable`

## Screenshot
![Screenshot 2021-06-10 at 09 35 21](https://user-images.githubusercontent.com/56078793/121492897-32a4b380-c9cf-11eb-83b6-9575f65cc29b.png)