### PR TITLE
Add ability to type and jump to item to `SelectE`

### DIFF
--- a/packages/react-component-library/cypress/selectors/SelectE.ts
+++ b/packages/react-component-library/cypress/selectors/SelectE.ts
@@ -1,0 +1,5 @@
+export default {
+  input: '[data-testid="select-input"]',
+  option: '[data-testid="select-option"]',
+  outerWrapper: '[data-testid="select-outer-wrapper"]',
+}

--- a/packages/react-component-library/cypress/selectors/index.ts
+++ b/packages/react-component-library/cypress/selectors/index.ts
@@ -2,6 +2,7 @@ import rangeSliderE from './RangeSliderE'
 import datePicker from './DatePicker'
 import contextMenu from './ContextMenu'
 import numberInputE from './NumberInputE'
+import selectE from './SelectE'
 import timeline from './timeline'
 import form from './form'
 
@@ -10,6 +11,7 @@ export default {
   datePicker,
   contextMenu,
   numberInputE,
+  selectE,
   timeline,
   form,
 }

--- a/packages/react-component-library/cypress/specs/SelectE/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/SelectE/index.spec.ts
@@ -1,0 +1,29 @@
+import { describe, cy, it, before } from 'local-cypress'
+
+import selectors from '../../selectors'
+
+describe('SelectE', () => {
+  before(() => {
+    cy.visit('/iframe.html?id=select-experimental--default&viewMode=story')
+  })
+
+  describe('when the component is focused', () => {
+    before(() => {
+      cy.get(selectors.selectE.outerWrapper).click()
+    })
+
+    it('renders four options', () => {
+      cy.get(selectors.selectE.option).should('have.length', 4)
+    })
+
+    describe('and `th` is typed', () => {
+      before(() => {
+        cy.get(selectors.selectE.outerWrapper).type('th{enter}')
+      })
+
+      it('sets the value as the item', () => {
+        cy.get(selectors.selectE.input).should('have.value', 'Three')
+      })
+    })
+  })
+})

--- a/packages/react-component-library/src/components/SelectE/ArrowButton.tsx
+++ b/packages/react-component-library/src/components/SelectE/ArrowButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { IconExpandLess, IconExpandMore } from '@defencedigital/icon-library'
 
+import { COMPONENT_SIZE } from '../Forms'
 import { InlineButton } from '../InlineButtons/InlineButton'
 
 const ICON_VIEW_BOX = '4 4 16 16'
@@ -12,21 +13,27 @@ interface InlineButtonProps {
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-export const ArrowButton: React.FC<InlineButtonProps> = ({
-  isOpen,
-  ...rest
-}) => (
-  <InlineButton
-    aria-label={`${isOpen ? 'Hide' : 'Show'} options`}
-    data-testid="select-arrow-button"
-    {...rest}
-  >
-    {isOpen ? (
-      <IconExpandLess size={18} viewBox={ICON_VIEW_BOX} />
-    ) : (
-      <IconExpandMore size={18} viewBox={ICON_VIEW_BOX} />
-    )}
-  </InlineButton>
-)
+export const ArrowButton = React.forwardRef<
+  HTMLButtonElement,
+  InlineButtonProps
+>(({ hasHover, isDisabled, isOpen, ...rest }, ref) => {
+  return (
+    <InlineButton
+      hasHover={hasHover}
+      isDisabled={isDisabled}
+      aria-label={`${isOpen ? 'Hide' : 'Show'} options`}
+      data-testid="select-arrow-button"
+      ref={ref}
+      size={COMPONENT_SIZE.FORMS}
+      {...rest}
+    >
+      {isOpen ? (
+        <IconExpandLess size={18} viewBox={ICON_VIEW_BOX} />
+      ) : (
+        <IconExpandMore size={18} viewBox={ICON_VIEW_BOX} />
+      )}
+    </InlineButton>
+  )
+})
 
 ArrowButton.displayName = 'ArrowButton'

--- a/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
@@ -26,17 +26,31 @@ export default {
 
 const Template: Story<SelectEProps> = (args) => (
   <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
-    <SelectE
-      /* eslint-disable react/no-children-prop */
-      children={[
-        <SelectEOption value="one">One</SelectEOption>,
-        <SelectEOption value="two">Two</SelectEOption>,
-        <SelectEOption value="three">Three</SelectEOption>,
-        <SelectEOption value="four">Four</SelectEOption>,
-      ]}
-      label="Some label"
-      {...args}
-    />
+    <SelectE label="Some label" {...args}>
+      <SelectEOption value="one">One</SelectEOption>
+      <SelectEOption value="two">Two</SelectEOption>
+      <SelectEOption value="three">Three</SelectEOption>
+      <SelectEOption value="four">Four</SelectEOption>
+    </SelectE>
+  </div>
+)
+
+const TemplateWIthIconsAndBadges: Story<SelectEProps> = (args) => (
+  <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
+    <SelectE label="Some label" {...args}>
+      <SelectEOption badge={100} icon={<IconAnchor />} value="one">
+        One
+      </SelectEOption>
+      <SelectEOption badge={110} icon={<IconRemove />} value="two">
+        Two
+      </SelectEOption>
+      <SelectEOption badge={111} icon={<IconAgriculture />} value="three">
+        Three
+      </SelectEOption>
+      <SelectEOption badge={112} icon={<IconBrightnessAuto />} value="four">
+        Four
+      </SelectEOption>
+    </SelectE>
   </div>
 )
 
@@ -57,20 +71,4 @@ WithValue.args = {
   value: 'two',
 }
 
-export const WithIconsAndBadges = Template.bind({})
-WithIconsAndBadges.args = {
-  children: [
-    <SelectEOption badge={100} icon={<IconAnchor />} value="one">
-      One
-    </SelectEOption>,
-    <SelectEOption badge={110} icon={<IconRemove />} value="two">
-      Two
-    </SelectEOption>,
-    <SelectEOption badge={111} icon={<IconAgriculture />} value="three">
-      Three
-    </SelectEOption>,
-    <SelectEOption badge={112} icon={<IconBrightnessAuto />} value="four">
-      Four
-    </SelectEOption>,
-  ],
-}
+export const WithIconsAndBadges = TemplateWIthIconsAndBadges.bind({})

--- a/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
@@ -21,6 +21,9 @@ export default {
           'This component wraps a popular open-source library. See comprehensive documentation [here](https://www.downshift-js.com/downshift/).',
       },
     },
+    options: {
+      enableShortcuts: false,
+    },
   },
 } as Meta
 

