### PR TITLE
fix(Timeline): Update scale index condition

### DIFF
--- a/packages/react-component-library/cypress/specs/timeline/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/timeline/index.spec.ts
@@ -264,6 +264,18 @@ describe('Compound Timeline', () => {
         it('should fill the width', () => {
           cy.get(selectors.timeline.month).should('have.css', 'width', '1023px')
         })
+
+        describe('resizing the window', () => {
+          before(() => {
+            cy.viewport(1500, 768)
+          })
+
+          it('still renders 1 day', () => {
+            cy.get(selectors.timeline.day)
+              .should('have.length', 1)
+              .should('have.css', 'width', '1499px')
+          })
+        })
       })
     })
 

--- a/packages/react-component-library/src/components/Timeline/context/reducer.ts
+++ b/packages/react-component-library/src/components/Timeline/context/reducer.ts
@@ -106,7 +106,7 @@ export function reducer(
     case TIMELINE_ACTIONS.INITIALISE: {
       const scaleOptions = buildScaleOptions(state.options, action.width)
       const currentScaleIndex =
-        state.currentScaleIndex ||
+        state.currentScaleIndex ??
         scaleOptions.findIndex(({ isDefault }) => isDefault)
       return {
         ...state,


### PR DESCRIPTION
## Related issue
Closes #2765 

## Overview
There is a bug when zoomed all the way in and resizing the window.

It is possible for the scale index to be 0 which is falsy but we still want to satisfy the `true` side of the condition.

## Reason
> Full-width timeline zooms out on viewport width increase

## Work carried out
- [x] Fix bug with test
