### PR TITLE
fix(Fieldset): Resolve CheckboxE and RadioE invalid state styling

### DIFF
--- a/packages/react-component-library/babel.config.js
+++ b/packages/react-component-library/babel.config.js
@@ -45,7 +45,15 @@ module.exports = {
       ],
     },
     test: {
-      plugins: ['@babel/plugin-transform-modules-commonjs'],
+      plugins: [
+        [
+          'babel-plugin-styled-components',
+          {
+            displayName: true,
+          },
+        ],
+        '@babel/plugin-transform-modules-commonjs',
+      ],
     },
   },
 }

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
@@ -6,7 +6,6 @@ import * as yup from 'yup'
 
 import { withFormik } from '../../enhancers/withFormik'
 import { CheckboxE, CheckboxEProps } from '.'
-import { Button } from '../Button'
 import { FormikGroupE } from '../FormikGroup'
 
 export default {
@@ -17,20 +16,16 @@ export default {
   },
 } as Meta
 
-export const Default: Story<CheckboxEProps> = (props) => (
-  <CheckboxE {...props} />
-)
+const Template: Story<CheckboxEProps> = (props) => <CheckboxE {...props} />
 
+export const Default = Template.bind({})
 Default.args = {
   id: undefined,
   label: 'Default checkbox',
   name: 'default',
 }
 
