### PR TITLE
fix(DatePicker): Allow update from side effect

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { ColorDanger600, ColorSuccess600 } from '@defencedigital/design-tokens'
 import {
@@ -11,6 +11,7 @@ import 'jest-styled-components'
 import userEvent from '@testing-library/user-event'
 
 import { DatePicker } from '.'
+import { Button } from '../Button'
 
 const NOW = '2019-12-05T11:00:00.000Z'
 
@@ -923,6 +924,48 @@ describe('DatePicker', () => {
         'placeholder',
         'yyyy/mm/dd'
       )
+    })
+  })
+
+  describe('when `startDate` and `endDate` are updated externally', () => {
+    beforeEach(() => {
+      const initialProps = {
+        startDate: new Date(2021, 11, 1),
+        endDate: new Date(2021, 11, 2),
+      }
+      const update1Props = {
+        ...initialProps,
+        startDate: new Date(2022, 11, 1),
+      }
+      const update2Props = {
+        ...update1Props,
+        endDate: new Date(2022, 11, 2),
+      }
+
+      const DatePickerWithUpdate = () => {
+        const [props, updateProps] = useState(initialProps)
+
+        return (
+          <>
+            <Button onClick={() => updateProps(update1Props)}>Update 1</Button>
+            <Button onClick={() => updateProps(update2Props)}>Update 2</Button>
+            <DatePicker {...props} isRange />
+          </>
+        )
+      }
+
+      wrapper = render(<DatePickerWithUpdate />)
+
+      wrapper.getByText('Update 1').click()
+      wrapper.getByText('Update 2').click()
+    })
+
+    it('set the value of the component to this date', () => {
+      return waitFor(() => {
+        expect(
+          wrapper.getByTestId('datepicker-input').getAttribute('value')
+        ).toBe('01/12/2022 - 02/12/2022')
+      })
     })
   })
 })

--- a/packages/react-component-library/src/components/DatePicker/useSelection.ts
+++ b/packages/react-component-library/src/components/DatePicker/useSelection.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { DateUtils, DayModifiers, RangeModifier } from 'react-day-picker'
 
 import { StateObject } from './types'
@@ -35,6 +35,13 @@ export const useSelection = (
     to: endDate,
   })
 
+  useEffect(() => {
+    setState({
+      from: startDate,
+      to: endDate,
+    })
+  }, [startDate, endDate])
+
   function handleDayClick(day: Date, dayModifiers?: DayModifiers) {
     if (dayModifiers && dayModifiers.disabled) {
       return
@@ -50,7 +57,7 @@ export const useSelection = (
       })
     }
 
-    (function closeOnSelection() {
+    ;(function closeOnSelection() {
       if (isRange && !newState.to) {
         return
       }


### PR DESCRIPTION
## Related issue
Closes #2631 

## Overview
Updates `startDate` and `endDate` stored in state when updated externally.

## Reason
`startDate` and `endDate` could be updated by a side effect.

> DatePicker startDate value does not change when updated externally

## Work carried out
- [x] Handle side effect