### PR TITLE
fix(Sidebar): Maintain static `Sheet` ID

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
@@ -15,6 +15,7 @@ export interface SheetProps extends ComponentWithClass {
   children: React.ReactElement
   placement?: Placement
   closeDelay?: number
+  id?: string
 }
 
 export const Sheet: React.FC<SheetProps> = ({
@@ -22,19 +23,19 @@ export const Sheet: React.FC<SheetProps> = ({
   children,
   placement = FLOATING_BOX_PLACEMENT.RIGHT,
   closeDelay = 250,
+  id = getId('sheet'),
 }) => {
   const { floatingBoxChildrenRef, isVisible, mouseEvents } = useHideShow(
     true,
     closeDelay
   )
-  const sheetId = getId('sheet')
 
   const SheetTarget = () => {
     return React.cloneElement(button as React.ReactElement, {
       ...button.props,
       ...mouseEvents,
       'aria-expanded': isVisible,
-      'aria-owns': sheetId,
+      'aria-owns': id,
     })
   }
 
@@ -47,7 +48,7 @@ export const Sheet: React.FC<SheetProps> = ({
     >
       <div ref={floatingBoxChildrenRef}>
         {React.cloneElement(children, {
-          id: sheetId,
+          id,
           'aria-expanded': isVisible,
         })}
       </div>

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.test.tsx
@@ -157,6 +157,17 @@ describe('Sidebar', () => {
         wrapper.queryByTestId('notification-button').click()
       })
 
+      it('should maintain static sheet ID', () => {
+        expect(wrapper.getByTestId('notification-button')).toHaveAttribute(
+          'aria-owns',
+          'sidebar-notifications'
+        )
+        expect(wrapper.getByTestId('notifications-sheet')).toHaveAttribute(
+          'id',
+          'sidebar-notifications'
+        )
+      })
+
       it('should spread arbitrary props on the notifications', () => {
         expect(wrapper.getByTestId('notifications-sheet')).toHaveAttribute(
           'data-arbitrary',

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.tsx
@@ -64,6 +64,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
       <div className="rn-sidebar__bottom">
         {notifications && (
           <Sheet
+            id="sidebar-notifications"
             button={
               <SheetButton
                 aria-label="Show notifications"


### PR DESCRIPTION
## Related issue

Closes #2656

## Overview

The `Sidebar` notifications sheet now maintains a static ID.

## Reason

>The dynamic UUID generation within the `Sheet` would cause Snapshots or Chromatic Storyshots to invalidate.

## Work carried out

- [x] Add automated test
- [x] Maintain a static `Sheet` ID for the `Sidebar` notifications panel 

## Developer notes

- This `Sidebar` component is marked as deprecated and we recommend instead using `SidebarE`. The `Sidebar` implementation is due to be removed in the next major `3.x.x` release.

- We usually avoid Jest snapshot testing (https://medium.com/@tomgold_48918/why-i-stopped-using-snapshot-testing-with-jest-3279fe41ffb2). We used to write snapshot tests and have since removed them from the design system.
