### PR TITLE
fix(Timeline): Use date control for stories

### DIFF
--- a/packages/react-component-library/jest.config.js
+++ b/packages/react-component-library/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/jest/__mocks__/fileMock.js',
   },
+  restoreMocks: true,
   testEnvironment: 'jsdom',
   testMatch: ['**/?(*.)(test).ts?(x)'],
   setupFilesAfterEnv: ['<rootDir>/jest/setupTests.js'],

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -58,9 +58,6 @@ describe('DatePicker', () => {
 
     days = new Array(31).map((i) => leadingZero(i + 1)) // [01, 02, ..., 31]
   })
-  afterAll(() => {
-    dateSpy.mockRestore()
-  })
 
   describe('default props', () => {
     beforeEach(() => {

--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -15,12 +15,15 @@ const HOVER_ON_ME = 'Hover on me!'
 const CONTENT_TEXT = 'This is some arbitrary JSX'
 
 jest.useFakeTimers()
-jest.spyOn(global, 'setTimeout')
 
 describe('Popover', () => {
   const content: React.ReactElement = <pre>{CONTENT_TEXT}</pre>
   let clickSpy: (e: React.MouseEvent) => void
   let wrapper: RenderResult
+
+  beforeEach(() => {
+    jest.spyOn(global, 'setTimeout')
+  })
 
   describe('when provided with arbitrary JSX content', () => {
     beforeEach(() => {

--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -49,6 +49,23 @@ export default {
     },
     layout: 'fullscreen',
   },
+  argTypes: {
+    endDate: {
+      control: {
+        type: 'date',
+      },
+    },
+    startDate: {
+      control: {
+        type: 'date',
+      },
+    },
+    today: {
+      control: {
+        type: 'date',
+      },
+    },
+  },
 } as Meta
 
 const disableScrollableRegionFocusableRule = {
@@ -64,8 +81,8 @@ const disableScrollableRegionFocusableRule = {
   },
 }
 
-export const Default: Story<TimelineProps> = (props) => (
-  <Timeline {...props}>
+const Template: Story<TimelineProps> = (args) => (
+  <Timeline {...args}>
     <TimelineTodayMarker />
     <TimelineMonths />
     <TimelineWeeks />
@@ -74,32 +91,21 @@ export const Default: Story<TimelineProps> = (props) => (
   </Timeline>
 )
 
+export const Default = Template.bind({})
 Default.args = {
-  startDate: new Date(2020, 0, 1),
-  today: new Date(2020, 0, 15),
+  startDate: new Date(2022, 0, 1),
+  today: new Date(2022, 0, 15),
 }
-
 Default.parameters = disableScrollableRegionFocusableRule
-
 Default.storyName = 'No data'
 
-export const BoundByFixedDates: Story<TimelineProps> = (props) => (
-  <Timeline
-    {...props}
-    startDate={new Date(2020, 0, 13)}
-    endDate={new Date(2020, 1, 15)}
-    today={new Date(2020, 0, 15)}
-  >
-    <TimelineTodayMarker />
-    <TimelineMonths />
-    <TimelineWeeks />
-    <TimelineDays />
-    <TimelineRows>{}</TimelineRows>
-  </Timeline>
-)
-
+export const BoundByFixedDates = Template.bind({})
+BoundByFixedDates.args = {
+  endDate: new Date(2021, 1, 15),
+  startDate: new Date(2021, 0, 13),
+  today: new Date(2021, 0, 15),
+}
 BoundByFixedDates.parameters = disableScrollableRegionFocusableRule
-
 BoundByFixedDates.storyName = 'Bound by fixed dates'
 
 export const WithData: Story<TimelineProps> = (props) => (
@@ -138,7 +144,6 @@ export const WithData: Story<TimelineProps> = (props) => (
 )
 
 WithData.parameters = disableScrollableRegionFocusableRule
-
 WithData.storyName = 'With data'
 
 export const WithSidebar: Story<TimelineProps> = (props) => (

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -90,7 +90,7 @@ export const Timeline: React.FC<TimelineProps> = ({
   children,
   className,
   dayWidth,
-  hasSide,
+  hasSide = false,
   hideScaling = false,
   hideToolbar = false,
   isFullWidth = false,

--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { isAfter } from 'date-fns'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TimelineProvider } from './context'
@@ -86,6 +87,15 @@ function getHoursBlockSize(
   )
 }
 
+function getEndDate(startDate: Date, endDate: Date) {
+  if (startDate && endDate && isAfter(startDate, endDate)) {
+    logger.error('`startDate` is after `endDate`')
+    return null
+  }
+
+  return endDate
+}
+
 export const Timeline: React.FC<TimelineProps> = ({
   children,
   className,
@@ -102,9 +112,9 @@ export const Timeline: React.FC<TimelineProps> = ({
   ...rest
 }) => {
   const options: TimelineOptions = {
-    endDate,
     range,
     startDate,
+    endDate: getEndDate(startDate, endDate),
     hoursBlockSize: getHoursBlockSize(children),
     unitWidth: dayWidth || unitWidth || DEFAULTS.UNIT_WIDTH,
   }

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -64,7 +64,7 @@ describe('Timeline', () => {
           className="test-class-name"
         >
           <TimelineMonths />
-          <TimelineRows>{ }</TimelineRows>
+          <TimelineRows>{}</TimelineRows>
         </Timeline>
       )
     })
@@ -83,7 +83,7 @@ describe('Timeline', () => {
           <TimelineWeeks />
           <TimelineDays />
           <TimelineHours />
-          <TimelineRows>{ }</TimelineRows>
+          <TimelineRows>{}</TimelineRows>
         </Timeline>
       )
 
@@ -374,7 +374,7 @@ describe('Timeline', () => {
             <TimelineMonths />
             <TimelineWeeks />
             <TimelineDays />
-            <TimelineRows>{ }</TimelineRows>
+            <TimelineRows>{}</TimelineRows>
           </Timeline>
         )
       })
@@ -509,7 +509,7 @@ describe('Timeline', () => {
           <TimelineMonths />
           <TimelineWeeks />
           <TimelineDays />
-          <TimelineRows>{ }</TimelineRows>
+          <TimelineRows>{}</TimelineRows>
         </Timeline>
       )
     })
@@ -804,7 +804,7 @@ describe('Timeline', () => {
               />
             )}
           />
-          <TimelineRows>{ }</TimelineRows>
+          <TimelineRows>{}</TimelineRows>
         </Timeline>
       )
     })
@@ -873,7 +873,7 @@ describe('Timeline', () => {
               />
             )}
           />
-          <TimelineRows>{ }</TimelineRows>
+          <TimelineRows>{}</TimelineRows>
         </Timeline>
       )
     })
@@ -923,7 +923,7 @@ describe('Timeline', () => {
               />
             )}
           />
-          <TimelineRows>{ }</TimelineRows>
+          <TimelineRows>{}</TimelineRows>
         </Timeline>
       )
     })
@@ -965,7 +965,7 @@ describe('Timeline', () => {
               />
             )}
           />
-          <TimelineRows>{ }</TimelineRows>
+          <TimelineRows>{}</TimelineRows>
         </Timeline>
       )
 
@@ -1268,7 +1268,7 @@ describe('Timeline', () => {
               <CustomTodayMarker today={today} offset={offset} />
             )}
           />
-          <TimelineRows>{ }</TimelineRows>
+          <TimelineRows>{}</TimelineRows>
         </Timeline>
       )
     })
