### PR TITLE
Make Formik a peer dependency and fix CRA template

### DIFF
--- a/.github/workflows/npmsmoketest.yml
+++ b/.github/workflows/npmsmoketest.yml
@@ -44,19 +44,18 @@ jobs:
           )
           for i in "${PACKAGES[@]}";
            do
-             contents="$(jq '.package.dependencies."@defencedigital/'$i'" = "file:../packages/'$i'"' $TEMPLATE)" \
+             contents="$(jq '.package.dependencies."@defencedigital/'$i'" = "file:'$GITHUB_WORKSPACE'/packages/'$i'"' $TEMPLATE)" \
              && echo "${contents}" > $TEMPLATE
            done
           cat $TEMPLATE
 
       - name: Create boilerplate app
         run: |
-          if [ -d "my-app" ]; then rm -Rf my-app ; fi
-          npx create-react-app my-app --template file:../${{ github.event.repository.name }}/packages/cra-template-defencedigital
+          if [ -d "$RUNNER_TEMP/my-app" ]; then rm -Rf $RUNNER_TEMP/my-app ; fi
+          npx create-react-app $RUNNER_TEMP/my-app --template file:../${{ github.event.repository.name }}/packages/cra-template-defencedigital
 
       - name: Build boilerlate app
         run: |
-          cd my-app
+          cd $RUNNER_TEMP/my-app
           grep version node_modules/@defencedigital/**/package.json
-          echo "SKIP_PREFLIGHT_CHECK=true" > .env  #workaround for babel-loader (8.2.2) CRA version issue
           yarn build

