### PR TITLE
feat(Breadcrumbs): Supplement interface with `href` and children

### DIFF
--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -14,7 +14,7 @@ export default {
 export const Default: Story<Nav<BreadcrumbsItemProps>> = ({ className }) => (
   <Breadcrumbs className={className}>
     <BreadcrumbsItem link={<Link href="/">Home</Link>} />
-    <BreadcrumbsItem link={<Link href="/components">Components</Link>} />
+    <BreadcrumbsItem href="/components">Components</BreadcrumbsItem>
     <BreadcrumbsItem
       link={<Link href="/components/breadcrumb">Breadcrumb</Link>}
     />

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -16,7 +16,6 @@ describe('Breadcrumbs', () => {
             data-arbitrary="arbitrary-breadcrumbs-item"
             link={<Link href="#home">Home</Link>}
           />
-          <BreadcrumbsItem link={<Link href="#ships">Ships</Link>} />
           <BreadcrumbsItem link={<Link href="#reports">Reports</Link>} />
           <BreadcrumbsItem link={<Link href="#stuff">Stuff</Link>} />
           <BreadcrumbsItem link={<Link href="#22">22nd April 2019</Link>} />
@@ -60,17 +59,17 @@ describe('Breadcrumbs', () => {
 
     it('should render a list of breadcrumbs', () => {
       const linkElements = wrapper.queryAllByTestId('breadcrumb')
-      expect(linkElements).toHaveLength(5)
+      expect(linkElements).toHaveLength(4)
     })
 
     it('should render four separators', () => {
       const linkElements = wrapper.queryAllByTestId('breadcrumb-separator')
-      expect(linkElements).toHaveLength(4)
+      expect(linkElements).toHaveLength(3)
     })
 
     it('should render the first 4 links as anchors', () => {
       const linkElements = wrapper.queryAllByTestId('link')
-      expect(linkElements).toHaveLength(4)
+      expect(linkElements).toHaveLength(3)
     })
 
     it('should render the last link as a title', () => {
@@ -79,7 +78,7 @@ describe('Breadcrumbs', () => {
     })
 
     it('should only include separators in for all but the first link', () => {
-      expect(wrapper.queryAllByTestId('link')).toHaveLength(4)
+      expect(wrapper.queryAllByTestId('link')).toHaveLength(3)
     })
   })
 
@@ -126,6 +125,25 @@ describe('Breadcrumbs', () => {
     it('should render one breadcrumb', () => {
       const linkElements = wrapper.queryAllByTestId('breadcrumb')
       expect(linkElements).toHaveLength(1)
+    })
+  })
+
+  describe('when href and children are used', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Breadcrumbs>
+          <BreadcrumbsItem href="#home">Home</BreadcrumbsItem>
+          <BreadcrumbsItem href="#reports">Reports</BreadcrumbsItem>
+        </Breadcrumbs>
+      )
+    })
+
+    it('should render the breadcrumb title', () => {
+      expect(wrapper.queryByText('Home')).toBeInTheDocument()
+    })
+
+    it('sould apply the `href` attribute', () => {
+      expect(wrapper.queryByText('Home')).toHaveAttribute('href', '#home')
     })
   })
 })

--- a/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -5,7 +5,7 @@ import { StyledBreadcrumbsItem } from './partials/StyledBreadcrumbsItem'
 import { StyledEndTitle } from './partials/StyledEndTitle'
 import { StyledIcon } from './partials/StyledIcon'
 
-export interface BreadcrumbsItemProps {
+export interface BreadcrumbsItemBaseProps {
   /**
    * Denotes whether this is the first item.
    * @private
@@ -16,28 +16,51 @@ export interface BreadcrumbsItemProps {
    * @private
    */
   isLast?: boolean
-  /**
-   * Link component to use for the item (custom implementation welcome).
-   */
-  link: React.ReactElement<LinkTypes>
 }
 
-function getText(isLast: boolean, link: React.ReactElement<LinkTypes>) {
+export interface BreadcrumbsItemWithLinkProps extends BreadcrumbsItemBaseProps {
+  /**
+   * Optional Link component to use for the item (redundant if `href` is used).
+   */
+  link: React.ReactElement<LinkTypes>
+  href?: never
+}
+
+export interface BreadcrumbsItemWithHrefProps extends BreadcrumbsItemBaseProps {
+  /**
+   * Optional `href` attribute to apply to HTML anchor (redundant if `link` is used).
+   */
+  href: string
+  link?: never
+}
+
+export type BreadcrumbsItemProps =
+  | BreadcrumbsItemWithLinkProps
+  | BreadcrumbsItemWithHrefProps
+
+function getText(
+  isLast: boolean,
+  link?: React.ReactElement<LinkTypes>,
+  href?: string,
+  children?: React.ReactNode
+): React.ReactElement {
   if (isLast) {
     return (
       <StyledEndTitle aria-current="page" data-testid="breadcrumb-end-title">
-        {(link as ReactElement).props.children}
+        {link ? (link as ReactElement).props.children : children}
       </StyledEndTitle>
     )
   }
 
-  return link
+  return link || <a href={href}>{children}</a>
 }
 
 export const BreadcrumbsItem: React.FC<BreadcrumbsItemProps> = ({
   isFirst,
   isLast,
   link,
+  href,
+  children,
   ...rest
 }) => {
   return (
@@ -46,7 +69,7 @@ export const BreadcrumbsItem: React.FC<BreadcrumbsItemProps> = ({
         <StyledIcon aria-hidden data-testid="breadcrumb-separator" />
       )}
 
-      {getText(isLast, link)}
+      {getText(isLast, link, href, children)}
     </StyledBreadcrumbsItem>
   )
 }


### PR DESCRIPTION
## Related issue

Closes #563

## Overview

Add ability to compose a Breadcrumb without relying on `Link` components.

## Work carried out

- [x] Enhance existing interface
- [x] Supplement existing tests and story