### PR TITLE
fix(StyledOuterWrapper): Fix height and label alignment problems

### DIFF
--- a/packages/react-component-library/cypress/specs/DatePickerE/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/DatePickerE/index.spec.ts
@@ -1,7 +1,9 @@
 import { describe, cy, it, before } from 'local-cypress'
 import { addDays, startOfMonth, format } from 'date-fns'
+import { ColorNeutral200 } from '@defencedigital/design-tokens'
 
 import { DATE_FORMAT } from '../../../src/constants'
+import { hexToRgb } from '../../helpers'
 import selectors from '../../selectors'
 import { transformDates } from '../../../src/components/DatePicker/useInputValue'
 
@@ -37,9 +39,9 @@ describe('DatePickerE', () => {
 
       it('should not be in an error state', () => {
         cy.get(selectors.datePicker.outerWrapper).should(
-          'has.border',
-          'color',
-          'rgba(0, 0, 0, 0)'
+          'have.css',
+          'box-shadow',
+          `${hexToRgb(ColorNeutral200)} 0px 0px 0px 1px`
         )
       })
     })
@@ -92,9 +94,9 @@ describe('DatePickerE', () => {
 
           it('should not be in an error state', () => {
             cy.get(selectors.datePicker.outerWrapper).should(
-              'has.border',
-              'color',
-              'rgba(0, 0, 0, 0)'
+              'have.css',
+              'box-shadow',
+              `${hexToRgb(ColorNeutral200)} 0px 0px 0px 1px`
             )
           })
         })

--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.test.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.test.tsx
@@ -12,12 +12,16 @@ import {
 import 'jest-styled-components'
 import userEvent from '@testing-library/user-event'
 
+import { BORDER_WIDTH } from '../../styled-components'
+import { COMPONENT_SIZE } from '../Forms'
 import { DatePickerE, DatePickerEOnChangeData } from '.'
 import { ButtonE } from '../ButtonE'
 import { DATE_VALIDITY } from './constants'
 
 const NOW = '2019-12-05T11:00:00.000Z'
-const ERROR_BORDER = `3px solid ${ColorDanger800.toUpperCase()}`
+const ERROR_BOX_SHADOW = `0 0 0 ${
+  BORDER_WIDTH[COMPONENT_SIZE.FORMS]
+} ${ColorDanger800.toUpperCase()}`
 
 function click(element: HTMLElement) {
   fireEvent.mouseDown(element)
@@ -437,7 +441,7 @@ describe('DatePickerE', () => {
             it('is in an error state', () => {
               expect(
                 wrapper.getByTestId('datepicker-outer-wrapper')
-              ).toHaveStyleRule('border', ERROR_BORDER)
+              ).toHaveStyleRule('box-shadow', ERROR_BOX_SHADOW)
             })
 
             it('calls the `onBlur` callback', () => {
@@ -466,7 +470,7 @@ describe('DatePickerE', () => {
             it('should not be in an error state', () => {
               expect(
                 wrapper.getByTestId('datepicker-outer-wrapper')
-              ).not.toHaveStyleRule('border', ERROR_BORDER)
+              ).not.toHaveStyleRule('box-shadow', ERROR_BOX_SHADOW)
             })
           })
 
@@ -480,7 +484,7 @@ describe('DatePickerE', () => {
             it('is in an error state', () => {
               expect(
                 wrapper.getByTestId('datepicker-outer-wrapper')
-              ).toHaveStyleRule('border', ERROR_BORDER)
+              ).toHaveStyleRule('box-shadow', ERROR_BOX_SHADOW)
             })
 
             it('calls the `onBlur` callback', () => {
@@ -508,7 +512,7 @@ describe('DatePickerE', () => {
           it('is in an error state', () => {
             expect(
               wrapper.getByTestId('datepicker-outer-wrapper')
-            ).toHaveStyleRule('border', ERROR_BORDER)
+            ).toHaveStyleRule('box-shadow', ERROR_BOX_SHADOW)
           })
         })
 
@@ -531,7 +535,7 @@ describe('DatePickerE', () => {
           it('is in an error state', () => {
             expect(
               wrapper.getByTestId('datepicker-outer-wrapper')
-            ).toHaveStyleRule('border', ERROR_BORDER)
+            ).toHaveStyleRule('box-shadow', ERROR_BOX_SHADOW)
           })
         })
       })
@@ -1028,8 +1032,8 @@ describe('DatePickerE', () => {
 
     it('should set the border on the outer wrapper', () => {
       expect(wrapper.getByTestId('datepicker-outer-wrapper')).toHaveStyleRule(
-        'border',
-        ERROR_BORDER
+        'box-shadow',
+        ERROR_BOX_SHADOW
       )
     })
   })
@@ -1076,7 +1080,7 @@ describe('DatePickerE', () => {
       it("isn't in an error state", () => {
         expect(
           wrapper.getByTestId('datepicker-outer-wrapper')
-        ).not.toHaveStyleRule('border', ERROR_BORDER)
+        ).not.toHaveStyleRule('box-shadow', ERROR_BOX_SHADOW)
       })
     })
 
@@ -1108,7 +1112,7 @@ describe('DatePickerE', () => {
           it('is in an error state', () => {
             expect(
               wrapper.getByTestId('datepicker-outer-wrapper')
-            ).toHaveStyleRule('border', ERROR_BORDER)
+            ).toHaveStyleRule('box-shadow', ERROR_BOX_SHADOW)
           })
         })
       }

