### PR TITLE
Fix items not showing on last day of `Timeline`

### DIFF
--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -2208,4 +2208,56 @@ describe('Timeline', () => {
       })
     })
   })
+
+  describe('when the `range` is `1` and `today` is the last day', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Timeline
+          startDate={new Date(2021, 0, 1)}
+          range={1}
+          today={new Date(2021, 0, 31, 12)}
+        >
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineDays />
+          <TimelineRows>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={new Date(2021, 0, 31, 0, 0, 0)}
+                  endDate={new Date(2021, 1, 1, 18, 0, 0)}
+                >
+                  Event 1
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={new Date(2021, 0, 31, 6, 0, 0)}
+                  endDate={new Date(2021, 1, 1, 18, 0, 0)}
+                >
+                  Event 2
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('should render the today marker', () => {
+      expect(
+        wrapper.queryByTestId('timeline-today-marker-wrapper')
+      ).toBeInTheDocument()
+    })
+
+    it('should render the first event', () => {
+      expect(wrapper.getByText('Event 1')).toBeInTheDocument()
+    })
+
+    it('should render the second event', () => {
+      expect(wrapper.getByText('Event 2')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 
-import { differenceInCalendarDays, isBefore, isAfter } from 'date-fns'
+import { differenceInCalendarDays, isAfter, isBefore } from 'date-fns'
 
 import { TimelineContext } from '../context'
 import { formatPx } from '../helpers'
@@ -37,16 +37,15 @@ export function useTimelinePosition(
   width: string
 } {
   const {
-    state: { currentScaleOption, days },
+    state: { currentScaleOption },
   } = useContext(TimelineContext)
 
-  const firstDateDisplayed = days[0].date
-  const lastDateDisplayed = days[days.length - 1].date
+  const { from: firstDateDisplayed, to: lastDateDisplayed } = currentScaleOption
 
-  const startsBeforeStart = isBefore(new Date(startDate), firstDateDisplayed)
-  const startsAfterEnd = isAfter(new Date(startDate), lastDateDisplayed)
-  const endsBeforeStart = isBefore(new Date(endDate), firstDateDisplayed)
-  const endsAfterEnd = isAfter(new Date(endDate), lastDateDisplayed)
+  const startsBeforeStart = isBefore(startDate, firstDateDisplayed)
+  const startsAfterEnd = isAfter(startDate, lastDateDisplayed)
+  const endsBeforeStart = isBefore(endDate, firstDateDisplayed)
+  const endsAfterEnd = isAfter(endDate, lastDateDisplayed)
 
   const width = startsBeforeStart
     ? getWidth(firstDateDisplayed, endDate)
@@ -62,14 +61,14 @@ export function useTimelinePosition(
       : getWidth(startDate, lastDateDisplayed) + 1
 
   return {
-    width: formatPx(currentScaleOption.widths.day, width),
-    offset: formatPx(currentScaleOption.widths.day, offset),
-    maxWidth: formatPx(currentScaleOption.widths.day, maxWidth),
-    startsBeforeStart,
-    startsAfterEnd,
-    endsBeforeStart,
     endsAfterEnd,
-    isBeforeStart: startsBeforeStart,
+    endsBeforeStart,
+    startsAfterEnd,
+    startsBeforeStart,
     isAfterEnd: startsAfterEnd,
+    isBeforeStart: startsBeforeStart,
+    maxWidth: formatPx(currentScaleOption.widths.day, maxWidth),
+    offset: formatPx(currentScaleOption.widths.day, offset),
+    width: formatPx(currentScaleOption.widths.day, width),
   }
 }

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 
-import { differenceInCalendarDays, isAfter, isBefore } from 'date-fns'
+import { differenceInCalendarDays, endOfDay, isAfter, isBefore } from 'date-fns'
 
 import { TimelineContext } from '../context'
 import { formatPx } from '../helpers'
@@ -43,9 +43,9 @@ export function useTimelinePosition(
   const { from: firstDateDisplayed, to: lastDateDisplayed } = currentScaleOption
 
   const startsBeforeStart = isBefore(startDate, firstDateDisplayed)
-  const startsAfterEnd = isAfter(startDate, lastDateDisplayed)
+  const startsAfterEnd = isAfter(startDate, endOfDay(lastDateDisplayed))
   const endsBeforeStart = isBefore(endDate, firstDateDisplayed)
-  const endsAfterEnd = isAfter(endDate, lastDateDisplayed)
+  const endsAfterEnd = isAfter(endDate, endOfDay(lastDateDisplayed))
 
   const width = startsBeforeStart
     ? getWidth(firstDateDisplayed, endDate)


### PR DESCRIPTION
## Related issue
Closes #2561 

## Overview
The last day is visible so if an item has a time on the last day then it should be shown.

## Reason
> Timeline doesn't consider times after 00:00 on last day as visible

## Work carried out
- [x] Tidy code
- [x] Apply fix

## Screenshot
![Screenshot 2021-07-13 at 11 35 02](https://user-images.githubusercontent.com/56078793/125437835-65f91d02-7aa9-40b3-b2e9-854bd1d44578.png)
