### PR TITLE
docs(Storybook): Enable dynamic source code generation

### DIFF
--- a/packages/react-component-library/.storybook/preview.js
+++ b/packages/react-component-library/.storybook/preview.js
@@ -29,9 +29,18 @@ function clickDocsButtonOnFirstLoad() {
 window.addEventListener('load', clickDocsButtonOnFirstLoad)
 
 export const parameters = {
+  jsx: {
+    // Filter out callback props injected by the Actions addon
+    // from dynamic code snippets on the Docs tab as these are
+    // noisy and usually not needed
+    filterProps: (value) =>
+      value !== undefined && value?.name !== 'actionHandler',
+  },
   docs: {
     source: {
-      type: 'code',
+      // Avoid breaking IE11 on Chromatic as WeakSet isn't available
+      // there
+      type: typeof WeakSet === undefined ? 'code' : 'auto',
     },
   },
   options: {

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react'
 import { Story, Meta } from '@storybook/react'
+import styled from 'styled-components'
 
 import { IconEdit, IconDelete, IconAdd } from '@defencedigital/icon-library'
 
@@ -20,26 +21,18 @@ export default {
   },
 } as Meta
 
-const ClickArea = React.forwardRef(({ children, ...rest }: any, ref: any) => (
-  <div
-    ref={ref}
-    style={{
-      display: 'inline-block',
-      padding: '1rem',
-      backgroundColor: '#c9c9c9',
-    }}
-    data-testid="storybook-context-menu-target"
-  >
-    {children}
-  </div>
-))
+const ClickArea = styled.div`
+  display: inline-block;
+  padding: 1rem;
+  background-color: #c9c9c9;
+`
 
 export const Default: Story<ContextMenuProps> = (props) => {
   const ref = useRef()
 
   return (
     <>
-      <ClickArea ref={ref}>
+      <ClickArea ref={ref} data-testid="storybook-context-menu-target">
         {props.clickType === 'left' ? 'Click on me' : 'Right click on me'}
       </ClickArea>
       <ContextMenu {...props} attachedToRef={ref}>

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
@@ -39,22 +39,21 @@ Default.args = {
   label: 'Example label',
 }
 
-export const WithIcons: Story<DropdownProps> = () => {
-  const iconOptions = options.map((option) => ({
-    ...option,
-    icon: <IconAnchor />,
-  }))
+const iconOptions = options.map((option) => ({
+  ...option,
+  icon: <IconAnchor />,
+}))
 
-  return (
-    <div style={{ height: '15rem' }}>
-      <Dropdown
-        options={iconOptions}
-        label="Example label"
-        labelIcon={<IconLayers />}
-        onSelect={action('onSelect')}
-      />
-    </div>
-  )
-}
+export const WithIcons: Story<DropdownProps> = (props) => (
+  <div style={{ height: '15rem' }}>
+    <Dropdown
+      {...props}
+      options={iconOptions}
+      label="Example label"
+      labelIcon={<IconLayers />}
+      onSelect={action('onSelect')}
+    />
+  </div>
+)
 
 WithIcons.storyName = 'With icons'

--- a/packages/react-component-library/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.stories.tsx
@@ -4,6 +4,7 @@ import { Story, Meta } from '@storybook/react'
 
 import { Modal, ModalProps } from './index'
 import { StyledMain } from './partials/StyledMain'
+import { StyledModal } from './partials/StyledModal'
 import { BUTTON_COLOR, ButtonProps } from '../Button'
 
 export default {
@@ -12,6 +13,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
     layout: 'fullscreen',
+    jsx: {
+      showFunctions: true,
+    },
   },
 } as Meta
 
@@ -33,25 +37,26 @@ const tertiaryButton: ButtonProps = {
   children: 'Tertiary',
 }
 
-// Styles extended for Storybook presentation
-const StyledModal = styled(Modal)`
-  position: absolute;
-  z-index: 1;
+const Wrapper = styled.div<{ $height: string }>`
+  height: ${({ $height }) => $height};
 
-  ${StyledMain} {
+  /* Styles extended for Storybook presentation */
+  ${StyledModal} {
     position: absolute;
+    z-index: 1;
+
+    ${StyledMain} {
+      position: absolute;
+    }
   }
 `
+
 const Template: Story<ModalProps> = (args) => (
-  <div
-    style={{
-      height: args.title && args.primaryButton ? '15rem' : '10rem',
-    }}
-  >
-    <StyledModal {...args}>
+  <Wrapper $height={args.title && args.primaryButton ? '15rem' : '10rem'}>
+    <Modal {...args}>
       <pre style={{ padding: '1rem' }}>Arbitrary JSX content</pre>
-    </StyledModal>
-  </div>
+    </Modal>
+  </Wrapper>
 )
 
 export const Default = Template.bind({})

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 import styled from 'styled-components'
 import { Story, Meta } from '@storybook/react'
 
-import { ProgressIndicator } from './index'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { StyledProgressIndicator } from './partials/StyledProgressIndicator'
+import { ProgressIndicator } from './index'
 
 export default {
   component: ProgressIndicator,
@@ -13,13 +14,17 @@ export default {
   },
 } as Meta
 
-const StyledProgressIndicator = styled(ProgressIndicator)`
-  position: absolute;
-  transform: translate(-50%, -50%);
+const Wrapper = styled.div`
+  height: 10rem;
+
+  ${StyledProgressIndicator} {
+    position: absolute;
+    transform: translate(-50%, -50%);
+  }
 `
 
 export const Default: Story<ComponentWithClass> = (props) => (
-  <div style={{ height: '10rem' }}>
-    <StyledProgressIndicator {...props} />
-  </div>
+  <Wrapper>
+    <ProgressIndicator {...props} />
+  </Wrapper>
 )

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -24,12 +24,13 @@ export default {
   },
 } as Meta
 
-export const Default: Story<SelectProps> = (props) => (
-  <div style={{ height: '10rem' }}>
-    <Select {...props} />
+const Template: Story<SelectProps> = (args) => (
+  <div style={{ height: args.isDisabled ? 'initial' : '10rem' }}>
+    <Select {...args} />
   </div>
 )
 
+export const Default = Template.bind({})
 Default.args = {
   options,
   label: 'Example label',
@@ -37,46 +38,30 @@ Default.args = {
   defaultMenuIsOpen: true,
 }
 
-export const Disabled: Story<SelectProps> = (props) => (
-  <Select
-    {...props}
-    options={options}
-    label="Example label"
-    name="select-disabled"
-    isDisabled
-  />
-)
-
-Disabled.storyName = 'Disabled'
-
-export const NotClearable: Story<SelectProps> = (props) => (
-  <Select
-    {...props}
-    options={options}
-    label="Example label"
-    name="select-disabled"
-    isClearable={false}
-  />
-)
-
-NotClearable.storyName = 'Not clearable'
-
-export const WithIcons: Story<SelectProps> = (props) => {
-  const iconOptions = options.map((option) => ({
-    ...option,
-    icon: <IconAnchor />,
-  }))
-
-  return (
-    <div style={{ height: '10rem' }}>
-      <Select
-        {...props}
-        options={iconOptions}
-        label="Example label"
-        name="select-icons"
-      />
-    </div>
-  )
+export const Disabled = Template.bind({})
+Disabled.args = {
+  options,
+  label: 'Example label',
+  name: 'select-disabled',
+  isDisabled: true,
 }
 
+export const NotClearable = Template.bind({})
+NotClearable.storyName = 'Not clearable'
+NotClearable.args = {
+  options,
+  label: 'Example label',
+  name: 'select-not-clearable',
+  isClearable: false,
+}
+
+export const WithIcons = Template.bind({})
 WithIcons.storyName = 'With icons'
+WithIcons.args = {
+  options: options.map((option) => ({
+    ...option,
+    icon: <IconAnchor />,
+  })),
+  label: 'Example label',
+  name: 'select-icons',
+}

--- a/packages/react-component-library/src/components/Table/Table.stories.tsx
+++ b/packages/react-component-library/src/components/Table/Table.stories.tsx
@@ -49,41 +49,39 @@ Default.args = {
   data: tableData,
 }
 
-export const ArbitraryCellContent: Story<TableProps> = (props) => {
-  const tableDataArbitraryCellContent = [
-    {
-      id: 'a',
-      first: 'Row 1 cell 1',
-      second: (
-        <Badge
-          colorVariant={BADGE_COLOR_VARIANT.FADED}
-          color={BADGE_COLOR.SUCCESS}
-        >
-          Online
-        </Badge>
-      ),
-    },
-    {
-      id: 'b',
-      first: 'Row 2 cell 1',
-      second: (
-        <Badge
-          colorVariant={BADGE_COLOR_VARIANT.FADED}
-          color={BADGE_COLOR.DANGER}
-        >
-          Offline
-        </Badge>
-      ),
-    },
-  ]
+const tableDataArbitraryCellContent = [
+  {
+    id: 'a',
+    first: 'Row 1 cell 1',
+    second: (
+      <Badge
+        colorVariant={BADGE_COLOR_VARIANT.FADED}
+        color={BADGE_COLOR.SUCCESS}
+      >
+        Online
+      </Badge>
+    ),
+  },
+  {
+    id: 'b',
+    first: 'Row 2 cell 1',
+    second: (
+      <Badge
+        colorVariant={BADGE_COLOR_VARIANT.FADED}
+        color={BADGE_COLOR.DANGER}
+      >
+        Offline
+      </Badge>
+    ),
+  },
+]
 
-  return (
-    <Table {...props} data={tableDataArbitraryCellContent}>
-      <TableColumn field="first">First column</TableColumn>
-      <TableColumn field="second">Status</TableColumn>
-    </Table>
-  )
-}
+export const ArbitraryCellContent: Story<TableProps> = (props) => (
+  <Table {...props} data={tableDataArbitraryCellContent}>
+    <TableColumn field="first">First column</TableColumn>
+    <TableColumn field="second">Status</TableColumn>
+  </Table>
+)
 
 ArbitraryCellContent.storyName = 'Arbitrary cell content'
 


### PR DESCRIPTION
## Related issue

Fixes #2811

## Overview

This turns on dynamic source code generation on the Docs tab in Storybook.

## Link to preview

https://5e25c277526d380020b5e418-ziursfrpsg.chromatic.com/

## Reason

To generate more useful code examples.

## Work carried out

- [x] Turn on dynamic source code generation by default
- [x] Check each docs page in Storybook
- [x] Tweak a few stories for better code snippets
- [x] Turn off source code generation for certain Select and Table stories due to incompatibility

## Demo

### Before

![code-before](https://user-images.githubusercontent.com/66470099/142246090-6c30a5d4-78fa-48ca-9133-44d9b19a3173.gif)

### After

![code-after](https://user-images.githubusercontent.com/66470099/142246104-3ae42c84-dc6e-4cb1-899e-0563b18ed26d.gif)

## Developer notes

There were a couple of limitations found which workarounds have been put in for:

- a couple of stories were being hit by storybookjs/storybook#16730, I've amended those stories to work around that
- it also breaks IE11 on Chromatic, so it's disabled there too

(If you want to look through the generated source more easily, you can set `parameters.docs.source.state` to `open` in `packages/react-component-library/.storybook/preview.js` open the code panels by default.)