### PR TITLE
Timeline Performance gains 

### DIFF
--- a/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { memo, useContext } from 'react'
 
 import { getKey } from '../../helpers'
 import { StyledDays } from './partials/StyledDays'
@@ -23,7 +23,7 @@ export type TimelineDaysProps =
   | TimelineDaysWithRenderContentProps
   | TimelineDaysWithChildrenProps
 
-export const TimelineDays: React.FC<TimelineDaysProps> = ({
+export const TimelineDays: React.FC<TimelineDaysProps> = memo(({
   render,
   ...rest
 }) => {
@@ -61,6 +61,6 @@ export const TimelineDays: React.FC<TimelineDaysProps> = ({
       {rowChildren}
     </TimelineHeaderRow>
   )
-}
+})
 
 TimelineDays.displayName = 'TimelineDays'

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, memo } from 'react'
 import { differenceInDays, endOfMonth, min as minDate, max } from 'date-fns'
 import { min as minNumber } from 'lodash'
 
@@ -47,7 +47,7 @@ function getSize(monthWidths: { daysTotal: number; monthWidth: number }[]) {
   return MONTH_SIZE.LARGE
 }
 
-export const TimelineMonths: React.FC<TimelineMonthsProps> = ({
+export const TimelineMonths = memo<TimelineMonthsProps>(({
   render,
   ...rest
 }) => {
@@ -97,6 +97,6 @@ export const TimelineMonths: React.FC<TimelineMonthsProps> = ({
       </StyledMonths>
     </TimelineHeaderRow>
   )
-}
+})
 
 TimelineMonths.displayName = 'TimelineMonths'

--- a/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { memo, useContext } from 'react'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { getKey } from '../../helpers'
@@ -33,7 +33,7 @@ export type TimelineWeeksProps =
   | TimelineWeeksWithRenderContentProps
   | TimelineWeeksWithChildrenProps
 
-export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({
+export const TimelineWeeks: React.FC<TimelineWeeksProps> = memo(({
   render,
   ...rest
 }) => {
@@ -75,6 +75,6 @@ export const TimelineWeeks: React.FC<TimelineWeeksProps> = ({
       {rowChildren}
     </TimelineHeaderRow>
   )
-}
+})
 
 TimelineWeeks.displayName = 'TimelineWeeks'

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -24,6 +24,7 @@ import {
   TimelineHours,
   TimelineMonths,
   TimelineRow,
+  TimelineRowProps,
   TimelineRows,
   TimelineSide,
   TimelineTodayMarker,
@@ -63,7 +64,7 @@ describe('Timeline', () => {
           className="test-class-name"
         >
           <TimelineMonths />
-          <TimelineRows>{}</TimelineRows>
+          <TimelineRows>{ }</TimelineRows>
         </Timeline>
       )
     })
@@ -82,7 +83,7 @@ describe('Timeline', () => {
           <TimelineWeeks />
           <TimelineDays />
           <TimelineHours />
-          <TimelineRows>{}</TimelineRows>
+          <TimelineRows>{ }</TimelineRows>
         </Timeline>
       )
 
@@ -373,7 +374,7 @@ describe('Timeline', () => {
             <TimelineMonths />
             <TimelineWeeks />
             <TimelineDays />
-            <TimelineRows>{}</TimelineRows>
+            <TimelineRows>{ }</TimelineRows>
           </Timeline>
         )
       })
@@ -508,7 +509,7 @@ describe('Timeline', () => {
           <TimelineMonths />
           <TimelineWeeks />
           <TimelineDays />
-          <TimelineRows>{}</TimelineRows>
+          <TimelineRows>{ }</TimelineRows>
         </Timeline>
       )
     })
@@ -803,7 +804,7 @@ describe('Timeline', () => {
               />
             )}
           />
-          <TimelineRows>{}</TimelineRows>
+          <TimelineRows>{ }</TimelineRows>
         </Timeline>
       )
     })
@@ -872,7 +873,7 @@ describe('Timeline', () => {
               />
             )}
           />
-          <TimelineRows>{}</TimelineRows>
+          <TimelineRows>{ }</TimelineRows>
         </Timeline>
       )
     })
@@ -922,7 +923,7 @@ describe('Timeline', () => {
               />
             )}
           />
-          <TimelineRows>{}</TimelineRows>
+          <TimelineRows>{ }</TimelineRows>
         </Timeline>
       )
     })
@@ -964,7 +965,7 @@ describe('Timeline', () => {
               />
             )}
           />
-          <TimelineRows>{}</TimelineRows>
+          <TimelineRows>{ }</TimelineRows>
         </Timeline>
       )
 
@@ -1267,7 +1268,7 @@ describe('Timeline', () => {
               <CustomTodayMarker today={today} offset={offset} />
             )}
           />
-          <TimelineRows>{}</TimelineRows>
+          <TimelineRows>{ }</TimelineRows>
         </Timeline>
       )
     })
