### PR TITLE
fix(Select): Correct label positioning

### DIFF
--- a/packages/react-component-library/src/components/Select/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledLabel.tsx
@@ -1,7 +1,7 @@
 import { selectors } from '@defencedigital/design-tokens'
 import styled from 'styled-components'
 
-const { color, fontSize, spacing } = selectors
+const { color, fontSize } = selectors
 
 export const StyledLabel = styled.label`
   display: block;
@@ -11,7 +11,7 @@ export const StyledLabel = styled.label`
   top: 0;
   left: 0;
   transform-origin: top left;
-  transform: translate(${spacing('6')}, ${spacing('6')}) scale(1);
+  transform: translate(12px, 13px) scale(1);
   transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
     transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
 `

--- a/packages/react-component-library/src/components/Select/partials/StyledValueContainer.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledValueContainer.tsx
@@ -7,11 +7,10 @@ import { StyledLabel } from './StyledLabel'
 const { spacing } = selectors
 
 export const StyledValueContainer = styled(components.ValueContainer)`
-  position: initial;
-  height: inherit;
-
   &&& {
     padding: 0 0 0 ${spacing('6')};
+    position: initial;
+    height: inherit;
   }
 
   &.rn-select__value-container--has-value ${StyledLabel} {


### PR DESCRIPTION
## Related issue

Fixes #2868

## Overview

This fixes a problem where the `Select` label was intermittently not vertically centred. 

## Link to preview

[Storybook](https://5e25c277526d380020b5e418-qewjykxiqj.chromatic.com/?path=/docs/select--default)

## Work carried out

- [x] Fix problem with styles being overridden using existing specificity trick
- [x] Tweak positioning of label

## Screenshot

### Before

![image](https://user-images.githubusercontent.com/66470099/145422118-efbda684-8110-47d7-8588-d9ce2c64fa46.png)

### After

![image](https://user-images.githubusercontent.com/66470099/145422190-fc85b78f-57a1-434b-a673-5d0cc3b953a6.png)

## Developer notes

This was happening particularly in Storybook, and was due to react-select's styles sometimes overriding our styles (probably a race condition as it uses emotion for styles).
