### PR TITLE
ci(GHA): Add failure notifications to release workflows

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -76,3 +76,13 @@ jobs:
         if: steps.initversion.outputs.version != steps.extractver.outputs.version
         run: |
           curl -X POST -d {} ${{ secrets.STORYBOOK_TOKEN }}
+
+      - name: Send notification on failure
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+        uses: defencedigital/design-system-slacknotify-action@master
+        with:
+          channel_id: C02H226CT33
+          status: FAILED
+          color: danger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,3 +78,13 @@ jobs:
         if: steps.initversion.outputs.version != steps.extractver.outputs.version
         run: |
           curl -X POST -d {} ${{ secrets.STORYBOOK_TOKEN }}
+
+      - name: Send notification on failure
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+        uses: defencedigital/design-system-slacknotify-action@master
+        with:
+          channel_id: C02H226CT33
+          status: FAILED
+          color: danger


### PR DESCRIPTION
## Related issue

closes #2804

## Overview

Add slack notifications for failed releases.  

## Reason

Recently we had some steps fail in the automated release workflow post the github release step.
The cause has been fixed via #2796, but this has highlighted the need for the team to be alerted to release failures of this nature.

## Work carried out

- [x] Added a new github action design-system-slacknotify-action
- [x] Added a 'Send notification on failure' step in the release workflows
- [x] Created a Slack bot called 'GitHub actions' with an Oauth token to write to the team notifications channel
- [x] Tested the above (see below example screenshot)

## Screenshot

![Screen Shot 2021-11-16 at 17 02 42](https://user-images.githubusercontent.com/61734183/142031246-0f180854-c6d0-4f0f-affd-404e3e5c7b4d.png)