@@ -2109,7 +2110,7 @@ describe('Timeline', () => {
           <TimelineMonths />
           <TimelineWeeks />
           <TimelineDays />
-          <TimelineRows>{}</TimelineRows>
+          <TimelineRows>{ }</TimelineRows>
         </Timeline>
       )
     })
@@ -2334,6 +2335,72 @@ describe('Timeline', () => {
       })
 
       expect(wrapper.queryAllByText('Event 1')).toHaveLength(0)
+    })
+  })
+
+
+  describe('when parent rerenders', () => {
+    let eventSpy: jest.Mock<JSX.Element>
+    beforeEach(() => {
+      eventSpy = jest.fn(() => <div>Event 1</div>)
+
+      const startDate = new Date(2020, 3, 1)
+      const today = new Date(2020, 3, 15)
+      const eventEndDate = new Date(2020, 3, 1)
+
+      let counter = 0
+
+      const TimelineWithUpdate: React.FC<{ children: React.ReactElement<TimelineRowProps> }> = ({ children }) => {
+
+        const [_, forceRerender] = useState({})
+        counter += 1
+
+        return (
+          <>
+            <Button onClick={() => forceRerender({})}>
+              Force update
+            </Button>
+            <div>Render: {counter}</div>
+            <Timeline startDate={startDate} today={today}>
+              <TimelineTodayMarker />
+              <TimelineMonths />
+              <TimelineWeeks />
+              <TimelineDays />
+              <TimelineRows>
+                {children}
+              </TimelineRows>
+            </Timeline>
+          </>
+        )
+      }
+
+      const TimelineRowsItem = () => (
+        <TimelineRow name="Row 1">
+          <TimelineEvents>
+            <TimelineEvent
+              startDate={startDate}
+              endDate={eventEndDate}
+              render={eventSpy}
+            />
+          </TimelineEvents>
+        </TimelineRow>
+      )
+
+      wrapper = render(
+        <TimelineWithUpdate>
+          <TimelineRowsItem />
+        </TimelineWithUpdate>
+      )
+    })
+
+    it('should not rerender children if props have not changed', async () => {
+      expect(eventSpy).toBeCalledTimes(1)
+      eventSpy.mockClear()
+
+      wrapper.getByText('Force update').click()
+      expect(await wrapper.findByText('Render: 2')).toBeInTheDocument()
+      expect(eventSpy).not.toBeCalled()
+
     })
   })
 })

--- a/packages/react-component-library/src/components/Timeline/context/index.tsx
+++ b/packages/react-component-library/src/components/Timeline/context/index.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useReducer } from 'react'
+import React, { createContext, useEffect, useReducer, useMemo } from 'react'
 
 import { initialState } from './state'
 import { reducer } from './reducer'
@@ -46,8 +46,12 @@ export const TimelineProvider: React.FC<TimelineProviderProps> = ({
     dispatch({ scaleOptions, type: TIMELINE_ACTIONS.CHANGE_START_DATE })
   }, [options.startDate])
 
+  const value = useMemo(() => ({ hasSide, state, dispatch }), [
+    hasSide, state, dispatch
+  ])
+
   return (
-    <TimelineContext.Provider value={{ hasSide, state, dispatch }}>
+    <TimelineContext.Provider value={value}>
       {children}
     </TimelineContext.Provider>
   )


### PR DESCRIPTION
## Overview

In applications where there is a lot of manipulation to the timeline with many events the performance degrades. 

I first notice that the timeline rerenders the whole tree if the parent component rerenders. 
See the profiling screenshot. 

<img width="1596" alt="Screenshot 2021-10-19 at 21 20 27" src="https://user-images.githubusercontent.com/75253719/137990064-58bf3e2d-6524-47b9-8da2-54311ad373c7.png">
This takes on average 200ms to rerender on a 2.2ghz  6 core i7  MacBook Pro  which is decent but does take significantly longer on our low powered devices (seconds) 

You man also notice that we applied some memoization components to our app which also did not help. 
The reason why is because the context is always a new object on every rerender. So any component that use the `TimelineContext` will rerender because the context state had change. 

With the changes made in this PR and the same optimisations applied in the previous test the render time dropped to <9 ms 
![image](https://user-images.githubusercontent.com/75253719/137991504-411a3941-5440-4f40-9193-7a489d7d0ce2.png)




## Reason

[Why did you do what you did? - feel free to copy from the ticket if the reason is there]

## Work carried out

[A list of work you have done, use markdown checklist format, if you leave any boxes unchecked, be sure to set this PR as a WIP]

**Example.**

- [x] A bit of work I completed
- [ ] A bit of work I did not complete

## Screenshot

[If the work is UI related then paste a screenshot of the update here.]

## Developer notes

[Sometimes, extra notes are needed to add clarity to a PR, add them here]
