### PR TITLE
test(DatePickerE): Add to form stories and related tests

### DIFF
--- a/packages/react-component-library/cypress/selectors/form.ts
+++ b/packages/react-component-library/cypress/selectors/form.ts
@@ -9,6 +9,8 @@ export default {
     switchOption: '[data-testid="switch-option"]',
     numberInput: '[data-testid="number-input"]',
     numberInputIncrease: '[data-testid="number-input-increase"]',
+    datePicker: '[data-testid="datepicker-outer-wrapper"]',
+    datePickerInput: '[data-testid="datepicker-input"]',
     rangeSlider: '[data-testid="rangeslider"]',
     rangeSliderRail: '[data-testid="rangeslider-rail"]',
   },

--- a/packages/react-component-library/cypress/specs/forms/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/forms/index.spec.ts
@@ -9,6 +9,7 @@ const expectedResult = {
     description: 'Hello, World!',
     exampleCheckbox: [],
     exampleRadio: 'Option 1',
+    exampleDatePicker: '2022-01-31T12:00:00.000Z',
     exampleRangeSlider: [28],
     exampleSwitch: '1',
     exampleNumberInput: 1,
@@ -21,6 +22,7 @@ const expectedResult = {
     exampleRadio: 'Option 1',
     exampleSwitch: '1',
     exampleNumberInput: 1,
+    exampleDatePicker: '2022-01-31T12:00:00.000Z',
     exampleRangeSlider: [28],
   },
   Native: {
@@ -31,6 +33,7 @@ const expectedResult = {
     exampleRadio: ['Option 1'],
     exampleSwitch: '1',
     exampleNumberInput: 1,
+    exampleDatePicker: '2022-01-31T12:00:00.000Z',
     exampleRangeSlider: [28],
   },
 }
@@ -70,6 +73,7 @@ describe('Form Examples', () => {
             cy.get(selectors.form.input.description).should('be.visible')
             cy.get(selectors.form.input.switch).should('be.visible')
             cy.get(selectors.form.input.numberInput).should('be.visible')
+            cy.get(selectors.form.input.datePicker).should('be.visible')
             cy.get(selectors.form.input.rangeSlider).should('be.visible')
           })
 
@@ -91,6 +95,7 @@ describe('Form Examples', () => {
               cy.get(selectors.form.input.radio).eq(0).click()
               cy.get(selectors.form.input.switchOption).eq(0).click()
               cy.get(selectors.form.input.numberInputIncrease).click()
+              cy.get(selectors.form.input.datePickerInput).type('31/01/2022')
               cy.get(selectors.form.input.rangeSliderRail).click(800, 0)
             })
 

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -1,3 +1,4 @@
+import { isBefore, isValid, parseISO } from 'date-fns'
 import React, { useState } from 'react'
 import { ComponentMeta } from '@storybook/react'
 import { Formik, Field } from 'formik'
@@ -8,6 +9,10 @@ import { RadioE } from '../../components/RadioE'
 import { CheckboxE } from '../../components/CheckboxE'
 import { ButtonE } from '../../components/ButtonE'
 import { NumberInputE } from '../../components/NumberInputE'
+import {
+  DatePickerE,
+  DatePickerEOnChangeData,
+} from '../../components/DatePickerE'
 import { SwitchE, SwitchEOption, SwitchEProps } from '../../components/SwitchE'
 import { RangeSliderE } from '../../components/RangeSliderE'
 import { FormikGroupE } from '../../components/FormikGroup'
@@ -42,8 +47,11 @@ const FormikTextAreaE = withFormik(TextAreaE)
 const FormikCheckboxE = withFormik(CheckboxE)
 const FormikRadioE = withFormik(RadioE)
 const FormikSwitchE = withFormik(SwitchEFormed)
+const FormikDatePickerE = withFormik(DatePickerE)
 const FormikNumberInputE = withFormik(NumberInputE)
-const FormikeRangeSliderE = withFormik(RangeSliderE)
+const FormikRangeSliderE = withFormik(RangeSliderE)
+
+const MINIMUM_DATE = parseISO('2022-01-01')
 
 export const Example: React.FC<unknown> = () => {
   const [formValues, setFormValues] = useState<FormValues>()
@@ -59,17 +67,24 @@ export const Example: React.FC<unknown> = () => {
           exampleRadio: [],
           exampleSwitch: '',
           exampleNumberInput: null,
+          exampleDatePicker: null,
           exampleRangeSlider: [20],
         }}
-        validate={(values) => {
+        validate={({ email, exampleDatePicker }) => {
           const errors: Record<string, unknown> = {}
 
-          if (!values.email) {
+          if (!email) {
             errors.email = 'Required'
-          } else if (
-            !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(values.email)
-          ) {
+          } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(email)) {
             errors.email = 'Invalid email address'
+          }
+
+          if (exampleDatePicker && !isValid(exampleDatePicker)) {
+            errors.exampleDatePicker = 'Enter a valid date'
+          }
+
+          if (isBefore(exampleDatePicker, MINIMUM_DATE)) {
+            errors.exampleDatePicker = 'Enter a date on or after 1 January 2022'
           }
 
           return errors
@@ -167,8 +182,16 @@ export const Example: React.FC<unknown> = () => {
               }}
             />
             <Field
+              name="exampleDatePicker"
+              component={FormikDatePickerE}
+              disabledDays={{ before: MINIMUM_DATE }}
+              onChange={({ startDate }: DatePickerEOnChangeData) => {
+                setFieldValue('exampleDatePicker', startDate)
+              }}
+            />
+            <Field
               name="exampleRangeSlider"
-              component={FormikeRangeSliderE}
+              component={FormikRangeSliderE}
               onChange={(newValues: ReadonlyArray<number>) => {
                 setFieldValue('exampleRangeSlider', newValues)
               }}

--- a/packages/react-component-library/src/forms/native/native.stories.tsx
+++ b/packages/react-component-library/src/forms/native/native.stories.tsx
@@ -1,3 +1,4 @@
+import { isBefore, isValid, parseISO } from 'date-fns'
 import React from 'react'
 import { ComponentMeta } from '@storybook/react'
 
@@ -5,6 +6,7 @@ import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'
 import { RadioE } from '../../components/RadioE'
 import { CheckboxE } from '../../components/CheckboxE'
+import { DatePickerE } from '../../components/DatePickerE'
 import { NumberInputE } from '../../components/NumberInputE'
 import { SwitchE, SwitchEOption } from '../../components/SwitchE'
 import { RangeSliderE } from '../../components/RangeSliderE'
@@ -20,8 +22,11 @@ export interface FormValues {
   exampleRadio: string[]
   exampleSwitch: string
   exampleNumberInput: number
+  exampleDatePicker: Date | null
   exampleRangeSlider: readonly [number, number?]
 }
+
+const MINIMUM_DATE = parseISO('2022-01-01')
 
 export const Example: React.FC<unknown> = () => {
   const {
@@ -42,6 +47,7 @@ export const Example: React.FC<unknown> = () => {
       exampleRadio: [],
       exampleSwitch: '',
       exampleNumberInput: null,
+      exampleDatePicker: null,
       exampleRangeSlider: [20],
     },
     {
@@ -50,6 +56,17 @@ export const Example: React.FC<unknown> = () => {
     },
     {
       email: (value: string): boolean => !value,
+      exampleDatePicker: (value) => {
+        if (value && !isValid(value)) {
+          return 'Enter a valid date'
+        }
+
+        if (isBefore(value, MINIMUM_DATE)) {
+          return 'Enter a date on or after 1 January 2022'
+        }
+
+        return false
+      },
       // ...
     }
   )
@@ -63,7 +80,7 @@ export const Example: React.FC<unknown> = () => {
           label="Email"
           value={formState.email}
           onChange={handleChange}
-          isInvalid={formErrors.email}
+          isInvalid={Boolean(formErrors.email)}
           data-testid="form-example-TextInputE-email"
         />
         {formErrors.email && <span>Required</span>}
@@ -155,6 +172,20 @@ export const Example: React.FC<unknown> = () => {
           value={formState.exampleNumberInput}
           data-testid="form-example-NumberInputE"
         />
+        <DatePickerE
+          onChange={({ startDate }) => {
+            handleChange({
+              currentTarget: {
+                name: 'exampleDatePicker',
+                value: startDate,
+              },
+            })
+          }}
+          disabledDays={{ before: MINIMUM_DATE }}
+        />
+        {formErrors.exampleDatePicker && (
+          <span>{formErrors.exampleDatePicker}</span>
+        )}
         <RangeSliderE
           onChange={(values: ReadonlyArray<number>) => {
             handleChange({

--- a/packages/react-component-library/src/forms/native/useNativeForm.ts
+++ b/packages/react-component-library/src/forms/native/useNativeForm.ts
@@ -2,25 +2,30 @@ import React, { useState } from 'react'
 
 import { sleep } from '../../helpers'
 
-interface FormErrors {
-  [key: string]: boolean
-}
+type Validators<FormValues> = Partial<{
+  [key in keyof FormValues]: (value: FormValues[key]) => boolean | string
+}>
+
+type FormErrors<FormValues> = Partial<{
+  [key in keyof FormValues]: boolean | string
+}>
 
 interface SyntheticFormEvent {
   currentTarget: {
     name: string
-    value: string | string[] | number | number[]
+    value: string | string[] | number | number[] | Date
   }
 }
 
-export const useNativeForm = <T>(
-  initialState: T,
-  initialErrors: FormErrors,
-  validation: Record<string, (value: string) => boolean>
+export const useNativeForm = <FormValues>(
+  initialState: FormValues,
+  initialErrors: FormErrors<FormValues>,
+  validation: Validators<FormValues>
 ) => {
-  const [formErrors, setFormErrors] = useState<FormErrors>(initialErrors)
-  const [formPayload, setFormPayload] = useState<T | undefined>()
-  const [formState, setFormState] = useState<T>(initialState)
+  const [formErrors, setFormErrors] =
+    useState<FormErrors<FormValues>>(initialErrors)
+  const [formPayload, setFormPayload] = useState<FormValues | undefined>()
+  const [formState, setFormState] = useState<FormValues>(initialState)
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
   const handleChange = (
@@ -31,7 +36,7 @@ export const useNativeForm = <T>(
     if (validation[name]) {
       setFormErrors({
         ...formErrors,
-        ...{ [name]: validation[name](String(value)) },
+        ...{ [name]: validation[name](value) },
       })
     }
 
@@ -81,7 +86,7 @@ export const useNativeForm = <T>(
 
     await sleep(400) // Simulate stubbed async action e.g. `fetch(...)`
 
-    if (!Object.values(formErrors).includes(true)) {
+    if (!Object.values(formErrors).some((error) => error)) {
       setFormPayload(formState)
     }
 

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { isBefore, isValid, parseISO } from 'date-fns'
 import React, { useState, useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form/dist/index.ie11'
 import { ComponentMeta } from '@storybook/react'
@@ -7,6 +8,7 @@ import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'
 import { RadioE } from '../../components/RadioE'
 import { CheckboxE } from '../../components/CheckboxE'
+import { DatePickerE } from '../../components/DatePickerE'
 import { NumberInputE } from '../../components/NumberInputE'
 import { SwitchE, SwitchEOption } from '../../components/SwitchE'
 import { RangeSliderE } from '../../components/RangeSliderE'
@@ -19,11 +21,14 @@ export interface FormValues {
   password: string
   description: string
   exampleCheckbox: string[]
+  exampleDatePicker: Date | null
   exampleRadio: string[]
   exampleSwitch: string
   exampleNumberInput: number
   exampleRangeSlider: number[]
 }
+
+const MINIMUM_DATE = parseISO('2022-01-01')
 
 export const Example: React.FC<unknown> = () => {
   const {
@@ -39,6 +44,7 @@ export const Example: React.FC<unknown> = () => {
       password: '',
       description: '',
       exampleCheckbox: [],
+      exampleDatePicker: null,
       exampleRadio: [],
       exampleSwitch: '',
       exampleNumberInput: null,
@@ -59,7 +65,6 @@ export const Example: React.FC<unknown> = () => {
   useEffect(() => {
     register({ name: 'exampleSwitch' })
     register({ name: 'exampleNumberInput' })
-    register({ name: 'exampleRangeSlider' })
   }, [register])
 
   const handleSwitchEChange = (e: React.FormEvent<HTMLInputElement>) =>
@@ -151,6 +156,36 @@ export const Example: React.FC<unknown> = () => {
           value={exampleNumberInputValue}
           data-testid="form-example-NumberInputE"
         />
+        <Controller
+          control={control}
+          name="exampleDatePicker"
+          rules={{
+            validate: (value) => {
+              if (value && !isValid(value)) {
+                return 'Enter a valid date'
+              }
+
+              if (isBefore(value, MINIMUM_DATE)) {
+                return 'Enter a date on or after 1 January 2022'
+              }
+
+              return true
+            },
+          }}
+          render={({ onChange }) => {
+            return (
+              <DatePickerE
+                onChange={({ startDate }) => {
+                  onChange(startDate)
+                }}
+                disabledDays={{ before: MINIMUM_DATE }}
+              />
+            )
+          }}
+        />
+        {errors.exampleDatePicker && (
+          <span>{errors.exampleDatePicker.message}</span>
+        )}
         <Controller
           control={control}
           name="exampleRangeSlider"


### PR DESCRIPTION
## Related issue

Resolves #2864

## Overview

This adds DatePickerE to the various form stories and updates the related Cypress tests.

## Link to preview

https://5e25c277526d380020b5e418-fpfepejezl.chromatic.com/?path=/docs/forms-formik--example

## Reason

To keep the form examples up to date.

## Work carried out

- [x] Update form stories
- [x] Update tests

## Developer notes

I noticed while working on this that passing the value from `onChange` back to the `startDate` prop causes bad behaviour – I've created a separate issue for that as it should work really: https://github.com/defencedigital/mod-uk-design-system/issues/2971
