### PR TITLE
fix(SelectE): Add drop shadow

### DIFF
--- a/packages/react-component-library/src/components/SelectE/partials/StyledOptionsWrapper.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOptionsWrapper.tsx
@@ -36,7 +36,7 @@ function getBoxShadow() {
       right: 0;
       bottom: 0;
       box-shadow: 0 0 0 3px ${color('action', '500')},
-        0 0 0 6px ${color('action', '100')};
+        0 0 0 6px ${color('action', '100')}, 0 2px 22px rgba(0, 0, 0, 0.2);
       pointer-events: none;
       border-radius: ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
     }


### PR DESCRIPTION
## Related issue
Fixes #2887 

## Overview
Adds a drop shadow to `SelectE`.

## Link to preview
https://selecte-drop-shadow.netlify.app/?path=/story/select-experimental--default

## Reason
> drop shadow needs adding to the outer wrapper.

## Work carried out
- [x] Add drop shadow

## Screenshot
![Screenshot 2021-12-10 at 13 50 09](https://user-images.githubusercontent.com/56078793/145584562-0b8af64e-caa7-4eb3-915b-cdb43f395654.png)
