### PR TITLE
fix(Storybook): Add more specific actions

### DIFF
--- a/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
@@ -13,9 +13,7 @@ import { withFormik } from '../../enhancers/withFormik'
 export default {
   component: TextInput,
   title: 'Text Input',
-  parameters: {
-    actions: { argTypesRegex: '^on.*' },
-  },
+  argTypes: { onBlur: { action: 'onBlur' } },
 } as Meta
 
 export const Default: Story<TextInputProps> = (props) => (

--- a/packages/react-component-library/src/components/TextInputE/TextInputE.stories.tsx
+++ b/packages/react-component-library/src/components/TextInputE/TextInputE.stories.tsx
@@ -1,20 +1,14 @@
 import React from 'react'
 import { Story, Meta } from '@storybook/react/types-6-0'
-import { action } from '@storybook/addon-actions'
-import { Field, Formik, Form } from 'formik'
-import * as yup from 'yup'
 
 import { IconSearch } from '@royalnavy/icon-library'
-import { Button } from '../Button'
 import { TextInputE, TextInputEProps } from '.'
-
-import { withFormik } from '../../enhancers/withFormik'
 
 export default {
   component: TextInputE,
   title: 'Text Input (Experimental)',
   parameters: {
-    actions: { argTypesRegex: '^on.*' },
+    argTypes: { onBlur: { action: 'onBlur' } },
   },
 } as Meta
 


### PR DESCRIPTION
## Related issue
Fixes #2473 

## Overview
The example configuration was adding an `action` for each callback which was having performance issues when changing the `TextInput` and `TextInputE`

## Reason
> onKeyDown is being passed into `TextInputE` (and `TextInput` + potentially more) for Storybook examples when it has not been specified, giving the impression that the component is laggy.

## Work carried out
- [x] Apply fix
