### PR TITLE
Refactor `ButtonE` and `SwitchE` to utilise `ComponentSizeType`

### DIFF
--- a/packages/react-component-library/src/components/ButtonE/ButtonE.stories.tsx
+++ b/packages/react-component-library/src/components/ButtonE/ButtonE.stories.tsx
@@ -3,11 +3,8 @@ import { Story, Meta } from '@storybook/react'
 
 import { IconBrightnessLow } from '@defencedigital/icon-library'
 import { ButtonE, ButtonEProps } from './index'
-import {
-  BUTTON_E_SIZE,
-  BUTTON_E_VARIANT,
-  BUTTON_E_ICON_POSITION,
-} from './constants'
+import { BUTTON_E_VARIANT, BUTTON_E_ICON_POSITION } from './constants'
+import { COMPONENT_SIZE } from '../Forms'
 
 export default {
   component: ButtonE,
@@ -155,7 +152,7 @@ DangerLoading.args = {
 export const Small = Template.bind({})
 Small.args = {
   variant: BUTTON_E_VARIANT.PRIMARY,
-  size: BUTTON_E_SIZE.SMALL,
+  size: COMPONENT_SIZE.SMALL,
   children: 'Small',
 }
 
@@ -163,7 +160,7 @@ export const SmallLoading = Template.bind({})
 SmallLoading.storyName = 'Small, loading'
 SmallLoading.args = {
   variant: BUTTON_E_VARIANT.PRIMARY,
-  size: BUTTON_E_SIZE.SMALL,
+  size: COMPONENT_SIZE.SMALL,
   children: 'Small, loading',
   isLoading: true,
 }
@@ -172,7 +169,7 @@ export const SmallIconNoText = Template.bind({})
 SmallIconNoText.storyName = 'Small, with icon, no text '
 SmallIconNoText.args = {
   variant: BUTTON_E_VARIANT.PRIMARY,
-  size: BUTTON_E_SIZE.SMALL,
+  size: COMPONENT_SIZE.SMALL,
   icon: <IconBrightnessLow />,
   title: 'Reduce brightness',
 }

--- a/packages/react-component-library/src/components/ButtonE/ButtonE.tsx
+++ b/packages/react-component-library/src/components/ButtonE/ButtonE.tsx
@@ -1,20 +1,13 @@
 import { IconLoader } from '@defencedigital/icon-library'
 import React, { FormEvent } from 'react'
 
-import {
-  BUTTON_E_ICON_POSITION,
-  BUTTON_E_SIZE,
-  BUTTON_E_VARIANT,
-} from './constants'
+import { BUTTON_E_ICON_POSITION, BUTTON_E_VARIANT } from './constants'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { StyledButton } from './partials/StyledButton'
 import { StyledIconWrapper } from './partials/StyledIconWrapper'
 import { StyledText } from './partials/StyledText'
 import { StyledIconLoaderWrapper } from './partials/StyledIconLoader'
-
-export type ButtonESizeType =
-  | typeof BUTTON_E_SIZE.SMALL
-  | typeof BUTTON_E_SIZE.FORMS
+import { ComponentSizeType, COMPONENT_SIZE } from '../Forms'
 
 export type ButtonEVariantType =
   | typeof BUTTON_E_VARIANT.PRIMARY
@@ -49,7 +42,7 @@ interface ButtonEBaseProps extends Omit<ComponentWithClass, 'children'> {
   /**
    * Size of the component.
    */
-  size?: ButtonESizeType
+  size?: ComponentSizeType
   /**
    * HTML type of the component (forms should use the `submit` type).
    */
@@ -92,7 +85,7 @@ export const ButtonE: React.FC<ButtonEProps> = ({
   icon,
   iconPosition = BUTTON_E_ICON_POSITION.RIGHT,
   onClick,
-  size = BUTTON_E_SIZE.FORMS,
+  size = COMPONENT_SIZE.FORMS,
   title,
   type = 'button',
   variant = BUTTON_E_VARIANT.PRIMARY,
@@ -114,7 +107,7 @@ export const ButtonE: React.FC<ButtonEProps> = ({
     >
       {isLoading && (
         <StyledIconLoaderWrapper data-testid="loading-icon" aria-hidden>
-          <IconLoader size={size === BUTTON_E_SIZE.FORMS ? 26 : 21} />
+          <IconLoader size={size === COMPONENT_SIZE.FORMS ? 26 : 21} />
         </StyledIconLoaderWrapper>
       )}
       <StyledText $isLoading={isLoading}>{children}</StyledText>

--- a/packages/react-component-library/src/components/ButtonE/constants.ts
+++ b/packages/react-component-library/src/components/ButtonE/constants.ts
@@ -1,8 +1,3 @@
-const BUTTON_E_SIZE = {
-  SMALL: 'small',
-  FORMS: 'forms',
-} as const
-
 const BUTTON_E_VARIANT = {
   PRIMARY: 'primary',
   SECONDARY: 'secondary',
@@ -15,4 +10,4 @@ const BUTTON_E_ICON_POSITION = {
   RIGHT: 'right',
 } as const
 
-export { BUTTON_E_SIZE, BUTTON_E_VARIANT, BUTTON_E_ICON_POSITION }
+export { BUTTON_E_VARIANT, BUTTON_E_ICON_POSITION }

--- a/packages/react-component-library/src/components/ButtonE/partials/StyledButton.tsx
+++ b/packages/react-component-library/src/components/ButtonE/partials/StyledButton.tsx
@@ -2,20 +2,13 @@ import styled, { css } from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 import { rgba } from 'polished'
 
-import {
-  BUTTON_E_ICON_POSITION,
-  BUTTON_E_SIZE,
-  BUTTON_E_VARIANT,
-} from '../constants'
-import {
-  ButtonEIconPositionType,
-  ButtonESizeType,
-  ButtonEVariantType,
-} from '../ButtonE'
+import { BUTTON_E_ICON_POSITION, BUTTON_E_VARIANT } from '../constants'
+import { ButtonEIconPositionType, ButtonEVariantType } from '../ButtonE'
+import { ComponentSizeType, COMPONENT_SIZE } from '../../Forms'
 
 interface StyledButtonProps {
   $variant: ButtonEVariantType
-  $size: ButtonESizeType
+  $size: ComponentSizeType
   $iconPosition: ButtonEIconPositionType
 }
 
@@ -45,7 +38,7 @@ export const StyledButton = styled.button<StyledButtonProps>`
   }
 
   ${({ $size }) =>
-    $size === BUTTON_E_SIZE.SMALL &&
+    $size === COMPONENT_SIZE.SMALL &&
     css`
       border-radius: 10px;
       height: 33px;

--- a/packages/react-component-library/src/components/ButtonE/partials/StyledIconWrapper.tsx
+++ b/packages/react-component-library/src/components/ButtonE/partials/StyledIconWrapper.tsx
@@ -1,14 +1,15 @@
 import styled, { css } from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
-import { BUTTON_E_ICON_POSITION, BUTTON_E_SIZE } from '../constants'
-import { ButtonEIconPositionType, ButtonESizeType } from '../ButtonE'
+import { BUTTON_E_ICON_POSITION } from '../constants'
+import { ButtonEIconPositionType } from '../ButtonE'
+import { ComponentSizeType, COMPONENT_SIZE } from '../../Forms'
 
 const { spacing } = selectors
 
 interface StyledIconWrapperProps {
   $buttonHasText: boolean
-  $buttonSize: ButtonESizeType
+  $buttonSize: ComponentSizeType
   $isLoading: boolean
   $iconPosition: ButtonEIconPositionType
 }
@@ -19,7 +20,7 @@ export const StyledIconWrapper = styled.span<StyledIconWrapperProps>`
   visibility: ${({ $isLoading }) => ($isLoading ? 'hidden' : 'initial')};
 
   ${({ $buttonSize, $buttonHasText }) =>
-    $buttonSize === BUTTON_E_SIZE.FORMS &&
+    $buttonSize === COMPONENT_SIZE.FORMS &&
     !$buttonHasText &&
     css`
       padding: 0 ${spacing('4')};

--- a/packages/react-component-library/src/components/SwitchE/SwitchE.stories.tsx
+++ b/packages/react-component-library/src/components/SwitchE/SwitchE.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { Story, Meta } from '@storybook/react'
 
-import { SwitchE, SwitchEOption, SwitchEProps, SWITCHE_SIZE } from '.'
+import { SwitchE, SwitchEOption, SwitchEProps } from '.'
+import { COMPONENT_SIZE } from '../Forms'
 
 export default {
   component: SwitchE,
@@ -59,5 +60,5 @@ export const Small = Template.bind({})
 Small.storyName = 'Small'
 Small.args = {
   name: 'switch-small',
-  size: SWITCHE_SIZE.SMALL,
+  size: COMPONENT_SIZE.SMALL,
 }

--- a/packages/react-component-library/src/components/SwitchE/SwitchE.tsx
+++ b/packages/react-component-library/src/components/SwitchE/SwitchE.tsx
@@ -2,16 +2,13 @@ import React, { useState, useEffect, useMemo } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 import { warnIfOverwriting, getKey } from '../../helpers'
-import { SWITCHE_SIZE, SwitchEOption, SwitchEOptionProps } from '.'
+import { SwitchEOption, SwitchEOptionProps } from '.'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { InputValidationProps } from '../../common/InputValidationProps'
 import { StyledSwitch } from './partials/StyledSwitch'
 import { StyledLegend } from './partials/StyledLegend'
 import { StyledContainer } from './partials/StyledContainer'
-
-export type SwitchESizeType =
-  | typeof SWITCHE_SIZE.SMALL
-  | typeof SWITCHE_SIZE.FORMS
+import { ComponentSizeType, COMPONENT_SIZE } from '../Forms'
 
 export type SwitchEChildType =
   | React.ReactElement<SwitchEOptionProps>
@@ -40,7 +37,7 @@ export interface SwitchEProps extends ComponentWithClass, InputValidationProps {
   /**
    * Size of the component.
    */
-  size?: SwitchESizeType
+  size?: ComponentSizeType
   /**
    * Toggles whether the component is disabled or not (preventing user interaction).
    */
@@ -56,7 +53,7 @@ export const SwitchE: React.FC<SwitchEProps> = ({
   value,
   label,
   onChange,
-  size = SWITCHE_SIZE.FORMS,
+  size = COMPONENT_SIZE.FORMS,
   isDisabled,
   isInvalid,
   children,

--- a/packages/react-component-library/src/components/SwitchE/constants.ts
+++ b/packages/react-component-library/src/components/SwitchE/constants.ts
@@ -1,8 +1,0 @@
-const SWITCHE_SIZE = {
-  FORMS: 'forms',
-  SMALL: 'small',
-} as const
-
-export {
-  SWITCHE_SIZE,
-}

--- a/packages/react-component-library/src/components/SwitchE/index.ts
+++ b/packages/react-component-library/src/components/SwitchE/index.ts
@@ -1,3 +1,2 @@
-export * from './constants'
 export * from './SwitchE'
 export * from './SwitchEOption'

--- a/packages/react-component-library/src/components/SwitchE/partials/StyledSwitch.tsx
+++ b/packages/react-component-library/src/components/SwitchE/partials/StyledSwitch.tsx
@@ -1,14 +1,13 @@
 import styled, { css } from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
-import { SwitchESizeType } from '../SwitchE'
 import { StyledContainer } from './StyledContainer'
 import { StyledSwitchOption } from './StyledSwitchOption'
 import { StyledLegend } from './StyledLegend'
-import { SWITCHE_SIZE } from '../constants'
+import { ComponentSizeType, COMPONENT_SIZE } from '../../Forms'
 
 interface StyledSwitchProps {
-  $size?: SwitchESizeType
+  $size?: ComponentSizeType
   $isDisabled?: boolean
   $isInvalid?: boolean
 }
@@ -20,7 +19,7 @@ export const StyledSwitch = styled.div<StyledSwitchProps>`
   font-size: ${fontSize('m')};
 
   ${({ $size }) =>
-    $size === SWITCHE_SIZE.SMALL &&
+    $size === COMPONENT_SIZE.SMALL &&
     css`
       & {
         font-size: ${fontSize('s')};


### PR DESCRIPTION
## Related issue

Closes #2827

## Overview

Refactor `ButtonE` and `SwitchE` to utilise `ComponentSizeType`.

## Reason

>Use common type  and constant across all form components.

## Work carried out

- [x] Refactor existing implementations