### PR TITLE
Add SelectE and AutocompleteE to form stories and related tests

### DIFF
--- a/packages/react-component-library/cypress/selectors/form.ts
+++ b/packages/react-component-library/cypress/selectors/form.ts
@@ -11,6 +11,7 @@ export default {
     numberInputIncrease: '[data-testid="number-input-increase"]',
     datePicker: '[data-testid="datepicker-outer-wrapper"]',
     datePickerInput: '[data-testid="datepicker-input"]',
+    select: '[data-testid="select"]',
     rangeSlider: '[data-testid="rangeslider"]',
     rangeSliderRail: '[data-testid="rangeslider-rail"]',
   },

--- a/packages/react-component-library/cypress/specs/forms/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/forms/index.spec.ts
@@ -11,6 +11,7 @@ const expectedResult = {
     exampleRadio: 'Option 1',
     exampleDatePicker: '2022-01-31T12:00:00.000Z',
     exampleSelect: 'three',
+    exampleAutocomplete: 'four',
     exampleRangeSlider: [28],
     exampleSwitch: '1',
     exampleNumberInput: 1,
@@ -25,6 +26,7 @@ const expectedResult = {
     exampleNumberInput: 1,
     exampleDatePicker: '2022-01-31T12:00:00.000Z',
     exampleSelect: 'three',
+    exampleAutocomplete: 'four',
     exampleRangeSlider: [28],
   },
   Native: {
@@ -37,9 +39,16 @@ const expectedResult = {
     exampleNumberInput: 1,
     exampleDatePicker: '2022-01-31T12:00:00.000Z',
     exampleSelect: 'three',
+    exampleAutocomplete: 'four',
     exampleRangeSlider: [28],
   },
 }
+
+const getSelect = () =>
+  cy.contains(selectors.form.input.select, 'Example select')
+
+const getAutocomplete = () =>
+  cy.contains(selectors.form.input.select, 'Example autocomplete')
 
 describe('Form Examples', () => {
   describe(
@@ -77,7 +86,8 @@ describe('Form Examples', () => {
             cy.get(selectors.form.input.switch).should('be.visible')
             cy.get(selectors.form.input.numberInput).should('be.visible')
             cy.get(selectors.form.input.datePicker).should('be.visible')
-            cy.get(selectors.form.input.select).should('be.visible')
+            getSelect().should('be.visible')
+            getAutocomplete().should('be.visible')
             cy.get(selectors.form.input.rangeSlider).should('be.visible')
           })
 
@@ -100,7 +110,8 @@ describe('Form Examples', () => {
               cy.get(selectors.form.input.switchOption).eq(0).click()
               cy.get(selectors.form.input.numberInputIncrease).click()
               cy.get(selectors.form.input.datePickerInput).type('31/01/2022')
-              cy.get(selectors.form.input.select).type('th{enter}')
+              getSelect().type('th{enter}')
+              getAutocomplete().type('fo{downArrow}{enter}')
               cy.get(selectors.form.input.rangeSliderRail).click(800, 0)
             })
 

--- a/packages/react-component-library/cypress/specs/forms/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/forms/index.spec.ts
@@ -10,6 +10,7 @@ const expectedResult = {
     exampleCheckbox: [],
     exampleRadio: 'Option 1',
     exampleDatePicker: '2022-01-31T12:00:00.000Z',
+    exampleSelect: 'three',
     exampleRangeSlider: [28],
     exampleSwitch: '1',
     exampleNumberInput: 1,
@@ -23,6 +24,7 @@ const expectedResult = {
     exampleSwitch: '1',
     exampleNumberInput: 1,
     exampleDatePicker: '2022-01-31T12:00:00.000Z',
+    exampleSelect: 'three',
     exampleRangeSlider: [28],
   },
   Native: {
@@ -34,6 +36,7 @@ const expectedResult = {
     exampleSwitch: '1',
     exampleNumberInput: 1,
     exampleDatePicker: '2022-01-31T12:00:00.000Z',
+    exampleSelect: 'three',
     exampleRangeSlider: [28],
   },
 }
@@ -74,6 +77,7 @@ describe('Form Examples', () => {
             cy.get(selectors.form.input.switch).should('be.visible')
             cy.get(selectors.form.input.numberInput).should('be.visible')
             cy.get(selectors.form.input.datePicker).should('be.visible')
+            cy.get(selectors.form.input.select).should('be.visible')
             cy.get(selectors.form.input.rangeSlider).should('be.visible')
           })
 
@@ -96,6 +100,7 @@ describe('Form Examples', () => {
               cy.get(selectors.form.input.switchOption).eq(0).click()
               cy.get(selectors.form.input.numberInputIncrease).click()
               cy.get(selectors.form.input.datePickerInput).type('31/01/2022')
+              cy.get(selectors.form.input.select).type('th{enter}')
               cy.get(selectors.form.input.rangeSliderRail).click(800, 0)
             })
 

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -2,6 +2,7 @@ import { isBefore, isValid, parseISO } from 'date-fns'
 import React, { useState } from 'react'
 import { ComponentMeta } from '@storybook/react'
 import { Formik, Field } from 'formik'
+import styled from 'styled-components'
 
 import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'
@@ -13,6 +14,7 @@ import {
   DatePickerE,
   DatePickerEOnChangeData,
 } from '../../components/DatePickerE'
+import { SelectE, SelectEOption } from '../../components/SelectE'
 import { SwitchE, SwitchEOption, SwitchEProps } from '../../components/SwitchE'
 import { RangeSliderE } from '../../components/RangeSliderE'
 import { FormikGroupE } from '../../components/FormikGroup'
@@ -27,6 +29,8 @@ export interface FormValues {
   exampleRadio: string[]
   exampleSwitch: string
   exampleNumberInput: number
+  exampleDatePicker: Date | null
+  exampleSelect: string | null
   exampleRangeSlider: number[]
 }
 
@@ -42,6 +46,10 @@ const SwitchEFormed: React.FC<SwitchEProps> = (props) => (
   </SwitchE>
 )
 
+const StyledRangeSliderE = styled(RangeSliderE)`
+  margin-top: 3rem;
+`
+
 const FormikTextInputE = withFormik(TextInputE)
 const FormikTextAreaE = withFormik(TextAreaE)
 const FormikCheckboxE = withFormik(CheckboxE)
@@ -49,7 +57,8 @@ const FormikRadioE = withFormik(RadioE)
 const FormikSwitchE = withFormik(SwitchEFormed)
 const FormikDatePickerE = withFormik(DatePickerE)
 const FormikNumberInputE = withFormik(NumberInputE)
-const FormikRangeSliderE = withFormik(RangeSliderE)
+const FormikSelectE = withFormik(SelectE)
+const FormikRangeSliderE = withFormik(StyledRangeSliderE)
 
 const MINIMUM_DATE = parseISO('2022-01-01')
 
@@ -58,7 +67,7 @@ export const Example: React.FC<unknown> = () => {
 
   return (
     <main>
-      <Formik
+      <Formik<FormValues>
         initialValues={{
           email: '',
           password: '',
@@ -68,6 +77,7 @@ export const Example: React.FC<unknown> = () => {
           exampleSwitch: '',
           exampleNumberInput: null,
           exampleDatePicker: null,
+          exampleSelect: null,
           exampleRangeSlider: [20],
         }}
         validate={({ email, exampleDatePicker }) => {
@@ -189,6 +199,20 @@ export const Example: React.FC<unknown> = () => {
                 setFieldValue('exampleDatePicker', startDate)
               }}
             />
+            <Field
+              name="exampleSelect"
+              component={FormikSelectE}
+              label="Example select"
+              value={values.exampleSelect}
+              onChange={(value: string | null) => {
+                setFieldValue('exampleSelect', value)
+              }}
+            >
+              <SelectEOption value="one">One</SelectEOption>
+              <SelectEOption value="two">Two</SelectEOption>
+              <SelectEOption value="three">Three</SelectEOption>
+              <SelectEOption value="four">Four</SelectEOption>
+            </Field>
             <Field
               name="exampleRangeSlider"
               component={FormikRangeSliderE}

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -8,6 +8,10 @@ import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'
 import { RadioE } from '../../components/RadioE'
 import { CheckboxE } from '../../components/CheckboxE'
+import {
+  AutocompleteE,
+  AutocompleteEOption,
+} from '../../components/AutocompleteE'
 import { ButtonE } from '../../components/ButtonE'
 import { NumberInputE } from '../../components/NumberInputE'
 import {
@@ -31,6 +35,7 @@ export interface FormValues {
   exampleNumberInput: number
   exampleDatePicker: Date | null
   exampleSelect: string | null
+  exampleAutocomplete: string | null
   exampleRangeSlider: number[]
 }
 
@@ -58,6 +63,7 @@ const FormikSwitchE = withFormik(SwitchEFormed)
 const FormikDatePickerE = withFormik(DatePickerE)
 const FormikNumberInputE = withFormik(NumberInputE)
 const FormikSelectE = withFormik(SelectE)
+const FormikAutocompleteE = withFormik(AutocompleteE)
 const FormikRangeSliderE = withFormik(StyledRangeSliderE)
 
 const MINIMUM_DATE = parseISO('2022-01-01')
@@ -78,6 +84,7 @@ export const Example: React.FC<unknown> = () => {
           exampleNumberInput: null,
           exampleDatePicker: null,
           exampleSelect: null,
+          exampleAutocomplete: null,
           exampleRangeSlider: [20],
         }}
         validate={({ email, exampleDatePicker }) => {
@@ -212,6 +219,20 @@ export const Example: React.FC<unknown> = () => {
               <SelectEOption value="two">Two</SelectEOption>
               <SelectEOption value="three">Three</SelectEOption>
               <SelectEOption value="four">Four</SelectEOption>
+            </Field>
+            <Field
+              name="exampleAutocomplete"
+              component={FormikAutocompleteE}
+              label="Example autocomplete"
+              value={values.exampleAutocomplete}
+              onChange={(value: string | null) => {
+                setFieldValue('exampleAutocomplete', value)
+              }}
+            >
+              <AutocompleteEOption value="one">One</AutocompleteEOption>
+              <AutocompleteEOption value="two">Two</AutocompleteEOption>
+              <AutocompleteEOption value="three">Three</AutocompleteEOption>
+              <AutocompleteEOption value="four">Four</AutocompleteEOption>
             </Field>
             <Field
               name="exampleRangeSlider"

--- a/packages/react-component-library/src/forms/native/native.stories.tsx
+++ b/packages/react-component-library/src/forms/native/native.stories.tsx
@@ -1,6 +1,7 @@
 import { isBefore, isValid, parseISO } from 'date-fns'
 import React from 'react'
 import { ComponentMeta } from '@storybook/react'
+import styled from 'styled-components'
 
 import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'
@@ -8,6 +9,7 @@ import { RadioE } from '../../components/RadioE'
 import { CheckboxE } from '../../components/CheckboxE'
 import { DatePickerE } from '../../components/DatePickerE'
 import { NumberInputE } from '../../components/NumberInputE'
+import { SelectE, SelectEOption } from '../../components/SelectE'
 import { SwitchE, SwitchEOption } from '../../components/SwitchE'
 import { RangeSliderE } from '../../components/RangeSliderE'
 import { ButtonE } from '../../components/ButtonE'
@@ -23,10 +25,15 @@ export interface FormValues {
   exampleSwitch: string
   exampleNumberInput: number
   exampleDatePicker: Date | null
+  exampleSelect: string | null
   exampleRangeSlider: readonly [number, number?]
 }
 
 const MINIMUM_DATE = parseISO('2022-01-01')
+
+const StyledRangeSliderE = styled(RangeSliderE)`
+  margin-top: 3rem;
+`
 
 export const Example: React.FC<unknown> = () => {
   const {
@@ -48,6 +55,7 @@ export const Example: React.FC<unknown> = () => {
       exampleSwitch: '',
       exampleNumberInput: null,
       exampleDatePicker: null,
+      exampleSelect: null,
       exampleRangeSlider: [20],
     },
     {
@@ -186,7 +194,24 @@ export const Example: React.FC<unknown> = () => {
         {formErrors.exampleDatePicker && (
           <span>{formErrors.exampleDatePicker}</span>
         )}
-        <RangeSliderE
+        <SelectE
+          label="Example select"
+          onChange={(value) => {
+            handleChange({
+              currentTarget: {
+                name: 'exampleSelect',
+                value,
+              },
+            })
+          }}
+          value={formState.exampleSelect}
+        >
+          <SelectEOption value="one">One</SelectEOption>
+          <SelectEOption value="two">Two</SelectEOption>
+          <SelectEOption value="three">Three</SelectEOption>
+          <SelectEOption value="four">Four</SelectEOption>
+        </SelectE>
+        <StyledRangeSliderE
           onChange={(values: ReadonlyArray<number>) => {
             handleChange({
               currentTarget: {

--- a/packages/react-component-library/src/forms/native/native.stories.tsx
+++ b/packages/react-component-library/src/forms/native/native.stories.tsx
@@ -6,6 +6,10 @@ import styled from 'styled-components'
 import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'
 import { RadioE } from '../../components/RadioE'
+import {
+  AutocompleteE,
+  AutocompleteEOption,
+} from '../../components/AutocompleteE'
 import { CheckboxE } from '../../components/CheckboxE'
 import { DatePickerE } from '../../components/DatePickerE'
 import { NumberInputE } from '../../components/NumberInputE'
@@ -26,6 +30,7 @@ export interface FormValues {
   exampleNumberInput: number
   exampleDatePicker: Date | null
   exampleSelect: string | null
+  exampleAutocomplete: string | null
   exampleRangeSlider: readonly [number, number?]
 }
 
@@ -56,6 +61,7 @@ export const Example: React.FC<unknown> = () => {
       exampleNumberInput: null,
       exampleDatePicker: null,
       exampleSelect: null,
+      exampleAutocomplete: null,
       exampleRangeSlider: [20],
     },
     {
@@ -211,6 +217,23 @@ export const Example: React.FC<unknown> = () => {
           <SelectEOption value="three">Three</SelectEOption>
           <SelectEOption value="four">Four</SelectEOption>
         </SelectE>
+        <AutocompleteE
+          label="Example autocomplete"
+          onChange={(value) => {
+            handleChange({
+              currentTarget: {
+                name: 'exampleAutocomplete',
+                value,
+              },
+            })
+          }}
+          value={formState.exampleAutocomplete}
+        >
+          <AutocompleteEOption value="one">One</AutocompleteEOption>
+          <AutocompleteEOption value="two">Two</AutocompleteEOption>
+          <AutocompleteEOption value="three">Three</AutocompleteEOption>
+          <AutocompleteEOption value="four">Four</AutocompleteEOption>
+        </AutocompleteE>
         <StyledRangeSliderE
           onChange={(values: ReadonlyArray<number>) => {
             handleChange({

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -3,6 +3,7 @@ import { isBefore, isValid, parseISO } from 'date-fns'
 import React, { useState, useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form/dist/index.ie11'
 import { ComponentMeta } from '@storybook/react'
+import styled from 'styled-components'
 
 import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'
@@ -10,6 +11,7 @@ import { RadioE } from '../../components/RadioE'
 import { CheckboxE } from '../../components/CheckboxE'
 import { DatePickerE } from '../../components/DatePickerE'
 import { NumberInputE } from '../../components/NumberInputE'
+import { SelectE, SelectEOption } from '../../components/SelectE'
 import { SwitchE, SwitchEOption } from '../../components/SwitchE'
 import { RangeSliderE } from '../../components/RangeSliderE'
 import { ButtonE } from '../../components/ButtonE'
@@ -25,10 +27,15 @@ export interface FormValues {
   exampleRadio: string[]
   exampleSwitch: string
   exampleNumberInput: number
+  exampleSelect: string | null
   exampleRangeSlider: number[]
 }
 
 const MINIMUM_DATE = parseISO('2022-01-01')
+
+const StyledRangeSliderE = styled(RangeSliderE)`
+  margin-top: 3rem;
+`
 
 export const Example: React.FC<unknown> = () => {
   const {
@@ -46,6 +53,7 @@ export const Example: React.FC<unknown> = () => {
       exampleCheckbox: [],
       exampleDatePicker: null,
       exampleRadio: [],
+      exampleSelect: null,
       exampleSwitch: '',
       exampleNumberInput: null,
       exampleRangeSlider: [20],
@@ -188,10 +196,22 @@ export const Example: React.FC<unknown> = () => {
         )}
         <Controller
           control={control}
+          name="exampleSelect"
+          render={({ onChange, value }) => (
+            <SelectE label="Example select" onChange={onChange} value={value}>
+              <SelectEOption value="one">One</SelectEOption>
+              <SelectEOption value="two">Two</SelectEOption>
+              <SelectEOption value="three">Three</SelectEOption>
+              <SelectEOption value="four">Four</SelectEOption>
+            </SelectE>
+          )}
+        />
+        <Controller
+          control={control}
           name="exampleRangeSlider"
           render={({ onChange, value }) => {
             return (
-              <RangeSliderE
+              <StyledRangeSliderE
                 onChange={onChange}
                 values={value}
                 domain={[0, 40]}

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -8,6 +8,10 @@ import styled from 'styled-components'
 import { TextInputE } from '../../components/TextInputE'
 import { TextAreaE } from '../../components/TextAreaE'
 import { RadioE } from '../../components/RadioE'
+import {
+  AutocompleteE,
+  AutocompleteEOption,
+} from '../../components/AutocompleteE'
 import { CheckboxE } from '../../components/CheckboxE'
 import { DatePickerE } from '../../components/DatePickerE'
 import { NumberInputE } from '../../components/NumberInputE'
@@ -28,6 +32,7 @@ export interface FormValues {
   exampleSwitch: string
   exampleNumberInput: number
   exampleSelect: string | null
+  exampleAutocomplete: null
   exampleRangeSlider: number[]
 }
 
@@ -204,6 +209,22 @@ export const Example: React.FC<unknown> = () => {
               <SelectEOption value="three">Three</SelectEOption>
               <SelectEOption value="four">Four</SelectEOption>
             </SelectE>
+          )}
+        />
+        <Controller
+          control={control}
+          name="exampleAutocomplete"
+          render={({ onChange, value }) => (
+            <AutocompleteE
+              label="Example autocomplete"
+              onChange={onChange}
+              value={value}
+            >
+              <AutocompleteEOption value="one">One</AutocompleteEOption>
+              <AutocompleteEOption value="two">Two</AutocompleteEOption>
+              <AutocompleteEOption value="three">Three</AutocompleteEOption>
+              <AutocompleteEOption value="four">Four</AutocompleteEOption>
+            </AutocompleteE>
           )}
         />
         <Controller


### PR DESCRIPTION
## Related issue

Resolves #2884

## Overview

This adds SelectE and AutocompleteE to the various form stories and updates the related Cypress tests.

## Link to preview

[Storybook](https://5e25c277526d380020b5e418-reilncanen.chromatic.com/?path=/docs/forms-formik--example)

## Reason

To keep the form examples up to date.

## Work carried out

- [x] Update form stories
- [x] Update tests