--- a/packages/react-component-library/src/components/InlineButtons/partials/StyledInlineButtons.tsx
+++ b/packages/react-component-library/src/components/InlineButtons/partials/StyledInlineButtons.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
 import { StyledIconWrapper } from './StyledIconWrapper'
@@ -6,26 +6,17 @@ import { StyledInlineButton } from './StyledInlineButton'
 
 const { color } = selectors
 
-export interface StyledInlineButtonsProps {
-  $isDisabled?: boolean
-}
-
-export const StyledInlineButtons = styled.div<StyledInlineButtonsProps>`
+export const StyledInlineButtons = styled.div`
   position: relative;
   display: flex;
   justify-content: center;
   text-align: center;
   align-items: center;
+  border-left: 1px solid ${color('neutral', '200')};
 
   ${StyledInlineButton} + ${StyledInlineButton} {
     & > ${StyledIconWrapper} {
       margin-left: 0;
     }
   }
-
-  ${({ $isDisabled }) =>
-    !$isDisabled &&
-    css`
-      border-left: 1px solid ${color('neutral', '200')};
-    `}
 `

--- a/packages/react-component-library/src/components/NumberInputE/Buttons.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/Buttons.tsx
@@ -45,7 +45,7 @@ export const Buttons: React.FC<ButtonsProps> = ({
   }
 
   return (
-    <StyledInlineButtons $isDisabled={isDisabled}>
+    <StyledInlineButtons>
       <InlineButton
         aria-label={`${capitalize(
           NUMBER_INPUT_BUTTON_TYPE.DECREASE

--- a/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
@@ -254,10 +254,10 @@ describe('SelectE', () => {
 
     it('displays in an error state', () => {
       expect(wrapper.getByTestId('select-outer-wrapper')).toHaveStyleRule(
-        'border',
-        `${
+        'box-shadow',
+        `0 0 0 ${
           BORDER_WIDTH[COMPONENT_SIZE.FORMS]
-        } solid ${ColorDanger800.toUpperCase()}`
+        } ${ColorDanger800.toUpperCase()}`
       )
     })
   })

--- a/packages/react-component-library/src/components/SelectE/partials/StyledOptions.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOptions.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { BORDER_RADIUS, BORDER_WIDTH } from '../../../styled-components'
+import { BORDER_RADIUS } from '../../../styled-components'
 import { COMPONENT_SIZE } from '../../Forms'
 
 export const StyledOptions = styled.ul`
@@ -9,13 +9,6 @@ export const StyledOptions = styled.ul`
   list-style-type: none;
   padding-left: 0;
   margin-left: 0;
-  border-radius: 0 0
-    calc(
-      ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]} -
-        ${BORDER_WIDTH[COMPONENT_SIZE.FORMS]}
-    )
-    calc(
-      ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]} -
-        ${BORDER_WIDTH[COMPONENT_SIZE.FORMS]}
-    );
+  border-radius: 0 0 ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]}
+    ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
 `

--- a/packages/react-component-library/src/components/SelectE/partials/StyledOptionsWrapper.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOptionsWrapper.tsx
@@ -1,10 +1,9 @@
 import styled, { css } from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
-import { BORDER_RADIUS, BORDER_WIDTH } from '../../../styled-components'
+import { BORDER_RADIUS } from '../../../styled-components'
 import { COMPONENT_SIZE } from '../../Forms'
 import { TEXT_INPUT_INPUT_HEIGHT } from '../../TextInputE/partials/StyledInput'
-import { isFirefox } from '../../../helpers'
 
 const { color, zIndex } = selectors
 
@@ -22,27 +21,18 @@ function getTopBorder() {
   `
 }
 
