### PR TITLE
test(RangeSliderE): Add to forms stories and Cypress suite

### DIFF
--- a/packages/react-component-library/cypress/selectors/form.ts
+++ b/packages/react-component-library/cypress/selectors/form.ts
@@ -9,6 +9,8 @@ export default {
     switchOption: '[data-testid="switch-option"]',
     numberInput: '[data-testid="number-input"]',
     numberInputIncrease: '[data-testid="number-input-increase"]',
+    rangeSlider: '[data-testid="rangeslider"]',
+    rangeSliderRail: '[data-testid="rangeslider-rail"]',
   },
   submit: '[data-testid="form-example-submit"]',
   values: '[data-testid="form-example-values"]',

--- a/packages/react-component-library/cypress/specs/forms/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/forms/index.spec.ts
@@ -2,6 +2,29 @@ import { describe, cy, it, before } from 'local-cypress'
 
 import selectors from '../../selectors'
 
+const expectedResult = {
+  'react-hook-form': {
+    email: 'hello@world.com',
+    password: 'password',
+    description: 'Hello, World!',
+    exampleCheckbox: [],
+    exampleRadio: 'Option 1',
+    exampleRangeSlider: [28],
+    exampleSwitch: '1',
+    exampleNumberInput: 1,
+  },
+  Formik: {
+    email: 'hello@world.com',
+    password: 'password',
+    description: 'Hello, World!',
+    exampleCheckbox: [],
+    exampleRadio: 'Option 1',
+    exampleSwitch: '1',
+    exampleNumberInput: 1,
+    exampleRangeSlider: [28],
+  },
+}
+
 describe('Form Examples', () => {
   describe(
     'when browsing on desktop',
@@ -33,6 +56,7 @@ describe('Form Examples', () => {
             cy.get(selectors.form.input.description).should('be.visible')
             cy.get(selectors.form.input.switch).should('be.visible')
             cy.get(selectors.form.input.numberInput).should('be.visible')
+            cy.get(selectors.form.input.rangeSlider).should('be.visible')
           })
 
           describe('when an empty form is submitted', () => {
@@ -53,6 +77,7 @@ describe('Form Examples', () => {
               cy.get(selectors.form.input.radio).eq(0).click()
               cy.get(selectors.form.input.switchOption).eq(0).click()
               cy.get(selectors.form.input.numberInputIncrease).click()
+              cy.get(selectors.form.input.rangeSliderRail).click(800, 0)
             })
 
             it('should not show any validation errors', () => {
@@ -70,19 +95,7 @@ describe('Form Examples', () => {
 
               it('should supply form the field values', () => {
                 cy.get(selectors.form.values).contains(
-                  JSON.stringify(
-                    {
-                      email: 'hello@world.com',
-                      password: 'password',
-                      description: 'Hello, World!',
-                      exampleCheckbox: [],
-                      exampleRadio: 'Option 1',
-                      exampleSwitch: '1',
-                      exampleNumberInput: 1,
-                    },
-                    null,
-                    2
-                  )
+                  JSON.stringify(expectedResult[name], null, 2)
                 )
               })
             })

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -9,6 +9,7 @@ import { CheckboxE } from '../../components/CheckboxE'
 import { ButtonE } from '../../components/ButtonE'
 import { NumberInputE } from '../../components/NumberInputE'
 import { SwitchE, SwitchEOption, SwitchEProps } from '../../components/SwitchE'
+import { RangeSliderE } from '../../components/RangeSliderE'
 import { FormikGroupE } from '../../components/FormikGroup'
 import { withFormik } from '../../enhancers/withFormik'
 import { sleep } from '../../helpers'
@@ -41,6 +42,7 @@ const FormikCheckboxE = withFormik(CheckboxE)
 const FormikRadioE = withFormik(RadioE)
 const FormikSwitchE = withFormik(SwitchEFormed)
 const FormikNumberInputE = withFormik(NumberInputE)
+const FormikeRangeSliderE = withFormik(RangeSliderE)
 
 export const ExampleFormik: React.FC<unknown> = () => {
   const [formValues, setFormValues] = useState<FormValues>()
@@ -56,6 +58,7 @@ export const ExampleFormik: React.FC<unknown> = () => {
           exampleRadio: [],
           exampleSwitch: '',
           exampleNumberInput: null,
+          exampleRangeSlider: [20],
         }}
         validate={(values) => {
           const errors: Record<string, unknown> = {}
@@ -161,6 +164,18 @@ export const ExampleFormik: React.FC<unknown> = () => {
               ) => {
                 setFieldValue('exampleNumberInput', newValue)
               }}
+            />
+            <Field
+              name="exampleRangeSlider"
+              component={FormikeRangeSliderE}
+              onChange={(newValues: ReadonlyArray<number>) => {
+                setFieldValue('exampleRangeSlider', newValues)
+              }}
+              domain={[0, 40]}
+              mode={1}
+              values={[20]}
+              tracksLeft
+              step={2}
             />
             <ButtonE
               type="submit"

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import React, { useState, useEffect } from 'react'
-import { useForm } from 'react-hook-form/dist/index.ie11'
+import { useForm, Controller } from 'react-hook-form/dist/index.ie11'
 import { Story, Meta } from '@storybook/react'
 
 import { TextInputE } from '../../components/TextInputE'
@@ -9,6 +9,7 @@ import { RadioE } from '../../components/RadioE'
 import { CheckboxE } from '../../components/CheckboxE'
 import { NumberInputE } from '../../components/NumberInputE'
 import { SwitchE, SwitchEOption } from '../../components/SwitchE'
+import { RangeSliderE } from '../../components/RangeSliderE'
 import { ButtonE } from '../../components/ButtonE'
 import { Fieldset } from '../../components/Fieldset'
 import { sleep } from '../../helpers'
@@ -21,10 +22,12 @@ export interface FormValues {
   exampleRadio: string[]
   exampleSwitch: string
   exampleNumberInput: number
+  exampleRangeSlider: number[]
 }
 
 export const ExampleReactHookForm: React.FC<unknown> = () => {
   const {
+    control,
     setValue,
     register,
     handleSubmit,
@@ -39,6 +42,7 @@ export const ExampleReactHookForm: React.FC<unknown> = () => {
       exampleRadio: [],
       exampleSwitch: '',
       exampleNumberInput: null,
+      exampleRangeSlider: [20],
     },
   })
 
@@ -55,6 +59,7 @@ export const ExampleReactHookForm: React.FC<unknown> = () => {
   useEffect(() => {
     register({ name: 'exampleSwitch' })
     register({ name: 'exampleNumberInput' })
+    register({ name: 'exampleRangeSlider' })
   }, [register])
 
   const handleSwitchEChange = (e: React.FormEvent<HTMLInputElement>) =>
@@ -145,6 +150,22 @@ export const ExampleReactHookForm: React.FC<unknown> = () => {
           onChange={handleNumberInputEChange}
           value={exampleNumberInputValue}
           data-testid="form-example-NumberInputE"
+        />
+        <Controller
+          control={control}
+          name="exampleRangeSlider"
+          render={({ onChange, value }) => {
+            return (
+              <RangeSliderE
+                onChange={onChange}
+                values={value}
+                domain={[0, 40]}
+                mode={1}
+                tracksLeft
+                step={2}
+              />
+            )
+          }}
         />
         <ButtonE
           type="submit"


### PR DESCRIPTION
## Related issue

Closes #2874

## Overview

Supplement forms stories and Cypress test suite with `RangeSliderE`.

## Reason

Forms components need to work when consumed by a multitude of different downstream companion libraries.

## Work carried out

- [x] Update related stories
- [x] Add additional assertions to test suite