### PR TITLE
Change default Storybook layout and improve Story sorting

### DIFF
--- a/packages/react-component-library/.storybook/preview.js
+++ b/packages/react-component-library/.storybook/preview.js
@@ -34,4 +34,10 @@ export const parameters = {
       type: 'code',
     },
   },
+  options: {
+    storySort: {
+      method: 'alphabetical',
+      includeNames: false,
+    },
+  },
 }

--- a/packages/react-component-library/.storybook/preview.js
+++ b/packages/react-component-library/.storybook/preview.js
@@ -29,7 +29,6 @@ function clickDocsButtonOnFirstLoad() {
 window.addEventListener('load', clickDocsButtonOnFirstLoad)
 
 export const parameters = {
-  layout: 'fullscreen',
   docs: {
     source: {
       type: 'code',

--- a/packages/react-component-library/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Alert, AlertProps, ALERT_VARIANT } from './index'
 

--- a/packages/react-component-library/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react-component-library/src/components/Avatar/Avatar.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Avatar, AvatarProps, AVATAR_VARIANT } from '.'
 

--- a/packages/react-component-library/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react-component-library/src/components/Avatar/Avatar.stories.tsx
@@ -3,7 +3,11 @@ import { Story, Meta } from '@storybook/react/types-6-0'
 
 import { Avatar, AvatarProps, AVATAR_VARIANT } from '.'
 
-export default { component: Avatar, title: 'Avatar' } as Meta
+export default {
+  component: Avatar,
+  parameters: { layout: 'fullscreen' },
+  title: 'Avatar',
+} as Meta
 
 export const Default: Story<AvatarProps> = ({ initials, variant }) => (
   <div style={{ background: '#c9c9c9', padding: 20 }}>

--- a/packages/react-component-library/src/components/Badge/Badge.stories.tsx
+++ b/packages/react-component-library/src/components/Badge/Badge.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import {
   Badge,

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Breadcrumbs, BreadcrumbsItemProps, BreadcrumbsItem } from '.'
 import { Link } from '../Link'

--- a/packages/react-component-library/src/components/Button/Button.stories.tsx
+++ b/packages/react-component-library/src/components/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { IconBrightnessLow } from '@defencedigital/icon-library'
 import { Button, ButtonProps } from './index'

--- a/packages/react-component-library/src/components/ButtonE/ButtonE.stories.tsx
+++ b/packages/react-component-library/src/components/ButtonE/ButtonE.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { IconBrightnessLow } from '@defencedigital/icon-library'
 import { ButtonE, ButtonEProps } from './index'

--- a/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
 import { IconBrightnessLow } from '@defencedigital/icon-library'

--- a/packages/react-component-library/src/components/CardFrame/CardFrame.stories.tsx
+++ b/packages/react-component-library/src/components/CardFrame/CardFrame.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { CardFrame } from './index'
 import { ComponentWithClass } from '../../common/ComponentWithClass'

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
@@ -11,7 +11,7 @@ import { FormikGroupE } from '../FormikGroup'
 
 export default {
   component: CheckboxE,
-  title: 'CheckboxE',
+  title: 'Checkbox (Experimental)',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },

--- a/packages/react-component-library/src/components/CheckboxEnhanced/CheckboxEnhanced.stories.tsx
+++ b/packages/react-component-library/src/components/CheckboxEnhanced/CheckboxEnhanced.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
 import { CheckboxEnhanced, CheckboxEnhancedProps } from '.'

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { IconEdit, IconDelete, IconAdd } from '@defencedigital/icon-library'
 

--- a/packages/react-component-library/src/components/DataList/DataList.stories.tsx
+++ b/packages/react-component-library/src/components/DataList/DataList.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { DataList, DataListProps, DataListItem } from './index'
 

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import * as yup from 'yup'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 

--- a/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Dialog, DialogProps } from './index'
 import { StyledMain } from '../Modal/partials/StyledMain'

--- a/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
@@ -19,6 +19,7 @@ export default {
   title: 'Dialog',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
+    layout: 'fullscreen',
   },
 } as Meta
 

--- a/packages/react-component-library/src/components/DismissibleBanner/DismissableBanner.stories.tsx
+++ b/packages/react-component-library/src/components/DismissibleBanner/DismissableBanner.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { DismissibleBanner, DismissibleBannerProps } from '.'
 

--- a/packages/react-component-library/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Drawer, DrawerProps } from '.'
 

--- a/packages/react-component-library/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.stories.tsx
@@ -9,6 +9,7 @@ export default {
   title: 'Drawer',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
+    layout: 'fullscreen',
   },
 } as Meta
 

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { IconLayers, IconAnchor } from '@defencedigital/icon-library'
 

--- a/packages/react-component-library/src/components/List/List.stories.tsx
+++ b/packages/react-component-library/src/components/List/List.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
 import { List, ListProps, ListItem } from '.'

