### PR TITLE
docs(Storybook): Resolve deprecation warnings

### DIFF
--- a/packages/react-component-library/.storybook/manager.js
+++ b/packages/react-component-library/.storybook/manager.js
@@ -1,3 +1,3 @@
 import { addons } from '@storybook/addons'
 
-addons.setConfig({ showRoots: false })
+addons.setConfig({ sidebar: { showRoots: false } })

--- a/packages/react-component-library/src/components/ThemedExample/ThemedExample.stories.tsx
+++ b/packages/react-component-library/src/components/ThemedExample/ThemedExample.stories.tsx
@@ -12,7 +12,6 @@ export default {
   title: 'Custom Theming',
   parameters: {
     a11y: {
-      disabled: true,
       config: {
         rules: [
           {


### PR DESCRIPTION
## Overview

This fixes a couple of deprecation warnings I noticed.

## Work carried out

- [x] Fix deprecation warnings

## Developer notes

See:

- https://github.com/storybookjs/storybook/blob/master/MIGRATION.md#deprecated-showroots-config-option
- https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-package-composition-disabled-parameter
