### PR TITLE
chore(Issues): Enforce issue template usage in template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## Related issue

closes #2572 

## Overview
Remove 'open a blank issue' option in the template chooser which can allow issues to be raised without the desired labels.


## Reason
To ensure that all new issues raised by non-team members have the 'awaiting triage' label applied so they can be detected and processed appropriately by the Design System team.


## Work carried out

- [x] Add issue template config file
