### PR TITLE
test(Forms): Add vanilla example coverage

### DIFF
--- a/packages/react-component-library/cypress/specs/forms/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/forms/index.spec.ts
@@ -23,7 +23,7 @@ const expectedResult = {
     exampleNumberInput: 1,
     exampleRangeSlider: [28],
   },
-  Vanilla: {
+  Native: {
     email: 'hello@world.com',
     password: 'password',
     description: 'Hello, World!',
@@ -46,15 +46,15 @@ describe('Form Examples', () => {
       const examples = [
         {
           name: 'Formik',
-          uri: '/iframe.html?id=forms-formik--default&viewMode=story',
+          uri: '/iframe.html?id=forms-formik--example&viewMode=story',
         },
         {
           name: 'react-hook-form',
-          uri: '/iframe.html?id=forms-react-hook-form--default&viewMode=story',
+          uri: '/iframe.html?id=forms-react-hook-form--example&viewMode=story',
         },
         {
-          name: 'Vanilla',
-          uri: '/iframe.html?id=forms-vanilla--default&viewMode=story',
+          name: 'Native',
+          uri: '/iframe.html?id=forms-native--example&viewMode=story',
         },
       ]
 

--- a/packages/react-component-library/cypress/specs/forms/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/forms/index.spec.ts
@@ -23,6 +23,16 @@ const expectedResult = {
     exampleNumberInput: 1,
     exampleRangeSlider: [28],
   },
+  Vanilla: {
+    email: 'hello@world.com',
+    password: 'password',
+    description: 'Hello, World!',
+    exampleCheckbox: [],
+    exampleRadio: ['Option 1'],
+    exampleSwitch: '1',
+    exampleNumberInput: 1,
+    exampleRangeSlider: [28],
+  },
 }
 
 describe('Form Examples', () => {
@@ -41,6 +51,10 @@ describe('Form Examples', () => {
         {
           name: 'react-hook-form',
           uri: '/iframe.html?id=forms-react-hook-form--default&viewMode=story',
+        },
+        {
+          name: 'Vanilla',
+          uri: '/iframe.html?id=forms-vanilla--default&viewMode=story',
         },
       ]
 

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -15,13 +15,14 @@ import { withFormik } from '../../enhancers/withFormik'
 import { sleep } from '../../helpers'
 
 export interface FormValues {
-  email?: string
-  password?: string
-  description?: string
+  email: string
+  password: string
+  description: string
   exampleCheckbox: string[]
   exampleRadio: string[]
   exampleSwitch: string
   exampleNumberInput: number
+  exampleRangeSlider: number[]
 }
 
 const SwitchEFormed: React.FC<SwitchEProps> = (props) => (

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentMeta } from '@storybook/react'
 import { Formik, Field } from 'formik'
 
 import { TextInputE } from '../../components/TextInputE'
@@ -45,7 +45,7 @@ const FormikSwitchE = withFormik(SwitchEFormed)
 const FormikNumberInputE = withFormik(NumberInputE)
 const FormikeRangeSliderE = withFormik(RangeSliderE)
 
-export const ExampleFormik: React.FC<unknown> = () => {
+export const Example: React.FC<unknown> = () => {
   const [formValues, setFormValues] = useState<FormValues>()
 
   return (
@@ -198,7 +198,5 @@ export const ExampleFormik: React.FC<unknown> = () => {
 
 export default {
   title: 'Forms/Formik',
-  component: ExampleFormik,
-} as Meta
-
-export const Default: Story<unknown> = () => <ExampleFormik />
+  component: Example,
+} as ComponentMeta<typeof Example>

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -158,7 +158,7 @@ export const ExampleFormik: React.FC<unknown> = () => {
               name="exampleNumberInput"
               component={FormikNumberInputE}
               onChange={(
-                event:
+                _:
                   | React.ChangeEvent<HTMLInputElement>
                   | React.MouseEvent<HTMLButtonElement>,
                 newValue: number

--- a/packages/react-component-library/src/forms/native/native.stories.tsx
+++ b/packages/react-component-library/src/forms/native/native.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentMeta } from '@storybook/react'
 
 import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'
@@ -23,7 +23,7 @@ export interface FormValues {
   exampleRangeSlider: readonly [number, number?]
 }
 
-export const ExampleNativeForm: React.FC<unknown> = () => {
+export const Example: React.FC<unknown> = () => {
   const {
     formErrors,
     formPayload,
@@ -188,7 +188,5 @@ export const ExampleNativeForm: React.FC<unknown> = () => {
 
 export default {
   title: 'Forms/Native',
-  component: ExampleNativeForm,
-} as Meta
-
-export const Default: Story<unknown> = () => <ExampleNativeForm />
+  component: Example,
+} as ComponentMeta<typeof Example>

--- a/packages/react-component-library/src/forms/native/native.stories.tsx
+++ b/packages/react-component-library/src/forms/native/native.stories.tsx
@@ -1,0 +1,194 @@
+import React from 'react'
+import { Story, Meta } from '@storybook/react'
+
+import { TextInputE } from '../../components/TextInputE'
+import { TextAreaE } from '../../components/TextAreaE'
+import { RadioE } from '../../components/RadioE'
+import { CheckboxE } from '../../components/CheckboxE'
+import { NumberInputE } from '../../components/NumberInputE'
+import { SwitchE, SwitchEOption } from '../../components/SwitchE'
+import { RangeSliderE } from '../../components/RangeSliderE'
+import { ButtonE } from '../../components/ButtonE'
+import { Fieldset } from '../../components/Fieldset'
+import { useNativeForm } from './useNativeForm'
+
+export interface FormValues {
+  email: string
+  password: string
+  description: string
+  exampleCheckbox: string[]
+  exampleRadio: string[]
+  exampleSwitch: string
+  exampleNumberInput: number
+  exampleRangeSlider: readonly [number, number?]
+}
+
+export const ExampleNativeForm: React.FC<unknown> = () => {
+  const {
+    formErrors,
+    formPayload,
+    formState,
+    handleChange,
+    handleCheckboxGroup,
+    handleRadioGroup,
+    isSubmitting,
+    onSubmit,
+  } = useNativeForm<FormValues>(
+    {
+      email: '',
+      password: '',
+      description: '',
+      exampleCheckbox: [],
+      exampleRadio: [],
+      exampleSwitch: '',
+      exampleNumberInput: null,
+      exampleRangeSlider: [20],
+    },
+    {
+      email: true,
+      // ...
+    },
+    {
+      email: (value: string): boolean => !value,
+      // ...
+    }
+  )
+
+  return (
+    <main>
+      <form onSubmit={onSubmit}>
+        <TextInputE
+          type="email"
+          name="email"
+          label="Email"
+          value={formState.email}
+          onChange={handleChange}
+          isInvalid={formErrors.email}
+          data-testid="form-example-TextInputE-email"
+        />
+        {formErrors.email && <span>Required</span>}
+        <TextInputE
+          type="password"
+          name="password"
+          label="Password"
+          value={formState.password}
+          onChange={handleChange}
+          data-testid="form-example-TextInputE-password"
+        />
+        <TextAreaE
+          name="description"
+          label="Description"
+          value={formState.description}
+          onChange={handleChange}
+          data-testid="form-example-TextAreaE-description"
+        />
+        <Fieldset>
+          <legend>Example checkbox selection</legend>
+          <CheckboxE
+            onChange={handleCheckboxGroup}
+            name="exampleCheckbox"
+            label="Option 1"
+            value="Option 1"
+          />
+          <CheckboxE
+            onChange={handleCheckboxGroup}
+            name="exampleCheckbox"
+            label="Option 2"
+            value="Option 2"
+          />
+          <CheckboxE
+            onChange={handleCheckboxGroup}
+            name="exampleCheckbox"
+            label="Option 3"
+            value="Option 3"
+          />
+        </Fieldset>
+        <Fieldset>
+          <legend>Example radio selection</legend>
+          <RadioE
+            onChange={handleRadioGroup}
+            name="exampleRadio"
+            label="Option 1"
+            value="Option 1"
+          />
+          <RadioE
+            onChange={handleRadioGroup}
+            name="exampleRadio"
+            label="Option 2"
+            value="Option 2"
+          />
+        </Fieldset>
+        <SwitchE
+          name="exampleSwitch"
+          label="Example switch selection"
+          onChange={(e: React.FormEvent<HTMLInputElement>) =>
+            handleChange({
+              currentTarget: {
+                name: 'exampleSwitch',
+                value: e.currentTarget.value,
+              },
+            })
+          }
+          value={formState.exampleSwitch}
+          data-testid="form-example-SwitchE"
+        >
+          <SwitchEOption label="One" value="1" />
+          <SwitchEOption label="Two" value="2" />
+          <SwitchEOption label="Three" value="3" />
+        </SwitchE>
+        <NumberInputE
+          name="exampleNumberInput"
+          label="Example number input"
+          onChange={(
+            _:
+              | React.ChangeEvent<HTMLInputElement>
+              | React.MouseEvent<HTMLButtonElement>,
+            newValue: number
+          ) => {
+            handleChange({
+              currentTarget: {
+                name: 'exampleNumberInput',
+                value: newValue,
+              },
+            })
+          }}
+          value={formState.exampleNumberInput}
+          data-testid="form-example-NumberInputE"
+        />
+        <RangeSliderE
+          onChange={(values: ReadonlyArray<number>) => {
+            handleChange({
+              currentTarget: {
+                name: 'exampleRangeSlider',
+                value: values as [],
+              },
+            })
+          }}
+          values={formState.exampleRangeSlider}
+          domain={[0, 40]}
+          mode={1}
+          tracksLeft
+          step={2}
+        />
+        <ButtonE
+          type="submit"
+          data-testid="form-example-submit"
+          isDisabled={isSubmitting}
+        >
+          Submit
+        </ButtonE>
+      </form>
+
+      <pre data-testid="form-example-values">
+        {JSON.stringify(formPayload, null, 2)}
+      </pre>
+    </main>
+  )
+}
+
+export default {
+  title: 'Forms/Native',
+  component: ExampleNativeForm,
+} as Meta
+
+export const Default: Story<unknown> = () => <ExampleNativeForm />

--- a/packages/react-component-library/src/forms/native/useNativeForm.ts
+++ b/packages/react-component-library/src/forms/native/useNativeForm.ts
@@ -1,0 +1,101 @@
+import React, { useState } from 'react'
+
+import { sleep } from '../../helpers'
+
+interface FormErrors {
+  [key: string]: boolean
+}
+
+interface SyntheticFormEvent {
+  currentTarget: {
+    name: string
+    value: string | string[] | number | number[]
+  }
+}
+
+export const useNativeForm = <T>(
+  initialState: T,
+  initialErrors: FormErrors,
+  validation: Record<string, (value: string) => boolean>
+) => {
+  const [formErrors, setFormErrors] = useState<FormErrors>(initialErrors)
+  const [formPayload, setFormPayload] = useState<T | undefined>()
+  const [formState, setFormState] = useState<T>(initialState)
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
+
+  const handleChange = (
+    e: React.FormEvent<HTMLInputElement> | SyntheticFormEvent
+  ): void => {
+    const { name, value } = e.currentTarget
+
+    if (validation[name]) {
+      setFormErrors({
+        ...formErrors,
+        ...{ [name]: validation[name](String(value)) },
+      })
+    }
+
+    setFormState({
+      ...formState,
+      ...{
+        [name]: value,
+      },
+    })
+  }
+
+  const handleCheckboxGroup = ({
+    currentTarget: { name, value, checked },
+  }: React.FormEvent<HTMLInputElement>): void => {
+    let newValues = [...formState[name]]
+
+    if (checked && !newValues.includes(value)) {
+      newValues.push(value)
+    } else {
+      newValues = newValues.filter((item: string) => item !== value)
+    }
+
+    handleChange({
+      currentTarget: {
+        name,
+        value: newValues,
+      },
+    })
+  }
+
+  const handleRadioGroup = ({
+    currentTarget: { name, value },
+  }: React.FormEvent<HTMLInputElement>): void => {
+    handleChange({
+      currentTarget: {
+        name,
+        value: [value],
+      },
+    })
+  }
+
+  const onSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    setIsSubmitting(true)
+
+    await sleep(400) // Simulate stubbed async action e.g. `fetch(...)`
+
+    if (!Object.values(formErrors).includes(true)) {
+      setFormPayload(formState)
+    }
+
+    setIsSubmitting(false)
+  }
+
+  return {
+    formErrors,
+    formPayload,
+    formState,
+    handleChange,
+    handleCheckboxGroup,
+    handleRadioGroup,
+    isSubmitting,
+    onSubmit,
+  }
+}

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import React, { useState, useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form/dist/index.ie11'
-import { Story, Meta } from '@storybook/react'
+import { ComponentMeta } from '@storybook/react'
 
 import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'
@@ -25,7 +25,7 @@ export interface FormValues {
   exampleRangeSlider: number[]
 }
 
-export const ExampleReactHookForm: React.FC<unknown> = () => {
+export const Example: React.FC<unknown> = () => {
   const {
     control,
     setValue,
@@ -185,7 +185,5 @@ export const ExampleReactHookForm: React.FC<unknown> = () => {
 
 export default {
   title: 'Forms/react-hook-form',
-  component: ExampleReactHookForm,
-} as Meta
-
-export const Default: Story<unknown> = () => <ExampleReactHookForm />
+  component: Example,
+} as ComponentMeta<typeof Example>

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -66,7 +66,7 @@ export const ExampleReactHookForm: React.FC<unknown> = () => {
     setValue('exampleSwitch', e.currentTarget.value)
 
   const handleNumberInputEChange = (
-    event:
+    _:
       | React.ChangeEvent<HTMLInputElement>
       | React.MouseEvent<HTMLButtonElement>,
     newValue: number

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,8 +7,7 @@ sonar.projectName=mod-uk-design-system
 # Path to sources
 sonar.sources=packages/react-component-library/src
 sonar.exclusions=**/*.test.ts,**/*.test.tsx*,**/*.stories.tsx*
-sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx*,**/*.stories.tsx*
-
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx*,**/*.stories.tsx*,packages/react-component-library/src/forms/**/*
 
 # Path to tests
 sonar.javascript.lcov.reportPaths=packages/react-component-library/coverage/lcov.info


### PR DESCRIPTION
## Related issue

Closes #2893

## Overview

Consume form components without relying on any companion libraries (Formik, react-hook-form etc).

## Reason

>We need to be sure that the form components work in a variety of use cases.

## Work carried out

- [x] Create new vanilla forms example
- [x] Tweak some types and code style
