### PR TITLE
Fix `Timeline` start date update from side effect

### DIFF
--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -1422,6 +1422,31 @@ describe('Timeline', () => {
       })
     })
 
+    describe('when navigating left', () => {
+      beforeEach(() => {
+        userEvent.click(wrapper.getByTestId('timeline-side-button-left'))
+      })
+
+      it('renders the correct number of days', () => {
+        const days = wrapper.queryAllByTestId('timeline-day-title')
+        expect(days).toHaveLength(41)
+        expect(days[0]).toHaveTextContent('27')
+        expect(days[days.length - 1]).toHaveTextContent('05')
+      })
+
+      it('should update the `startDate`', () => {
+        expect(wrapper.getByTestId('timeline-start-date')).toHaveTextContent(
+          '2019-12-27T00:00:00.000Z'
+        )
+      })
+
+      it('should update the `endDate`', () => {
+        expect(wrapper.getByTestId('timeline-end-date')).toHaveTextContent(
+          '2020-02-05T00:00:00.000Z'
+        )
+      })
+    })
+
     describe('when navigating right', () => {
       beforeEach(() => {
         userEvent.click(wrapper.getByTestId('timeline-side-button-right'))

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { ColorNeutral100, ColorNeutral200 } from '@defencedigital/design-tokens'
 import { css, CSSProp } from 'styled-components'
@@ -7,6 +7,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import timezoneMock from 'timezone-mock'
 import userEvent from '@testing-library/user-event'
 
+import { Button } from '../../Button'
 import {
   NO_DATA_MESSAGE,
   TIMELINE_BLOCK_SIZE,
@@ -2283,6 +2284,56 @@ describe('Timeline', () => {
 
     it('should render the second event', () => {
       expect(wrapper.getByText('Event 2')).toBeInTheDocument()
+    })
+  })
+
+  describe('when `startDate` is updated externally', () => {
+    beforeEach(() => {
+      const TimelineWithUpdate = () => {
+        const [startDate, updateStartDate] = useState<Date>(
+          new Date(2020, 3, 1)
+        )
+
+        return (
+          <>
+            <Button onClick={() => updateStartDate(new Date(2020, 6, 1))}>
+              Update
+            </Button>
+            <Timeline startDate={startDate} today={new Date(2020, 3, 15)}>
+              <TimelineTodayMarker />
+              <TimelineMonths />
+              <TimelineWeeks />
+              <TimelineDays />
+              <TimelineRows>
+                <TimelineRow name="Row 1">
+                  <TimelineEvents>
+                    <TimelineEvent
+                      startDate={new Date(2020, 3, 13)}
+                      endDate={new Date(2020, 3, 18)}
+                    >
+                      Event 1
+                    </TimelineEvent>
+                  </TimelineEvents>
+                </TimelineRow>
+              </TimelineRows>
+            </Timeline>
+          </>
+        )
+      }
+
+      wrapper = render(<TimelineWithUpdate />)
+
+      wrapper.getByText('Update').click()
+    })
+
+    it('should not show the event', async () => {
+      await waitFor(() => {
+        expect(wrapper.queryByTestId('timeline-month')).toHaveTextContent(
+          'July 2020'
+        )
+      })
+
+      expect(wrapper.queryAllByText('Event 1')).toHaveLength(0)
     })
   })
 })

--- a/packages/react-component-library/src/components/Timeline/context/index.tsx
+++ b/packages/react-component-library/src/components/Timeline/context/index.tsx
@@ -1,8 +1,13 @@
-import React, { createContext, useReducer } from 'react'
+import React, { createContext, useEffect, useReducer } from 'react'
 
 import { initialState } from './state'
 import { reducer } from './reducer'
-import { TimelineContextDefault, TimelineProviderProps } from './types'
+import {
+  TIMELINE_ACTIONS,
+  TimelineContextDefault,
+  TimelineProviderProps,
+} from './types'
+import { initialiseScaleOptions } from './timeline_scales'
 
 const timelineContextDefaults: TimelineContextDefault = {
   hasSide: false,
@@ -23,6 +28,23 @@ export const TimelineProvider: React.FC<TimelineProviderProps> = ({
     options,
     today,
   })
+
+  useEffect(() => {
+    if (!state.currentScaleOption) {
+      return
+    }
+
+    const scaleOptions = initialiseScaleOptions(
+      {
+        ...options,
+        endDate: state.getNewEndDate(),
+        hoursBlockSize: state.currentScaleOption.hoursBlockSize,
+      },
+      state.width
+    )
+
+    dispatch({ scaleOptions, type: TIMELINE_ACTIONS.CHANGE_START_DATE })
+  }, [options.startDate])
 
   return (
     <TimelineContext.Provider value={{ hasSide, state, dispatch }}>

--- a/packages/react-component-library/src/components/Timeline/context/reducer.ts
+++ b/packages/react-component-library/src/components/Timeline/context/reducer.ts
@@ -116,6 +116,7 @@ export function reducer(
         currentScaleOption: scaleOptions[currentScaleIndex],
         width: action.width,
       }
+    case TIMELINE_ACTIONS.CHANGE_START_DATE:
     case TIMELINE_ACTIONS.GET_PREV:
     case TIMELINE_ACTIONS.GET_NEXT:
       return {

--- a/packages/react-component-library/src/components/Timeline/context/reducer.ts
+++ b/packages/react-component-library/src/components/Timeline/context/reducer.ts
@@ -103,6 +103,7 @@ export function reducer(
 ): TimelineState | never {
   switch (action.type) {
     case TIMELINE_ACTIONS.CHANGE_WIDTH:
+    case TIMELINE_ACTIONS.INITIALISE:
       /* eslint-disable no-case-declarations */
       const scaleOptions = initialiseScaleOptions(state.options, action.width)
       const currentScaleIndex =

--- a/packages/react-component-library/src/components/Timeline/context/state.ts
+++ b/packages/react-component-library/src/components/Timeline/context/state.ts
@@ -4,6 +4,16 @@ const initialState: TimelineState = {
   currentScaleIndex: null,
   currentScaleOption: null,
   days: [],
+  getNewEndDate(intervalMultiplier = 1) {
+    if (this.options.endDate && this.currentScaleOption.isDefault) {
+      return this.currentScaleOption.calculateDate(
+        this.currentScaleOption.to,
+        this.currentScaleOption.intervalSize * intervalMultiplier
+      )
+    }
+
+    return null
+  },
   hours: [],
   months: [],
   options: null,

--- a/packages/react-component-library/src/components/Timeline/context/types.ts
+++ b/packages/react-component-library/src/components/Timeline/context/types.ts
@@ -64,6 +64,7 @@ export type TimelineState = {
 }
 
 export const TIMELINE_ACTIONS = {
+  CHANGE_START_DATE: 'CHANGE_START_DATE',
   CHANGE_WIDTH: 'CHANGE_WIDTH',
   GET_NEXT: 'GET_NEXT',
   GET_PREV: 'GET_PREV',
@@ -71,6 +72,10 @@ export const TIMELINE_ACTIONS = {
 } as const
 
 export type TimelineAction =
+  | {
+      type: typeof TIMELINE_ACTIONS.CHANGE_START_DATE
+      scaleOptions: TimelineScaleOption[]
+    }
   | {
       type: typeof TIMELINE_ACTIONS.CHANGE_WIDTH
       width: number

--- a/packages/react-component-library/src/components/Timeline/context/types.ts
+++ b/packages/react-component-library/src/components/Timeline/context/types.ts
@@ -68,6 +68,7 @@ export const TIMELINE_ACTIONS = {
   CHANGE_WIDTH: 'CHANGE_WIDTH',
   GET_NEXT: 'GET_NEXT',
   GET_PREV: 'GET_PREV',
+  INITIALISE: 'INITIALISE',
   SCALE: 'SCALE',
 } as const
 
@@ -87,6 +88,10 @@ export type TimelineAction =
   | {
       type: typeof TIMELINE_ACTIONS.GET_PREV
       scaleOptions: TimelineScaleOption[]
+    }
+  | {
+      type: typeof TIMELINE_ACTIONS.INITIALISE
+      width: number
     }
   | { type: typeof TIMELINE_ACTIONS.SCALE; scaleIndex: number }
 

--- a/packages/react-component-library/src/components/Timeline/context/types.ts
+++ b/packages/react-component-library/src/components/Timeline/context/types.ts
@@ -53,6 +53,7 @@ export type TimelineState = {
   currentScaleIndex: number
   currentScaleOption: TimelineScaleOption
   days: TimelineDay[]
+  getNewEndDate: (intervalMultiplier?: number) => Date
   hours: TimelineHour[]
   months: TimelineMonth[]
   options: TimelineOptions

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineWidth.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineWidth.ts
@@ -20,21 +20,30 @@ export function useTimelineWidth(
     return timelineWidth - 1 - sideWidth
   }
 
-  function dispatchWidthChange() {
-    dispatch({
-      type: TIMELINE_ACTIONS.CHANGE_WIDTH,
-      width: isFullWidth ? getWidth() : null,
-    })
+  function dispatchWidthChange(
+    type:
+      | typeof TIMELINE_ACTIONS.CHANGE_WIDTH
+      | typeof TIMELINE_ACTIONS.INITIALISE = TIMELINE_ACTIONS.CHANGE_WIDTH
+  ) {
+    return () => {
+      dispatch({
+        type,
+        width: isFullWidth ? getWidth() : null,
+      })
+    }
   }
 
   /* eslint-disable consistent-return */
   useEffect(() => {
-    dispatchWidthChange()
+    dispatchWidthChange(TIMELINE_ACTIONS.INITIALISE)()
 
     if (isFullWidth) {
-      window.addEventListener('resize', debounce(dispatchWidthChange, 250))
+      window.addEventListener('resize', debounce(dispatchWidthChange(), 250))
       return () => {
-        window.removeEventListener('resize', debounce(dispatchWidthChange, 250))
+        window.removeEventListener(
+          'resize',
+          debounce(dispatchWidthChange(), 250)
+        )
       }
     }
   }, [])


### PR DESCRIPTION
## Related issue
Closes #2470 

## Overview
It is possible that `startDate` is updated as a side effect and therefore the `Timeline` needs to update. This change dispatches an event which is handled by the reducer.

## Reason
> Would it be possible that the timeline updates when the startDate props has changed?

## Work carried out
- [x] Tidy up existing code
- [x] Handle `startDate`
