### PR TITLE
test(NumberInputE): Add form Cypress tests

### DIFF
--- a/packages/react-component-library/cypress/selectors/NumberInputE.ts
+++ b/packages/react-component-library/cypress/selectors/NumberInputE.ts
@@ -1,0 +1,5 @@
+export default {
+  decrease: '[data-testid="number-input-decrease"]',
+  increase: '[data-testid="number-input-increase"]',
+  input: '[data-testid="number-input-input"]',
+}

--- a/packages/react-component-library/cypress/selectors/form.ts
+++ b/packages/react-component-library/cypress/selectors/form.ts
@@ -6,8 +6,10 @@ export default {
     checkbox: '[data-testid="checkbox"]',
     radio: '[data-testid="radio"]',
     switch: '[data-testid="switch"]',
-    switchOption: '[data-testid="switch-option"]'
+    switchOption: '[data-testid="switch-option"]',
+    numberInput: '[data-testid="number-input"]',
+    numberInputIncrease: '[data-testid="number-input-increase"]',
   },
   submit: '[data-testid="form-example-submit"]',
-  values: '[data-testid="form-example-values"]'
+  values: '[data-testid="form-example-values"]',
 }

--- a/packages/react-component-library/cypress/selectors/index.ts
+++ b/packages/react-component-library/cypress/selectors/index.ts
@@ -1,6 +1,7 @@
 import rangeSliderE from './RangeSliderE'
 import datePicker from './DatePicker'
 import contextMenu from './ContextMenu'
+import numberInputE from './NumberInputE'
 import timeline from './timeline'
 import form from './form'
 
@@ -8,6 +9,7 @@ export default {
   rangeSliderE,
   datePicker,
   contextMenu,
+  numberInputE,
   timeline,
   form,
 }

--- a/packages/react-component-library/cypress/specs/NumberInputE/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/NumberInputE/index.spec.ts
@@ -1,0 +1,35 @@
+import { before, cy, describe, it } from 'local-cypress'
+
+import selectors from '../../selectors'
+
+describe('NumberInputE', () => {
+  before(() => {
+    cy.visit(
+      '/iframe.html?id=number-input-experimental--default&viewMode=story'
+    )
+  })
+
+  it('renders the number input without a value', () => {
+    cy.get(selectors.numberInputE.input).should('have.value', '')
+  })
+
+  describe('when the increase button is clicked', () => {
+    before(() => {
+      cy.get(selectors.numberInputE.increase).click()
+    })
+
+    it('should increment the value', () => {
+      cy.get(selectors.numberInputE.input).should('have.value', '1')
+    })
+  })
+
+  describe('when the decrease button is clicked', () => {
+    before(() => {
+      cy.get(selectors.numberInputE.decrease).click()
+    })
+
+    it('should decrement the value', () => {
+      cy.get(selectors.numberInputE.input).should('have.value', '0')
+    })
+  })
+})