-export const Disabled: Story<CheckboxEProps> = (props) => (
-  <CheckboxE {...props} />
-)
-
+export const Disabled = Template.bind({})
 Disabled.args = {
   id: undefined,
   isDisabled: true,
@@ -39,10 +34,7 @@ Disabled.args = {
   checked: true,
 }
 
-export const Invalid: Story<CheckboxEProps> = (props) => (
-  <CheckboxE {...props} />
-)
-
+export const Invalid = Template.bind({})
 Invalid.args = {
   id: undefined,
   label: 'Invalid checkbox',
@@ -61,6 +53,10 @@ export const WithFormikGroup: Story<CheckboxEProps> = () => {
       exampleWithError: [],
     }
 
+    const initialTouched = {
+      exampleWithError: true,
+    }
+
     const validationSchema = yup.object().shape({
       exampleWithError: yup.array().min(1),
     })
@@ -70,6 +66,8 @@ export const WithFormikGroup: Story<CheckboxEProps> = () => {
     return (
       <Formik
         initialValues={initialValues}
+        initialTouched={initialTouched}
+        validateOnMount
         onSubmit={action('onSubmit')}
         validationSchema={validationSchema}
       >
@@ -121,8 +119,6 @@ export const WithFormikGroup: Story<CheckboxEProps> = () => {
               type="checkbox"
             />
           </FormikGroupE>
-          <br />
-          <Button type="submit">Submit</Button>
         </Form>
       </Formik>
     )

--- a/packages/react-component-library/src/components/Fieldset/Fieldset.tsx
+++ b/packages/react-component-library/src/components/Fieldset/Fieldset.tsx
@@ -3,7 +3,6 @@ import styled, { css } from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
-
 import { StyledCheckboxWrapper } from '../CheckboxE/partials/StyledCheckboxWrapper'
 import { StyledCheckbox } from '../CheckboxE/partials/StyledCheckbox'
 import { StyledRadioWrapper } from '../RadioE/partials/StyledRadioWrapper'
@@ -21,12 +20,21 @@ const { color, spacing } = selectors
 
 const StyledFieldset = styled.fieldset<StyledFieldsetProps>`
   display: inline-block;
-  border: 1px solid transparent;
+  position: relative;
   padding: unset;
+  border: none;
   border-radius: 15px;
 
   legend {
     padding: ${spacing('10')} 0 ${spacing('8')};
+  }
+
+  ${StyledRadioWrapper}, ${StyledCheckboxWrapper} {
+    margin-top: -1px;
+
+    &:first-of-type {
+      margin-top: unset;
+    }
   }
 
   ${StyledRadioWrapper}, ${StyledCheckboxWrapper} {
@@ -70,43 +78,58 @@ const StyledFieldset = styled.fieldset<StyledFieldsetProps>`
   ${({ $isInvalid }) =>
     $isInvalid &&
     css`
-      border: 1px solid ${color('danger', '800')};
-      box-shadow: inset 0 0 0 1px ${color('danger', '800')},
-        0 0 0 2px ${color('danger', '800')};
+      &::after {
+        box-shadow: inset 0 0 0 1px ${color('danger', '800')},
+          0 0 0 2px ${color('danger', '800')};
+        border-radius: 15px;
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        pointer-events: none;
+      }
 
       ${StyledRadioWrapper},
       ${StyledCheckboxWrapper} {
         ${StyledCheckbox}, ${StyledRadio} {
           border-color: ${color('neutral', '200')};
           box-shadow: unset;
-          border-right-color: ${color('danger', '800')};
-          border-left-color: ${color('danger', '800')};
+          border-right-color: transparent;
+          border-left-color: transparent;
         }
       }
 
       ${StyledRadioWrapper}:first-of-type,
       ${StyledCheckboxWrapper}:first-of-type {
         ${StyledCheckbox}, ${StyledRadio} {
-          border-top-color: ${color('danger', '800')};
-        }
+          border-top-color: transparent;
 
-        &:active,
-        &:focus-within {
-          border-top-color: ${color('action', '500')};
+          &:active,
+          &:focus-within {
+            border-top-color: ${color('action', '500')};
+          }
         }
       }
 
       ${StyledRadioWrapper}:last-of-type,
       ${StyledCheckboxWrapper}:last-of-type {
         ${StyledCheckbox}, ${StyledRadio} {
-          border-bottom-color: ${color('danger', '800')};
+          border-bottom-color: transparent;
+
+          &:active,
+          &:focus-within {
+            border-bottom-color: ${color('action', '500')};
+          }
         }
       }
     `}
 `
 
-export const Fieldset: React.FC<FieldsetProps> = (props) => {
-  return <StyledFieldset {...props} />
+export const Fieldset: React.FC<FieldsetProps> = ({ isInvalid, ...rest }) => {
+  return <StyledFieldset $isInvalid={isInvalid} {...rest} />
 }
 
 Fieldset.displayName = 'Fieldset'

--- a/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
@@ -6,7 +6,6 @@ import * as yup from 'yup'
 
 import { withFormik } from '../../enhancers/withFormik'
 import { RadioE, RadioEProps } from '.'
-import { Button } from '../Button'
 import { FormikGroupE } from '../FormikGroup'
 
 export default {
@@ -17,8 +16,9 @@ export default {
   },
 } as Meta
 
-export const Default: Story<RadioEProps> = (props) => <RadioE {...props} />
+const Template: Story<RadioEProps> = (props) => <RadioE {...props} />
 
+export const Default = Template.bind({})
 Default.args = {
   id: undefined,
   label: 'Default radio',
@@ -26,8 +26,7 @@ Default.args = {
   defaultChecked: true,
 }
 
-export const Disabled: Story<RadioEProps> = (props) => <RadioE {...props} />
-
+export const Disabled = Template.bind({})
 Disabled.args = {
   id: undefined,
   isDisabled: true,
@@ -35,8 +34,7 @@ Disabled.args = {
   name: 'disabled',
 }
 
-export const Invalid: Story<RadioEProps> = (props) => <RadioE {...props} />
-
+export const Invalid = Template.bind({})
 Invalid.args = {
   id: undefined,
   label: 'Invalid radio',
@@ -55,6 +53,10 @@ export const WithFormikGroup: Story<RadioEProps> = () => {
       exampleWithError: '',
     }
 
+    const initialTouched = {
+      exampleWithError: true,
+    }
+
     const validationSchema = yup.object().shape({
       exampleWithError: yup.string().required(),
     })
@@ -64,6 +66,8 @@ export const WithFormikGroup: Story<RadioEProps> = () => {
     return (
       <Formik
         initialValues={initialValues}
+        initialTouched={initialTouched}
+        validateOnMount
         onSubmit={action('onSubmit')}
         validationSchema={validationSchema}
       >
@@ -109,8 +113,6 @@ export const WithFormikGroup: Story<RadioEProps> = () => {
               value="3"
             />
           </FormikGroupE>
-          <br />
-          <Button type="submit">Submit</Button>
         </Form>
       </Formik>
     )


### PR DESCRIPTION
## Related issue

Closes #2777 
Closes #2778

## Overview

Fix `CheckboxE` and `RadioE` invalid state styling issues.

## Reason

When in an invalid state the components were incorrect.

## Work carried out

- [x] Enable `displayName` for Styled Components `BABEL_ENV` test
- [x] Fix styling issues
- [x] Update Storybook story to cover invalid Fieldset state via Chromatic snapshot
- [x] Refactor story format to leverage `Template.bind`

## Screenshot

<img width="362" alt="Screenshot 2021-11-29 at 10 48 23" src="https://user-images.githubusercontent.com/48086589/143854727-7639e367-849f-42da-bad7-07550dca300d.png">
<img width="280" alt="Screenshot 2021-11-29 at 10 48 54" src="https://user-images.githubusercontent.com/48086589/143854735-0e7c2ba9-8296-4b29-a023-2a383c3bfed5.png">

## Developer notes

https://styled-components.com/docs/tooling#better-debugging