### PR TITLE
ci(GHA): Exclude sonar scans for dependabot PR's

### DIFF
--- a/.github/workflows/build_and_test_feature.yml
+++ b/.github/workflows/build_and_test_feature.yml
@@ -229,6 +229,7 @@ jobs:
 
         - name: SonarCloud Scan
           uses: Royal-Navy/sonarcloud-github-action@master
+          if: ${{ github.actor != 'dependabot[bot]' }}
           env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
            SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Related issue

fixes #2445 

## Overview

Skip sonar scan step for dependabot PR's