--- a/packages/react-component-library/cypress/specs/forms/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/forms/index.spec.ts
@@ -32,6 +32,7 @@ describe('Form Examples', () => {
             cy.get(selectors.form.input.password).should('be.visible')
             cy.get(selectors.form.input.description).should('be.visible')
             cy.get(selectors.form.input.switch).should('be.visible')
+            cy.get(selectors.form.input.numberInput).should('be.visible')
           })
 
           describe('when an empty form is submitted', () => {
@@ -51,6 +52,7 @@ describe('Form Examples', () => {
               cy.get(selectors.form.input.description).type('Hello, World!')
               cy.get(selectors.form.input.radio).eq(0).click()
               cy.get(selectors.form.input.switchOption).eq(0).click()
+              cy.get(selectors.form.input.numberInputIncrease).click()
             })
 
             it('should not show any validation errors', () => {
@@ -76,6 +78,7 @@ describe('Form Examples', () => {
                       exampleCheckbox: [],
                       exampleRadio: 'Option 1',
                       exampleSwitch: '1',
+                      exampleNumberInput: 1,
                     },
                     null,
                     2

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
@@ -44,9 +44,7 @@ describe('NumberInputE', () => {
     text: string
   }) {
     it('sets the `aria-value*` attribute', () => {
-      const container = wrapper.getByTestId(
-        'number-input-container'
-      ) as HTMLDivElement
+      const container = wrapper.getByTestId('number-input') as HTMLDivElement
 
       if (min) {
         expect(container).toHaveAttribute('aria-valuemin', min.toString())
@@ -86,7 +84,7 @@ describe('NumberInputE', () => {
     })
 
     it('sets the default `aria-label` attribute', () => {
-      expect(wrapper.getByTestId('number-input-container')).toHaveAttribute(
+      expect(wrapper.getByTestId('number-input')).toHaveAttribute(
         'aria-label',
         'Number input'
       )
@@ -105,7 +103,7 @@ describe('NumberInputE', () => {
     })
 
     it('applies the correct `role` attribute', () => {
-      expect(wrapper.getByTestId('number-input-container')).toHaveAttribute(
+      expect(wrapper.getByTestId('number-input')).toHaveAttribute(
         'role',
         'spinbutton'
       )
@@ -127,7 +125,7 @@ describe('NumberInputE', () => {
 
     it('does not set the `aria-labelledby` attribute', () => {
       const numberInputId = wrapper
-        .getByTestId('number-input-container')
+        .getByTestId('number-input')
         .getAttribute('id')
 
       expect(
@@ -259,7 +257,7 @@ describe('NumberInputE', () => {
     })
 
     it('sets the `aria-label` attribute to the root element', () => {
-      expect(wrapper.getByTestId('number-input-container')).toHaveAttribute(
+      expect(wrapper.getByTestId('number-input')).toHaveAttribute(
         'aria-label',
         'Label'
       )
@@ -291,14 +289,14 @@ describe('NumberInputE', () => {
     })
 
     it('sets the correct `aria-valuemin` attribute', () => {
-      expect(wrapper.getByTestId('number-input-container')).toHaveAttribute(
+      expect(wrapper.getByTestId('number-input')).toHaveAttribute(
         'aria-valuemin',
         '0'
       )
     })
 
     it('aplies the `aria-valuemax` attribute', () => {
-      expect(wrapper.getByTestId('number-input-container')).toHaveAttribute(
+      expect(wrapper.getByTestId('number-input')).toHaveAttribute(
         'aria-valuemax',
         '3'
       )
@@ -426,7 +424,7 @@ describe('NumberInputE', () => {
     })
 
     it('sets the CSS modifier', () => {
-      expect(wrapper.getByTestId('number-input-container').classList).toContain(
+      expect(wrapper.getByTestId('number-input').classList).toContain(
         'number-input__custom'
       )
     })

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.tsx
@@ -187,7 +187,7 @@ export const NumberInputE: React.FC<NumberInputEProps> = ({
     <StyledNumberInput
       aria-label={label || 'Number input'}
       className={className}
-      data-testid="number-input-container"
+      data-testid="number-input"
       id={numberInputId}
       role="spinbutton"
       aria-valuemin={min}

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -7,6 +7,7 @@ import { TextAreaE } from '../../components/TextAreaE'
 import { RadioE } from '../../components/RadioE'
 import { CheckboxE } from '../../components/CheckboxE'
 import { ButtonE } from '../../components/ButtonE'
+import { NumberInputE } from '../../components/NumberInputE'
 import { SwitchE, SwitchEOption, SwitchEProps } from '../../components/SwitchE'
 import { FormikGroupE } from '../../components/FormikGroup'
 import { withFormik } from '../../enhancers/withFormik'
@@ -19,6 +20,7 @@ export interface FormValues {
   exampleCheckbox: string[]
   exampleRadio: string[]
   exampleSwitch: string
+  exampleNumberInput: number
 }
 
 const SwitchEFormed: React.FC<SwitchEProps> = (props) => (
@@ -38,6 +40,7 @@ const FormikTextAreaE = withFormik(TextAreaE)
 const FormikCheckboxE = withFormik(CheckboxE)
 const FormikRadioE = withFormik(RadioE)
 const FormikSwitchE = withFormik(SwitchEFormed)
+const FormikNumberInputE = withFormik(NumberInputE)
 
 export const ExampleFormik: React.FC<unknown> = () => {
   const [formValues, setFormValues] = useState<FormValues>()
@@ -52,6 +55,7 @@ export const ExampleFormik: React.FC<unknown> = () => {
           exampleCheckbox: [],
           exampleRadio: [],
           exampleSwitch: '',
+          exampleNumberInput: null,
         }}
         validate={(values) => {
           const errors: Record<string, unknown> = {}
@@ -144,6 +148,18 @@ export const ExampleFormik: React.FC<unknown> = () => {
               component={FormikSwitchE}
               onChange={(event: React.FormEvent<HTMLInputElement>) => {
                 setFieldValue('exampleSwitch', event.currentTarget.value)
+              }}
+            />
+            <Field
+              name="exampleNumberInput"
+              component={FormikNumberInputE}
+              onChange={(
+                event:
+                  | React.ChangeEvent<HTMLInputElement>
+                  | React.MouseEvent<HTMLButtonElement>,
+                newValue: number
+              ) => {
+                setFieldValue('exampleNumberInput', newValue)
               }}
             />
             <ButtonE

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -7,6 +7,7 @@ import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'
 import { RadioE } from '../../components/RadioE'
 import { CheckboxE } from '../../components/CheckboxE'
+import { NumberInputE } from '../../components/NumberInputE'
 import { SwitchE, SwitchEOption } from '../../components/SwitchE'
 import { ButtonE } from '../../components/ButtonE'
 import { Fieldset } from '../../components/Fieldset'
@@ -19,6 +20,7 @@ export interface FormValues {
   exampleCheckbox: string[]
   exampleRadio: string[]
   exampleSwitch: string
+  exampleNumberInput: number
 }
 
 export const ExampleReactHookForm: React.FC<unknown> = () => {
@@ -36,10 +38,12 @@ export const ExampleReactHookForm: React.FC<unknown> = () => {
       exampleCheckbox: [],
       exampleRadio: [],
       exampleSwitch: '',
+      exampleNumberInput: null,
     },
   })
 
   const exampleSwitchValue = watch('exampleSwitch')
+  const exampleNumberInputValue = watch('exampleNumberInput')
 
   const [formValues, setFormValues] = useState<FormValues>()
 
@@ -50,10 +54,18 @@ export const ExampleReactHookForm: React.FC<unknown> = () => {
 
   useEffect(() => {
     register({ name: 'exampleSwitch' })
+    register({ name: 'exampleNumberInput' })
   }, [register])
 
   const handleSwitchEChange = (e: React.FormEvent<HTMLInputElement>) =>
     setValue('exampleSwitch', e.currentTarget.value)
+
+  const handleNumberInputEChange = (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.MouseEvent<HTMLButtonElement>,
+    newValue: number
+  ) => setValue('exampleNumberInput', newValue)
 
   return (
     <main>
@@ -127,6 +139,13 @@ export const ExampleReactHookForm: React.FC<unknown> = () => {
           <SwitchEOption label="Two" value="2" />
           <SwitchEOption label="Three" value="3" />
         </SwitchE>
+        <NumberInputE
+          name="exampleNumberInput"
+          label="Example number input"
+          onChange={handleNumberInputEChange}
+          value={exampleNumberInputValue}
+          data-testid="form-example-NumberInputE"
+        />
         <ButtonE
           type="submit"
           data-testid="form-example-submit"


### PR DESCRIPTION
## Related issue
Closes #2748 

## Overview
Backfill tests for `NumberInputE`.

## Reason
These were left over from `NumberInputE` work.

## Work carried out
- [x] Add `forms` tests
- [x] Add `NumberInputE` tests