### PR TITLE
ci(Dependabot): Fix automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,4 @@
-name: Automerge
+name: Dependabot Automerge
 
 on:
   workflow_run:
@@ -38,13 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [Test_visual_regression]
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v1.1.1
-        with:
-          github-token: "${{ secrets.MERGE_BOT }}"
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+      - name: Auto merge Dependabot minor and patch version bumps
         uses: defencedigital/design-system-mergeme-action@master
         with:
           GITHUB_TOKEN: ${{ secrets.MERGE_BOT }}
+          PRESET: DEPENDABOT_MINOR

--- a/.github/workflows/build_and_test_feature.yml
+++ b/.github/workflows/build_and_test_feature.yml
@@ -233,6 +233,7 @@ jobs:
   Test_visual_regression:
     runs-on: ubuntu-latest
     needs: [Build_icon_library, Test_react-component-library]
+    # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Git clone repository


### PR DESCRIPTION
## Related issue

Closes #2939

## Overview

Use existing automerge action [preset functionality](https://github.com/defencedigital/design-system-mergeme-action#presets).

## Reason

>The old workflow was reliant on being triggered by a Pull Request event.

## Work carried out

- [x] Use action preset for limiting automerge to SemVer minor and patch
- [x] Add comment to code to explain confusing conditional logic

## Developer notes

Action workflows triggered by @dependabot are [read only and do not have access to secrets](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/).

I wonder if there is a potential issue with cache invalidation. The cache key is reliant on a secret:

https://github.com/defencedigital/mod-uk-design-system/blob/8a472d1bcee7bae30fce1bf74dad481141b3f56b/.github/workflows/build_and_test_feature.yml#L16