### PR TITLE
feat(SelectE): Add No results

### DIFF
--- a/packages/react-component-library/cypress/selectors/AutocompleteE.ts
+++ b/packages/react-component-library/cypress/selectors/AutocompleteE.ts
@@ -1,0 +1,3 @@
+export default {
+  noResults: '[data-testid="autocomplete-no-results"]',
+}

--- a/packages/react-component-library/cypress/selectors/SelectE.ts
+++ b/packages/react-component-library/cypress/selectors/SelectE.ts
@@ -1,5 +1,6 @@
 export default {
   input: '[data-testid="select-input"]',
+  label: '[data-testid="select-label"]',
   option: '[data-testid="select-option"]',
   outerWrapper: '[data-testid="select-outer-wrapper"]',
 }

--- a/packages/react-component-library/cypress/selectors/index.ts
+++ b/packages/react-component-library/cypress/selectors/index.ts
@@ -1,12 +1,14 @@
-import form from './form'
+import autocompleteE from './AutocompleteE'
 import contextMenu from './ContextMenu'
 import datePicker from './DatePicker'
+import form from './form'
 import numberInputE from './NumberInputE'
 import rangeSliderE from './RangeSliderE'
 import selectE from './SelectE'
 import timeline from './timeline'
 
 export default {
+  autocompleteE,
   contextMenu,
   datePicker,
   form,

--- a/packages/react-component-library/cypress/specs/AutocompleteE/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/AutocompleteE/index.spec.ts
@@ -33,6 +33,10 @@ describe('AutocompleteE', () => {
         })
       })
 
+      it('does not render the `No results for t` text', () => {
+        cy.get(selectors.autocompleteE.noResults).should('not.exist')
+      })
+
       describe('and the `Three` option is clicked', () => {
         beforeEach(() => {
           cy.get(selectors.selectE.option).eq(0).click()
@@ -52,6 +56,20 @@ describe('AutocompleteE', () => {
       it('renders no options', () => {
         const options = cy.get(selectors.selectE.option)
         options.should('have.length', 0)
+      })
+    })
+
+    describe('and `z` is typed', () => {
+      beforeEach(() => {
+        cy.get(selectors.selectE.input).type('z')
+      })
+
+      it('renders no options', () => {
+        cy.get(selectors.selectE.option).should('have.length', 0)
+      })
+
+      it('renders the `No results for z` text', () => {
+        cy.get(selectors.autocompleteE.noResults).should('be.visible')
       })
     })
   })

--- a/packages/react-component-library/cypress/specs/AutocompleteE/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/AutocompleteE/index.spec.ts
@@ -71,6 +71,20 @@ describe('AutocompleteE', () => {
       it('renders the `No results for z` text', () => {
         cy.get(selectors.autocompleteE.noResults).should('be.visible')
       })
+
+      describe('and the component is blurred', () => {
+        beforeEach(() => {
+          cy.get('body').click()
+        })
+
+        it('keeps the small label', () => {
+          cy.get(selectors.selectE.label).should(
+            'have.css',
+            'transform',
+            'matrix(0.75, 0, 0, 0.75, 11, 6)'
+          )
+        })
+      })
     })
   })
 })

--- a/packages/react-component-library/src/components/AutocompleteE/AutocompleteE.tsx
+++ b/packages/react-component-library/src/components/AutocompleteE/AutocompleteE.tsx
@@ -57,7 +57,7 @@ export const AutocompleteE: React.FC<AutocompleteEProps> = ({
   return (
     <SelectLayout
       hasLabelFocus={isOpen}
-      hasSelectedItem={!!selectedItem}
+      hasSelectedItem={!!inputValue}
       id={id}
       inputProps={getInputProps({
         onFocus: () => {

--- a/packages/react-component-library/src/components/AutocompleteE/AutocompleteE.tsx
+++ b/packages/react-component-library/src/components/AutocompleteE/AutocompleteE.tsx
@@ -11,6 +11,7 @@ import {
 } from '../SelectBase'
 import { useInput } from './hooks/useInput'
 import { useItems } from './hooks/useItems'
+import { NoResults } from './NoResults'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AutocompleteEProps extends SelectBaseProps {}
@@ -98,6 +99,7 @@ export const AutocompleteE: React.FC<AutocompleteEProps> = ({
             isHighlighted: highlightedIndex === index,
           })
         })}
+      {inputValue && !items.length && <NoResults>{inputValue}</NoResults>}
     </SelectLayout>
   )
 }

--- a/packages/react-component-library/src/components/AutocompleteE/NoResults.tsx
+++ b/packages/react-component-library/src/components/AutocompleteE/NoResults.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import { StyledNoResults } from './partials/StyledNoResults'
+
+export const NoResults: React.FC = ({ children }) => (
+  <StyledNoResults data-testid="autocomplete-no-results">
+    <em>
+      No results for<strong>{`\u00A0${children}`}</strong>
+    </em>
+  </StyledNoResults>
+)
+
+NoResults.displayName = 'NoResults'

--- a/packages/react-component-library/src/components/AutocompleteE/partials/StyledNoResults.tsx
+++ b/packages/react-component-library/src/components/AutocompleteE/partials/StyledNoResults.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components'
+import { selectors } from '@defencedigital/design-tokens'
+
+import { COMPONENT_SIZE } from '../../Forms'
+import { TEXT_INPUT_INPUT_HEIGHT } from '../../TextInputE/partials/StyledInput'
+
+const { color, fontSize } = selectors
+
+export const StyledNoResults = styled.span`
+  height: ${TEXT_INPUT_INPUT_HEIGHT[COMPONENT_SIZE.FORMS]};
+  padding: 0 11px;
+  display: flex;
+  align-items: center;
+  color: ${color('neutral', '400')};
+  font-size: ${fontSize('m')};
+
+  &,
+  * {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+`

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledOption.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledOption.tsx
@@ -7,7 +7,7 @@ import { TEXT_INPUT_INPUT_HEIGHT } from '../../TextInputE/partials/StyledInput'
 const { color, fontSize, spacing } = selectors
 
 export interface StyledOptionsProps {
-  $isHighlighted: boolean
+  $isHighlighted?: boolean
 }
 
 export const StyledOption = styled.li<StyledOptionsProps>`


### PR DESCRIPTION
## Related issue
Closes #2960

## Overview
If there are no results for the filter then a message should be displayed as per design.

## Link to preview
https://autocomplete-noitems.netlify.app/?path=/story/autocomplete-experimental--default

## Reason
The user needs feedback and this is in the spec.

## Work carried out
- [x] Add message

## Screenshot
![2022-01-12 20 11 23](https://user-images.githubusercontent.com/56078793/149216407-dc3c2d28-7169-470a-a9c5-7b1a44f8635f.gif)
