### PR TITLE
feat(FloatingBox): Integrate with DatePickerE

### DIFF
--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
@@ -1,31 +1,27 @@
 import React, { useState } from 'react'
 import { Placement } from '@popperjs/core'
 import { DayPickerProps } from 'react-day-picker'
-import { Transition } from 'react-transition-group'
 
 import {
   FLOATING_BOX_PLACEMENT,
-  FLOATING_BOX_SCHEME,
+  FloatingBox,
 } from '../../primitives/FloatingBox'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { DATE_FORMAT } from '../../constants'
 import { DatePickerEInput } from './DatePickerEInput'
 import { DropdownIndicatorIcon } from '../Dropdown/DropdownIndicatorIcon'
-import { FloatingBoxContent } from '../../primitives/FloatingBox/FloatingBoxContent'
 import { getId, hasClass } from '../../helpers'
 import { InputValidationProps } from '../../common/InputValidationProps'
-import { StyledArrow } from '../../primitives/FloatingBox/partials/StyledArrow'
 import { StyledButton } from './partials/StyledButton'
 import { StyledDatePickerEInput } from './partials/StyledDatePickerEInput'
 import { StyledDayPicker } from './partials/StyledDayPicker'
-import { StyledFloatingBox } from '../../primitives/FloatingBox/partials/StyledFloatingBox'
 import { StyledInputWrapper } from './partials/StyledInputWrapper'
 import { StyledLabel } from './partials/StyledLabel'
 import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
 import { StyledSeparator } from './partials/StyledSeparator'
 import { useDatePickerEOpenClose } from './useDatePickerEOpenClose'
 import { useExternalId } from '../../hooks/useExternalId'
-import { useFloatingElement } from '../../hooks/useFloatingElement'
+import { useStatefulRef } from '../../hooks/useStatefulRef'
 import { useSelection } from './useSelection'
 
 export interface DatePickerEProps
@@ -135,6 +131,7 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
     isInvalid || hasClass(className, 'is-invalid')
   )
   const [currentMonth, setCurrentMonth] = useState<Date>(null)
+  const [floatingBoxTarget, setFloatingBoxTarget] = useStatefulRef()
 
   const { from, to } = state
   const modifiers = { start: from, end: to }
@@ -146,28 +143,13 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
 
   const placeholder = isRange ? null : datePickerFormat.toLowerCase()
 
-  const {
-    targetElementRef,
-    floatingElementRef,
-    arrowElementRef,
-    styles,
-    attributes,
-  } = useFloatingElement(placement)
-
-  const TRANSITION_STYLES = {
-    entering: { opacity: 0 },
-    entered: { opacity: 1 },
-    exiting: { opacity: 0 },
-    exited: { opacity: 0 },
-  }
-
   return (
     <>
       <StyledDatePickerEInput
         className={className}
         data-testid="datepicker-input-wrapper"
         $isDisabled={isDisabled}
-        ref={targetElementRef}
+        ref={setFloatingBoxTarget}
       >
         <StyledOuterWrapper
           data-testid="datepicker-outer-wrapper"
@@ -226,49 +208,30 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
           </StyledButton>
         </StyledOuterWrapper>
       </StyledDatePickerEInput>
-      <Transition in={open} timeout={0} unmountOnExit>
-        {(transitionState) => (
-          <StyledFloatingBox
-            ref={floatingElementRef}
-            role="dialog"
-            data-testid="floating-box"
-            aria-modal
-            aria-labelledby={titleId}
-            aria-live="polite"
-            style={{ ...styles.popper, ...TRANSITION_STYLES[transitionState] }}
-            {...attributes.popper}
-          >
-            <FloatingBoxContent
-              contentId={contentId}
-              scheme={FLOATING_BOX_SCHEME.LIGHT}
-              data-testid="floating-box-content"
-            >
-              <StyledArrow
-                $placement={
-                  attributes?.popper?.['data-popper-placement'] as Placement
-                }
-                ref={arrowElementRef}
-                style={styles.arrow}
-                {...attributes.arrow}
-              />
-              <div ref={floatingBoxChildrenRef}>
-                <StyledDayPicker
-                  numberOfMonths={isRange ? 2 : 1}
-                  selectedDays={[from, { from, to }]}
-                  modifiers={modifiers}
-                  month={currentMonth}
-                  onDayClick={handleDayClick}
-                  initialMonth={from || initialMonth}
-                  disabledDays={disabledDays}
-                  $isRange={isRange}
-                  $isVisible={open}
-                  onFocus={onCalendarFocus}
-                />
-              </div>
-            </FloatingBoxContent>
-          </StyledFloatingBox>
-        )}
-      </Transition>
+      <FloatingBox
+        isVisible={open}
+        placement={placement}
+        targetElement={floatingBoxTarget}
+        role="dialog"
+        aria-modal
+        aria-labelledby={titleId}
+        aria-live="polite"
+      >
+        <div ref={floatingBoxChildrenRef}>
+          <StyledDayPicker
+            numberOfMonths={isRange ? 2 : 1}
+            selectedDays={[from, { from, to }]}
+            modifiers={modifiers}
+            month={currentMonth}
+            onDayClick={handleDayClick}
+            initialMonth={from || initialMonth}
+            disabledDays={disabledDays}
+            $isRange={isRange}
+            $isVisible={open}
+            onFocus={onCalendarFocus}
+          />
+        </div>
+      </FloatingBox>
     </>
   )
 }

