### PR TITLE
fix(FloatingBox): Handle `isVisible` using `Transition`

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -40,13 +40,8 @@ describe('DatePicker', () => {
     it('updates the ARIA attributes on the input button', () => {
       const button = wrapper.getByTestId('datepicker-input-button')
 
-      const dayPickerId = wrapper
-        .getByTestId('floating-box-content')
-        .getAttribute('id')
-
       expect(button).toHaveAttribute('aria-expanded', ariaExpanded)
       expect(button).toHaveAttribute('aria-label', ariaLabel)
-      expect(button).toHaveAttribute('aria-owns', dayPickerId)
     })
   }
 

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Placement } from '@popperjs/core'
 import { v4 as uuidv4 } from 'uuid'
 import { DayPickerProps } from 'react-day-picker'
+import { Transition } from 'react-transition-group'
 
 import {
   FLOATING_BOX_PLACEMENT,
@@ -176,6 +177,13 @@ export const DatePicker: React.FC<DatePickerProps> = ({
     attributes,
   } = useFloatingElement(legacyPlacementMap[placement] || placement)
 
+  const TRANSITION_STYLES = {
+    entering: { opacity: 0 },
+    entered: { opacity: 1 },
+    exiting: { opacity: 0 },
+    exited: { opacity: 0 },
+  }
+
   return (
     <>
       <StyledDatePickerInput
@@ -241,47 +249,50 @@ export const DatePicker: React.FC<DatePickerProps> = ({
           </StyledButton>
         </StyledOuterWrapper>
       </StyledDatePickerInput>
-      <StyledFloatingBox
-        ref={floatingElementRef}
-        role="dialog"
-        data-testid="floating-box"
-        aria-modal
-        aria-labelledby={titleId}
-        aria-live="polite"
-        $isVisible={open}
-        style={styles.popper}
-        {...attributes.popper}
-        {...rest}
-      >
-        <FloatingBoxContent
-          contentId={contentId}
-          scheme={FLOATING_BOX_SCHEME.LIGHT}
-          data-testid="floating-box-content"
-        >
-          <StyledArrow
-            $placement={
-              attributes?.popper?.['data-popper-placement'] as Placement
-            }
-            ref={arrowElementRef}
-            style={styles.arrow}
-            {...attributes.arrow}
-          />
-          <div ref={floatingBoxChildrenRef}>
-            <StyledDayPicker
-              numberOfMonths={isRange ? 2 : 1}
-              selectedDays={[from, { from, to }]}
-              modifiers={modifiers}
-              month={currentMonth}
-              onDayClick={handleDayClick}
-              initialMonth={startDate || initialMonth}
-              disabledDays={disabledDays}
-              $isRange={isRange}
-              $isVisible={open}
-              onFocus={onCalendarFocus}
-            />
-          </div>
-        </FloatingBoxContent>
-      </StyledFloatingBox>
+      <Transition in={open} timeout={0} unmountOnExit>
+        {(transitionState) => (
+          <StyledFloatingBox
+            ref={floatingElementRef}
+            role="dialog"
+            data-testid="floating-box"
+            aria-modal
+            aria-labelledby={titleId}
+            aria-live="polite"
+            style={{ ...styles.popper, ...TRANSITION_STYLES[transitionState] }}
+            {...attributes.popper}
+            {...rest}
+          >
+            <FloatingBoxContent
+              contentId={contentId}
+              scheme={FLOATING_BOX_SCHEME.LIGHT}
+              data-testid="floating-box-content"
+            >
+              <StyledArrow
+                $placement={
+                  attributes?.popper?.['data-popper-placement'] as Placement
+                }
+                ref={arrowElementRef}
+                style={styles.arrow}
+                {...attributes.arrow}
+              />
+              <div ref={floatingBoxChildrenRef}>
+                <StyledDayPicker
+                  numberOfMonths={isRange ? 2 : 1}
+                  selectedDays={[from, { from, to }]}
+                  modifiers={modifiers}
+                  month={currentMonth}
+                  onDayClick={handleDayClick}
+                  initialMonth={startDate || initialMonth}
+                  disabledDays={disabledDays}
+                  $isRange={isRange}
+                  $isVisible={open}
+                  onFocus={onCalendarFocus}
+                />
+              </div>
+            </FloatingBoxContent>
+          </StyledFloatingBox>
+        )}
+      </Transition>
     </>
   )
 }

--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -71,7 +71,9 @@ describe('Popover', () => {
       })
 
       it('to be visible to the end user', () => {
-        expect(wrapper.getByTestId('floating-box-content')).toBeVisible()
+        return waitFor(() => {
+          expect(wrapper.getByTestId('floating-box-content')).toBeVisible()
+        })
       })
 
       it('renders the provided arbitrary JSX', () => {
@@ -119,7 +121,9 @@ describe('Popover', () => {
       })
 
       it('to be visible to the end user', () => {
-        expect(wrapper.getByTestId('floating-box-content')).toBeVisible()
+        return waitFor(() => {
+          expect(wrapper.getByTestId('floating-box-content')).toBeVisible()
+        })
       })
 
       describe('and the user clicks on the target again', () => {
@@ -195,11 +199,19 @@ describe('Popover', () => {
       )
     })
 
-    it('should spread arbitrary props', () => {
-      expect(wrapper.getByTestId('popover')).toHaveAttribute(
-        'data-arbitrary',
-        'arbitrary'
-      )
+    describe('and the user hovers on the target element', () => {
+      beforeEach(() => {
+        fireEvent.mouseEnter(wrapper.getByText(HOVER_ON_ME))
+      })
+
+      it('should spread arbitrary props', () => {
+        return waitFor(() => {
+          expect(wrapper.getByTestId('popover')).toHaveAttribute(
+            'data-arbitrary',
+            'arbitrary'
+          )
+        })
+      })
     })
   })
 })

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
@@ -457,10 +457,10 @@ describe('Masthead', () => {
     })
 
     it('should not show the links', () => {
-      expect(wrapper.queryByText('Profile')).not.toBeVisible()
-      expect(wrapper.queryByText('Settings')).not.toBeVisible()
-      expect(wrapper.queryByText('Support')).not.toBeVisible()
-      expect(wrapper.queryByText('Logout')).not.toBeVisible()
+      expect(wrapper.queryByText('Profile')).not.toBeInTheDocument()
+      expect(wrapper.queryByText('Settings')).not.toBeInTheDocument()
+      expect(wrapper.queryByText('Support')).not.toBeInTheDocument()
+      expect(wrapper.queryByText('Logout')).not.toBeInTheDocument()
     })
 
     describe('and the avatar is clicked', () => {
@@ -469,10 +469,12 @@ describe('Masthead', () => {
       })
 
       it('should show the links', () => {
-        expect(wrapper.getByText('Profile')).toBeVisible()
-        expect(wrapper.getByText('Settings')).toBeVisible()
-        expect(wrapper.getByText('Support')).toBeVisible()
-        expect(wrapper.getByText('Logout')).toBeVisible()
+        return waitFor(() => {
+          expect(wrapper.getByText('Profile')).toBeVisible()
+          expect(wrapper.getByText('Settings')).toBeVisible()
+          expect(wrapper.getByText('Support')).toBeVisible()
+          expect(wrapper.getByText('Logout')).toBeVisible()
+        })
       })
 
       it('should spread arbitrary props on the user item', () => {

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Placement } from '@popperjs/core'
+import { Transition } from 'react-transition-group'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { FloatingBoxContent } from './FloatingBoxContent'
@@ -24,6 +25,13 @@ export interface FloatingBoxProps extends PositionType, ComponentWithClass {
   placement?: Placement
 }
 
+const TRANSITION_STYLES = {
+  entering: { opacity: 0 },
+  entered: { opacity: 1 },
+  exiting: { opacity: 0 },
+  exited: { opacity: 0 },
+}
+
 export const FloatingBox: React.FC<FloatingBoxProps> = ({
   contentId = getId('floating-box'),
   scheme = FLOATING_BOX_SCHEME.LIGHT,
@@ -46,33 +54,36 @@ export const FloatingBox: React.FC<FloatingBoxProps> = ({
   return (
     <>
       <StyledTarget ref={targetElementRef}>{renderTarget}</StyledTarget>
-      <StyledFloatingBox
-        ref={floatingElementRef}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        role="dialog"
-        data-testid="floating-box"
-        $isVisible={isVisible}
-        style={styles.popper}
-        {...attributes.popper}
-        {...rest}
-      >
-        <FloatingBoxContent
-          contentId={contentId}
-          scheme={scheme}
-          data-testid="floating-box-content"
-        >
-          <StyledArrow
-            $placement={
-              attributes?.popper?.['data-popper-placement'] as Placement
-            }
-            ref={arrowElementRef}
-            style={styles.arrow}
-            {...attributes.arrow}
-          />
-          {children}
-        </FloatingBoxContent>
-      </StyledFloatingBox>
+      <Transition in={isVisible} timeout={0} unmountOnExit>
+        {(state) => (
+          <StyledFloatingBox
+            style={{ ...styles.popper, ...TRANSITION_STYLES[state] }}
+            ref={floatingElementRef}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+            role="dialog"
+            data-testid="floating-box"
+            {...attributes.popper}
+            {...rest}
+          >
+            <FloatingBoxContent
+              contentId={contentId}
+              scheme={scheme}
+              data-testid="floating-box-content"
+            >
+              <StyledArrow
+                $placement={
+                  attributes?.popper?.['data-popper-placement'] as Placement
+                }
+                ref={arrowElementRef}
+                style={styles.arrow}
+                {...attributes.arrow}
+              />
+              {children}
+            </FloatingBoxContent>
+          </StyledFloatingBox>
+        )}
+      </Transition>
     </>
   )
 }

--- a/packages/react-component-library/src/primitives/FloatingBox/partials/StyledFloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/partials/StyledFloatingBox.tsx
@@ -1,25 +1,9 @@
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
 
 const { zIndex } = selectors
 
-interface StyledFloatingBoxProps {
-  $isVisible?: boolean
-}
-
-export const StyledFloatingBox = styled.div<StyledFloatingBoxProps>`
+export const StyledFloatingBox = styled.div`
   z-index: ${zIndex('dropdown', 1)};
   padding: 0.5rem;
-
-  opacity: 0;
-  pointer-events: none;
-  transition: 100ms opacity linear;
-
-  ${({ $isVisible }) =>
-    $isVisible &&
-    css`
-      opacity: 1;
-      pointer-events: all;
-      transition: 100ms opacity linear;
-    `}
 `


### PR DESCRIPTION
## Related issue

Closes #2467 & Closes #2483

## Overview

Use `Transition` with `FloatingBox` and gracefully unmount component from DOM when hidden.

## Reason

>Chromatic snapshots were flagging an invisible 1px change upon every snapshot regeneration.

## Work carried out

- [x] Refactor `FloatingBox` and `DatePicker` transition implementation

## Developer notes

Also resolves #2483 as side effect.