### PR TITLE
fix(Fieldset): Improve styling in IE11

### DIFF
--- a/packages/react-component-library/src/components/Fieldset/Fieldset.tsx
+++ b/packages/react-component-library/src/components/Fieldset/Fieldset.tsx
@@ -21,7 +21,7 @@ const { color, spacing } = selectors
 const StyledFieldset = styled.fieldset<StyledFieldsetProps>`
   display: inline-block;
   position: relative;
-  padding: unset;
+  padding: 0;
   border: none;
   border-radius: 15px;
 
@@ -33,13 +33,13 @@ const StyledFieldset = styled.fieldset<StyledFieldsetProps>`
     margin-top: -1px;
 
     &:first-of-type {
-      margin-top: unset;
+      margin-top: 0;
     }
   }
 
   ${StyledRadioWrapper}, ${StyledCheckboxWrapper} {
     ${StyledCheckbox}, ${StyledRadio} {
-      border-radius: unset;
+      border-radius: 0;
       border-bottom-width: 1px;
       border-bottom-color: transparent;
 
@@ -96,7 +96,7 @@ const StyledFieldset = styled.fieldset<StyledFieldsetProps>`
       ${StyledCheckboxWrapper} {
         ${StyledCheckbox}, ${StyledRadio} {
           border-color: ${color('neutral', '200')};
-          box-shadow: unset;
+          box-shadow: none;
           border-right-color: transparent;
           border-left-color: transparent;
         }


### PR DESCRIPTION
## Related issue

Resolves #2847

## Overview

This fixes the main styling problems in IE11 when `CheckboxE` and `RadioE` are used in a `Fieldset` or a `FormikGroupE`.

## Link to preview

[Storybook](https://5e25c277526d380020b5e418-gdbyovpcdf.chromatic.com/?path=/docs/checkbox-experimental--with-formik-group)

## Reason

The styling was broken in IE11.

## Work carried out

- [x] Replace uses of `unset` with explicit values

## Screenshot

### CheckboxE

#### Before

![cbe-before](https://user-images.githubusercontent.com/66470099/145443248-da4d3cad-32cb-414c-b16d-09b9041f083c.PNG)

#### After

![checkbox-e-after](https://user-images.githubusercontent.com/66470099/145443259-cb44a60d-3634-48cc-8240-37839bb57c50.PNG)

### RadioE

#### Before

![radio-e-before](https://user-images.githubusercontent.com/66470099/145443269-ead6c3b3-ab61-49c9-8773-521c9cff10e3.PNG)

#### After

![radio-e-after](https://user-images.githubusercontent.com/66470099/145443274-c54f764d-6e3b-4965-80a2-e388cdcb76e4.PNG)

## Developer notes

These were happening because IE doesn't support the `unset` keyword (nor `initial` or `all`).

It does support `inherit` but that doesn't make sense for many properties.

I've changed replaced these usages of `unset` with what the initial values are according to MDN.

Note that we have other uses of `unset` etc. around the code base which may need to be reviewed separately.
