### PR TITLE
test(DatePicker): Fix Cypress border assertions in Firefox

### DIFF
--- a/packages/react-component-library/cypress/specs/DatePicker/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/DatePicker/index.spec.ts
@@ -1,10 +1,6 @@
 import { describe, cy, it, before } from 'local-cypress'
 import { addDays, startOfMonth, format } from 'date-fns'
-import {
-  ColorAction600,
-  ColorNeutral200,
-  ColorDanger600,
-} from '@defencedigital/design-tokens'
+import { ColorAction600, ColorNeutral200 } from '@defencedigital/design-tokens'
 
 import { DATE_FORMAT } from '../../../src/constants'
 import { hexToRgb } from '../../helpers'
@@ -39,25 +35,13 @@ describe('DatePicker', () => {
         cy.get(selectors.datePicker.input).should('have.value', expected)
       })
 
-      it('should not be in an error state', { browser: '!firefox' }, () => {
+      it('should not be in an error state', () => {
         cy.get(selectors.datePicker.outerWrapper).should(
-          'have.css',
-          'border',
-          `1px solid ${hexToRgb(ColorNeutral200)}`
+          'has.border',
+          'color',
+          hexToRgb(ColorNeutral200)
         )
       })
-
-      it(
-        'should not be in an error state (firefox)',
-        { browser: 'firefox' },
-        () => {
-          cy.get(selectors.datePicker.outerWrapper).should(
-            'not.have.css',
-            'border',
-            `1px solid ${hexToRgb(ColorDanger600)}`
-          )
-        }
-      )
     })
   })
 
@@ -107,25 +91,13 @@ describe('DatePicker', () => {
             cy.wait(1000)
           })
 
-          it('should not be in an error state', { browser: '!firefox' }, () => {
+          it('should not be in an error state', () => {
             cy.get(selectors.datePicker.outerWrapper).should(
-              'have.css',
-              'border',
-              `1px solid ${hexToRgb(ColorAction600)}`
+              'has.border',
+              'color',
+              hexToRgb(ColorAction600)
             )
           })
-
-          it(
-            'should not be in an error state (firefox)',
-            { browser: 'firefox' },
-            () => {
-              cy.get(selectors.datePicker.outerWrapper).should(
-                'not.have.css',
-                'border',
-                `1px solid ${hexToRgb(ColorDanger600)}`
-              )
-            }
-          )
         })
       })
     })

--- a/packages/react-component-library/cypress/specs/DatePickerE/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/DatePickerE/index.spec.ts
@@ -41,25 +41,13 @@ describe('DatePickerE', () => {
         cy.get(selectors.datePicker.input).should('have.value', expected)
       })
 
-      it('should not be in an error state', { browser: '!firefox' }, () => {
+      it('should not be in an error state', () => {
         cy.get(selectors.datePicker.outerWrapper).should(
-          'have.css',
-          'border',
-          `1px solid ${hexToRgb(ColorNeutral200)}`
+          'has.border',
+          'color',
+          hexToRgb(ColorNeutral200)
         )
       })
-
-      it(
-        'should not be in an error state (firefox)',
-        { browser: 'firefox' },
-        () => {
-          cy.get(selectors.datePicker.outerWrapper).should(
-            'not.have.css',
-            'border',
-            `1px solid ${hexToRgb(ColorDanger600)}`
-          )
-        }
-      )
     })
   })
 
@@ -109,25 +97,13 @@ describe('DatePickerE', () => {
             cy.wait(1000)
           })
 
-          it('should not be in an error state', { browser: '!firefox' }, () => {
+          it('should not be in an error state', () => {
             cy.get(selectors.datePicker.outerWrapper).should(
-              'have.css',
-              'border',
-              `1px solid ${hexToRgb(ColorAction600)}`
+              'has.border',
+              'color',
+              hexToRgb(ColorAction600)
             )
           })
-
-          it(
-            'should not be in an error state (firefox)',
-            { browser: 'firefox' },
-            () => {
-              cy.get(selectors.datePicker.outerWrapper).should(
-                'not.have.css',
-                'border',
-                `1px solid ${hexToRgb(ColorDanger600)}`
-              )
-            }
-          )
         })
       })
     })

--- a/packages/react-component-library/cypress/support/assertions.ts
+++ b/packages/react-component-library/cypress/support/assertions.ts
@@ -1,0 +1,23 @@
+/// <reference types="cypress/types/chai" />
+/// <reference types="cypress/types/chai-jquery" />
+
+export {}
+
+chai.use((_chai) => {
+  function hasBorder(
+    borderProperty: 'color' | 'style' | 'width',
+    value: string
+  ) {
+    // eslint-disable-next-line no-underscore-dangle
+    const $element = this._obj
+
+    ;['top', 'right', 'bottom', 'left'].forEach((side) => {
+      new _chai.Assertion($element).to.have.css(
+        `border-${side}-${borderProperty}`,
+        value
+      )
+    })
+  }
+
+  _chai.Assertion.addMethod('border', hasBorder)
+})

--- a/packages/react-component-library/cypress/support/index.ts
+++ b/packages/react-component-library/cypress/support/index.ts
@@ -1,4 +1,5 @@
 import './commands'
+import './assertions'
 import consoleErrors from './consoleErrors'
 
 consoleErrors.check()

--- a/packages/react-component-library/cypress/support/types.d.ts
+++ b/packages/react-component-library/cypress/support/types.d.ts
@@ -1,0 +1,20 @@
+/// <reference types="cypress" />
+
+declare namespace Cypress {
+  /**
+   * Assertion that checks if a border property has a certain value on all sides in a way
+   * that is compatible with both Chrome and Firefox.
+   *
+   * @example
+   ```
+   cy.get('foo').should('has.border', 'color', 'red')
+   ```
+   */
+  interface Chainer<Subject> {
+    (
+      chainer: 'has.border',
+      property: 'color' | 'style' | 'width',
+      value: string
+    ): Chainable<Subject>
+  }
+}


### PR DESCRIPTION
## Related issue

Resolves #2809

## Overview

Update the Cypress border assertions for DatePicker and DatePickerE to work in both Firefox and Chrome.

## Reason

CSS assertions on the `border` shorthand property aren't supported in Firefox. Assertions on the constituent components have to be done instead (`border-top-color`, `border-right-color` etc.) (which works in Chrome as well).

## Work carried out

- [x] Add custom Cypress Chai assertion for border styles
- [x] Update DatePicker and DatePickerE Cypress tests

## Developer notes

I added a custom Chai assertion to do these kind of assertions more easily.
