### PR TITLE
feat(NumberInputE): Add float step support

### DIFF
--- a/packages/react-component-library/src/components/NumberInputE/Buttons.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/Buttons.tsx
@@ -7,6 +7,7 @@ import { InlineButton } from '../InlineButtons/InlineButton'
 import { NUMBER_INPUT_BUTTON_TYPE } from './constants'
 import { StyledDivider } from './partials/StyledDivider'
 import { StyledInlineButtons } from '../InlineButtons/partials/StyledInlineButtons'
+import { countDecimals } from '../../helpers'
 
 export interface ButtonsProps {
   isDisabled: boolean
@@ -15,11 +16,11 @@ export interface ButtonsProps {
   name: string
   onClick: (
     event: React.MouseEvent<HTMLButtonElement>,
-    newValue: number
+    newValue: string
   ) => void
   size: ComponentSizeType
   step?: number
-  value: number
+  value: string
 }
 
 const iconLookup = {
@@ -34,12 +35,15 @@ export const Buttons: React.FC<ButtonsProps> = ({
   step,
   value,
 }) => {
-  function onButtonClick(getNewValue: () => number) {
+  const digits = countDecimals(step)
+
+  function onButtonClick(getNewValue: () => string) {
     return (event: React.MouseEvent<HTMLButtonElement>) => {
       const target = event.currentTarget
       target.blur()
 
       const newValue = getNewValue()
+
       onClick(event, newValue)
     }
   }
@@ -52,7 +56,9 @@ export const Buttons: React.FC<ButtonsProps> = ({
         )} the input value`}
         data-testid={`number-input-${NUMBER_INPUT_BUTTON_TYPE.DECREASE}`}
         isDisabled={isDisabled}
-        onClick={onButtonClick(() => (value || 0) - step)}
+        onClick={onButtonClick(() =>
+          ((parseFloat(value) || 0) - step).toFixed(digits)
+        )}
         size={size}
       >
         {iconLookup[NUMBER_INPUT_BUTTON_TYPE.DECREASE]}
@@ -64,7 +70,9 @@ export const Buttons: React.FC<ButtonsProps> = ({
         )} the input value`}
         data-testid={`number-input-${NUMBER_INPUT_BUTTON_TYPE.INCREASE}`}
         isDisabled={isDisabled}
-        onClick={onButtonClick(() => (value || 0) + step)}
+        onClick={onButtonClick(() =>
+          ((parseFloat(value) || 0) + step).toFixed(digits)
+        )}
         size={size}
       >
         {iconLookup[NUMBER_INPUT_BUTTON_TYPE.INCREASE]}

--- a/packages/react-component-library/src/components/NumberInputE/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/Input.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { isFinite, isNil } from 'lodash'
+import { isNil } from 'lodash'
 
 import { ComponentSizeType } from '../Forms'
 import { InputValidationProps } from '../../common/InputValidationProps'
@@ -18,7 +18,7 @@ export interface InputProps extends InputValidationProps {
   onFocus: (event: React.FormEvent<HTMLInputElement>) => void
   placeholder?: string
   size: ComponentSizeType
-  value?: number
+  value?: string
 }
 
 export const Input: React.FC<InputProps> = ({
@@ -26,7 +26,6 @@ export const Input: React.FC<InputProps> = ({
   isDisabled,
   id,
   label,
-  placeholder = '',
   size,
   value,
   ...rest
@@ -52,7 +51,7 @@ export const Input: React.FC<InputProps> = ({
         data-testid="number-input-input"
         disabled={isDisabled}
         id={id}
-        value={isFinite(value) ? value : ''}
+        value={value || ''}
         {...rest}
       />
     </StyledInputWrapper>

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.stories.tsx
@@ -17,6 +17,11 @@ const Template: Story<NumberInputEProps> = (args) => <NumberInputE {...args} />
 
 export const Default = Template.bind({})
 
+export const SteppedFloats = Template.bind({})
+SteppedFloats.args = {
+  step: 0.25,
+}
+
 export const Small = Template.bind({})
 Small.args = {
   size: COMPONENT_SIZE.SMALL,

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.stories.tsx
@@ -22,6 +22,11 @@ SteppedFloats.args = {
   step: 0.25,
 }
 
+export const Placeholder = Template.bind({})
+Placeholder.args = {
+  placeholder: 'Example placeholder',
+}
+
 export const Small = Template.bind({})
 Small.args = {
   size: COMPONENT_SIZE.SMALL,

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
@@ -199,7 +199,6 @@ describe('NumberInputE', () => {
 
         userEvent.type(input, '1')
         userEvent.type(input, 'a')
-        userEvent.type(input, '.')
         userEvent.type(input, '2')
       })
 
@@ -211,16 +210,12 @@ describe('NumberInputE', () => {
         expect(onChangeSpy.mock.calls[1][1]).toEqual(1)
       })
 
-      it('calls the `onChange` callback yet again with `1`', () => {
-        expect(onChangeSpy.mock.calls[2][1]).toEqual(1)
-      })
-
       it('calls the `onChange` callback again with `12`', () => {
-        expect(onChangeSpy.mock.calls[3][1]).toEqual(12)
+        expect(onChangeSpy.mock.calls[2][1]).toEqual(12)
       })
 
       assertInputValue('12')
-      assertOnChangeCall(12, 4)
+      assertOnChangeCall(12, 3)
     })
 
     describe('and the user types a value', () => {
@@ -410,11 +405,15 @@ describe('NumberInputE', () => {
     })
   })
 
-  describe('when the step is specified', () => {
+  describe.each([
+    ['3', '0'],
+    ['0.1', '0.0'],
+    ['0.25', '0.00'],
+  ])('when a step of %s is specified', (step, zero) => {
     beforeEach(() => {
       const props = {
         ...defaultProps,
-        step: 3,
+        step: Number(step),
       }
 
       onChangeSpy = jest.spyOn(props, 'onChange')
@@ -428,7 +427,7 @@ describe('NumberInputE', () => {
         increase.click()
       })
 
-      assertInputValue('3')
+      assertInputValue(step)
 
       describe('and the decrease button is clicked', () => {
         beforeEach(() => {
@@ -436,7 +435,7 @@ describe('NumberInputE', () => {
           decrease.click()
         })
 
-        assertInputValue('0')
+        assertInputValue(zero)
       })
     })
   })

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
@@ -341,7 +341,7 @@ describe('NumberInputE', () => {
         increase.click()
       })
 
-      assertInputValue('4')
+      assertInputValue('3')
 
       describe('and the decrease button is clicked four times', () => {
         beforeEach(() => {

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.tsx
@@ -262,8 +262,10 @@ export const NumberInputE: React.FC<NumberInputEProps> = ({
           min={min}
           name={name}
           onClick={(e, newValue) => {
-            setCommittedValue(newValue)
-            onChange(e, newValue)
+            if (canCommit(newValue)) {
+              setCommittedValue(newValue)
+              onChange(e, newValue)
+            }
           }}
           size={size}
           step={step}

--- a/packages/react-component-library/src/components/NumberInputE/useValue.ts
+++ b/packages/react-component-library/src/components/NumberInputE/useValue.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-export function useValue(value: number) {
+export function useValue(value: string) {
   const [committedValue, setCommittedValue] = useState(value)
 
   useEffect(() => {

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -63,6 +63,14 @@ function sleep(ms: number): Promise<undefined> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function countDecimals(value: number): number {
+  if (Math.floor(value) === value) {
+    return 0
+  }
+
+  return value.toString().split('.')[1].length || 0
+}
+
 export {
   getInitials,
   getId,
@@ -72,4 +80,5 @@ export {
   warnIfOverwriting,
   withKey,
   sleep,
+  countDecimals,
 }


### PR DESCRIPTION
## Related issue

Closes #1128

## Overview

Add support for stepped floats to `NumberInputE`.

## Link to preview

https://61c1ab613913be2c341df66a--numberinputefloats.netlify.app

## Reason

Component would not work correctly with float steps.

## Work carried out

- [x] Fix issue where validation was not invoked on step
- [x] Handle floating point steps
- [x] Add ability to type in a floating point number

## Developer notes

If we let users enter typed input and there is a step, should we be validating their typed input? 

Not doing so allows them to circumvent the step.

- If component is stepped:
    - Valid typed user input is:
        - Numbers that are a result of X increments/decrements of step (from initial value) / modulus 0
        - e.g. Typed Input: 2.25, Initial Value: 1, Step: 0.25, Increments: 5 / (2.25 % 0.25 === 0)
