### PR TITLE
Add badge and icons to `SelectE`

### DIFF
--- a/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
@@ -20,12 +20,17 @@ export default {
 
 const Template: Story<SelectEProps> = (args) => (
   <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
-    <SelectE label="Some label" {...args}>
-      <SelectEOption value="one">One</SelectEOption>
-      <SelectEOption value="two">Two</SelectEOption>
-      <SelectEOption value="three">Three</SelectEOption>
-      <SelectEOption value="four">Four</SelectEOption>
-    </SelectE>
+    <SelectE
+      /* eslint-disable react/no-children-prop */
+      children={[
+        <SelectEOption value="one">One</SelectEOption>,
+        <SelectEOption value="two">Two</SelectEOption>,
+        <SelectEOption value="three">Three</SelectEOption>,
+        <SelectEOption value="four">Four</SelectEOption>,
+      ]}
+      label="Some label"
+      {...args}
+    />
   </div>
 )
 
@@ -44,4 +49,22 @@ WithError.args = {
 export const WithValue = Template.bind({})
 WithValue.args = {
   value: 'two',
+}
+
+export const WithBadges = Template.bind({})
+WithBadges.args = {
+  children: [
+    <SelectEOption badge={100} value="one">
+      One
+    </SelectEOption>,
+    <SelectEOption badge={110} value="two">
+      Two
+    </SelectEOption>,
+    <SelectEOption badge={111} value="three">
+      Three
+    </SelectEOption>,
+    <SelectEOption badge={112} value="four">
+      Four
+    </SelectEOption>,
+  ],
 }

--- a/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
 import { Story, Meta } from '@storybook/react/types-6-0'
+import {
+  IconAgriculture,
+  IconAnchor,
+  IconBrightnessAuto,
+  IconRemove,
+} from '@defencedigital/icon-library'
 
 import { SelectE, SelectEProps } from './index'
 import { SelectEOption } from './SelectEOption'
@@ -51,19 +57,19 @@ WithValue.args = {
   value: 'two',
 }
 
-export const WithBadges = Template.bind({})
-WithBadges.args = {
+export const WithIconsAndBadges = Template.bind({})
+WithIconsAndBadges.args = {
   children: [
-    <SelectEOption badge={100} value="one">
+    <SelectEOption badge={100} icon={<IconAnchor />} value="one">
       One
     </SelectEOption>,
-    <SelectEOption badge={110} value="two">
+    <SelectEOption badge={110} icon={<IconRemove />} value="two">
       Two
     </SelectEOption>,
-    <SelectEOption badge={111} value="three">
+    <SelectEOption badge={111} icon={<IconAgriculture />} value="three">
       Three
     </SelectEOption>,
-    <SelectEOption badge={112} value="four">
+    <SelectEOption badge={112} icon={<IconBrightnessAuto />} value="four">
       Four
     </SelectEOption>,
   ],

--- a/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
@@ -3,6 +3,11 @@ import '@testing-library/jest-dom/extend-expect'
 import { fireEvent, render, RenderResult } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ColorAction000, ColorDanger800 } from '@defencedigital/design-tokens'
+import {
+  IconAgriculture,
+  IconAnchor,
+  IconRemove,
+} from '@defencedigital/icon-library'
 
 import { BORDER_WIDTH } from '../../styled-components'
 import { COMPONENT_SIZE } from '../Forms'
@@ -286,6 +291,43 @@ describe('SelectE', () => {
 
     it('does not set the value', () => {
       expect(wrapper.getByTestId('select-input')).toHaveValue('')
+    })
+  })
+
+  describe('when options have icons', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <SelectE id="select-id" label="Label">
+          <SelectEOption
+            icon={<IconAnchor data-testid="select-icon" />}
+            value="one"
+          >
+            One
+          </SelectEOption>
+          <SelectEOption
+            icon={<IconRemove data-testid="select-icon" />}
+            value="two"
+          >
+            Two
+          </SelectEOption>
+          <SelectEOption
+            icon={<IconAgriculture data-testid="select-icon" />}
+            value="three"
+          >
+            Three
+          </SelectEOption>
+        </SelectE>
+      )
+    })
+
+    describe('and clicking on the input', () => {
+      beforeEach(() => {
+        userEvent.click(wrapper.getByTestId('select-input'))
+      })
+
+      it('displays 3 icons', () => {
+        expect(wrapper.queryAllByTestId('select-icon')).toHaveLength(3)
+      })
     })
   })
 

