### PR TITLE
fix(Select): Set selected option with side effect

### DIFF
--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -242,4 +242,53 @@ describe('Select', () => {
       })
     })
   })
+
+  describe('when the options are updated externally', () => {
+    beforeEach(() => {
+      const initialOptions = options
+      const updatedOptions = [
+        {
+          badge: 'Badge 2',
+          label: 'Option 2',
+          value: '2',
+        },
+        {
+          badge: 'Badge 3',
+          label: 'Option 3',
+          value: '3',
+        },
+      ]
+
+      const SelectWithUpdate = () => {
+        const [selectOptions, updateSelectOptions] = useState(initialOptions)
+        const [value, setValue] = useState('2')
+
+        return (
+          <>
+            <Button
+              onClick={() => {
+                updateSelectOptions(updatedOptions)
+                setValue('3')
+              }}
+            >
+              Update
+            </Button>
+            <Select options={selectOptions} value={value} />
+          </>
+        )
+      }
+
+      wrapper = render(<SelectWithUpdate />)
+
+      wrapper.getByText('Update').click()
+    })
+
+    it('should render the select with the selected value', () => {
+      return waitFor(() => {
+        expect(
+          wrapper.getByTestId('select-single-value-label')
+        ).toHaveTextContent('Option 3')
+      })
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Select/useSelectedOption.ts
+++ b/packages/react-component-library/src/components/Select/useSelectedOption.ts
@@ -23,7 +23,7 @@ export function useSelectedOption(
     setSelectedOption(
       options.find((option) => option.value === selectedValue) || null
     )
-  }, [selectedValue])
+  }, [options, selectedValue])
 
   return {
     selectedOption,


### PR DESCRIPTION
## Related issue
Fixes #2508 

## Overview
`useEffect` needs to watch the `options` if they change to set the selected option again.

## Reason
> breaks with the latest version of the design system when adding a default value, because the setSelectedOption does not run again when the options have updated.

## Work carried out
- [x] Apply fix