--- a/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
@@ -115,7 +115,7 @@ describe('SelectE', () => {
 
     describe('when the arrow button is clicked', () => {
       beforeEach(() => {
-        wrapper.getByTestId('select-arrow-button').click()
+        userEvent.click(wrapper.getByTestId('select-arrow-button'))
       })
 
       it('displays the items', () => {
@@ -129,7 +129,7 @@ describe('SelectE', () => {
 
       describe('and the second item is clicked', () => {
         beforeEach(() => {
-          wrapper.getByText('Two').click()
+          userEvent.click(wrapper.getByText('Two'))
         })
 
         it('hides the items', () => {
@@ -147,7 +147,7 @@ describe('SelectE', () => {
 
         describe('and the clear button is clicked', () => {
           beforeEach(() => {
-            wrapper.getByTestId('select-clear-button').click()
+            userEvent.click(wrapper.getByTestId('select-clear-button'))
           })
 
           it('resets the value', () => {
@@ -232,7 +232,7 @@ describe('SelectE', () => {
 
     describe('when clicking on the arrow button', () => {
       beforeEach(() => {
-        wrapper.getByTestId('select-arrow-button').click()
+        userEvent.click(wrapper.getByTestId('select-arrow-button'))
       })
 
       it('does not show the items', () => {

--- a/packages/react-component-library/src/components/SelectE/SelectEOption.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectEOption.tsx
@@ -14,30 +14,30 @@ export interface SelectEOptionProps extends ComponentWithClass {
   value: string
 }
 
-export const SelectEOption: React.FC<SelectEOptionProps> = ({
-  badge,
-  icon,
-  children,
-  isHighlighted,
-  ...rest
-}) => (
-  <StyledOption
-    $isHighlighted={isHighlighted}
-    data-testid="select-option"
-    {...rest}
-  >
-    {icon}
-    <StyledOptionText>{children}</StyledOptionText>
-    {badge && (
-      <StyledOptionBadge
-        data-testid="select-badge"
-        size={BADGE_SIZE.XSMALL}
-        variant={BADGE_VARIANT.PILL}
-      >
-        {badge}
-      </StyledOptionBadge>
-    )}
-  </StyledOption>
-)
+export const SelectEOption = React.forwardRef<
+  HTMLLIElement,
+  SelectEOptionProps
+>(({ badge, icon, children, isHighlighted, ...rest }, ref) => {
+  return (
+    <StyledOption
+      $isHighlighted={isHighlighted}
+      data-testid="select-option"
+      ref={ref}
+      {...rest}
+    >
+      {icon}
+      <StyledOptionText>{children}</StyledOptionText>
+      {badge && (
+        <StyledOptionBadge
+          data-testid="select-badge"
+          size={BADGE_SIZE.XSMALL}
+          variant={BADGE_VARIANT.PILL}
+        >
+          {badge}
+        </StyledOptionBadge>
+      )}
+    </StyledOption>
+  )
+})
 
 SelectEOption.displayName = 'SelectEOption'

--- a/packages/react-component-library/src/components/SelectE/partials/StyledOptions.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOptions.tsx
@@ -11,4 +11,8 @@ export const StyledOptions = styled.ul`
   margin-left: 0;
   border-radius: 0 0 ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]}
     ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
+
+  &:focus {
+    outline: none;
+  }
 `

--- a/packages/react-component-library/src/components/SelectE/partials/StyledOptionsWrapper.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOptionsWrapper.tsx
@@ -7,6 +7,10 @@ import { TEXT_INPUT_INPUT_HEIGHT } from '../../TextInputE/partials/StyledInput'
 
 const { color, zIndex } = selectors
 
+interface StyledOptionsWrapperProps {
+  $isVisible: boolean
+}
+
 function getTopBorder() {
   return css`
     &::before {
@@ -39,7 +43,8 @@ function getBoxShadow() {
   `
 }
 
-export const StyledOptionsWrapper = styled.div`
+export const StyledOptionsWrapper = styled.div<StyledOptionsWrapperProps>`
+  display: ${({ $isVisible }) => ($isVisible ? 'block' : 'none')};
   z-index: ${zIndex('dropdown', 1)};
   position: absolute;
   width: 100%;


### PR DESCRIPTION
## Related issue
Closes #2885 

## Overview
Refactors `SelectE` to use `useSelect` and now it is possible to type and jump to an option.

## Link to preview
https://selecte-typing.netlify.app/?path=/story/select-experimental--default

## Reason
This is normal behaviour for a `select`.

## Work carried out
- [x] Refactor stories
- [x] Refactor `SelectE`