-function getLightBoxShadow() {
-  function getMargin() {
-    if (isFirefox()) {
-      return '-8px -3px -3px -3px'
-    }
-
-    return '-6px -3px -3px -3px'
-  }
-
+function getBoxShadow() {
   return css`
     &::after {
       z-index: ${zIndex('dropdown', 0)};
       content: '';
       position: absolute;
-      margin: ${getMargin()};
-      top: calc(-2px - ${TEXT_INPUT_INPUT_HEIGHT[COMPONENT_SIZE.FORMS]});
+      top: -${TEXT_INPUT_INPUT_HEIGHT[COMPONENT_SIZE.FORMS]};
       left: 0;
       right: 0;
       bottom: 0;
-      box-shadow: 0 0 0 ${BORDER_WIDTH[COMPONENT_SIZE.FORMS]}
-        ${color('action', '100')};
+      box-shadow: 0 0 0 3px ${color('action', '500')},
+        0 0 0 6px ${color('action', '100')};
       pointer-events: none;
       border-radius: ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
     }
@@ -54,12 +44,9 @@ export const StyledOptionsWrapper = styled.div`
   position: absolute;
   width: 100%;
   background: ${color('neutral', 'white')};
-  border: ${BORDER_WIDTH[COMPONENT_SIZE.FORMS]} solid ${color('action', '500')};
-  border-top: none;
   border-radius: 0 0 ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]}
     ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
-  padding-top: 2px;
   margin-bottom: 5px;
   ${getTopBorder()}
-  ${getLightBoxShadow()}
+  ${getBoxShadow()}
 `

--- a/packages/react-component-library/src/components/SelectE/partials/StyledOuterWrapper.tsx
+++ b/packages/react-component-library/src/components/SelectE/partials/StyledOuterWrapper.tsx
@@ -1,15 +1,11 @@
 import styled, { css } from 'styled-components'
-import { selectors } from '@defencedigital/design-tokens'
 
 import { COMPONENT_SIZE } from '../../Forms'
 import {
   BORDER_RADIUS,
-  BORDER_WIDTH,
   StyledOuterWrapper as StyledOuterWrapperBase,
   StyledOuterWrapperProps,
 } from '../../../styled-components/partials/StyledOuterWrapper'
-
-const { color } = selectors
 
 export const StyledOuterWrapper = styled(
   StyledOuterWrapperBase
@@ -20,12 +16,8 @@ export const StyledOuterWrapper = styled(
   ${({ $hasFocus, $size = COMPONENT_SIZE.FORMS }) => {
     if ($hasFocus) {
       return css`
-        border-bottom: none;
-        /* Prevents black border issue */
-        border-bottom-color: ${color('action', '500')};
         border-radius: ${BORDER_RADIUS[$size]} ${BORDER_RADIUS[$size]} 0 0;
         box-shadow: unset;
-        padding-bottom: ${BORDER_WIDTH[$size]};
       `
     }
 

--- a/packages/react-component-library/src/components/TextInputE/partials/StyledInput.tsx
+++ b/packages/react-component-library/src/components/TextInputE/partials/StyledInput.tsx
@@ -54,8 +54,10 @@ export const StyledInput = styled.input<StyledInputProps>`
   ${removeAutoFillBackground()}
 
   color: ${color('neutral', '600')};