--- a/packages/react-component-library/src/components/Popover/Popover.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.tsx
@@ -15,7 +15,7 @@ import { useHideShow } from '../../hooks/useHideShow'
 export interface PopoverProps
   extends Omit<
     FloatingBoxProps,
-    'onMouseEnter' | 'onMouseLeave' | 'renderTarget'
+    'onMouseEnter' | 'onMouseLeave' | 'renderTarget' | 'targetElement'
   > {
   /**
    * JSX target element to attach the Popover to.

--- a/packages/react-component-library/src/hooks/useFloatingElement.ts
+++ b/packages/react-component-library/src/hooks/useFloatingElement.ts
@@ -1,38 +1,41 @@
-import { useState, Dispatch, SetStateAction } from 'react'
+import { Dispatch, SetStateAction } from 'react'
 import { PositioningStrategy, Placement } from '@popperjs/core'
 import { usePopper } from 'react-popper'
 
+import { useStatefulRef } from './useStatefulRef'
+
 export const useFloatingElement = (
   placement: Placement = 'bottom',
-  strategy: PositioningStrategy = 'fixed'
+  strategy: PositioningStrategy = 'fixed',
+  externalTargetElement?: Element
 ): {
-  targetElementRef: Dispatch<SetStateAction<any>>
+  targetElementRef: Dispatch<SetStateAction<Element>>
   floatingElementRef: Dispatch<SetStateAction<HTMLElement | null>>
-  arrowElementRef: Dispatch<SetStateAction<string | HTMLElement | null>>
+  arrowElementRef: Dispatch<SetStateAction<HTMLElement | null>>
   styles: { [key: string]: React.CSSProperties }
   attributes: { [key: string]: { [key: string]: string } | undefined }
 } => {
-  const [targetElement, targetElementRef] = <any>useState(null)
+  const [targetElement, targetElementRef] = useStatefulRef()
+  const [floatingElement, floatingElementRef] = useStatefulRef<HTMLElement>()
+  const [arrowElement, arrowElementRef] = useStatefulRef<HTMLElement>()
 
-  const [floatingElement, floatingElementRef] =
-    useState<HTMLElement | null>(null)
-
-  const [arrowElement, arrowElementRef] =
-    useState<string | HTMLElement | null>(null)
-
-  const { styles, attributes } = usePopper(targetElement, floatingElement, {
-    modifiers: [
-      {
-        name: 'arrow',
-        options: {
-          element: arrowElement,
-          padding: 20,
+  const { styles, attributes } = usePopper(
+    externalTargetElement || targetElement,
+    floatingElement,
+    {
+      modifiers: [
+        {
+          name: 'arrow',
+          options: {
+            element: arrowElement,
+            padding: 20,
+          },
         },
-      },
-    ],
-    placement,
-    strategy,
-  })
+      ],
+      placement,
+      strategy,
+    }
+  )
 
   return {
     targetElementRef,

--- a/packages/react-component-library/src/hooks/useStatefulRef.ts
+++ b/packages/react-component-library/src/hooks/useStatefulRef.ts
@@ -1,0 +1,12 @@
+import { useState } from 'react'
+
+/**
+ * Small wrapper around useState for keeping a ref value in the state.
+ *
+ * @example
+ * const [element, setElement] = useStatefulRef()
+ * <input ref={setElement} />
+ */
+export function useStatefulRef<ValueType = Element>() {
+  return useState<ValueType | null>(null)
+}

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Story, Meta } from '@storybook/react'
 
-import { FloatingBox, FloatingBoxProps } from './FloatingBox'
+import { FloatingBox, FloatingBoxWithEmbeddedTargetProps } from './FloatingBox'
 import { FLOATING_BOX_SCHEME } from './constants'
 
 export default {
@@ -13,7 +13,7 @@ export default {
   },
 } as Meta
 