--- a/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
@@ -174,6 +174,10 @@ describe('SelectE', () => {
       it('shows the items', () => {
         expect(wrapper.queryAllByTestId('select-option')).toHaveLength(3)
       })
+
+      it('does not display badges', () => {
+        expect(wrapper.queryAllByTestId('select-badge')).toHaveLength(0)
+      })
     })
   })
 
@@ -282,6 +286,38 @@ describe('SelectE', () => {
 
     it('does not set the value', () => {
       expect(wrapper.getByTestId('select-input')).toHaveValue('')
+    })
+  })
+
+  describe('when options have badges', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <SelectE id="select-id" label="Label">
+          <SelectEOption badge={1} value="one">
+            One
+          </SelectEOption>
+          <SelectEOption badge={2} value="two">
+            Two
+          </SelectEOption>
+          <SelectEOption badge={3} value="three">
+            Three
+          </SelectEOption>
+        </SelectE>
+      )
+    })
+
+    describe('when clicking on the input', () => {
+      beforeEach(() => {
+        userEvent.click(wrapper.getByTestId('select-input'))
+      })
+
+      it('displays 3 badges', () => {
+        const badges = wrapper.queryAllByTestId('select-badge')
+        expect(badges[0]).toHaveTextContent('1')
+        expect(badges[1]).toHaveTextContent('2')
+        expect(badges[2]).toHaveTextContent('3')
+        expect(badges).toHaveLength(3)
+      })
     })
   })
 })

