### PR TITLE
chore(Husky): Upgrade Husky config and fix lint-staged/commitlint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ dist
 .DS_Store
 .vscode/
 .idea
-.husky
 
 lerna-debug.log*
 npm-debug.log*

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn run lint-staged

--- a/package.json
+++ b/package.json
@@ -65,12 +65,7 @@
     "lerna:prerelease": "yarn lerna:run-version --conventional-prerelease=* --no-changelog -m \"chore(Prerelease): %v [skip ci]\"",
     "lerna:version": "yarn lerna:run-version --conventional-graduate --create-release github -m \"chore(Release): %v\"",
     "lerna:run-version": "lerna version --force-publish=* --tag-version-prefix=''",
-    "audit": "./scripts/audit/audit.sh"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lerna run --parallel lint-staged",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
+    "audit": "./scripts/audit/audit.sh",
+    "prepare": "husky install"
   }
 }


### PR DESCRIPTION
## Related issue

None

## Overview

Upgrade the Husky configuration to the v7 format and fix the lint-staged and commitlint hooks.
## Reason

How Husky works changed in version 5 and its scripts were moved from `package.json` to a `.husky` directory.

This meant Husky, lint-staged and commitlint weren't working as we had new versions of these installed but an old Husky configuration.

This upgrades the Husky configuration using https://github.com/typicode/husky-4-to-7 (plus some tweaks) and gets things working again.

## Work carried out

- [x] Upgrade Husky configuration
- [x] Manually test commitlint and lint-staged

## Screenshot

### commitlint

#### Before

![Screenshot from 2021-10-19 09-56-24](https://user-images.githubusercontent.com/66470099/137877431-7f868017-0ec2-43e0-a0bb-31c198fc729a.png)

#### After

![Screenshot from 2021-10-19 09-54-55](https://user-images.githubusercontent.com/66470099/137877082-5b8e0635-d5fe-47ac-81b9-5591183f1469.png)

### lint-staged 

#### Before

![Screenshot from 2021-10-19 09-56-59](https://user-images.githubusercontent.com/66470099/137877466-24e55f45-2459-4fbf-884f-9ec68768fe0b.png)

#### After

![Screenshot from 2021-10-19 09-51-18](https://user-images.githubusercontent.com/66470099/137876612-4d34f881-b98a-4069-be3f-47f1fdd737ff.png)

## Developer notes

Husky hooks now live in the `.husky` directory. Note that when `yarn install` is run in the root directory, a `.husky/_` directory is created. This doesn't get committed to Git as it is automatically .gitignored.

Please test this locally as we may be running in different environments. You'll need to run `yarn install` after switching to this branch.