@@ -2151,7 +2151,7 @@ describe('Timeline', () => {
           <TimelineMonths />
           <TimelineWeeks />
           <TimelineDays />
-          <TimelineRows>{ }</TimelineRows>
+          <TimelineRows>{}</TimelineRows>
         </Timeline>
       )
     })
@@ -2379,7 +2379,6 @@ describe('Timeline', () => {
     })
   })
 
-
   describe('when parent rerenders', () => {
     let eventSpy: jest.Mock<JSX.Element>
     beforeEach(() => {
@@ -2391,25 +2390,22 @@ describe('Timeline', () => {
 
       let counter = 0
 
-      const TimelineWithUpdate: React.FC<{ children: React.ReactElement<TimelineRowProps> }> = ({ children }) => {
-
+      const TimelineWithUpdate: React.FC<{
+        children: React.ReactElement<TimelineRowProps>
+      }> = ({ children }) => {
         const [_, forceRerender] = useState({})
         counter += 1
 
         return (
           <>
-            <Button onClick={() => forceRerender({})}>
-              Force update
-            </Button>
+            <Button onClick={() => forceRerender({})}>Force update</Button>
             <div>Render: {counter}</div>
             <Timeline startDate={startDate} today={today}>
               <TimelineTodayMarker />
               <TimelineMonths />
               <TimelineWeeks />
               <TimelineDays />
-              <TimelineRows>
-                {children}
-              </TimelineRows>
+              <TimelineRows>{children}</TimelineRows>
             </Timeline>
           </>
         )
@@ -2441,7 +2437,6 @@ describe('Timeline', () => {
       wrapper.getByText('Force update').click()
       expect(await wrapper.findByText('Render: 2')).toBeInTheDocument()
       expect(eventSpy).not.toBeCalled()
-
     })
   })
 })

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -2094,6 +2094,47 @@ describe('Timeline', () => {
     })
   })
 
+  describe('when `endDate` is before `startDate`', () => {
+    let consoleErrorSpy: jest.SpyInstance
+
+    beforeAll(() => {
+      timezoneMock.register('Europe/London')
+    })
+
+    beforeEach(() => {
+      consoleErrorSpy = jest.spyOn(global.console, 'error')
+
+      wrapper = render(
+        <Timeline
+          startDate={new Date(2020, 9, 5)}
+          endDate={new Date(2020, 1, 1)}
+        >
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineWeeks />
+          <TimelineDays />
+          <TimelineRows>{}</TimelineRows>
+        </Timeline>
+      )
+    })
+
+    afterAll(() => {
+      timezoneMock.unregister()
+    })
+
+    it('renders the default number of days', () => {
+      const days = wrapper.queryAllByTestId('timeline-day')
+
+      expect(days).toHaveLength(31)
+    })
+
+    it('writes an error to the console', () => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'ERROR - RNDS - `startDate` is after `endDate`'
+      )
+    })
+  })
+
   describe('when `endDate` and `unitWidth` are specified', () => {
     beforeAll(() => {
       timezoneMock.register('Europe/London')

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.test.tsx
@@ -10,14 +10,10 @@ describe('Notification', () => {
   let wrapper: RenderResult
   let dateSpy: jest.SpyInstance
 
-  beforeAll(() => {
+  beforeEach(() => {
     dateSpy = jest
       .spyOn(Date, 'now')
       .mockImplementation(() => new Date(NOW).valueOf())
-  })
-
-  afterAll(() => {
-    dateSpy.mockRestore()
   })
 
   describe('when the notification happened less than five minutes ago', () => {


### PR DESCRIPTION
## Related issue
Closes #2706

## Overview
Uses the date control for date fields in `Timeline` stories.

## Reason
Control is suited to dates.

## Work carried out
- [x] Use date control
- [x] Log error when `endDate` is less than `startDate`

## Screenshot
### Controls
![Screenshot 2021-11-22 at 14 20 10](https://user-images.githubusercontent.com/56078793/142878285-5dbfc806-b74b-4eec-9a99-0e3c89ac9449.png)

### Error
![Screenshot 2021-11-22 at 14 19 57](https://user-images.githubusercontent.com/56078793/142878304-cae2cc55-a4b2-488a-adc8-b24e714870b8.png)
