### PR TITLE
fix(Helpers): Make `isFirefox` helper node safe

### DIFF
--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -23,12 +23,18 @@ function hasClass(allClasses: string, className: string): boolean {
 }
 
 function isFirefox(): boolean {
+  if (typeof navigator === 'undefined') {
+    logger.warn('`navigator` object does not exist')
+
+    return false
+  }
+
   return navigator.userAgent.toLowerCase().indexOf('firefox') > -1
 }
 
 function isIE11(): boolean {
   if (typeof window === 'undefined') {
-    logger.warn(`window object does not exist`)
+    logger.warn('`window` object does not exist')
 
     return false
   }


### PR DESCRIPTION
## Related issue

Closes #2905

## Overview

Check that the `navigator` object exists.

## Reason

In some instance the `navigator` object does not exist - for example when server side rendering a NextJS app via node.

## Work carried out

- [x] Add `typeof` check

## Screenshot

<img width="1271" alt="Screenshot 2021-12-13 at 10 40 10" src="https://user-images.githubusercontent.com/48086589/145798796-1306866f-be73-4d0f-a8c2-693a2ff08d53.png">

## Developer notes

Same principle used with the `isIE11` helper.