--- a/packages/react-component-library/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.stories.tsx
@@ -11,6 +11,7 @@ export default {
   title: 'Modal',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
+    layout: 'fullscreen',
   },
 } as Meta
 

--- a/packages/react-component-library/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Modal, ModalProps } from './index'
 import { StyledMain } from './partials/StyledMain'

--- a/packages/react-component-library/src/components/Nav/Nav.stories.tsx
+++ b/packages/react-component-library/src/components/Nav/Nav.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import {
   IconArrowDropDown,
   IconArrowDropUp,

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import { IconBrightnessHigh } from '@defencedigital/icon-library'

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { IconBrightnessHigh } from '@defencedigital/icon-library'
 
 import { COMPONENT_SIZE } from '../Forms'

--- a/packages/react-component-library/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Pagination, PaginationProps } from '.'
 

--- a/packages/react-component-library/src/components/Panel/Panel.stories.tsx
+++ b/packages/react-component-library/src/components/Panel/Panel.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Panel } from './index'
 import { ComponentWithClass } from '../../common/ComponentWithClass'

--- a/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.stories.tsx
+++ b/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.stories.tsx
@@ -8,6 +8,7 @@ export default {
   title: 'Phase Banner',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
+    layout: 'fullscreen',
   },
 } as Meta
 

--- a/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.stories.tsx
+++ b/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { PhaseBanner, PhaseBannerProps } from '.'
 

--- a/packages/react-component-library/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { FLOATING_BOX_SCHEME } from '../../primitives/FloatingBox'
 import { Popover, PopoverProps } from '.'

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { ProgressIndicator } from './index'
 import { ComponentWithClass } from '../../common/ComponentWithClass'

--- a/packages/react-component-library/src/components/Radio/Radio.stories.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'

--- a/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'

--- a/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
@@ -11,7 +11,7 @@ import { FormikGroupE } from '../FormikGroup'
 
 export default {
   component: RadioE,
-  title: 'RadioE',
+  title: 'Radio (Experimental)',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },

--- a/packages/react-component-library/src/components/RadioEnhanced/RadioEnhanced.stories.tsx
+++ b/packages/react-component-library/src/components/RadioEnhanced/RadioEnhanced.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
 import { RadioEnhanced, RadioEnhancedProps } from '.'

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import {
   IconBrightnessLow,

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { IconAnchor } from '@defencedigital/icon-library'
 
 import { Select, SelectProps } from './index'

--- a/packages/react-component-library/src/components/Switch/Switch.stories.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
 import { Field, Formik, Form } from 'formik'

--- a/packages/react-component-library/src/components/SwitchE/SwitchE.stories.tsx
+++ b/packages/react-component-library/src/components/SwitchE/SwitchE.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { SwitchE, SwitchEOption, SwitchEProps, SWITCHE_SIZE } from '.'
 

--- a/packages/react-component-library/src/components/TabNav/TabNav.stories.tsx
+++ b/packages/react-component-library/src/components/TabNav/TabNav.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Link } from '../Link'
 import { TabNav, TabNavItem } from '.'

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Tab, TabSet, TabSetProps, ScrollableTabSetProps } from '.'
 

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -9,6 +9,7 @@ export default {
   title: 'Tab Set',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
+    layout: 'fullscreen',
   },
 } as Meta
 

--- a/packages/react-component-library/src/components/Table/Table.stories.tsx
+++ b/packages/react-component-library/src/components/Table/Table.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Badge, BADGE_COLOR_VARIANT, BADGE_COLOR } from '../Badge'
 import { Table, TableProps, TableColumn } from '.'

--- a/packages/react-component-library/src/components/Table/Table.stories.tsx
+++ b/packages/react-component-library/src/components/Table/Table.stories.tsx
@@ -10,6 +10,7 @@ export default {
   title: 'Table',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
+    layout: 'fullscreen',
   },
 } as Meta
 

--- a/packages/react-component-library/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'

--- a/packages/react-component-library/src/components/TextAreaE/TextAreaE.stories.tsx
+++ b/packages/react-component-library/src/components/TextAreaE/TextAreaE.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { TextAreaE, TextAreaEProps } from '.'
 

--- a/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'

--- a/packages/react-component-library/src/components/TextInputE/TextInputE.stories.tsx
+++ b/packages/react-component-library/src/components/TextInputE/TextInputE.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { IconSearch } from '@defencedigital/icon-library'
 import { TextInputE, TextInputEProps } from '.'

--- a/packages/react-component-library/src/components/ThemedExample/ThemedExample.stories.tsx
+++ b/packages/react-component-library/src/components/ThemedExample/ThemedExample.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import {

--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -47,6 +47,7 @@ export default {
           'A collection of composable and presentation agnostic Compound Components, Hooks and a Context Provider, to help aid in the creation of scheduling based user-interfaces. Visit the [Compound Timeline microsite](https://timeline.royalnavy.io/) for more comprehensive documentation.',
       },
     },