--- a/.github/workflows/npmsmoketest.yml
+++ b/.github/workflows/npmsmoketest.yml
@@ -38,7 +38,6 @@ jobs:
           TEMPLATE=packages/cra-template-defencedigital/template.json
           PACKAGES=(
            design-tokens
-           css-framework
            fonts
            icon-library
            react-component-library

--- a/.github/workflows/npmsmoketest.yml
+++ b/.github/workflows/npmsmoketest.yml
@@ -7,57 +7,57 @@ on:
   pull_request:
 
 jobs:
-     NPM_smoketest:
-      runs-on: ubuntu-latest
+  NPM_smoketest:
+    runs-on: ubuntu-latest
 
-      steps:
-        - name: Git clone repository
-          uses: actions/checkout@v2
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v2
 
-        - name: Cache Node modules
-          uses: actions/cache@v2
-          with:
-            path: '**/node_modules'
-            key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
 
-        - name: Install Dependencies
-          run: |
-            yarn install
+      - name: Install Dependencies
+        run: |
+          yarn install
 
-        - name: Build design-tokens
-          run: yarn --cwd packages/design-tokens build
+      - name: Build design-tokens
+        run: yarn --cwd packages/design-tokens build
 
-        - name: Build icon-library
-          run: yarn --cwd packages/icon-library build
+      - name: Build icon-library
+        run: yarn --cwd packages/icon-library build
 
-        - name: Build react-component-library
-          run: yarn --cwd packages/react-component-library build
+      - name: Build react-component-library
+        run: yarn --cwd packages/react-component-library build
 
-        - name: Update CRA template to use local packages
-          run: |
-           TEMPLATE=packages/cra-template-defencedigital/template.json
-           PACKAGES=(
-            design-tokens
-            css-framework
-            fonts
-            icon-library
-            react-component-library
-           )
-           for i in "${PACKAGES[@]}";
-            do
-              contents="$(jq '.package.dependencies."@defencedigital/'$i'" = "file:../packages/'$i'"' $TEMPLATE)" \
-              && echo "${contents}" > $TEMPLATE
-            done
-           cat $TEMPLATE
+      - name: Update CRA template to use local packages
+        run: |
+          TEMPLATE=packages/cra-template-defencedigital/template.json
+          PACKAGES=(
+           design-tokens
+           css-framework
+           fonts
+           icon-library
+           react-component-library
+          )
+          for i in "${PACKAGES[@]}";
+           do
+             contents="$(jq '.package.dependencies."@defencedigital/'$i'" = "file:../packages/'$i'"' $TEMPLATE)" \
+             && echo "${contents}" > $TEMPLATE
+           done
+          cat $TEMPLATE
 
-        - name: Create boilerplate app
-          run: |
-           if [ -d "my-app" ]; then rm -Rf my-app ; fi
-           npx create-react-app my-app --template file:../${{ github.event.repository.name }}/packages/cra-template-defencedigital
+      - name: Create boilerplate app
+        run: |
+          if [ -d "my-app" ]; then rm -Rf my-app ; fi
+          npx create-react-app my-app --template file:../${{ github.event.repository.name }}/packages/cra-template-defencedigital
 
-        - name: Build boilerlate app
-          run: |
-           cd my-app
-           grep version node_modules/@defencedigital/**/package.json
-           echo "SKIP_PREFLIGHT_CHECK=true" > .env  #workaround for babel-loader (8.2.2) CRA version issue
-           yarn build
+      - name: Build boilerlate app
+        run: |
+          cd my-app
+          grep version node_modules/@defencedigital/**/package.json
+          echo "SKIP_PREFLIGHT_CHECK=true" > .env  #workaround for babel-loader (8.2.2) CRA version issue
+          yarn build

--- a/.github/workflows/npmsmoketest.yml
+++ b/.github/workflows/npmsmoketest.yml
@@ -59,3 +59,8 @@ jobs:
           cd $RUNNER_TEMP/my-app
           grep version node_modules/@defencedigital/**/package.json
           yarn build
+
+      - name: Lint boilerlate app
+        run: |
+          cd $RUNNER_TEMP/my-app
+          yarn lint

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ Please refer to the [component demo pages](https://design-system.digital.mod.uk/
 
 ### Installation
 
-To install and save to your projects package.json dependencies, run:
+To install and save to your project's package.json dependencies, run:
 
 ```
 # with npm
-npm install @defencedigital/fonts @defencedigital/react-component-library
+npm install @defencedigital/fonts @defencedigital/react-component-library styled-components formik
 
 # ...or with yarn
-yarn add @defencedigital/fonts @defencedigital/react-component-library
+yarn add @defencedigital/fonts @defencedigital/react-component-library styled-components formik
 ```
 
-Note: As of `2.16.0` the [`styled-components`](https://github.com/styled-components/styled-components) package is now a required [peerDependency](https://nodejs.org/en/blog/npm/peer-dependencies/).
+Note: [`styled-components`](https://styled-components.com/) and [`formik`](https://formik.org/) are required [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/) and are installed with the above commands.
 
 ### Quick start
 

--- a/packages/cra-template-defencedigital/template.json
+++ b/packages/cra-template-defencedigital/template.json
@@ -3,7 +3,7 @@
     "author": "Defence Digital",
     "scripts": {
       "codegen": "gql-gen --config codegen.yml",
-      "lint": "eslint src/* --ext .ts --ext .tsx"
+      "lint": "eslint src --ext .ts --ext .tsx"
     },
     "dependencies": {
       "@apollo/client": "^3.5.6",

--- a/packages/cra-template-defencedigital/template.json
+++ b/packages/cra-template-defencedigital/template.json
@@ -7,7 +7,6 @@
     },
     "dependencies": {
       "@apollo/client": "^3.5.6",
-      "@defencedigital/css-framework": "latest",
       "@defencedigital/design-tokens": "latest",
       "@defencedigital/eslint-config-react": "latest",
       "@defencedigital/fonts": "latest",

--- a/packages/cra-template-defencedigital/template.json
+++ b/packages/cra-template-defencedigital/template.json
@@ -25,6 +25,7 @@
       "@types/react-dom": "^17.0.11",
       "@types/react-router-dom": "^5.3.2",
       "@types/styled-components": "^5.1.18",
+      "formik": "^2.2.9",
       "graphql": "^16.1.0",
       "jest-canvas-mock": "^2.3.0",
       "react-router-dom": "^5.1.2",

--- a/packages/react-component-library/README.md
+++ b/packages/react-component-library/README.md
@@ -6,15 +6,17 @@ A collection of React components written for Defence Digital web applications.
 
 The Defence Digital React Component Library is available as an [NPM package](https://www.npmjs.com/package/@defencedigital/react-component-library).
 
-```
+To install it, run the relevant command for your package manager:
+
+```shell
 // npm
-npm install @defencedigital/fonts @defencedigital/react-component-library
+npm install @defencedigital/fonts @defencedigital/react-component-library styled-components formik
 
 // yarn
-yarn add @defencedigital/fonts @defencedigital/react-component-library
+yarn add @defencedigital/fonts @defencedigital/react-component-library styled-components formik
 ```
 
-NOTE: As of `2.16.0` the [`styled-components`](https://github.com/styled-components/styled-components) package is now a required [peerDependency](https://nodejs.org/en/blog/npm/peer-dependencies/).
+Note: [`styled-components`](https://styled-components.com/) and [`formik`](https://formik.org/) are required [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/) and are installed with the above commands.
 
 ## Usage
 

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -192,6 +192,7 @@
     "styled-theming": "^2.2.0"
   },
   "peerDependencies": {
+    "formik": "^2 || ^3",
     "styled-components": ">= 5"
   }
 }


### PR DESCRIPTION
## Related issue

Resolves #2769 

## Overview

This:

- makes Formik a peer dependency and documents this
- adds `formik` to the CRA template
- fixes problems with the lint command in the CRA template
- fixes problems with the smoke test that hid these problems
- removes the dependency on `@defencedigital/css-framework ` from the CRA template

## Reason

To:

- make sure the documentation is accurate
- make sure the CRA template works and is current
- make sure the smoke test catches problems

## Work carried out

- [x] Move the test app in the smoke test to a different directory
- [x] Add formik as a peer dependency and document this
- [x] Fix the lint command in the CRA template and make sure this is tested
- [x] Remove the `@defencedigital/css-framework` dependency from the CRA template

## Developer notes

The main problem with the smoke test was that it was creating the test app within the monorepo, and normal Node.js import resolution means that the monorepo's `node_modules` directory was also being used (and hence formik was imported from there).

The fix used was to create the test app somewhere else (in the temp directory). (I was also going to put a `lerna clean` in, but didn't as it would probably interfere with the `node_modules` caching.)

I've created #2915 as a separate issue for making Formik optional. (I haven't labelled it as next major but it can be added if we think it should be.)