### PR TITLE
fix(NumberInputE): Don't blur buttons on click

### DIFF
--- a/packages/react-component-library/src/components/NumberInputE/Buttons.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/Buttons.tsx
@@ -39,11 +39,7 @@ export const Buttons: React.FC<ButtonsProps> = ({
 
   function onButtonClick(getNewValue: () => string) {
     return (event: React.MouseEvent<HTMLButtonElement>) => {
-      const target = event.currentTarget
-      target.blur()
-
       const newValue = getNewValue()
-
       onClick(event, newValue)
     }
   }

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
@@ -175,6 +175,28 @@ describe('NumberInputE', () => {
       })
     })
 
+    describe.each([
+      { buttonType: 'increase', expectedValue: '1' },
+      { buttonType: 'decrease', expectedValue: '-1' },
+    ])(
+      'and Enter is pressed with the $buttonType button focused',
+      ({ buttonType, expectedValue }) => {
+        let increase: HTMLElement
+
+        beforeEach(() => {
+          increase = wrapper.getByTestId(`number-input-${buttonType}`)
+          increase.focus()
+          userEvent.keyboard('{Enter}')
+        })
+
+        assertInputValue(expectedValue)
+
+        it(`does not blur the ${buttonType} button`, () => {
+          expect(increase).toHaveFocus()
+        })
+      }
+    )
+
     describe('and the user types values', () => {
       beforeEach(() => {
         userEvent.type(input, '1')


### PR DESCRIPTION
## Related issue

Resolves #2759

## Overview

This stops the `NumberInputE` increase and decrease buttons from blurring themselves on click. (This affects all ways of clicking e.g. left mouse button, Enter, Space).

## Link to preview

[Storybook](https://5e25c277526d380020b5e418-nujclwrjnc.chromatic.com/?path=/docs/number-input-experimental--default)

[Non-Storybook](https://red-playground.netlify.app/)

## Reason

The focus shouldn't be manipulated in this way, and it prevents e.g. pressing Enter multiple times on the button.

## Work carried out

- [x] Remove blurring logic

## Demo

### Before

![Screencast_13-01-22_11:17:04](https://user-images.githubusercontent.com/66470099/149320832-9ffd38c2-7148-474d-9e7b-0dedbd6c5a14.gif)

### After

![Screencast_13-01-22_11:17:52](https://user-images.githubusercontent.com/66470099/149320840-5cf69a64-acbb-4ac9-9ac2-92105493679b.gif)
