### PR TITLE
chore(Storybook): Fix undefined text in page when running locally

### DIFF
--- a/packages/react-component-library/.storybook/main.js
+++ b/packages/react-component-library/.storybook/main.js
@@ -15,7 +15,7 @@ module.exports = {
   ],
   previewHead: (head) => `
     ${head}
-    ${process.env.NETLIFY && newRelic.script}
+    ${process.env.NETLIFY ? newRelic.script : ''}
   `,
   stories: ['../src/**/*.stories.tsx'],
 }


### PR DESCRIPTION
## Related issue

Fixes #2741

## Overview

This fixes a bug when running Storybook when the NETLIFY environment variable is unset that caused the text 'undefined' to appear in the page.

## Reason

It was annoying.

## Work carried out

- [x] Get rid of the undefined text

## Screenshot

### Before

![image](https://user-images.githubusercontent.com/66470099/138723407-4f644f5e-2268-47e0-a3b7-10916b4ceaba.png)

### After

![image](https://user-images.githubusercontent.com/66470099/138724945-64d671f3-f678-4e56-88bd-be00eb8ee578.png)


## Developer notes

This regressed in c68489c12e499d38a3f1765dec2d94d577834470.

It was happening because `process.env.NETLIFY` was being injected into the page HEAD, and `process.env.NETLIFY` was undefined in this case.