### PR TITLE
fix(StyledOuterWrapper): Add disabled state cursor style

### DIFF
--- a/packages/react-component-library/src/components/TextAreaE/partials/StyledOuterWrapper.tsx
+++ b/packages/react-component-library/src/components/TextAreaE/partials/StyledOuterWrapper.tsx
@@ -1,14 +1,23 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { isIE11 } from '../../../helpers'
 import {
   StyledOuterWrapper as StyledOuterWrapperBase,
   StyledOuterWrapperProps,
 } from '../../../styled-components'
+import { StyledLabel } from './StyledLabel'
 
 export const StyledOuterWrapper = styled(
   StyledOuterWrapperBase
 )<StyledOuterWrapperProps>`
   position: relative;
   padding: ${isIE11() ? '21px' : '19px'} 8px 8px 8px;
+
+  ${({ $isDisabled }) =>
+    $isDisabled &&
+    css`
+      ${StyledLabel} {
+        background-color: transparent;
+      }
+    `}
 `

--- a/packages/react-component-library/src/styled-components/partials/StyledOuterWrapper.tsx
+++ b/packages/react-component-library/src/styled-components/partials/StyledOuterWrapper.tsx
@@ -52,6 +52,10 @@ export const StyledOuterWrapper = styled.div<StyledOuterWrapperProps>`
         ${defaults};
         background-color: ${color('neutral', '000')};
         border: 1px solid transparent;
+
+        * {
+          cursor: not-allowed;
+        }
       `
     }
 


### PR DESCRIPTION
## Related issue

Closes #2791 
Closes #2792

## Overview

Add missing cursor not-allowed style for disabled state. Applies to all components utilising `StyledOuterWrapper`.

## Reason

This is consistent with styling used else where to denote disabled states of components.

## Work carried out

- [x] Add `StyledOuterWrapper` cursor styles
- [x] Adjust `TextAreaE` disabled styled