### PR TITLE
Add clear button to `SelectE`

### DIFF
--- a/packages/react-component-library/src/components/SelectE/ClearButton.tsx
+++ b/packages/react-component-library/src/components/SelectE/ClearButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { IconClose } from '@defencedigital/icon-library'
+
+import { COMPONENT_SIZE } from '../Forms'
+import { StyledInlineButton } from './partials/StyledInlineButton'
+
+interface InlineButtonProps {
+  isDisabled: boolean
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+export const ClearButton: React.FC<InlineButtonProps> = ({
+  isDisabled,
+  ...rest
+}) => (
+  <StyledInlineButton
+    $size={COMPONENT_SIZE.FORMS}
+    aria-label="Clear value"
+    data-testid="select-clear-button"
+    disabled={isDisabled}
+    type="button"
+    {...rest}
+  >
+    <IconClose />
+  </StyledInlineButton>
+)
+
+ClearButton.displayName = 'ClearButton'

--- a/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
@@ -67,6 +67,10 @@ describe('SelectE', () => {
       expect(wrapper.getByTestId('select-input')).toHaveValue('')
     })
 
+    it('does not display a clear button', () => {
+      expect(wrapper.queryAllByTestId('select-clear-button')).toHaveLength(0)
+    })
+
     it('does not display the items', () => {
       expect(wrapper.queryAllByTestId('select-option')).toHaveLength(0)
     })
@@ -134,6 +138,20 @@ describe('SelectE', () => {
         it('calls the `onChange` callback', () => {
           expect(onChangeSpy).toHaveBeenCalledTimes(1)
           expect(onChangeSpy).toHaveBeenCalledWith('two')
+        })
+
+        describe('and the clear button is clicked', () => {
+          beforeEach(() => {
+            wrapper.getByTestId('select-clear-button').click()
+          })
+
+          it('resets the value', () => {
+            expect(wrapper.getByTestId('select-input')).toHaveValue('')
+          })
+
+          it('calls the `onChange` callback', () => {
+            expect(onChangeSpy).toHaveBeenCalledWith(null)
+          })
         })
       })
     })

--- a/packages/react-component-library/src/components/SelectE/SelectE.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import Downshift from 'downshift'
 
 import { ArrowButton } from './ArrowButton'
+import { ClearButton } from './ClearButton'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { getId } from '../../helpers'
 import { SelectEOptionProps } from './SelectEOption'
@@ -48,7 +49,7 @@ export interface SelectEProps extends ComponentWithClass {
   /**
    * Optional handler invoked when the selected value changes.
    */
-  onChange?: (value: string) => void
+  onChange?: (value: string | null) => void
   /**
    * Optional HTML `value` attribute to apply to the component.
    */
@@ -88,13 +89,14 @@ export const SelectE: React.FC<SelectEProps> = ({
       onChange={(selection) => {
         if (onChange) {
           const child = getChildBy(children, 'children', selection)
-          onChange((child as React.ReactElement)?.props?.value)
+          onChange((child as React.ReactElement)?.props?.value ?? null)
         }
       }}
       initialSelectedItem={getSelectedValue(children, value)}
       itemToString={(item) => item || ''}
     >
       {({
+        clearSelection,
         getInputProps,
         getItemProps,
         getMenuProps,
@@ -157,6 +159,12 @@ export const SelectE: React.FC<SelectEProps> = ({
                   />
                 </StyledInputWrapper>
                 <StyledInlineButtons>
+                  {inputValue && (
+                    <ClearButton
+                      isDisabled={isDisabled}
+                      onClick={() => clearSelection()}
+                    />
+                  )}
                   <ArrowButton
                     hasHover={hasHover}
                     isDisabled={isDisabled}

--- a/packages/react-component-library/src/components/SelectE/partials/StyledInlineButton.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledInlineButton.tsx
@@ -4,7 +4,7 @@ import { selectors } from '@defencedigital/design-tokens'
 import { COMPONENT_SIZE, ComponentSizeType } from '../../Forms'
 
 export interface StyledInlineButtonProps {
-  $hasHover: boolean
+  $hasHover?: boolean
   $size: ComponentSizeType
 }
 

--- a/packages/react-component-library/src/components/SelectE/partials/StyledInlineButtons.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledInlineButtons.tsx
@@ -1,9 +1,15 @@
 import styled from 'styled-components'
 
+import { StyledInlineButton } from './StyledInlineButton'
+
 export const StyledInlineButtons = styled.div`
   position: relative;
   display: flex;
   justify-content: center;
   text-align: center;
   align-items: center;
+
+  ${StyledInlineButton} + ${StyledInlineButton} {
+    margin-left: 0;
+  }
 `


### PR DESCRIPTION
## Related issue
Closes #2846 

## Overview
Adds a clear button to `SelectE`.

## Link to preview
https://selecte-clear.netlify.app/?path=/story/select-experimental--default

## Reason
When an option has been selected then it may need to be cleared.

## Work carried out
- [x] Add clear button

## Screenshot
![2021-12-07 15 42 57](https://user-images.githubusercontent.com/56078793/145060587-dffc7c58-abf7-4c7e-a729-71a560163873.gif)

## Notes
- Button sizes will be picked up in a [separate ticket](https://github.com/defencedigital/mod-uk-design-system/issues/2883).