### PR TITLE
fix(Modal): Update `overflow-y` to be `auto`

### DIFF
--- a/packages/react-component-library/src/components/Modal/Modal.test.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.test.tsx
@@ -86,7 +86,7 @@ describe('Modal', () => {
         )
         expect(wrapper.getByTestId('modal-main')).toHaveStyleRule(
           'overflow-y',
-          'scroll'
+          'auto'
         )
       })
 

--- a/packages/react-component-library/src/components/Modal/partials/StyledMain.tsx
+++ b/packages/react-component-library/src/components/Modal/partials/StyledMain.tsx
@@ -14,7 +14,7 @@ export const StyledMain = styled.article`
   bottom: 0;
   border-radius: 8px 8px 0 0;
   max-height: 95vh;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   ${mq({ gte: 'xs' })`
     border-radius: 5px;


### PR DESCRIPTION
## Related issue
Fixes #2598 

## Overview
On some browsers the scrollbars were showing even when content does not overflow.

## Reason
> Dialogue boxes have a strange border on them

## Work carried out
- [x] Apply fix

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/56078793/138120807-ace7654d-67c8-45de-a5a4-bbbb90ba84cd.png)

### After
![image](https://user-images.githubusercontent.com/56078793/138120839-15f2fbef-28bd-4cf2-92a9-7bb9f5c78c04.png)