-export const Default: Story<FloatingBoxProps> = (props) => (
+export const Default: Story<FloatingBoxWithEmbeddedTargetProps> = (props) => (
   <FloatingBox isVisible renderTarget={<div />} {...props}>
     <div style={{ padding: '0 1rem' }}>
       <pre>Arbitrary JSX content</pre>
@@ -25,7 +25,7 @@ Default.args = {
   scheme: FLOATING_BOX_SCHEME.LIGHT,
 }
 
-export const Dark: Story<FloatingBoxProps> = (props) => (
+export const Dark: Story<FloatingBoxWithEmbeddedTargetProps> = (props) => (
   <FloatingBox
     isVisible
     renderTarget={<div />}

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.test.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { render, RenderResult } from '@testing-library/react'
 
 import { FloatingBox } from '.'
+import { useStatefulRef } from '../../hooks/useStatefulRef'
 
 describe('FloatingBox', () => {
   let wrapper: RenderResult
@@ -45,12 +46,59 @@ describe('FloatingBox', () => {
       )
     })
 
+    it('renders an embedded target', () => {
+      expect(
+        wrapper.getByTestId('floating-box-styled-target')
+      ).toBeInTheDocument()
+    })
+
     it('renders the box', () => {
-      expect(wrapper.queryByTestId('floating-box')).toBeInTheDocument()
+      expect(wrapper.getByTestId('floating-box')).toBeInTheDocument()
     })
 
     it('renders the provided renderTarget JSX', () => {
       expect(wrapper.getByText('Hello, World!')).toBeInTheDocument()
+    })
+
+    it('renders the provided arbitrary JSX', () => {
+      expect(wrapper.getByTestId('floating-box-content').innerHTML).toContain(
+        renderToStaticMarkup(children)
+      )
+    })
+  })
+
+  describe('when provided a `renderTargetElement` and arbitrary JSX content', () => {
+    beforeEach(() => {
+      children = <pre>This is some arbitrary JSX</pre>
+
+      const TestComponent = () => {
+        const [element, setElement] = useStatefulRef()
+
+        return (
+          <>
+            <div ref={setElement}>Hello, World!</div>
+            <FloatingBox
+              isVisible
+              targetElement={element}
+              role="dialog"
+              aria-modal
+            >
+              {children}
+            </FloatingBox>
+          </>
+        )
+      }
+      wrapper = render(<TestComponent />)
+    })
+
+    it('renders the box', () => {
+      expect(wrapper.queryByTestId('floating-box')).toBeInTheDocument()
+    })
+
+    it('does not render an embedded target', () => {
+      expect(
+        wrapper.queryByTestId('floating-box-styled-target')
+      ).not.toBeInTheDocument()
     })
 
     it('renders the provided arbitrary JSX', () => {

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -13,17 +13,39 @@ import { StyledArrow } from './partials/StyledArrow'
 import { useFloatingElement } from '../../hooks/useFloatingElement'
 import { FLOATING_BOX_SCHEME } from './constants'
 
-export interface FloatingBoxProps extends PositionType, ComponentWithClass {
+export interface FloatingBoxBaseProps extends PositionType, ComponentWithClass {
   role?: string
   contentId?: string
   scheme?: FloatingBoxSchemeType
   onMouseEnter?: (e: React.MouseEvent) => void
   onMouseLeave?: (e: React.MouseEvent) => void
   children?: React.ReactElement
-  renderTarget?: React.ReactElement
   isVisible?: boolean
   placement?: Placement
 }
+
+export interface FloatingBoxWithExternalTargetProps
+  extends FloatingBoxBaseProps {
+  renderTarget?: never
+  /**
+   * External element that the floating box should attach to.
+   */
+  targetElement?: Element
+}
+
+export interface FloatingBoxWithEmbeddedTargetProps
+  extends FloatingBoxBaseProps {
+  /**
+   * JSX to render, representing the element that the floating
+   * box should attach to.
+   */
+  renderTarget?: React.ReactElement
+  targetElement?: never
+}
+
+export type FloatingBoxProps =
+  | FloatingBoxWithExternalTargetProps
+  | FloatingBoxWithEmbeddedTargetProps
 
 const TRANSITION_STYLES = {
   entering: { opacity: 0 },
@@ -39,6 +61,7 @@ export const FloatingBox: React.FC<FloatingBoxProps> = ({
   onMouseLeave,
   children,
   renderTarget,
+  targetElement,
   isVisible,
   placement = 'auto',
   ...rest
@@ -49,11 +72,18 @@ export const FloatingBox: React.FC<FloatingBoxProps> = ({
     arrowElementRef,
     styles,
     attributes,
-  } = useFloatingElement(placement)
+  } = useFloatingElement(placement, undefined, targetElement)
 
   return (
     <>
-      <StyledTarget ref={targetElementRef}>{renderTarget}</StyledTarget>
+      {renderTarget && (
+        <StyledTarget
+          ref={targetElementRef}
+          data-testid="floating-box-styled-target"
+        >
+          {renderTarget}
+        </StyledTarget>
+      )}
       <Transition in={isVisible} timeout={0} unmountOnExit>
         {(state) => (
           <StyledFloatingBox


### PR DESCRIPTION
## Related issue

#2439

(Split from #2841.)

## Overview

This makes it possible for FloatingBox to use an external target element, and integrates it with DatePickerE.

## Reason

Code reuse and to simplify DatePickerE.

(It wasn't possible to integrate it as it was as the styling on `StyledTarget` interferes with the width of the date picker input.)

## Work carried out

- [x] Add ability for FloatingBox to use an external target
- [x] Update DatePickerE to use FloatingBox
