### PR TITLE
chore(Release): Update GitHub Actions workflows for npm 7

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -64,13 +64,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         run: |
-          npm publish --tag latest packages/design-tokens
-          npm publish --tag latest packages/css-framework
-          npm publish --tag latest packages/eslint-config-react
-          npm publish --tag latest packages/fonts
-          npm publish --tag latest packages/icon-library
-          npm publish --tag latest packages/react-component-library
-          npm publish --tag latest packages/cra-template-defencedigital
+          npm publish --tag latest ./packages/design-tokens
+          npm publish --tag latest ./packages/css-framework
+          npm publish --tag latest ./packages/eslint-config-react
+          npm publish --tag latest ./packages/fonts
+          npm publish --tag latest ./packages/icon-library
+          npm publish --tag latest ./packages/react-component-library
+          npm publish --tag latest ./packages/cra-template-defencedigital
 
       - name: Publish Storybook
         if: steps.initversion.outputs.version != steps.extractver.outputs.version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         run: |
-          npm publish --tag latest packages/design-tokens
-          npm publish --tag latest packages/css-framework
-          npm publish --tag latest packages/eslint-config-react
-          npm publish --tag latest packages/fonts
-          npm publish --tag latest packages/icon-library
-          npm publish --tag latest packages/react-component-library
-          npm publish --tag latest packages/cra-template-defencedigital
+          npm publish --tag latest ./packages/design-tokens
+          npm publish --tag latest ./packages/css-framework
+          npm publish --tag latest ./packages/eslint-config-react
+          npm publish --tag latest ./packages/fonts
+          npm publish --tag latest ./packages/icon-library
+          npm publish --tag latest ./packages/react-component-library
+          npm publish --tag latest ./packages/cra-template-defencedigital
 
       - name: Publish Storybook
         if: steps.initversion.outputs.version != steps.extractver.outputs.version


### PR DESCRIPTION
## Related issue

#2796 

## Overview

Fix the `npm publish` commands in the release workflows.

## Reason

The release workflow [was failing](https://github.com/defencedigital/mod-uk-design-system/runs/4220352258?check_suite_focus=true) since the update to Node.js 16 (which came with a new version of npm).

This is because `a/b` is interpreted as a GitHub repo in npm 7 and 8 when running `npm publish`, `./a/b` has to be used to specify a relative path.

## Work carried out

- [x] Update the `npm publish` commands in the release workflows.
