### PR TITLE
fix(NumberInputE): Improve handling of invalid input

### DIFF
--- a/packages/react-component-library/cypress/specs/NumberInputE/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/NumberInputE/index.spec.ts
@@ -3,7 +3,7 @@ import { before, cy, describe, it } from 'local-cypress'
 import selectors from '../../selectors'
 
 describe('NumberInputE', () => {
-  before(() => {
+  beforeEach(() => {
     cy.visit(
       '/iframe.html?id=number-input-experimental--default&viewMode=story'
     )
@@ -14,7 +14,7 @@ describe('NumberInputE', () => {
   })
 
   describe('when the increase button is clicked', () => {
-    before(() => {
+    beforeEach(() => {
       cy.get(selectors.numberInputE.increase).click()
     })
 
@@ -24,12 +24,30 @@ describe('NumberInputE', () => {
   })
 
   describe('when the decrease button is clicked', () => {
-    before(() => {
+    beforeEach(() => {
       cy.get(selectors.numberInputE.decrease).click()
     })
 
     it('should decrement the value', () => {
-      cy.get(selectors.numberInputE.input).should('have.value', '0')
+      cy.get(selectors.numberInputE.input).should('have.value', '-1')
+    })
+  })
+
+  const TYPED_VALUE_CASES = [
+    ['100.123.456', '100.123456'],
+    ['100.123', '100.123'],
+    ['100.invalid456', '100.456'],
+  ]
+
+  TYPED_VALUE_CASES.forEach(([textToType, expectedValue]) => {
+    describe(`when typing "${textToType}"`, () => {
+      beforeEach(() => {
+        cy.get(selectors.numberInputE.input).type(textToType)
+      })
+
+      it(`the value is "${expectedValue}"`, () => {
+        cy.get(selectors.numberInputE.input).should('have.value', expectedValue)
+      })
     })
   })
 })

--- a/packages/react-component-library/src/components/NumberInputE/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/Input.tsx
@@ -13,9 +13,11 @@ export interface InputProps extends InputValidationProps {
   id?: string
   label?: string
   name: string
+  onBeforeInput: (event: React.FormEvent<HTMLInputElement>) => void
   onBlur: (event: React.FormEvent<HTMLInputElement>) => void
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onFocus: (event: React.FormEvent<HTMLInputElement>) => void
+  onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void
   placeholder?: string
   size: ComponentSizeType
   value?: string

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
@@ -77,10 +77,14 @@ describe('NumberInputE', () => {
   })
 
   describe('when minimal props', () => {
+    let input: HTMLElement
+
     beforeEach(() => {
       onChangeSpy = jest.spyOn(defaultProps, 'onChange')
 
       wrapper = render(<NumberInputE {...defaultProps} />)
+
+      input = wrapper.getByTestId('number-input-input')
     })
 
     it('sets the default `aria-label` attribute', () => {
@@ -136,9 +140,7 @@ describe('NumberInputE', () => {
     })
 
     it('sets the name attribute', () => {
-      expect(
-        wrapper.getByTestId('number-input-input').getAttribute('name')
-      ).toEqual('number-input')
+      expect(input.getAttribute('name')).toEqual('number-input')
     })
 
     it('does not display a footnote', () => {
@@ -174,8 +176,6 @@ describe('NumberInputE', () => {
 
     describe('and the user types values', () => {
       beforeEach(() => {
-        const input = wrapper.getByTestId('number-input-input')
-
         userEvent.type(input, '1')
         userEvent.type(input, '2')
         userEvent.type(input, '3')
@@ -195,8 +195,6 @@ describe('NumberInputE', () => {
 
     describe('and the user types a value with invalid characters', () => {
       beforeEach(() => {
-        const input = wrapper.getByTestId('number-input-input')
-
         userEvent.type(input, '1')
         userEvent.type(input, 'a')
         userEvent.type(input, '2')
@@ -220,8 +218,6 @@ describe('NumberInputE', () => {
 
     describe('and the user types a value', () => {
       beforeEach(() => {
-        const input = wrapper.getByTestId('number-input-input')
-
         userEvent.type(input, '1')
       })
 
@@ -230,8 +226,6 @@ describe('NumberInputE', () => {
 
       describe('and the user deletes the value', () => {
         beforeEach(() => {
-          const input = wrapper.getByTestId('number-input-input')
-
           userEvent.type(input, '{backspace}')
         })
 
@@ -296,6 +290,8 @@ describe('NumberInputE', () => {
   })
 
   describe('when max and min are specified', () => {
+    let input: HTMLElement
+
     beforeEach(() => {
       const props = {
         ...defaultProps,
@@ -311,6 +307,8 @@ describe('NumberInputE', () => {
           <input type="text" data-testid="next-field" />
         </>
       )
+
+      input = wrapper.getByTestId('number-input-input')
     })
 
     it('sets the correct `aria-valuemin` attribute', () => {
@@ -356,12 +354,12 @@ describe('NumberInputE', () => {
         const increase = wrapper.getByTestId('number-input-increase')
         increase.click()
 
-        wrapper.getByTestId('number-input-input').focus()
+        input.focus()
       })
 
       describe('and the value is changed to an alpha character', () => {
         beforeEach(() => {
-          fireEvent.change(wrapper.getByTestId('number-input-input'), {
+          fireEvent.change(input, {
             target: {
               value: 'a',
             },
@@ -373,7 +371,7 @@ describe('NumberInputE', () => {
 
       describe('and the value is changed to a valid number', () => {
         beforeEach(() => {
-          fireEvent.change(wrapper.getByTestId('number-input-input'), {
+          fireEvent.change(input, {
             target: {
               value: '3',
             },
@@ -385,7 +383,7 @@ describe('NumberInputE', () => {
 
       describe('and the value is changed to a number outside the max min range', () => {
         beforeEach(() => {
-          fireEvent.change(wrapper.getByTestId('number-input-input'), {
+          fireEvent.change(input, {
             target: {
               value: '4',
             },

--- a/packages/react-component-library/src/components/NumberInputE/useChangeHandlers.ts
+++ b/packages/react-component-library/src/components/NumberInputE/useChangeHandlers.ts
@@ -1,0 +1,53 @@
+import { isNil } from 'lodash'
+import React, { useCallback } from 'react'
+
+import { canCommit, isValueValid } from './validation'
+
+export function useChangeHandlers(
+  min: number | undefined,
+  max: number | undefined,
+  onChange: (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.MouseEvent<HTMLButtonElement>,
+    newValue: number
+  ) => void,
+  setCommittedValue: React.Dispatch<React.SetStateAction<string>>
+): {
+  handleButtonClick: (
+    event: React.MouseEvent<HTMLButtonElement>,
+    newValue: string
+  ) => void
+  handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+} {
+  const handleInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (!isValueValid(event.currentTarget.value)) {
+        return
+      }
+
+      const newValue = event.currentTarget.value || null
+
+      if (!newValue || canCommit(newValue, min, max)) {
+        setCommittedValue(newValue)
+        onChange(event, isNil(newValue) ? null : Number(newValue))
+      }
+    },
+    [min, max, onChange, setCommittedValue]
+  )
+
+  const handleButtonClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>, newValue: string) => {
+      if (canCommit(newValue, min, max)) {
+        setCommittedValue(newValue)
+        onChange(event, Number(newValue))
+      }
+    },
+    [min, max, onChange, setCommittedValue]
+  )
+
+  return {
+    handleButtonClick,
+    handleInputChange,
+  }
+}

--- a/packages/react-component-library/src/components/NumberInputE/useEarlyValidation.ts
+++ b/packages/react-component-library/src/components/NumberInputE/useEarlyValidation.ts
@@ -1,0 +1,64 @@
+import React, { useCallback } from 'react'
+
+import { areCharactersValid } from './validation'
+
+export function useEarlyValidation(): {
+  handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void
+  handleBeforeInput: (
+    event:
+      | React.FormEvent<HTMLInputElement>
+      | React.CompositionEvent<HTMLInputElement>
+  ) => void
+} {
+  /**
+   * Block invalid input before the DOM is updated where possible (to
+   * avoid the cursor jumping).
+   *
+   * Note: React simulates this event using other native events.
+   */
+  const handleBeforeInput = useCallback(
+    (
+      event:
+        | React.FormEvent<HTMLInputElement>
+        | React.CompositionEvent<HTMLInputElement>
+    ) => {
+      // Unfortunately, the event seems to be typed incorrectly at present
+      // (without the data property)
+      if (!('data' in event)) {
+        return
+      }
+
+      // data could contain a single character, or something longer
+      // in case of pasting. The text could be an insertion or a
+      // replacement (if existing text was selected).
+      const { data } = event
+
+      if (!areCharactersValid(data)) {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+    },
+    []
+  )
+
+  /**
+   * Block a second decimal point from being typed (before the DOM is
+   * updated, to avoid the cursor jumping).
+   */
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      const currentValue = event.currentTarget.value
+
+      if (event.key === '.' && currentValue.includes('.')) {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+    },
+    []
+  )
+
+  return {
+    handleBeforeInput,
+    handleKeyDown,
+  }
+}

--- a/packages/react-component-library/src/components/NumberInputE/useValue.ts
+++ b/packages/react-component-library/src/components/NumberInputE/useValue.ts
@@ -1,6 +1,9 @@
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-export function useValue(value: string) {
+export function useValue(value: string): {
+  committedValue: string
+  setCommittedValue: React.Dispatch<React.SetStateAction<string>>
+} {
   const [committedValue, setCommittedValue] = useState(value)
 
   useEffect(() => {

--- a/packages/react-component-library/src/components/NumberInputE/validation.ts
+++ b/packages/react-component-library/src/components/NumberInputE/validation.ts
@@ -1,0 +1,33 @@
+import { isFinite, isNil } from 'lodash'
+
+export function areCharactersValid(characters: string): boolean {
+  return /^[0-9.]*$/.test(characters)
+}
+
+export function isValueValid(value: string): boolean {
+  return /^\d*(\.\d*)?$/.test(value)
+}
+
+export function isWithinRange(
+  max: number,
+  min: number,
+  newValue: number
+): boolean {
+  const isNotBelowMin = isNil(min) || newValue >= min
+  const isNotAboveMax = isNil(max) || newValue <= max
+
+  return isNotBelowMin && isNotAboveMax
+}
+
+export function canCommit(
+  newValue: string,
+  min: number | undefined,
+  max: number | undefined
+): boolean {
+  const parsedValue = parseFloat(newValue)
+
+  return (
+    (isFinite(parsedValue) && isWithinRange(max, min, parsedValue)) ||
+    parsedValue === null
+  )
+}


### PR DESCRIPTION
## Related issue

Fixes #2948

## Overview

This makes a few changes to NumberInputE. It:

- stops invalid numbers from being pasted. Previously, invalid characters were stripped from pasted values, but we decided that that was undesirable and blocking invalid pastes would be an improvement
- stops a second decimal point being entered (whether typed or pasted before or after the first decimal point)
- where possible, stops the cursor jumping about when invalid characters are typed in the middle of the field
- removes some `onBlur` logic that appeared to be redundant

## Link to preview

- [Storybook](https://5e25c277526d380020b5e418-gswqgmkssr.chromatic.com/?path=/docs/number-input-experimental--default/)
- [Non-Storybook](https://red-playground.netlify.app/) (works in IE 11)

## Reason

For more consistent behaviour, and to avoid user input being silently altered.

## Work carried out

- [x] Tidy up tests slightly
- [x] Rework number validation logic

## Demos (Chrome)

<details>
<summary>Typing multiple decimal points</summary>

### Before

![type-point-before](https://user-images.githubusercontent.com/66470099/148565371-b0b9bea3-6826-41bd-a55e-34763cc81d71.gif)

### After

![type-point-after](https://user-images.githubusercontent.com/66470099/148565377-189db65f-1690-4fd4-92a7-bf7e7dbaca4b.gif)

</details>

<details>
<summary>Pasting text</summary>

### Before

![pasting-before](https://user-images.githubusercontent.com/66470099/148566204-8927aa0c-e158-4a87-aa7d-4e79a462156a.gif)

### After

![pasting-after](https://user-images.githubusercontent.com/66470099/148566231-d54e0499-33ee-448b-82a6-06f4ed53ac09.gif)

</details>

<details>
<summary>Typing letters earlier in the middle of the field</summary>

### Before

![letters-before](https://user-images.githubusercontent.com/66470099/148566459-6e360eca-6c5f-43d4-8a34-3a14ec99c295.gif)

### After

![letters-after](https://user-images.githubusercontent.com/66470099/148566467-eb2ca725-5a9e-48a1-b688-92ea4352cd73.gif)

</details>

## Developer notes

Relevant comments are in the code.

I've tested this in Firefox, Chrome and IE 11 and it seems to behave well.

(I wanted to add Cypress tests for pasting as well, but it doesn't have that functionality built in, and simulating the event doesn't work for this.)