-  font-size: ${({ $size }) => TEXT_INPUT_FONT_SIZE[$size]};
-  height: ${({ $size }) => TEXT_INPUT_INPUT_HEIGHT[$size]};
+  font-size: ${({ $size = COMPONENT_SIZE.FORMS }) =>
+    TEXT_INPUT_FONT_SIZE[$size]};
+  height: ${({ $size = COMPONENT_SIZE.FORMS }) =>
+    TEXT_INPUT_INPUT_HEIGHT[$size]};
 
   &:focus {
     outline: 0;

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -22,16 +22,6 @@ function hasClass(allClasses: string, className: string): boolean {
   return allClasses && allClasses.split(' ').includes(className)
 }
 
-function isFirefox(): boolean {
-  if (typeof navigator === 'undefined') {
-    logger.warn('`navigator` object does not exist')
-
-    return false
-  }
-
-  return navigator.userAgent.toLowerCase().indexOf('firefox') > -1
-}
-
 function isIE11(): boolean {
   if (typeof window === 'undefined') {
     logger.warn('`window` object does not exist')
@@ -78,7 +68,6 @@ export {
   getId,
   getKey,
   hasClass,
-  isFirefox,
   isIE11,
   warnIfOverwriting,
   withKey,

--- a/packages/react-component-library/src/styled-components/partials/StyledOuterWrapper.tsx
+++ b/packages/react-component-library/src/styled-components/partials/StyledOuterWrapper.tsx
@@ -5,14 +5,24 @@ import { COMPONENT_SIZE, ComponentSizeType } from '../../components/Forms'
 
 const { color } = selectors
 
+// Note: These are used with box shadows rather than borders, and for box
+// shadows the values are taken to the inner edge of the shadow (rather
+// than the outer edge for borders). To get the value that would be used
+// with a normal border, the border width should be added to the radius
+// value.
 export const BORDER_RADIUS = {
-  [COMPONENT_SIZE.SMALL]: '10px',
-  [COMPONENT_SIZE.FORMS]: '15px',
+  [COMPONENT_SIZE.SMALL]: '8px',
+  [COMPONENT_SIZE.FORMS]: '12px',
 }
 
 export const BORDER_WIDTH = {
   [COMPONENT_SIZE.SMALL]: '2px',
   [COMPONENT_SIZE.FORMS]: '3px',
+}
+
+const SECONDARY_BORDER_WIDTH = {
+  [COMPONENT_SIZE.SMALL]: '4px',
+  [COMPONENT_SIZE.FORMS]: '6px',
 }
 
 export interface StyledOuterWrapperProps {
@@ -26,7 +36,7 @@ export const StyledOuterWrapper = styled.div<StyledOuterWrapperProps>`
   ${({ $hasFocus, $isDisabled, $isInvalid, $size = COMPONENT_SIZE.FORMS }) => {
     const defaults = css`
       background-color: ${color('neutral', 'white')};
-      border: ${BORDER_WIDTH[$size]} solid transparent;
+      border: none;
       border-radius: ${BORDER_RADIUS[$size]};
       box-shadow: 0 0 0 1px ${color('neutral', '200')};
       transition: border-color 350ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
@@ -36,8 +46,8 @@ export const StyledOuterWrapper = styled.div<StyledOuterWrapperProps>`
     if ($hasFocus) {
       return css`
         ${defaults};
-        border: ${BORDER_WIDTH[$size]} solid ${color('action', '500')};
-        box-shadow: 0 0 0 ${BORDER_WIDTH[$size]} ${color('action', '100')};
+        box-shadow: 0 0 0 ${BORDER_WIDTH[$size]} ${color('action', '500')},
+          0 0 0 ${SECONDARY_BORDER_WIDTH[$size]} ${color('action', '100')};
       `
     }
 
@@ -45,7 +55,6 @@ export const StyledOuterWrapper = styled.div<StyledOuterWrapperProps>`
       return css`
         ${defaults};
         background-color: ${color('neutral', '000')};
-        border: ${BORDER_WIDTH[$size]} solid transparent;
         box-shadow: unset;
 
         * {
@@ -57,8 +66,7 @@ export const StyledOuterWrapper = styled.div<StyledOuterWrapperProps>`
     if ($isInvalid) {
       return css`
         ${defaults};
-        border: ${BORDER_WIDTH[$size]} solid ${color('danger', '800')};
-        box-shadow: unset;
+        box-shadow: 0 0 0 ${BORDER_WIDTH[$size]} ${color('danger', '800')};
       `
     }
 


### PR DESCRIPTION
## Related issue

Resolves #2889 

## Overview

This fixes a few styling problems with the experimental components:

- corrects their heights
- fixes problems with label positioning

## Link to preview

[Storybook](https://red-playground.netlify.app/)

## Reason

To make sure the components look as intended.

## Work carried out

- [x] Rework borders to use box shadows instead
- [x] Update positioning of SelectE options
- [x] Correct heights of components

## Screenshot

A couple of examples:

### NumberInputE

#### Before

![image](https://user-images.githubusercontent.com/66470099/146387555-7383bf03-be19-4602-8d81-90e0f2f1f9c0.png)

#### After

![image](https://user-images.githubusercontent.com/66470099/146386521-28492c75-0a0a-4883-9daa-1c69be6eb210.png)

### SelectE

#### Before

![image](https://user-images.githubusercontent.com/66470099/146387379-167ddd64-935b-4d65-a0ac-5baecdfa93cd.png)

#### After

![image](https://user-images.githubusercontent.com/66470099/146386403-eab0f45d-1247-4ab9-b156-da6638990a05.png)

## Developer notes

This was done by making more use of box shadows instead of borders.

Affected components are:

- SelectE
- DatePickerE
- NumberInputE
- TextAreaE
- TextInputE