--- a/packages/react-component-library/src/components/SelectE/SelectEOption.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectEOption.tsx
@@ -8,6 +8,7 @@ import { StyledOptionText } from './partials/StyledOptionText'
 
 export interface SelectEOptionProps extends ComponentWithClass {
   badge?: string | number
+  icon?: React.ReactNode
   children: string
   isHighlighted?: boolean
   value: string
@@ -15,6 +16,7 @@ export interface SelectEOptionProps extends ComponentWithClass {
 
 export const SelectEOption: React.FC<SelectEOptionProps> = ({
   badge,
+  icon,
   children,
   isHighlighted,
   ...rest
@@ -24,6 +26,7 @@ export const SelectEOption: React.FC<SelectEOptionProps> = ({
     data-testid="select-option"
     {...rest}
   >
+    {icon}
     <StyledOptionText>{children}</StyledOptionText>
     {badge && (
       <StyledOptionBadge

--- a/packages/react-component-library/src/components/SelectE/SelectEOption.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectEOption.tsx
@@ -1,15 +1,20 @@
 import React from 'react'
 
+import { BADGE_SIZE, BADGE_VARIANT } from '../Badge'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { StyledOption } from './partials/StyledOption'
+import { StyledOptionBadge } from './partials/StyledOptionBadge'
+import { StyledOptionText } from './partials/StyledOptionText'
 
 export interface SelectEOptionProps extends ComponentWithClass {
+  badge?: string | number
   children: string
   isHighlighted?: boolean
   value: string
 }
 
 export const SelectEOption: React.FC<SelectEOptionProps> = ({
+  badge,
   children,
   isHighlighted,
   ...rest
@@ -19,7 +24,16 @@ export const SelectEOption: React.FC<SelectEOptionProps> = ({
     data-testid="select-option"
     {...rest}
   >
-    {children}
+    <StyledOptionText>{children}</StyledOptionText>
+    {badge && (
+      <StyledOptionBadge
+        data-testid="select-badge"
+        size={BADGE_SIZE.XSMALL}
+        variant={BADGE_VARIANT.PILL}
+      >
+        {badge}
+      </StyledOptionBadge>
+    )}
   </StyledOption>
 )
 

--- a/packages/react-component-library/src/components/SelectE/partials/StyledOption.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOption.tsx
@@ -4,7 +4,7 @@ import { selectors } from '@defencedigital/design-tokens'
 import { COMPONENT_SIZE } from '../../Forms'
 import { TEXT_INPUT_INPUT_HEIGHT } from '../../TextInputE/partials/StyledInput'
 
-const { color, spacing } = selectors
+const { color, fontSize, spacing } = selectors
 
 interface StyledOptionsProps {
   $isHighlighted: boolean
@@ -17,6 +17,7 @@ export const StyledOption = styled.li<StyledOptionsProps>`
   align-items: center;
   cursor: pointer;
   color: ${color('neutral', '400')};
+  font-size: ${fontSize('m')};
 
   &:hover {
     background-color: ${color('neutral', '100')};

--- a/packages/react-component-library/src/components/SelectE/partials/StyledOption.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOption.tsx
@@ -4,7 +4,7 @@ import { selectors } from '@defencedigital/design-tokens'
 import { COMPONENT_SIZE } from '../../Forms'
 import { TEXT_INPUT_INPUT_HEIGHT } from '../../TextInputE/partials/StyledInput'
 
-const { color } = selectors
+const { color, spacing } = selectors
 
 interface StyledOptionsProps {
   $isHighlighted: boolean
@@ -27,4 +27,12 @@ export const StyledOption = styled.li<StyledOptionsProps>`
     css`
       background-color: ${color('neutral', '100')};
     `}
+
+  & > svg {
+    height: 16px;
+    width: 16px;
+    transform: translateY(1px);
+    margin-right: ${spacing('4')};
+    color: ${color('neutral', '400')};
+  }
 `

--- a/packages/react-component-library/src/components/SelectE/partials/StyledOption.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOption.tsx
@@ -12,7 +12,7 @@ interface StyledOptionsProps {
 
 export const StyledOption = styled.li<StyledOptionsProps>`
   height: ${TEXT_INPUT_INPUT_HEIGHT[COMPONENT_SIZE.FORMS]};
-  padding-left: 11px;
+  padding: 0 11px;
   display: flex;
   align-items: center;
   cursor: pointer;

--- a/packages/react-component-library/src/components/SelectE/partials/StyledOptionBadge.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOptionBadge.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+
+import { Badge } from '../../Badge'
+
+export const StyledOptionBadge = styled(Badge)`
+  transform: translateY(1px);
+`

--- a/packages/react-component-library/src/components/SelectE/partials/StyledOptionText.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOptionText.tsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components'
+
+export const StyledOptionText = styled.span`
+  flex: 1;
+`

--- a/packages/react-component-library/src/components/SelectE/partials/StyledOptionsWrapper.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOptionsWrapper.tsx
@@ -14,7 +14,7 @@ function getTopBorder() {
       content: '';
       position: absolute;
       left: 0;
-      top: 1px;
+      top: 0;
       height: 1px;
       width: 100%;
       border-bottom: 1px solid ${color('neutral', '200')};


### PR DESCRIPTION
## Related issue
Closes #2438 

## Overview
Adds the badge and icons to `SelectE`.

## Link to preview
https://selecte-icons.netlify.app/?path=/story/select-experimental--with-icons-and-badge

## Reason
Required for feature parity.

## Work carried out
- [x] Add badge
- [x] Add icons

## Screenshot
![Screenshot 2021-12-07 at 15 55 13](https://user-images.githubusercontent.com/56078793/145062369-3da69908-e274-4ba9-9b1d-2b26ed2b4456.png)
