### PR TITLE
fix(DatePicker): Resolve tab order issues

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -25,6 +25,7 @@ describe('DatePicker', () => {
   let label: string
   let onChange: (data: { startDate: Date; endDate: Date }) => void
   let onBlur: (e: React.FormEvent) => void
+  let onCalendarFocus: (e: React.SyntheticEvent) => void
   let dateSpy: jest.SpyInstance
   let days: string[]
   let onSubmitSpy: (e: React.FormEvent) => void
@@ -69,6 +70,7 @@ describe('DatePicker', () => {
       startDate = new Date(2019, 11, 1)
       onChange = jest.fn()
       onBlur = jest.fn()
+      onCalendarFocus = jest.fn()
 
       wrapper = render(
         <>
@@ -76,6 +78,7 @@ describe('DatePicker', () => {
             startDate={startDate}
             onChange={onChange}
             onBlur={onBlur}
+            onCalendarFocus={onCalendarFocus}
           />
           <div data-testid="datepicker-outside" />
         </>
@@ -266,6 +269,45 @@ describe('DatePicker', () => {
           it('hides the day picker container', () => {
             return waitFor(() => {
               expect(wrapper.getByTestId('floating-box')).not.toBeVisible()
+            })
+          })
+
+          describe('and the tab key is pressed', () => {
+            beforeEach(async () => {
+              wrapper.getByTestId('datepicker-input').focus()
+
+              await userEvent.tab()
+            })
+
+            it('focuses the picker open/close button', () => {
+              expect(
+                wrapper.getByTestId('datepicker-input-button')
+              ).toHaveFocus()
+            })
+
+            describe('and the space key is pressed', () => {
+              beforeEach(async () => {
+                const button = wrapper.getByTestId('datepicker-input-button')
+
+                await userEvent.type(button, '{space}', { skipClick: true })
+              })
+
+              it('closes the picker container', () => {
+                expect(
+                  wrapper.getByTestId('datepicker-input-button')
+                ).toHaveAttribute('aria-label', 'Show day picker')
+              })
+            })
+
+            describe('and the tab  key is pressed again', () => {
+              beforeEach(async () => {
+                await userEvent.tab()
+              })
+
+              it('focuses the picker container', () => {
+                expect(onCalendarFocus).toHaveBeenCalledTimes(1)
+                // NOTE: `react-day-picker` internals from here on down
+              })
             })
           })
 

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -77,6 +77,10 @@ export interface DatePickerProps
    */
   onChange?: (data: { startDate: Date; endDate: Date }) => void
   /**
+   * Optional handler to be invoked when the calendar is focussed.
+   */
+  onCalendarFocus?: (e: React.SyntheticEvent) => void
+  /**
    * Start date of the picker (the first date selected by end user).
    */
   startDate?: Date
@@ -115,6 +119,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   isValid,
   label = 'Select Date',
   onChange,
+  onCalendarFocus,
   startDate,
   value,
   isOpen,
@@ -272,6 +277,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
               disabledDays={disabledDays}
               $isRange={isRange}
               $isVisible={open}
+              onFocus={onCalendarFocus}
             />
           </div>
         </FloatingBoxContent>

--- a/packages/react-component-library/src/components/DatePicker/partials/StyledButton.tsx
+++ b/packages/react-component-library/src/components/DatePicker/partials/StyledButton.tsx
@@ -17,4 +17,9 @@ export const StyledButton = styled.button`
   &:disabled {
     cursor: not-allowed;
   }
+
+  &:focus {
+    outline: 1px dotted #212121;
+    outline: 5px auto -webkit-focus-ring-color;
+  }
 `

--- a/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
@@ -26,8 +26,12 @@ export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
     position: relative;
     flex-direction: row;
     padding-bottom: ${spacing('8')};
-    outline: none;
     user-select: none;
+
+    &:focus {
+      outline: 1px dotted #212121;
+      outline: 5px auto -webkit-focus-ring-color;
+    }
   }
 
   .DayPicker-Months {

--- a/packages/react-component-library/src/components/DatePicker/useInputKeys.ts
+++ b/packages/react-component-library/src/components/DatePicker/useInputKeys.ts
@@ -45,7 +45,7 @@ export function useInputKeys(
     return null
   }
 
-  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): null => {
     setHasError(false)
 
     const isTabKey = e.keyCode === 9
@@ -53,8 +53,6 @@ export function useInputKeys(
 
     if (isTabKey) {
       checkNewDate(value)
-
-      return onComplete()
     }
 
     return null


### PR DESCRIPTION
## Related issue

Closes #2177

## Overview

Resolve issues with `DatePicker` tab order / keyboard control.

Exposes `onCalendarFocus` handler as a side effect.

## Reason

>When tabbing from a focussed DatePicker input the calendar would not gain focus.

## Work carried out

- [x] Add automated tests
- [x] Expose `onCalendarFocus` handler
- [x] Update `useInputKeys` hook to account for tab behaviour

## Screenshot

![2021-06-10 12 39 46](https://user-images.githubusercontent.com/48086589/121519360-87edbe80-c9e9-11eb-818b-f5efaf70649d.gif)

## Developer notes

This fix was made possible thanks to the recent positioning refactor and introduction of the `useFloatingElement` hook.
