### PR TITLE
feat(Dialog): Move cancel button to secondary position

### DIFF
--- a/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
@@ -3,14 +3,20 @@ import styled from 'styled-components'
 import { Story, Meta } from '@storybook/react'
 
 import { Dialog, DialogProps } from './index'
+import { StyledDialog } from './partials/StyledDialog'
 import { StyledMain } from '../Modal/partials/StyledMain'
 
-const StyledDialog = styled(Dialog)`
-  position: absolute;
-  z-index: 1;
+const Wrapper = styled.div`
+  height: 14rem;
 
-  ${StyledMain} {
+  /* Styles extended for Storybook presentation */
+  ${StyledDialog} {
     position: absolute;
+    z-index: 1;
+
+    ${StyledMain} {
+      position: absolute;
+    }
   }
 `
 
@@ -23,26 +29,23 @@ export default {
   },
 } as Meta
 
-export const Default: Story<DialogProps> = (props) => (
-  <div style={{ height: '10rem' }}>
-    {/* Styles extended for Storybook presentation */}
-    <StyledDialog {...props} />
-  </div>
+const Template: Story<DialogProps> = (args) => (
+  <Wrapper>
+    <Dialog {...args} />
+  </Wrapper>
 )
 
+export const Default = Template.bind({})
 Default.args = {
   title: 'Example Title',
   description: 'Example description',
   isOpen: true,
 }
 
-export const Danger: Story<DialogProps> = () => (
-  <div style={{ height: '10rem' }}>
-    <StyledDialog
-      title="Example Title"
-      description="Example description"
-      isDanger
-      isOpen
-    />
-  </div>
-)
+export const Danger = Template.bind({})
+Danger.args = {
+  title: 'Example Title',
+  description: 'Example description',
+  isDanger: true,
+  isOpen: true,
+}

--- a/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
@@ -77,10 +77,10 @@ describe('Modal', () => {
         })
       })
 
-      describe('and the tertiary button is clicked', () => {
+      describe('and the secondary button is clicked', () => {
         beforeEach(() => {
           fireEvent(
-            wrapper.getByTestId('modal-tertiary'),
+            wrapper.getByTestId('modal-secondary'),
             new MouseEvent('click', {
               bubbles: true,
               cancelable: true,

--- a/packages/react-component-library/src/components/Dialog/Dialog.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.tsx
@@ -65,7 +65,7 @@ export const Dialog: React.FC<DialogProps> = ({
       titleId={titleId}
       descriptionId={descriptionId}
       primaryButton={confirmButton}
-      tertiaryButton={cancelButton}
+      secondaryButton={cancelButton}
       {...rest}
     >
       <StyledBody data-testid="dialog-body">

--- a/packages/react-component-library/src/components/Dialog/partials/StyledDialog.tsx
+++ b/packages/react-component-library/src/components/Dialog/partials/StyledDialog.tsx
@@ -2,13 +2,9 @@ import { selectors } from '@defencedigital/design-tokens'
 import styled from 'styled-components'
 
 import { Modal } from '../../Modal'
-import { StyledButton } from '../../Button/partials/StyledButton'
-import { StyledFooter } from '../../Modal/partials/StyledFooter'
-import { StyledIcon } from '../../Button/partials/StyledIcon'
 import { StyledMain } from '../../Modal/partials/StyledMain'
-import { StyledPrimaryButton } from '../../Modal/partials/StyledPrimaryButton'
 
-const { mq, spacing } = selectors
+const { mq } = selectors
 
 export const StyledDialog = styled(Modal)`
   ${StyledMain} {
@@ -16,24 +12,5 @@ export const StyledDialog = styled(Modal)`
       width: 100%;
       max-width: 480px;
     `}
-  }
-
-  ${StyledFooter} {
-    ${StyledButton} {
-      display: block;
-      width: 100%;
-
-      ${mq({ gte: 'xs' })`
-        width: auto;
-      `}
-    }
-
-    ${StyledIcon} {
-      transform: translateY(2px);
-    }
-
-    ${StyledPrimaryButton} {
-      margin-left: 0;
-    }
   }
 `

--- a/packages/react-component-library/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.stories.tsx
@@ -52,7 +52,7 @@ const Wrapper = styled.div<{ $height: string }>`
 `
 
 const Template: Story<ModalProps> = (args) => (
-  <Wrapper $height={args.title && args.primaryButton ? '15rem' : '10rem'}>
+  <Wrapper $height={args.title && args.primaryButton ? '17rem' : '12rem'}>
     <Modal {...args}>
       <pre style={{ padding: '1rem' }}>Arbitrary JSX content</pre>
     </Modal>


### PR DESCRIPTION
## Related issue

Resolves #2444

## Overview

This makes `Dialog` use the secondary button position for its cancel button.

It also corrects the heights of the Modal and Dialog stories on the Storybook Docs tab.

## Link to preview

[Storybook](https://5e25c277526d380020b5e418-xfkocjjbyu.chromatic.com/)

## Reason

> The button order/placement for the Dialog component is not currently consistent with that of the Modal component, even though they serve similar purposes.
>
> Consistency is key here and the decision is to adapt the button order for the Dialog component to match that of Modal.

## Work carried out

- [x] Change cancel button to be in the secondary button position
- [x] Remove now-redundant footer styling overrides
- [x] Improve Modal and Dialog stories

## Screenshot

### Before

![image](https://user-images.githubusercontent.com/66470099/149131509-a0354bad-09b0-495c-b2d1-ebd300c99efe.png)

### After

![image](https://user-images.githubusercontent.com/66470099/149131562-479c93a6-35da-4aae-8a5e-4f41a3bd00e0.png)

## Developer notes

Note that the Dialog buttons are hard-coded and cancel button was previously a secondary button passed as a tertiary button to Modal. This change simply makes that hard-coded button a secondary button.