+    layout: 'fullscreen',
   },
 } as Meta
 

--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { css, CSSProp } from 'styled-components'
 import { format } from 'date-fns'
 import {

--- a/packages/react-component-library/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { useToasts, Options } from 'react-toast-notifications'
 
 import { ToastProvider, Toast, ToastProps } from '.'

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Tooltip, TooltipProps } from '.'
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -32,6 +32,7 @@ export default {
   title: 'Masthead',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
+    layout: 'fullscreen',
   },
 } as Meta
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import {
   IconChatBubble,
   IconExitToApp,

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Graph, House, Tools } from '../../../icons'
 import { Link } from '../../Link'

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
@@ -30,6 +30,7 @@ export default {
           'This API has been marked as deprecated. Consider using the new experimental Sidebar implementation.',
       },
     },
+    layout: 'fullscreen',
   },
 } as Meta
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.stories.tsx
@@ -55,6 +55,7 @@ export default {
           'This API is experimental and may change outside of the typical semver release cycle.',
       },
     },
+    layout: 'fullscreen',
   },
 } as Meta
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import {
   IconHome,

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 import { Formik, Field } from 'formik'
 
 import { TextInputE } from '../../components/TextInputE'

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form/dist/index.ie11'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'

--- a/packages/react-component-library/src/primitives/Container/Container.stories.tsx
+++ b/packages/react-component-library/src/primitives/Container/Container.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { Container, ContainerProps } from '.'
 

--- a/packages/react-component-library/src/primitives/Container/Container.stories.tsx
+++ b/packages/react-component-library/src/primitives/Container/Container.stories.tsx
@@ -3,7 +3,11 @@ import { Story, Meta } from '@storybook/react/types-6-0'
 
 import { Container, ContainerProps } from '.'
 
-export default { component: Container, title: 'Container' } as Meta
+export default {
+  component: Container,
+  parameters: { layout: 'fullscreen' },
+  title: 'Container',
+} as Meta
 
 export const Default: Story<ContainerProps> = ({ children, ...rest }) => (
   <Container {...rest}>{children}</Container>

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { Story, Meta } from '@storybook/react'
 
 import { FloatingBox, FloatingBoxProps } from './FloatingBox'
 import { FLOATING_BOX_SCHEME } from './constants'

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
@@ -9,6 +9,7 @@ export default {
   title: 'Floating Box',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
+    layout: 'fullscreen',
   },
 } as Meta
 


### PR DESCRIPTION
## Overview

This makes a couple of changes:

- changes the default layout of stories from `fullscreen` to the default layout (`padded`) (while changing certain stories to use `fullscreen` where it makes sense)
- sorts folders in Storybook alphabetically
- changes the Meta and Story types to be imported from `@storybook/react` instead of `@storybook/react/types-6-0`

## Link to preview

https://5e25c277526d380020b5e418-kqmsqxgvha.chromatic.com/

## Reason

### Layout

For many stories, a full-screen layout was problematic because it caused shadows and borders to be out of view on the Canvas tab:

![image](https://user-images.githubusercontent.com/66470099/142195990-f36b799e-57e3-4dc4-80fe-e39a6416b8c4.png)

With padding these can be properly seen:

![image](https://user-images.githubusercontent.com/66470099/142196327-e78ad697-40c6-468a-8e26-f7eb56c500f1.png)

I've gone through and manually applied the `fullscreen` layout to stories for components where it makes sense or wasn't getting in the way of borders or shadows.

(There shouldn't be any change to the Docs tab.)

### Sorting

The change to sorting is to stop some story folders being sorted last:

![image](https://user-images.githubusercontent.com/66470099/142196446-34cd663a-181c-4a82-b332-e0aeb1560b9b.png)

Instead these are sorted alphabetically:

![image](https://user-images.githubusercontent.com/66470099/142196573-fd518c76-7eb6-4ccf-936f-92e0ca152e4a.png)

There is no change to the sorting of individual stories, but note that we are currently getting hit by this in production: https://github.com/storybookjs/storybook/issues/15574

This is currently causing some individual stories to be in the wrong order in production e.g. https://storybook.design-system.digital.mod.uk/?path=/docs/range-slider--custom-value-formatter

### Imports

This change is to simply make the imports in line with [examples in the Storybook docs](https://storybook.js.org/docs/react/get-started/setup):

![image](https://user-images.githubusercontent.com/66470099/142196896-77dd86d4-6f31-4366-bc4a-727ec11509e1.png)

## Work carried out

- [x] Remove the default `fullscreen` layout override
- [x] Go through stories and set certain ones to use a `fullscreen` layout as appropriate
- [x] Configure story sorting
- [x] Correct type imports
