### PR TITLE
fix(Helpers): Handle non existent `window` object gracefully

### DIFF
--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -23,6 +23,12 @@ function hasClass(allClasses: string, className: string) {
 }
 
 function isIE11() {
+  if (typeof window === 'undefined') {
+    logger.warn(`window object does not exist`)
+
+    return false
+  }
+
   // @ts-ignore
   return !!window.MSInputMethodContext && !!document.documentMode
 }


### PR DESCRIPTION
## Overview

Handle non-existent `window` object gracefully.

## Reason

Sometimes the `window` object is non-existent in downstream builds - for example NextJS static site generation.
