### PR TITLE
build(GitHubActions): Restrict @dependabot automerge to patches

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,46 +9,42 @@ on:
     branches:
       - 'dependabot/**'
 
-
 jobs:
-
   Test_visual_regression:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'dependabot[bot]' }}
     steps:
-
       - name: Git clone repository
         uses: actions/checkout@v2
         with:
             fetch-depth: 0
-
       - name: Cache Node modules
         uses: actions/cache@v2
         with:
             path: '**/node_modules'
             key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
-
       - name: Build icon-library
         run: |
             yarn install --frozen-lockfile
             yarn --cwd packages/icon-library build
-
       - name: Build design-tokens
         run: |
             yarn --cwd packages/design-tokens build
-
       - name: Run visual regression tests
         run: |
             yarn --cwd packages/react-component-library chromatic --project-token=${{secrets.CHROMATIC_TOKEN}}
-
-
   Automerge:
     name: Merge Dependabot PR's
     runs-on: ubuntu-latest
     needs: [Test_visual_regression]
     steps:
-
-      - name: Run merge me action
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.MERGE_BOT }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
         uses: defencedigital/design-system-mergeme-action@master
         with:
           GITHUB_TOKEN: ${{ secrets.MERGE_BOT }}


### PR DESCRIPTION
## Related issue

Closes #2921

## Overview

Restrict dependabot automerge to patch releases.

## Reason

>Dependabot keeps merging breaking changes. Notably for tooling.
>
>I'm not convinced of the integrity of the current workflow.

## Work carried out

- [x] Add some conditonal logic

## Developer notes

Currently figuring out how best to test this change...
