### PR TITLE
Enable rule of hook linting rules

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -6,6 +6,7 @@ module.exports = {
   },
   extends: [
     'airbnb',
+    'airbnb/hooks',
     'plugin:@typescript-eslint/recommended',
     'prettier',
     'plugin:jest/recommended',
@@ -19,16 +20,6 @@ module.exports = {
     'arrow-body-style': 0,
     camelCase: 0,
     curly: ['error', 'all'],
-    'import/extensions': [
-      'error',
-      'ignorePackages',
-      {
-        js: 'never',
-        jsx: 'never',
-        ts: 'never',
-        tsx: 'never',
-      },
-    ],
     'import/no-extraneous-dependencies': 0,
     'import/no-unresolved': 0,
     'import/prefer-default-export': 0,

--- a/packages/react-component-library/src/components/DatePicker/useDatePickerOpenClose.ts
+++ b/packages/react-component-library/src/components/DatePicker/useDatePickerOpenClose.ts
@@ -1,10 +1,8 @@
-import React, { useRef } from 'react'
+import React, { useCallback, useRef } from 'react'
 
 import { useDocumentClick, useOpenClose } from '../../hooks'
 
-export function useDatePickerOpenClose(
-  isOpen = false
-): {
+export function useDatePickerOpenClose(isOpen = false): {
   floatingBoxChildrenRef: React.RefObject<HTMLDivElement>
   handleOnClose: () => void
   inputButtonRef: React.RefObject<HTMLButtonElement>
@@ -17,14 +15,13 @@ export function useDatePickerOpenClose(
   const inputButtonRef = useRef()
   const inputRef = useRef()
 
-  function handleDatePickerOnClose() {
+  const handleDatePickerOnClose = useCallback(() => {
     handleOnClose(null)
-  }
+  }, [handleOnClose])
 
   useDocumentClick(
     [floatingBoxChildrenRef, inputButtonRef, inputRef],
-    handleDatePickerOnClose,
-    [open]
+    handleDatePickerOnClose
   )
 
   return {

--- a/packages/react-component-library/src/components/DatePicker/useInputKeys.ts
+++ b/packages/react-component-library/src/components/DatePicker/useInputKeys.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { addHours, isMatch, parse } from 'date-fns'
 import { DayPickerProps, ModifiersUtils } from 'react-day-picker'
 import { isNil } from 'lodash'
@@ -22,10 +22,7 @@ export function useInputKeys(
   revertKeyedValue: () => void
 } {
   const [keyedValue, setKeyedValue] = useState<string>()
-
-  function revertKeyedValue() {
-    setKeyedValue(null)
-  }
+  const revertKeyedValue = useCallback(() => setKeyedValue(null), [])
 
   function onChange(e: React.ChangeEvent<HTMLInputElement>) {
     setKeyedValue(e.target.value)

--- a/packages/react-component-library/src/components/DatePicker/useInputValue.ts
+++ b/packages/react-component-library/src/components/DatePicker/useInputValue.ts
@@ -44,7 +44,7 @@ export function useInputValue(
     if (!hasFocus) {
       setInputKey(getId('date-picker-input'))
     }
-  }, [from, to])
+  }, [from, to, datePickerFormat, hasFocus, revertKeyedValue])
 
   return {
     displayValue,

--- a/packages/react-component-library/src/components/NumberInput/useInputText.ts
+++ b/packages/react-component-library/src/components/NumberInput/useInputText.ts
@@ -58,6 +58,7 @@ export function useInputText(value: number, unitPosition: UnitPosition) {
 
     if (unitPosition === UNIT_POSITION.AFTER) {
       const offset = textWidth + paddingLeft + EXTRA_SPACING
+      setInputOffset(0)
       setUnitOffset(offset)
       setCanShow(true)
     } else {
@@ -65,7 +66,7 @@ export function useInputText(value: number, unitPosition: UnitPosition) {
       setUnitOffset(paddingLeft)
       setCanShow(true)
     }
-  }, [value])
+  }, [value, unitPosition])
 
   return { canShow, inputRef, inputOffset, unitOffset }
 }

--- a/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
@@ -61,7 +61,7 @@ export const TimelineRow: React.FC<TimelineRowProps> = ({
   ...rest
 }) => {
   const classes = classNames('timeline__row', className)
-  const { noCells, rowContentRef } = useTimelineRowContent(isHeader, [children])
+  const { noCells, rowContentRef } = useTimelineRowContent(isHeader, children)
   const { css: contentCss, ...restContentProps } = contentProps
   const { css: headerCss, ...restHeaderProps } = headerProps
 

--- a/packages/react-component-library/src/components/Timeline/context/index.tsx
+++ b/packages/react-component-library/src/components/Timeline/context/index.tsx
@@ -7,7 +7,7 @@ import {
   TimelineContextDefault,
   TimelineProviderProps,
 } from './types'
-import { initialiseScaleOptions } from './timeline_scales'
+import { buildScaleOptions } from './timeline_scales'
 
 const timelineContextDefaults: TimelineContextDefault = {
   hasSide: false,
@@ -34,7 +34,7 @@ export const TimelineProvider: React.FC<TimelineProviderProps> = ({
       return
     }
 
-    const scaleOptions = initialiseScaleOptions(
+    const scaleOptions = buildScaleOptions(
       {
         ...options,
         endDate: state.getNewEndDate(),
@@ -46,9 +46,10 @@ export const TimelineProvider: React.FC<TimelineProviderProps> = ({
     dispatch({ scaleOptions, type: TIMELINE_ACTIONS.CHANGE_START_DATE })
   }, [options.startDate])
 
-  const value = useMemo(() => ({ hasSide, state, dispatch }), [
-    hasSide, state, dispatch
-  ])
+  const value = useMemo(
+    () => ({ hasSide, state, dispatch }),
+    [hasSide, state, dispatch]
+  )
 
   return (
     <TimelineContext.Provider value={value}>

--- a/packages/react-component-library/src/components/Timeline/context/index.tsx
+++ b/packages/react-component-library/src/components/Timeline/context/index.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useEffect, useReducer, useMemo } from 'react'
 
+import { usePrevious } from '../../../hooks'
 import { initialState } from './state'
 import { reducer } from './reducer'
 import {
@@ -29,8 +30,14 @@ export const TimelineProvider: React.FC<TimelineProviderProps> = ({
     today,
   })
 
+  const prevStartDate = usePrevious(options.startDate)
+
   useEffect(() => {
     if (!state.currentScaleOption) {
+      return
+    }
+
+    if (prevStartDate === undefined || prevStartDate === options.startDate) {
       return
     }
 
@@ -44,7 +51,7 @@ export const TimelineProvider: React.FC<TimelineProviderProps> = ({
     )
 
     dispatch({ scaleOptions, type: TIMELINE_ACTIONS.CHANGE_START_DATE })
-  }, [options.startDate])
+  }, [options, prevStartDate, state])
 
   const value = useMemo(
     () => ({ hasSide, state, dispatch }),

--- a/packages/react-component-library/src/components/Timeline/context/reducer.ts
+++ b/packages/react-component-library/src/components/Timeline/context/reducer.ts
@@ -18,7 +18,7 @@ import {
 } from './types'
 
 import { WEEK_START } from '../constants'
-import { initialiseScaleOptions } from './timeline_scales'
+import { buildScaleOptions } from './timeline_scales'
 
 const HOURS_IN_DAY = 24
 
@@ -103,9 +103,8 @@ export function reducer(
 ): TimelineState | never {
   switch (action.type) {
     case TIMELINE_ACTIONS.CHANGE_WIDTH:
-    case TIMELINE_ACTIONS.INITIALISE:
-      /* eslint-disable no-case-declarations */
-      const scaleOptions = initialiseScaleOptions(state.options, action.width)
+    case TIMELINE_ACTIONS.INITIALISE: {
+      const scaleOptions = buildScaleOptions(state.options, action.width)
       const currentScaleIndex =
         state.currentScaleIndex ||
         scaleOptions.findIndex(({ isDefault }) => isDefault)
@@ -117,6 +116,7 @@ export function reducer(
         currentScaleOption: scaleOptions[currentScaleIndex],
         width: action.width,
       }
+    }
     case TIMELINE_ACTIONS.CHANGE_START_DATE:
     case TIMELINE_ACTIONS.GET_PREV:
     case TIMELINE_ACTIONS.GET_NEXT:

--- a/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
+++ b/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
@@ -125,7 +125,7 @@ function getMaxWidth(
   return unitWidthTotal
 }
 
-function initialiseScaleOptions(
+function buildScaleOptions(
   { endDate, hoursBlockSize, range, startDate, unitWidth }: TimelineOptions,
   timelineWidth?: number
 ): TimelineScaleOption[] {
@@ -148,4 +148,4 @@ function initialiseScaleOptions(
   })
 }
 
-export { initialiseScaleOptions }
+export { buildScaleOptions }

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineFrame.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineFrame.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 
-import { initialiseScaleOptions } from '../context/timeline_scales'
+import { buildScaleOptions } from '../context/timeline_scales'
 import { TimelineContext } from '../context'
 import { TIMELINE_ACTIONS } from '../context/types'
 
@@ -20,7 +20,7 @@ export function useTimelineFrame(): {
       currentScaleOption.intervalSize * intervalMultiplier
     )
 
-    const newScaleOptions = initialiseScaleOptions(
+    const newScaleOptions = buildScaleOptions(
       {
         ...options,
         startDate: newStartDate,

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineRowContent.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineRowContent.ts
@@ -1,8 +1,12 @@
-import { useEffect, useRef, useState, MutableRefObject } from 'react'
+import React, { useEffect, useRef, useState, MutableRefObject } from 'react'
+
+import { TimelineEventsProps } from '../TimelineEvents'
 
 export function useTimelineRowContent(
   isHeader: boolean,
-  deps?: ReadonlyArray<any>
+  children:
+    | React.ReactElement<TimelineEventsProps>
+    | React.ReactElement<TimelineEventsProps>[]
 ): {
   noCells: boolean
   rowContentRef: MutableRefObject<HTMLDivElement>
@@ -10,14 +14,17 @@ export function useTimelineRowContent(
   const rowContentRef = useRef(null)
   const [noCells, setNoCells] = useState<boolean>(false)
 
-  if (!isHeader) {
-    useEffect(() => {
-      const cells = rowContentRef.current.querySelectorAll('[role="cell"]')
-      if (!cells.length) {
-        setNoCells(true)
-      }
-    }, deps)
-  }
+  useEffect(() => {
+    if (isHeader) {
+      setNoCells(false)
+      return
+    }
+
+    const cells = rowContentRef.current.querySelectorAll('[role="cell"]')
+    if (!cells.length) {
+      setNoCells(true)
+    }
+  }, [isHeader, children])
 
   return {
     noCells,

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineZoom.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineZoom.ts
@@ -1,7 +1,6 @@
-import { useContext, useEffect, useState } from 'react'
+import { useContext } from 'react'
 import { isNil } from 'lodash'
 
-import { buildScaleOptions } from '../context/timeline_scales'
 import { TIMELINE_ACTIONS } from '../context/types'
 import { TimelineContext } from '../context'
 
@@ -13,20 +12,10 @@ export function useTimelineZoom(): {
 } {
   const {
     dispatch,
-    state: { currentScaleIndex, options, scaleOptions, width },
+    state: { currentScaleIndex, scaleOptions },
   } = useContext(TimelineContext)
-  const [timelineScaleOptions, setTimelineScaleOptions] = useState(scaleOptions)
   const canZoomIn = isNil(currentScaleIndex) || currentScaleIndex > 0
-  const canZoomOut = currentScaleIndex < timelineScaleOptions.length - 1
-
-  useEffect(() => {
-    const newScaleOptions = buildScaleOptions(options, width)
-    setTimelineScaleOptions(newScaleOptions)
-  }, [width])
-
-  useEffect(() => {
-    setTimelineScaleOptions(scaleOptions)
-  }, [scaleOptions])
+  const canZoomOut = currentScaleIndex < scaleOptions.length - 1
 
   function zoomIn() {
     dispatch({

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineZoom.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineZoom.ts
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from 'react'
 import { isNil } from 'lodash'
 
-import { initialiseScaleOptions } from '../context/timeline_scales'
+import { buildScaleOptions } from '../context/timeline_scales'
 import { TIMELINE_ACTIONS } from '../context/types'
 import { TimelineContext } from '../context'
 
@@ -20,7 +20,7 @@ export function useTimelineZoom(): {
   const canZoomOut = currentScaleIndex < timelineScaleOptions.length - 1
 
   useEffect(() => {
-    const newScaleOptions = initialiseScaleOptions(options, width)
+    const newScaleOptions = buildScaleOptions(options, width)
     setTimelineScaleOptions(newScaleOptions)
   }, [width])
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 
 import { TextInput } from '../../TextInput'
 import { RightArrow } from '../../../icons'
@@ -26,11 +26,16 @@ export const SearchBar: React.FC<SearchbarProps> = ({
   const searchBoxRef = useRef()
   const [term, setTerm] = useState('')
 
-  useDocumentClick(searchBoxRef, (event: Event) => {
-    if (!searchButton.current.contains(event.target)) {
-      setShowSearch(false)
-    }
-  })
+  const onDocumentClick = useCallback(
+    (event: Event) => {
+      if (!searchButton.current.contains(event.target)) {
+        setShowSearch(false)
+      }
+    },
+    [searchButton, setShowSearch]
+  )
+
+  useDocumentClick(searchBoxRef, onDocumentClick)
 
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()

--- a/packages/react-component-library/src/hooks/index.ts
+++ b/packages/react-component-library/src/hooks/index.ts
@@ -1,9 +1,6 @@
 import { useDocumentClick } from './useDocumentClick'
 import { useOpenClose } from './useOpenClose'
 import { useFloatingElement } from './useFloatingElement'
+import { usePrevious } from './usePrevious'
 
-export {
-  useDocumentClick,
-  useOpenClose,
-  useFloatingElement
-}
+export { useDocumentClick, useOpenClose, useFloatingElement, usePrevious }

--- a/packages/react-component-library/src/hooks/useDocumentClick.ts
+++ b/packages/react-component-library/src/hooks/useDocumentClick.ts
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { find } from 'lodash'
 
 // workaround for undefined error in typescript, node.current might not be defined
@@ -12,38 +12,47 @@ const NODE_CURRENT = {
  * not be raised
  *
  * @param onDocumentClick - if the click is outside of nodes then the callback
- * will be raised
+ * will be raised. Use useCallback for this to avoid the event listener being
+ * reattached unnecessarily
  *
- * @param deps - monitored for change when assigning the document click
+ * @param isEnabled - whether the on click handler is enabled. Can be set
+ * to false if the hook needs to be enabled or disabled dynamically
  */
 export function useDocumentClick(
   nodes:
     | React.MutableRefObject<undefined>
     | React.MutableRefObject<undefined>[],
   onDocumentClick: (event: Event) => void,
-  deps?: ReadonlyArray<any>
+  isEnabled = true
 ) {
-  function handleDocumentClick(event: Event) {
-    const nonClickableRefs = Array.isArray(nodes) ? nodes : [nodes]
+  const handleDocumentClick = useCallback(
+    (event: Event) => {
+      const nonClickableRefs = Array.isArray(nodes) ? nodes : [nodes]
 
-    const nonClickableRef = find(
-      nonClickableRefs,
-      (node: React.MutableRefObject<undefined>) => {
-        const current = node.current || NODE_CURRENT
-        return current.contains(event.target)
+      const nonClickableRef = find(
+        nonClickableRefs,
+        (node: React.MutableRefObject<undefined>) => {
+          const current = node.current || NODE_CURRENT
+          return current.contains(event.target)
+        }
+      )
+
+      if (!nonClickableRef) {
+        onDocumentClick(event)
       }
-    )
-
-    if (!nonClickableRef) {
-      onDocumentClick(event)
-    }
-  }
+    },
+    [nodes, onDocumentClick]
+  )
 
   useEffect(() => {
+    if (!isEnabled) {
+      return null
+    }
+
     document.addEventListener('mousedown', handleDocumentClick)
 
     return () => {
       document.removeEventListener('mousedown', handleDocumentClick)
     }
-  }, deps)
+  }, [handleDocumentClick, isEnabled])
 }

--- a/packages/react-component-library/src/hooks/useHideShow.ts
+++ b/packages/react-component-library/src/hooks/useHideShow.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import { useDocumentClick } from '.'
 
@@ -7,14 +7,14 @@ export function useHideShow(isClick: boolean, closeDelay: number) {
   const timerRef = useRef(null)
   const floatingBoxChildrenRef = useRef()
 
-  function hideElement() {
+  const hideElement = useCallback(() => {
     if (isVisible) {
       timerRef.current = setTimeout(() => {
         timerRef.current = null
         setIsVisible(false)
       }, closeDelay)
     }
-  }
+  }, [closeDelay, isVisible])
 
   function showElement() {
     if (timerRef.current !== null) {
@@ -24,9 +24,7 @@ export function useHideShow(isClick: boolean, closeDelay: number) {
     setIsVisible(true)
   }
 
-  if (isClick) {
-    useDocumentClick(floatingBoxChildrenRef, hideElement, [isVisible])
-  }
+  useDocumentClick(floatingBoxChildrenRef, hideElement, isClick)
 
   function getMouseEvents() {
     if (isClick) {

--- a/packages/react-component-library/src/hooks/useOpenClose.ts
+++ b/packages/react-component-library/src/hooks/useOpenClose.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 export function useOpenClose<TEvent>(
   isOpen: boolean,
@@ -10,13 +10,16 @@ export function useOpenClose<TEvent>(
     setOpen(isOpen)
   }, [isOpen])
 
-  function handleOnClose(event: TEvent) {
-    setOpen(false)
+  const handleOnClose = useCallback(
+    (event: TEvent) => {
+      setOpen(false)
 
-    if (onClose) {
-      onClose(event)
-    }
-  }
+      if (onClose) {
+        onClose(event)
+      }
+    },
+    [onClose]
+  )
 
   function toggle(event: TEvent) {
     const newOpen = !open

--- a/packages/react-component-library/src/hooks/usePrevious.ts
+++ b/packages/react-component-library/src/hooks/usePrevious.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from 'react'
+
+export function usePrevious<Value>(value: Value) {
+  const ref = useRef<Value | undefined>()
+  useEffect(() => {
+    ref.current = value
+  })
+  return ref.current
+}


### PR DESCRIPTION
## Related issue

#2454

## Overview

This enables the `react-hooks/rules-of-hooks` and `react-hooks/exhaustive-deps` ESLint rules and fixes the resulting errors across the code base.

## Link to preview

https://rules-of-hooks.netlify.app/

## Reason

These are standard React linting rules that should be running to prevent bugs.

## Work carried out

- [x] Fix rule of hook linting errors in DatePicker
- [x] Ditto, for NumberInput
- [x] Ditto, for useDocumentClick and related components
- [x] Ditto, for the Timeline
- [x] Add 'airbnb/hooks' to the ESLint configuration

## Developer notes

A full list of fixed errors can be found here:

https://gist.github.com/jpveooys/fb7251f6495d5dd1851f13d01bfc980a

All tests are passing, but I'd suggest doing some manual testing to double-check there haven't been any regressions.

These components have had changes:

- Date picker
- Number input
- Timeline

Additionally, the useDocumentClick changes affect the following components:

- Date picker
- Popover (in click mode)
- Masthead search
- Masthead user menu
- Sidebar (deprecated) notifications
- Sidebar (experimental) sub-navigation, notifications, user menu

I'd recommend looking at the commits individually.

You may find it easier to review with changes to white space hidden:

![image](https://user-images.githubusercontent.com/66470099/139459455-c86d930f-f24f-4dc0-ae8b-35ca51376cd1.png)

A new [`usePrevious`](https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state) hook has been added. This can be used to get the previous value of any variable (typically a prop).

Various uses of [`useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback) have been added as well. This stops inline functions from being redefined with each render, which can cause performance problems (would cause effects to run more frequently than needed in this case, can cause unnecessary re-renders in others).

## Related issues to raise

A couple of existing bugs were found while testing this:

- https://github.com/defencedigital/mod-uk-design-system/issues/2766
- https://github.com/defencedigital/mod-uk-design-system/issues/2765