### PR TITLE
fix(DocsSite): Adjust top-level navigation order

### DIFF
--- a/packages/docs-site/src/components/presenters/Masthead/index.js
+++ b/packages/docs-site/src/components/presenters/Masthead/index.js
@@ -22,6 +22,17 @@ const MastHead = ({ navItems }) => {
     setOpen(!open)
   }
 
+  const aboutNavItem = navItems.pop()
+
+  const combinedNav = [
+    ...navItems,
+    {
+      href: 'https://timeline.royalnavy.io',
+      label: 'Compound Timeline',
+    },
+    aboutNavItem,
+  ]
+
   return (
     <div className="masthead">
       <Link
@@ -76,16 +87,7 @@ const MastHead = ({ navItems }) => {
             open ? 'is-open' : 'is-closed'
           }`}
         >
-          <Nav
-            orientation="horizontal"
-            navItems={[
-              ...navItems,
-              {
-                href: 'https://timeline.royalnavy.io',
-                label: 'Compound Timeline',
-              },
-            ]}
-          />
+          <Nav orientation="horizontal" navItems={combinedNav} />
         </div>
       )}
     </div>

--- a/packages/docs-site/src/library/pages/about/index.md
+++ b/packages/docs-site/src/library/pages/about/index.md
@@ -4,7 +4,7 @@ description: ''
 tags: public
 pageClass: ''
 template: default
-index: 0
+index: 7
 header: true
 ---
 


### PR DESCRIPTION
## Related issue

Closes #2430 

## Overview

Change incorrect top level navigation order.

## Reason

>About page should come last.

## Screenshot

<img width="1384" alt="Screenshot 2021-06-15 at 09 21 18" src="https://user-images.githubusercontent.com/48086589/122018757-103ddc00-cdbb-11eb-8307-fe6013c21242.png">
