### PR TITLE
ci(GHA): Add variable to node cache key

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Build icon-library
         run: |

--- a/.github/workflows/build_and_test_feature.yml
+++ b/.github/workflows/build_and_test_feature.yml
@@ -17,7 +17,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Cache Cypress binary
           uses: actions/cache@v2
@@ -71,7 +71,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: check commits
           run: |
@@ -91,7 +91,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Get dependencies & run lint
           run: |
@@ -118,7 +118,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Get dependencies & run lint
           run: |
@@ -145,7 +145,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Attach workspace
           uses: actions/download-artifact@v2
@@ -179,7 +179,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Cache Cypress binary
           uses: actions/cache@v2
@@ -228,7 +228,7 @@ jobs:
            uses: actions/cache@v2
            with:
              path: '**/node_modules'
-             key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+             key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
          - name: Attach workspace
            uses: actions/download-artifact@v2
@@ -252,7 +252,7 @@ jobs:
            uses: actions/cache@v2
            with:
              path: '**/node_modules'
-             key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+             key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
          - name: Jest design-tokens
            run: |
@@ -274,7 +274,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Attach workspace
           uses: actions/download-artifact@v2

--- a/.github/workflows/build_and_test_master.yml
+++ b/.github/workflows/build_and_test_master.yml
@@ -16,7 +16,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Cache Cypress binary
           uses: actions/cache@v2
@@ -67,7 +67,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Get dependencies & run lint
           run: |
@@ -94,7 +94,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Get dependencies & run lint
           run: |
@@ -121,7 +121,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Attach workspace
           uses: actions/download-artifact@v2
@@ -154,7 +154,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Cache Cypress binary
           uses: actions/cache@v2
@@ -203,7 +203,7 @@ jobs:
            uses: actions/cache@v2
            with:
              path: '**/node_modules'
-             key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+             key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
          - name: Attach workspace
            uses: actions/download-artifact@v2
@@ -227,7 +227,7 @@ jobs:
            uses: actions/cache@v2
            with:
              path: '**/node_modules'
-             key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+             key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
          - name: Jest design-tokens
            run: |
@@ -248,7 +248,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Attach workspace
           uses: actions/download-artifact@v2

--- a/.github/workflows/npmsmoketest.yml
+++ b/.github/workflows/npmsmoketest.yml
@@ -18,7 +18,7 @@ jobs:
           uses: actions/cache@v2
           with:
             path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
         - name: Install Dependencies
           run: |


### PR DESCRIPTION
## Related issue

closes #2701 

## Overview

Refresh node module cache in GHA workflows

## Reason
Due to the npm scope change, we need to refresh the node module cache in GHA workflows as it is currently causing some workflow steps to fail.

## Work carried out

Added a variable to the cache key to reset the cache.  Also in the future we can use the secret value to toggle the cache without having to make changes to the cache key in the workflows.