### PR TITLE
fix(NumberInputE): Sanitize input before invoking `parseInt`

### DIFF
--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
@@ -173,12 +173,12 @@ describe('NumberInputE', () => {
     })
 
     describe('and the user types values', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         const input = wrapper.getByTestId('number-input-input')
 
-        await userEvent.type(input, '1')
-        await userEvent.type(input, '2')
-        await userEvent.type(input, '3')
+        userEvent.type(input, '1')
+        userEvent.type(input, '2')
+        userEvent.type(input, '3')
       })
 
       it('calls the `onChange` callback once with `1`', () => {
@@ -193,7 +193,7 @@ describe('NumberInputE', () => {
       assertOnChangeCall(123, 3)
     })
 
-    describe('and the user types a value with an invalid character', () => {
+    describe('and the user types a value with invalid characters', () => {
       beforeEach(() => {
         const input = wrapper.getByTestId('number-input-input')
 
@@ -224,20 +224,20 @@ describe('NumberInputE', () => {
     })
 
     describe('and the user types a value', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         const input = wrapper.getByTestId('number-input-input')
 
-        await userEvent.type(input, '1')
+        userEvent.type(input, '1')
       })
 
       assertInputValue('1')
       assertOnChangeCall(1, 1)
 
       describe('and the user deletes the value', () => {
-        beforeEach(async () => {
+        beforeEach(() => {
           const input = wrapper.getByTestId('number-input-input')
 
-          await userEvent.type(input, '{backspace}')
+          userEvent.type(input, '{backspace}')
         })
 
         assertInputValue('')

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
@@ -193,6 +193,36 @@ describe('NumberInputE', () => {
       assertOnChangeCall(123, 3)
     })
 
+    describe('and the user types a value with an invalid character', () => {
+      beforeEach(() => {
+        const input = wrapper.getByTestId('number-input-input')
+
+        userEvent.type(input, '1')
+        userEvent.type(input, 'a')
+        userEvent.type(input, '.')
+        userEvent.type(input, '2')
+      })
+
+      it('calls the `onChange` callback with `1`', () => {
+        expect(onChangeSpy.mock.calls[0][1]).toEqual(1)
+      })
+
+      it('calls the `onChange` callback again with `1`', () => {
+        expect(onChangeSpy.mock.calls[1][1]).toEqual(1)
+      })
+
+      it('calls the `onChange` callback yet again with `1`', () => {
+        expect(onChangeSpy.mock.calls[2][1]).toEqual(1)
+      })
+
+      it('calls the `onChange` callback again with `12`', () => {
+        expect(onChangeSpy.mock.calls[3][1]).toEqual(12)
+      })
+
+      assertInputValue('12')
+      assertOnChangeCall(12, 4)
+    })
+
     describe('and the user types a value', () => {
       beforeEach(async () => {
         const input = wrapper.getByTestId('number-input-input')
@@ -334,7 +364,7 @@ describe('NumberInputE', () => {
         wrapper.getByTestId('number-input-input').focus()
       })
 
-      describe('and the user types an invalid character', () => {
+      describe('and the value is changed to an alpha character', () => {
         beforeEach(() => {
           fireEvent.change(wrapper.getByTestId('number-input-input'), {
             target: {
@@ -343,10 +373,10 @@ describe('NumberInputE', () => {
           })
         })
 
-        assertInputValue('1')
+        assertInputValue('')
       })
 
-      describe('and the user types a valid number', () => {
+      describe('and the value is changed to a valid number', () => {
         beforeEach(() => {
           fireEvent.change(wrapper.getByTestId('number-input-input'), {
             target: {
@@ -358,7 +388,7 @@ describe('NumberInputE', () => {
         assertInputValue('3')
       })
 
-      describe('and the user types an number outside the max min range', () => {
+      describe('and the value is changed to a number outside the max min range', () => {
         beforeEach(() => {
           fireEvent.change(wrapper.getByTestId('number-input-input'), {
             target: {

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.tsx
@@ -134,12 +134,13 @@ function formatValue(displayValue: number, prefix: string, suffix: string) {
 
 function getNewValue(event: React.FormEvent<HTMLInputElement>): number {
   const { value } = event.currentTarget
+  const sanitizedValue = value.replace(/\D/g, '')
 
-  if (value === '') {
+  if (sanitizedValue === '') {
     return null
   }
 
-  return parseInt(value, 10)
+  return parseInt(sanitizedValue, 10)
 }
 
 function isWithinRange(max: number, min: number, newValue: number) {


### PR DESCRIPTION
## Related issue

Closes #2767

## Overview

Sanitize input before parsing. You can now only type in numeric characters.

## Reason

>Typing an alpha character would cause everything after that character to be purged by `parseInt`.

## Work carried out

- [x] Supplement with additional tests
- [x] Sanitize input before parsing
