### PR TITLE
chore(Storybook): Use Storybook 6.3 component types where possible

### DIFF
--- a/packages/react-component-library/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.stories.tsx
@@ -1,11 +1,17 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Alert, AlertProps, ALERT_VARIANT } from './index'
+import { Alert, ALERT_VARIANT } from './index'
 
-export default { component: Alert, title: 'Alert' } as Meta
+export default { component: Alert, title: 'Alert' } as ComponentMeta<
+  typeof Alert
+>
 
-export const Default: Story<AlertProps> = ({ title, children, variant }) => (
+export const Default: ComponentStory<typeof Alert> = ({
+  title,
+  children,
+  variant,
+}) => (
   <Alert title={title} variant={variant}>
     {children}
   </Alert>
@@ -18,9 +24,10 @@ Default.args = {
   variant: ALERT_VARIANT.INFO,
 }
 
-export const WithoutTitle: Story<AlertProps> = ({ children, variant }) => (
-  <Alert variant={variant}>{children}</Alert>
-)
+export const WithoutTitle: ComponentStory<typeof Alert> = ({
+  children,
+  variant,
+}) => <Alert variant={variant}>{children}</Alert>
 
 WithoutTitle.args = {
   children:

--- a/packages/react-component-library/src/components/AutocompleteE/Autocomplete.stories.tsx
+++ b/packages/react-component-library/src/components/AutocompleteE/Autocomplete.stories.tsx
@@ -5,9 +5,9 @@ import {
   IconBrightnessAuto,
   IconRemove,
 } from '@defencedigital/icon-library'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { AutocompleteE, AutocompleteEOption, AutocompleteEProps } from './index'
+import { AutocompleteE, AutocompleteEOption } from './index'
 
 export default {
   component: AutocompleteE,
@@ -15,9 +15,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof AutocompleteE>
 
-const Template: Story<AutocompleteEProps> = (args) => (
+const Template: ComponentStory<typeof AutocompleteE> = (args) => (
   <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
     <AutocompleteE label="Some label" {...args}>
       <AutocompleteEOption value="one">One</AutocompleteEOption>
@@ -28,7 +28,9 @@ const Template: Story<AutocompleteEProps> = (args) => (
   </div>
 )
 
-const TemplateWIthIconsAndBadges: Story<AutocompleteEProps> = (args) => (
+const TemplateWIthIconsAndBadges: ComponentStory<typeof AutocompleteE> = (
+  args
+) => (
   <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
     <AutocompleteE label="Some label" {...args}>
       <AutocompleteEOption badge={100} icon={<IconAnchor />} value="one">

--- a/packages/react-component-library/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react-component-library/src/components/Avatar/Avatar.stories.tsx
@@ -1,15 +1,18 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Avatar, AvatarProps, AVATAR_VARIANT } from '.'
+import { Avatar, AVATAR_VARIANT } from '.'
 
 export default {
   component: Avatar,
   parameters: { layout: 'fullscreen' },
   title: 'Avatar',
-} as Meta
+} as ComponentMeta<typeof Avatar>
 
-export const Default: Story<AvatarProps> = ({ initials, variant }) => (
+export const Default: ComponentStory<typeof Avatar> = ({
+  initials,
+  variant,
+}) => (
   <div style={{ background: '#c9c9c9', padding: 20 }}>
     <Avatar initials={initials} variant={variant} />
   </div>

--- a/packages/react-component-library/src/components/Badge/Badge.stories.tsx
+++ b/packages/react-component-library/src/components/Badge/Badge.stories.tsx
@@ -1,18 +1,19 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import {
   Badge,
-  BadgeProps,
   BADGE_COLOR,
   BADGE_COLOR_VARIANT,
   BADGE_SIZE,
   BADGE_VARIANT,
 } from '.'
 
-export default { component: Badge, title: 'Badge' } as Meta
+export default { component: Badge, title: 'Badge' } as ComponentMeta<
+  typeof Badge
+>
 
-export const Default: Story<BadgeProps> = ({
+export const Default: ComponentStory<typeof Badge> = ({
   color,
   colorVariant,
   size,

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,17 +1,16 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Breadcrumbs, BreadcrumbsItemProps, BreadcrumbsItem } from '.'
+import { Breadcrumbs, BreadcrumbsItem } from '.'
 import { Link } from '../Link'
-import { Nav } from '../../common/Nav'
 
 export default {
   component: Breadcrumbs,
   subcomponents: { BreadcrumbsItem },
   title: 'Breadcrumbs',
-} as Meta
+} as ComponentMeta<typeof Breadcrumbs>
 
-export const Default: Story<Nav<BreadcrumbsItemProps>> = ({ className }) => (
+export const Default: ComponentStory<typeof Breadcrumbs> = ({ className }) => (
   <Breadcrumbs className={className}>
     <BreadcrumbsItem link={<Link href="/">Home</Link>} />
     <BreadcrumbsItem href="/components">Components</BreadcrumbsItem>

--- a/packages/react-component-library/src/components/Button/Button.stories.tsx
+++ b/packages/react-component-library/src/components/Button/Button.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { IconBrightnessLow } from '@defencedigital/icon-library'
-import { Button, ButtonProps } from './index'
+import { Button } from './index'
 import {
   BUTTON_COLOR,
   BUTTON_SIZE,
@@ -14,46 +14,51 @@ export default {
   component: Button,
   title: 'Button',
   parameters: { actions: { argTypesRegex: '^on.*' } },
-} as Meta
+} as ComponentMeta<typeof Button>
 
-export const Default: Story<ButtonProps> = ({ children, ...rest }) => (
-  <Button {...rest}>{children}</Button>
-)
+export const Default: ComponentStory<typeof Button> = ({
+  children,
+  ...rest
+}) => <Button {...rest}>{children}</Button>
 
 Default.args = {
   children: 'Default',
 }
 
-export const Primary: Story<ButtonProps> = ({ children, ...rest }) => (
-  <Button {...rest}>{children}</Button>
-)
+export const Primary: ComponentStory<typeof Button> = ({
+  children,
+  ...rest
+}) => <Button {...rest}>{children}</Button>
 
 Primary.args = {
   variant: BUTTON_VARIANT.PRIMARY,
   children: 'Primary',
 }
 
-export const Secondary: Story<ButtonProps> = ({ children, ...rest }) => (
-  <Button {...rest}>{children}</Button>
-)
+export const Secondary: ComponentStory<typeof Button> = ({
+  children,
+  ...rest
+}) => <Button {...rest}>{children}</Button>
 
 Secondary.args = {
   variant: BUTTON_VARIANT.SECONDARY,
   children: 'Secondary',
 }
 
-export const Tertiary: Story<ButtonProps> = ({ children, ...rest }) => (
-  <Button {...rest}>{children}</Button>
-)
+export const Tertiary: ComponentStory<typeof Button> = ({
+  children,
+  ...rest
+}) => <Button {...rest}>{children}</Button>
 
 Tertiary.args = {
   variant: BUTTON_VARIANT.TERTIARY,
   children: 'Tertiary',
 }
 
-export const Danger: Story<ButtonProps> = ({ children, ...rest }) => (
-  <Button {...rest}>{children}</Button>
-)
+export const Danger: ComponentStory<typeof Button> = ({
+  children,
+  ...rest
+}) => <Button {...rest}>{children}</Button>
 
 Danger.args = {
   variant: BUTTON_VARIANT.PRIMARY,
@@ -61,7 +66,7 @@ Danger.args = {
   children: 'Danger',
 }
 
-export const Small: Story<ButtonProps> = ({ children, ...rest }) => (
+export const Small: ComponentStory<typeof Button> = ({ children, ...rest }) => (
   <Button {...rest}>{children}</Button>
 )
 
@@ -71,7 +76,7 @@ Small.args = {
   children: 'Small',
 }
 
-export const Large: Story<ButtonProps> = ({ children, ...rest }) => (
+export const Large: ComponentStory<typeof Button> = ({ children, ...rest }) => (
   <Button {...rest}>{children}</Button>
 )
 
@@ -81,7 +86,7 @@ Large.args = {
   children: 'Large',
 }
 
-export const Disabled: Story<ButtonProps> = ({ children }) => (
+export const Disabled: ComponentStory<typeof Button> = ({ children }) => (
   <Button isDisabled>{children}</Button>
 )
 
@@ -89,7 +94,7 @@ Disabled.args = {
   children: 'Disabled',
 }
 
-export const WithLeftIcon: Story<ButtonProps> = ({
+export const WithLeftIcon: ComponentStory<typeof Button> = ({
   icon,
   iconPosition,
   children,
@@ -107,7 +112,7 @@ WithLeftIcon.args = {
 
 WithLeftIcon.storyName = 'With left icon'
 
-export const WithRightIcon: Story<ButtonProps> = ({
+export const WithRightIcon: ComponentStory<typeof Button> = ({
   icon,
   iconPosition,
   children,

--- a/packages/react-component-library/src/components/ButtonE/ButtonE.stories.tsx
+++ b/packages/react-component-library/src/components/ButtonE/ButtonE.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { IconBrightnessLow } from '@defencedigital/icon-library'
-import { ButtonE, ButtonEProps } from './index'
+import { ButtonE } from './index'
 import { BUTTON_E_VARIANT, BUTTON_E_ICON_POSITION } from './constants'
 import { COMPONENT_SIZE } from '../Forms'
 
@@ -10,9 +10,9 @@ export default {
   component: ButtonE,
   title: 'Button (Experimental)',
   parameters: { actions: { argTypesRegex: '^on.*' } },
-} as Meta
+} as ComponentMeta<typeof ButtonE>
 
-const Template: Story<ButtonEProps> = (args) => <ButtonE {...args} />
+const Template: ComponentStory<typeof ButtonE> = (args) => <ButtonE {...args} />
 
 export const Default = Template.bind({})
 Default.args = {

--- a/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/react-component-library/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
 import { IconBrightnessLow } from '@defencedigital/icon-library'
@@ -14,9 +14,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof ButtonGroup>
 
-export const Default: Story<ButtonGroupProps> = ({ size }) => (
+export const Default: ComponentStory<typeof ButtonGroup> = ({ size }) => (
   <ButtonGroup size={size}>
     <ButtonGroupItem onClick={action('onClick - One')}>One</ButtonGroupItem>
     <ButtonGroupItem onClick={action('onClick - Two')}>Two</ButtonGroupItem>
@@ -34,7 +34,7 @@ Default.args = {
   size: BUTTON_SIZE.REGULAR,
 }
 
-export const Small: Story<ButtonGroupProps> = ({ size }) => (
+export const Small: ComponentStory<typeof ButtonGroup> = ({ size }) => (
   <ButtonGroup size={size}>
     <ButtonGroupItem onClick={action('onClick')}>One</ButtonGroupItem>
     <ButtonGroupItem>Two</ButtonGroupItem>
@@ -48,7 +48,9 @@ Small.args = {
   size: BUTTON_SIZE.SMALL,
 }
 
-export const Large: Story<ButtonGroupProps> = ({ size }: ButtonGroupProps) => (
+export const Large: ComponentStory<typeof ButtonGroup> = ({
+  size,
+}: ButtonGroupProps) => (
   <ButtonGroup size={size}>
     <ButtonGroupItem onClick={action('onClick')}>One</ButtonGroupItem>
     <ButtonGroupItem>Two</ButtonGroupItem>

--- a/packages/react-component-library/src/components/CardFrame/CardFrame.stories.tsx
+++ b/packages/react-component-library/src/components/CardFrame/CardFrame.stories.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { CardFrame } from './index'
-import { ComponentWithClass } from '../../common/ComponentWithClass'
 
-export default { component: CardFrame, title: 'Card Frame' } as Meta
+export default { component: CardFrame, title: 'Card Frame' } as ComponentMeta<
+  typeof CardFrame
+>
 
-export const Default: Story<ComponentWithClass> = ({ children, ...props }) => (
-  <CardFrame {...props}>{children}</CardFrame>
-)
+export const Default: ComponentStory<typeof CardFrame> = ({
+  children,
+  ...props
+}) => <CardFrame {...props}>{children}</CardFrame>
 
 Default.args = {
   children: 'Arbitrary JSX',

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'
 
 import { withFormik } from '../../enhancers/withFormik'
-import { Checkbox, CheckboxProps } from '.'
+import { Checkbox } from '.'
 import { Button } from '../Button'
 import { FormikGroup } from '../FormikGroup'
 
@@ -15,9 +15,11 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof Checkbox>
 
-export const Default: Story<CheckboxProps> = (props) => <Checkbox {...props} />
+export const Default: ComponentStory<typeof Checkbox> = (props) => (
+  <Checkbox {...props} />
+)
 
 Default.args = {
   id: undefined,
@@ -26,7 +28,9 @@ Default.args = {
   isChecked: true,
 }
 
-export const Disabled: Story<CheckboxProps> = (props) => <Checkbox {...props} />
+export const Disabled: ComponentStory<typeof Checkbox> = (props) => (
+  <Checkbox {...props} />
+)
 
 Disabled.args = {
   id: undefined,
@@ -35,7 +39,9 @@ Disabled.args = {
   name: 'disabled',
 }
 
-export const Invalid: Story<CheckboxProps> = (props) => <Checkbox {...props} />
+export const Invalid: ComponentStory<typeof Checkbox> = (props) => (
+  <Checkbox {...props} />
+)
 
 Invalid.args = {
   id: undefined,
@@ -44,7 +50,7 @@ Invalid.args = {
   isInvalid: true,
 }
 
-export const WithFormik: Story<CheckboxProps> = () => {
+export const WithFormik: ComponentStory<typeof Checkbox> = () => {
   const CheckboxForm = () => {
     interface Data {
       [key: string]: boolean
@@ -99,7 +105,7 @@ export const WithFormik: Story<CheckboxProps> = () => {
 
 WithFormik.storyName = 'Formik'
 
-export const WithFormikGroup: Story<CheckboxProps> = () => {
+export const WithFormikGroup: ComponentStory<typeof Checkbox> = () => {
   const CheckboxForm = () => {
     interface Data {
       [key: string]: string

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'
 
 import { withFormik } from '../../enhancers/withFormik'
-import { CheckboxE, CheckboxEProps } from '.'
+import { CheckboxE } from '.'
 import { FormikGroupE } from '../FormikGroup'
 
 export default {
@@ -14,9 +14,11 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof CheckboxE>
 
-const Template: Story<CheckboxEProps> = (props) => <CheckboxE {...props} />
+const Template: ComponentStory<typeof CheckboxE> = (props) => (
+  <CheckboxE {...props} />
+)
 
 export const Default = Template.bind({})
 Default.args = {
@@ -42,7 +44,7 @@ Invalid.args = {
   isInvalid: true,
 }
 
-export const WithFormikGroup: Story<CheckboxEProps> = () => {
+export const WithFormikGroup: ComponentStory<typeof CheckboxE> = () => {
   const CheckboxForm = () => {
     interface Data {
       [key: string]: string[]

--- a/packages/react-component-library/src/components/CheckboxEnhanced/CheckboxEnhanced.stories.tsx
+++ b/packages/react-component-library/src/components/CheckboxEnhanced/CheckboxEnhanced.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-import { CheckboxEnhanced, CheckboxEnhancedProps } from '.'
+import { CheckboxEnhanced } from '.'
 
 export default {
   component: CheckboxEnhanced,
@@ -10,9 +10,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof CheckboxEnhanced>
 
-export const Default: Story<CheckboxEnhancedProps> = (props) => (
+export const Default: ComponentStory<typeof CheckboxEnhanced> = (props) => (
   <CheckboxEnhanced {...props} />
 )
 
@@ -23,7 +23,7 @@ Default.args = {
   isChecked: true,
 }
 
-export const WithDescription: Story<CheckboxEnhancedProps> = () => (
+export const WithDescription: ComponentStory<typeof CheckboxEnhanced> = () => (
   <CheckboxEnhanced
     name="withdescription"
     title="With description"
@@ -33,7 +33,7 @@ export const WithDescription: Story<CheckboxEnhancedProps> = () => (
 
 WithDescription.storyName = 'With description'
 
-export const GridLayout: Story<CheckboxEnhancedProps> = () => (
+export const GridLayout: ComponentStory<typeof CheckboxEnhanced> = () => (
   <form
     onSubmit={(e) => {
       e.preventDefault()

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -1,15 +1,10 @@
 import React, { useRef } from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import styled from 'styled-components'
 
 import { IconEdit, IconDelete, IconAdd } from '@defencedigital/icon-library'
 
-import {
-  ContextMenu,
-  ContextMenuProps,
-  ContextMenuItem,
-  ContextMenuDivider,
-} from '.'
+import { ContextMenu, ContextMenuItem, ContextMenuDivider } from '.'
 import { Link } from '../Link'
 
 export default {
@@ -19,7 +14,7 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof ContextMenu>
 
 const ClickArea = styled.div`
   display: inline-block;
@@ -27,7 +22,7 @@ const ClickArea = styled.div`
   background-color: #c9c9c9;
 `
 
-export const Default: Story<ContextMenuProps> = (props) => {
+export const Default: ComponentStory<typeof ContextMenu> = (props) => {
   const ref = useRef()
 
   return (
@@ -60,7 +55,7 @@ export const Default: Story<ContextMenuProps> = (props) => {
 
 Default.storyName = 'Default'
 
-export const WithIcons: Story<ContextMenuProps> = (props) => {
+export const WithIcons: ComponentStory<typeof ContextMenu> = (props) => {
   const ref = useRef()
 
   return (

--- a/packages/react-component-library/src/components/DataList/DataList.stories.tsx
+++ b/packages/react-component-library/src/components/DataList/DataList.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { DataList, DataListProps, DataListItem } from './index'
+import { DataList, DataListItem } from './index'
 
 export default {
   component: DataList,
@@ -10,7 +10,7 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof DataList>
 
 const disableDefinitionList = {
   a11y: {
@@ -29,7 +29,7 @@ const disableDefinitionList = {
   },
 }
 
-export const Default: Story<DataListProps> = (props) => (
+export const Default: ComponentStory<typeof DataList> = (props) => (
   <DataList {...props}>
     <DataListItem description="Name">Horatio Nelson</DataListItem>
     <DataListItem description="Age">44</DataListItem>
@@ -48,7 +48,7 @@ Default.args = {
 
 Default.storyName = 'Default'
 
-export const Collapsible: Story<DataListProps> = () => (
+export const Collapsible: ComponentStory<typeof DataList> = () => (
   <DataList title="Example Title" isCollapsible>
     <DataListItem description="Name">Horatio Nelson</DataListItem>
     <DataListItem description="Age">44</DataListItem>

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import * as yup from 'yup'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 
 import { withFormik } from '../../enhancers/withFormik'
-import { DatePicker, DatePickerProps } from '.'
+import { DatePicker } from '.'
 
 import { Button } from '../Button'
 
@@ -25,9 +25,9 @@ export default {
       },
     },
   },
-} as Meta
+} as ComponentMeta<typeof DatePicker>
 
-export const Default: Story<DatePickerProps> = (props) => (
+export const Default: ComponentStory<typeof DatePicker> = (props) => (
   <DatePicker {...props} />
 )
 
@@ -36,7 +36,7 @@ Default.args = {
   startDate: undefined,
 }
 
-export const CustomFormat: Story<DatePickerProps> = (props) => (
+export const CustomFormat: ComponentStory<typeof DatePicker> = (props) => (
   <DatePicker
     {...props}
     format="yyyy/MM/dd"
@@ -46,25 +46,25 @@ export const CustomFormat: Story<DatePickerProps> = (props) => (
 
 CustomFormat.storyName = 'Custom format'
 
-export const CustomInitialMonth: Story<DatePickerProps> = (props) => (
-  <DatePicker {...props} initialMonth={new Date(2021, 1)} />
-)
+export const CustomInitialMonth: ComponentStory<typeof DatePicker> = (
+  props
+) => <DatePicker {...props} initialMonth={new Date(2021, 1)} />
 
 CustomInitialMonth.storyName = 'Custom initial month'
 
-export const CustomLabel: Story<DatePickerProps> = (props) => (
+export const CustomLabel: ComponentStory<typeof DatePicker> = (props) => (
   <DatePicker {...props} label="Custom label" />
 )
 
 CustomLabel.storyName = 'Custom label'
 
-export const Disabled: Story<DatePickerProps> = (props) => (
+export const Disabled: ComponentStory<typeof DatePicker> = (props) => (
   <DatePicker {...props} isDisabled />
 )
 
 Disabled.storyName = 'Disabled'
 
-export const DisabledDays: Story<DatePickerProps> = (props) => (
+export const DisabledDays: ComponentStory<typeof DatePicker> = (props) => (
   <DatePicker
     {...props}
     startDate={new Date(2021, 3, 1)}
@@ -81,13 +81,13 @@ export const DisabledDays: Story<DatePickerProps> = (props) => (
 
 DisabledDays.storyName = 'Disabled days'
 
-export const Range: Story<DatePickerProps> = (props) => (
+export const Range: ComponentStory<typeof DatePicker> = (props) => (
   <DatePicker {...props} isRange />
 )
 
 Range.storyName = 'Range'
 
-export const WithFormik: Story<DatePickerProps> = (props) => {
+export const WithFormik: ComponentStory<typeof DatePicker> = (props) => {
   interface Data {
     startDate: Date
     endDate: Date

--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.stories.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { Meta, Story } from '@storybook/react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { parseISO } from 'date-fns'
 import { Field, Form, Formik } from 'formik'
 import React from 'react'
@@ -7,7 +7,7 @@ import * as yup from 'yup'
 
 import { withFormik } from '../../enhancers'
 import { ButtonE } from '../ButtonE'
-import { DatePickerE, DatePickerEProps } from '.'
+import { DatePickerE } from '.'
 
 export default {
   component: DatePickerE,
@@ -25,9 +25,11 @@ export default {
       },
     },
   },
-} as Meta
+} as ComponentMeta<typeof DatePickerE>
 
-const Template: Story<DatePickerEProps> = (args) => <DatePickerE {...args} />
+const Template: ComponentStory<typeof DatePickerE> = (args) => (
+  <DatePickerE {...args} />
+)
 
 export const Default = Template.bind({})
 
@@ -88,7 +90,7 @@ RangeWithExistingValue.args = {
   endDate: parseISO('2021-12-15'),
 }
 
-export const WithFormik: Story<DatePickerEProps> = (props) => {
+export const WithFormik: ComponentStory<typeof DatePickerE> = (props) => {
   interface Data {
     startDate: Date
     endDate: Date

--- a/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Dialog, DialogProps } from './index'
+import { Dialog } from './index'
 import { StyledDialog } from './partials/StyledDialog'
 import { StyledMain } from '../Modal/partials/StyledMain'
 
@@ -27,9 +27,9 @@ export default {
     actions: { argTypesRegex: '^on.*' },
     layout: 'fullscreen',
   },
-} as Meta
+} as ComponentMeta<typeof Dialog>
 
-const Template: Story<DialogProps> = (args) => (
+const Template: ComponentStory<typeof Dialog> = (args) => (
   <Wrapper>
     <Dialog {...args} />
   </Wrapper>

--- a/packages/react-component-library/src/components/DismissibleBanner/DismissableBanner.stories.tsx
+++ b/packages/react-component-library/src/components/DismissibleBanner/DismissableBanner.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentMeta, Story } from '@storybook/react'
 
-import { DismissibleBanner, DismissibleBannerProps } from '.'
+import { DismissibleBanner, DismissibleBannerWithTitleProps } from '.'
 
 export default {
   component: DismissibleBanner,
@@ -9,18 +9,21 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof DismissibleBanner>
 
-export const Default: Story<any> = ({ children, ...rest }) => (
-  <DismissibleBanner {...rest}>{children}</DismissibleBanner>
-)
+export const Default: Story<DismissibleBannerWithTitleProps> = ({
+  children,
+  ...rest
+}) => <DismissibleBanner {...rest}>{children}</DismissibleBanner>
 
 Default.args = {
   title: 'Example Title',
   children: 'Example description',
 }
 
-export const HiddenCheckbox: Story<any> = (props) => (
+export const HiddenCheckbox: Story<DismissibleBannerWithTitleProps> = (
+  props
+) => (
   <DismissibleBanner {...props} hasCheckbox={false} title="Example Title">
     Example description
   </DismissibleBanner>

--- a/packages/react-component-library/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Drawer, DrawerProps } from '.'
+import { Drawer } from '.'
 
 export default {
   component: Drawer,
@@ -11,7 +11,7 @@ export default {
     actions: { argTypesRegex: '^on.*' },
     layout: 'fullscreen',
   },
-} as Meta
+} as ComponentMeta<typeof Drawer>
 
 const StyledDrawer = styled(Drawer)`
   position: absolute;
@@ -19,7 +19,7 @@ const StyledDrawer = styled(Drawer)`
   transform: translate(-10px, 10px);
 `
 
-export const Default: Story<DrawerProps> = (props) => (
+export const Default: ComponentStory<typeof Drawer> = (props) => (
   <div style={{ height: '20rem' }}>
     {/* Styles extended for Storybook presentation */}
     <StyledDrawer {...props}>

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { IconLayers, IconAnchor } from '@defencedigital/icon-library'
 
-import { Dropdown, DropdownProps } from './Dropdown'
+import { Dropdown } from './Dropdown'
 
 export default {
   component: Dropdown,
@@ -17,7 +17,7 @@ export default {
       },
     },
   },
-} as Meta
+} as ComponentMeta<typeof Dropdown>
 
 const options = [
   { value: 'option', label: 'Option' },
@@ -26,7 +26,7 @@ const options = [
   { value: 'disabled', label: 'Disabled', isDisabled: true },
 ]
 
-export const Default: Story<DropdownProps> = (props) => {
+export const Default: ComponentStory<typeof Dropdown> = (props) => {
   return (
     <div style={{ height: '15rem' }}>
       <Dropdown {...props} />
@@ -44,7 +44,7 @@ const iconOptions = options.map((option) => ({
   icon: <IconAnchor />,
 }))
 
-export const WithIcons: Story<DropdownProps> = (props) => (
+export const WithIcons: ComponentStory<typeof Dropdown> = (props) => (
   <div style={{ height: '15rem' }}>
     <Dropdown
       {...props}

--- a/packages/react-component-library/src/components/List/List.stories.tsx
+++ b/packages/react-component-library/src/components/List/List.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-import { List, ListProps, ListItem } from '.'
+import { List, ListItem } from '.'
 
 export default {
   component: List,
@@ -11,9 +11,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof List>
 
-export const Default: Story<ListProps> = (props) => (
+export const Default: ComponentStory<typeof List> = (props) => (
   <List {...props}>
     <ListItem onClick={action('onClick')} title="List item 1">
       This is the description for item 1

--- a/packages/react-component-library/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Modal, ModalProps } from './index'
+import { Modal } from './index'
 import { StyledMain } from './partials/StyledMain'
 import { StyledModal } from './partials/StyledModal'
 import { BUTTON_COLOR, ButtonProps } from '../Button'
@@ -17,7 +17,7 @@ export default {
       showFunctions: true,
     },
   },
-} as Meta
+} as ComponentMeta<typeof Modal>
 
 const primaryButton: ButtonProps = {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -51,7 +51,7 @@ const Wrapper = styled.div<{ $height: string }>`
   }
 `
 
-const Template: Story<ModalProps> = (args) => (
+const Template: ComponentStory<typeof Modal> = (args) => (
   <Wrapper $height={args.title && args.primaryButton ? '17rem' : '12rem'}>
     <Modal {...args}>
       <pre style={{ padding: '1rem' }}>Arbitrary JSX content</pre>

--- a/packages/react-component-library/src/components/Nav/Nav.stories.tsx
+++ b/packages/react-component-library/src/components/Nav/Nav.stories.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import {
   IconArrowDropDown,
   IconArrowDropUp,
 } from '@defencedigital/icon-library'
 
 import { Button } from '../Button'
-import { Nav, NavProps } from '.'
+import { Nav } from '.'
 import { useOpenClose } from '../../hooks'
 
 export default {
@@ -15,7 +15,7 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof Nav>
 
 const navItems = [
   {
@@ -69,19 +69,19 @@ const navItemsWithChildren = [
   ...navItems,
 ]
 
-export const Default: Story<NavProps> = (props) => <Nav {...props} />
+export const Default: ComponentStory<typeof Nav> = (props) => <Nav {...props} />
 
 Default.args = {
   navItems: navItemsWithChildren,
 }
 
-export const Horizontal: Story<NavProps> = () => (
+export const Horizontal: ComponentStory<typeof Nav> = () => (
   <Nav navItems={navItems} orientation="horizontal" />
 )
 
 Horizontal.storyName = 'Horizontal'
 
-export const CustomItem: Story<NavProps> = () => {
+export const CustomItem: ComponentStory<typeof Nav> = () => {
   const customNavItems = [
     {
       to: '#',
@@ -111,7 +111,7 @@ export const CustomItem: Story<NavProps> = () => {
 
 CustomItem.storyName = 'Custom item'
 
-export const PrimaryNavigation: Story<NavProps> = () => {
+export const PrimaryNavigation: ComponentStory<typeof Nav> = () => {
   const { open, toggle } = useOpenClose(true)
 
   interface CustomLink {

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import { IconBrightnessHigh } from '@defencedigital/icon-library'
 import * as yup from 'yup'
 
 import { Button } from '../Button'
-import { NumberInput, NumberInputProps } from './NumberInput'
+import { NumberInput } from './NumberInput'
 import { withFormik } from '../../enhancers/withFormik'
 import { UNIT_POSITION } from './constants'
 
@@ -18,9 +18,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof NumberInput>
 
-export const Default: Story<NumberInputProps> = (props) => (
+export const Default: ComponentStory<typeof NumberInput> = (props) => (
   <NumberInput {...props} />
 )
 
@@ -29,25 +29,25 @@ Default.args = {
   name: 'number-input-default',
 }
 
-export const Condensed: Story<NumberInputProps> = (props) => (
+export const Condensed: ComponentStory<typeof NumberInput> = (props) => (
   <NumberInput {...props} isCondensed name="number-input-condensed" />
 )
 
 Condensed.storyName = 'Condensed'
 
-export const Clearable: Story<NumberInputProps> = (props) => (
+export const Clearable: ComponentStory<typeof NumberInput> = (props) => (
   <NumberInput {...props} canClear name="number-input-clearable" value={10} />
 )
 
 Clearable.storyName = 'Clearable'
 
-export const Disabled: Story<NumberInputProps> = (props) => (
+export const Disabled: ComponentStory<typeof NumberInput> = (props) => (
   <NumberInput {...props} isDisabled name="number-input-disabled" />
 )
 
 Disabled.storyName = 'Disabled'
 
-export const WithFootnote: Story<NumberInputProps> = (props) => (
+export const WithFootnote: ComponentStory<typeof NumberInput> = (props) => (
   <NumberInput
     {...props}
     footnote="Footnote"
@@ -57,13 +57,13 @@ export const WithFootnote: Story<NumberInputProps> = (props) => (
 
 WithFootnote.storyName = 'With footnote'
 
-export const WithLabel: Story<NumberInputProps> = (props) => (
+export const WithLabel: ComponentStory<typeof NumberInput> = (props) => (
   <NumberInput {...props} label="Label" name="number-input-label" />
 )
 
 WithLabel.storyName = 'With label'
 
-export const Placeholder: Story<NumberInputProps> = (props) => (
+export const Placeholder: ComponentStory<typeof NumberInput> = (props) => (
   <NumberInput
     {...props}
     label="Label"
@@ -74,7 +74,9 @@ export const Placeholder: Story<NumberInputProps> = (props) => (
 
 Placeholder.storyName = 'With placeholder'
 
-export const StartAdornmentIcon: Story<NumberInputProps> = (props) => (
+export const StartAdornmentIcon: ComponentStory<typeof NumberInput> = (
+  props
+) => (
   <NumberInput
     {...props}
     name="number-input-start-adornment-icon"
@@ -84,7 +86,9 @@ export const StartAdornmentIcon: Story<NumberInputProps> = (props) => (
 
 StartAdornmentIcon.storyName = 'With start adornment icon'
 
-export const StartAdornmentText: Story<NumberInputProps> = (props) => (
+export const StartAdornmentText: ComponentStory<typeof NumberInput> = (
+  props
+) => (
   <NumberInput
     {...props}
     name="number-input-start-adornment-text"
@@ -94,7 +98,7 @@ export const StartAdornmentText: Story<NumberInputProps> = (props) => (
 
 StartAdornmentText.storyName = 'With start adornment text'
 
-export const WithUnit: Story<NumberInputProps> = (props) => (
+export const WithUnit: ComponentStory<typeof NumberInput> = (props) => (
   <NumberInput
     {...props}
     name="number-input-unit"
@@ -106,7 +110,7 @@ export const WithUnit: Story<NumberInputProps> = (props) => (
 WithUnit.storyName = 'With unit'
 WithUnit.parameters = chromaticIgnore
 
-export const WithUnitLabel: Story<NumberInputProps> = (props) => (
+export const WithUnitLabel: ComponentStory<typeof NumberInput> = (props) => (
   <NumberInput
     {...props}
     label="Cost"
@@ -119,7 +123,7 @@ export const WithUnitLabel: Story<NumberInputProps> = (props) => (
 WithUnitLabel.storyName = 'With unit and label'
 WithUnitLabel.parameters = chromaticIgnore
 
-export const UnitBefore: Story<NumberInputProps> = (props) => (
+export const UnitBefore: ComponentStory<typeof NumberInput> = (props) => (
   <NumberInput
     {...props}
     name="number-input-unit-before"
@@ -131,7 +135,7 @@ export const UnitBefore: Story<NumberInputProps> = (props) => (
 
 UnitBefore.storyName = 'With unit before'
 
-export const WithFormik: Story<NumberInputProps> = (props) => {
+export const WithFormik: ComponentStory<typeof NumberInput> = (props) => {
   const errorText = 'Something went wrong!'
 
   const validationSchema = yup.object().shape({

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.stories.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { IconBrightnessHigh } from '@defencedigital/icon-library'
 
 import { COMPONENT_SIZE } from '../Forms'
-import { NumberInputE, NumberInputEProps } from './NumberInputE'
+import { NumberInputE } from './NumberInputE'
 
 export default {
   component: NumberInputE,
@@ -17,9 +17,11 @@ export default {
       },
     },
   },
-} as Meta
+} as ComponentMeta<typeof NumberInputE>
 
-const Template: Story<NumberInputEProps> = (args) => <NumberInputE {...args} />
+const Template: ComponentStory<typeof NumberInputE> = (args) => (
+  <NumberInputE {...args} />
+)
 
 export const Default = Template.bind({})
 

--- a/packages/react-component-library/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Pagination, PaginationProps } from '.'
+import { Pagination } from '.'
 
 export default {
   component: Pagination,
@@ -9,9 +9,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof Pagination>
 
-export const Default: Story<PaginationProps> = (props) => (
+export const Default: ComponentStory<typeof Pagination> = (props) => (
   <Pagination {...props} />
 )
 
@@ -21,7 +21,7 @@ Default.args = {
   total: 1000,
 }
 
-export const InitialPage: Story<PaginationProps> = (props) => (
+export const InitialPage: ComponentStory<typeof Pagination> = (props) => (
   <Pagination {...props} initialPage={5} pageSize={10} total={1000} />
 )
 

--- a/packages/react-component-library/src/components/Panel/Panel.stories.tsx
+++ b/packages/react-component-library/src/components/Panel/Panel.stories.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { Panel } from './index'
-import { ComponentWithClass } from '../../common/ComponentWithClass'
 
-export default { component: Panel, title: 'Panel' } as Meta
+export default { component: Panel, title: 'Panel' } as ComponentMeta<
+  typeof Panel
+>
 
-export const Default: Story<ComponentWithClass> = ({ children, ...rest }) => (
-  <Panel {...rest}>{children}</Panel>
-)
+export const Default: ComponentStory<typeof Panel> = ({
+  children,
+  ...rest
+}) => <Panel {...rest}>{children}</Panel>
 
 Default.args = {
   children: 'Hello, World!',

--- a/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.stories.tsx
+++ b/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { PhaseBanner, PhaseBannerProps } from '.'
+import { PhaseBanner } from '.'
 
 export default {
   component: PhaseBanner,
@@ -10,23 +10,25 @@ export default {
     actions: { argTypesRegex: '^on.*' },
     layout: 'fullscreen',
   },
-} as Meta
+} as ComponentMeta<typeof PhaseBanner>
 
-export const Default: Story<PhaseBannerProps> = (props) => (
+export const Default: ComponentStory<typeof PhaseBanner> = (props) => (
   <PhaseBanner {...props} />
 )
 
-export const Beta: Story<PhaseBannerProps> = () => <PhaseBanner phase="beta" />
+export const Beta: ComponentStory<typeof PhaseBanner> = () => (
+  <PhaseBanner phase="beta" />
+)
 
 Beta.storyName = 'Beta'
 
-export const CustomLink: Story<PhaseBannerProps> = () => (
+export const CustomLink: ComponentStory<typeof PhaseBanner> = () => (
   <PhaseBanner link="#" />
 )
 
 CustomLink.storyName = 'Custom link'
 
-export const CustomText: Story<PhaseBannerProps> = () => (
+export const CustomText: ComponentStory<typeof PhaseBanner> = () => (
   <PhaseBanner>
     Custom html can go here. <strong>This part is in bold!</strong>
   </PhaseBanner>
@@ -34,7 +36,7 @@ export const CustomText: Story<PhaseBannerProps> = () => (
 
 CustomText.storyName = 'Custom text'
 
-export const FullWidth: Story<PhaseBannerProps> = () => (
+export const FullWidth: ComponentStory<typeof PhaseBanner> = () => (
   <PhaseBanner isFullWidth />
 )
 

--- a/packages/react-component-library/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { FLOATING_BOX_SCHEME } from '../../primitives/FloatingBox'
-import { Popover, PopoverProps } from '.'
+import { Popover } from '.'
 
 export default {
   component: Popover,
@@ -10,7 +10,7 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof Popover>
 
 const popoverTarget = (text = 'Hover on me') => (
   <div
@@ -24,7 +24,7 @@ const popoverTarget = (text = 'Hover on me') => (
   </div>
 )
 
-export const Default: Story<PopoverProps> = (props) => (
+export const Default: ComponentStory<typeof Popover> = (props) => (
   <Popover {...props}>{popoverTarget()}</Popover>
 )
 
@@ -32,7 +32,7 @@ Default.args = {
   content: <pre style={{ padding: '1rem' }}>This is some arbitrary JSX</pre>,
 }
 
-export const Dark: Story<PopoverProps> = () => (
+export const Dark: ComponentStory<typeof Popover> = () => (
   <Popover
     content={<pre style={{ padding: '1rem' }}>This is some arbitrary JSX</pre>}
     scheme={FLOATING_BOX_SCHEME.DARK}
@@ -43,7 +43,7 @@ export const Dark: Story<PopoverProps> = () => (
 
 Dark.storyName = 'Dark'
 
-export const ClickToActivate: Story<PopoverProps> = () => (
+export const ClickToActivate: ComponentStory<typeof Popover> = () => (
   <Popover
     content={<pre style={{ padding: '1rem' }}>This is some arbitrary JSX</pre>}
     isClick

--- a/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
+++ b/packages/react-component-library/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { StyledProgressIndicator } from './partials/StyledProgressIndicator'
 import { ProgressIndicator } from './index'
 
@@ -12,7 +11,7 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof ProgressIndicator>
 
 const Wrapper = styled.div`
   height: 10rem;
@@ -23,7 +22,7 @@ const Wrapper = styled.div`
   }
 `
 
-export const Default: Story<ComponentWithClass> = (props) => (
+export const Default: ComponentStory<typeof ProgressIndicator> = (props) => (
   <Wrapper>
     <ProgressIndicator {...props} />
   </Wrapper>

--- a/packages/react-component-library/src/components/Radio/Radio.stories.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'
 
 import { withFormik } from '../../enhancers/withFormik'
-import { Radio, RadioProps } from '.'
+import { Radio } from '.'
 import { Button } from '../Button'
 import { FormikGroup } from '../FormikGroup'
 
@@ -15,9 +15,11 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof Radio>
 
-export const Default: Story<RadioProps> = (props) => <Radio {...props} />
+export const Default: ComponentStory<typeof Radio> = (props) => (
+  <Radio {...props} />
+)
 
 Default.args = {
   id: undefined,
@@ -26,7 +28,9 @@ Default.args = {
   isChecked: true,
 }
 
-export const Disabled: Story<RadioProps> = (props) => <Radio {...props} />
+export const Disabled: ComponentStory<typeof Radio> = (props) => (
+  <Radio {...props} />
+)
 
 Disabled.args = {
   id: undefined,
@@ -35,7 +39,9 @@ Disabled.args = {
   name: 'disabled',
 }
 
-export const Invalid: Story<RadioProps> = (props) => <Radio {...props} />
+export const Invalid: ComponentStory<typeof Radio> = (props) => (
+  <Radio {...props} />
+)
 
 Invalid.args = {
   id: undefined,
@@ -44,7 +50,7 @@ Invalid.args = {
   isInvalid: true,
 }
 
-export const WithFormik: Story<RadioProps> = () => {
+export const WithFormik: ComponentStory<typeof Radio> = () => {
   const RadioForm = () => {
     interface Data {
       [key: string]: string
@@ -97,7 +103,7 @@ export const WithFormik: Story<RadioProps> = () => {
 
 WithFormik.storyName = 'Formik'
 
-export const WithFormikGroup: Story<RadioProps> = () => {
+export const WithFormikGroup: ComponentStory<typeof Radio> = () => {
   const RadioForm = () => {
     interface Data {
       [key: string]: string

--- a/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'
 
 import { withFormik } from '../../enhancers/withFormik'
-import { RadioE, RadioEProps } from '.'
+import { RadioE } from '.'
 import { FormikGroupE } from '../FormikGroup'
 
 export default {
@@ -14,9 +14,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof RadioE>
 
-const Template: Story<RadioEProps> = (props) => <RadioE {...props} />
+const Template: ComponentStory<typeof RadioE> = (props) => <RadioE {...props} />
 
 export const Default = Template.bind({})
 Default.args = {
@@ -42,7 +42,7 @@ Invalid.args = {
   isInvalid: true,
 }
 
-export const WithFormikGroup: Story<RadioEProps> = () => {
+export const WithFormikGroup: ComponentStory<typeof RadioE> = () => {
   const RadioForm = () => {
     interface Data {
       [key: string]: string

--- a/packages/react-component-library/src/components/RadioEnhanced/RadioEnhanced.stories.tsx
+++ b/packages/react-component-library/src/components/RadioEnhanced/RadioEnhanced.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-import { RadioEnhanced, RadioEnhancedProps } from '.'
+import { RadioEnhanced } from '.'
 
 export default {
   component: RadioEnhanced,
@@ -10,9 +10,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof RadioEnhanced>
 
-export const Default: Story<RadioEnhancedProps> = (props) => (
+export const Default: ComponentStory<typeof RadioEnhanced> = (props) => (
   <RadioEnhanced {...props} />
 )
 
@@ -23,7 +23,7 @@ Default.args = {
   isChecked: true,
 }
 
-export const WithDescription: Story<RadioEnhancedProps> = () => (
+export const WithDescription: ComponentStory<typeof RadioEnhanced> = () => (
   <RadioEnhanced
     name="withdescription"
     title="With description"
@@ -33,7 +33,7 @@ export const WithDescription: Story<RadioEnhancedProps> = () => (
 
 WithDescription.storyName = 'With description'
 
-export const GridLayout: Story<RadioEnhancedProps> = () => (
+export const GridLayout: ComponentStory<typeof RadioEnhanced> = () => (
   <form
     onSubmit={(e) => {
       e.preventDefault()

--- a/packages/react-component-library/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import {
   IconBrightnessLow,
   IconBrightnessHigh,
 } from '@defencedigital/icon-library'
-import { RangeSlider, RangeSliderProps } from './index'
+import { RangeSlider } from './index'
 
 export default {
   component: RangeSlider,
@@ -13,7 +13,7 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof RangeSlider>
 
 const disableColorContrastRule = {
   a11y: {
@@ -28,7 +28,7 @@ const disableColorContrastRule = {
   },
 }
 
-export const Default: Story<RangeSliderProps> = (props) => (
+export const Default: ComponentStory<typeof RangeSlider> = (props) => (
   <div style={{ display: 'flex', height: '5rem' }}>
     <RangeSlider {...props} />
   </div>
@@ -43,7 +43,7 @@ Default.args = {
 
 Default.parameters = disableColorContrastRule
 
-export const MultipleHandles: Story<RangeSliderProps> = (props) => (
+export const MultipleHandles: ComponentStory<typeof RangeSlider> = (props) => (
   <div style={{ display: 'flex', height: '5rem' }}>
     <RangeSlider
       {...props}
@@ -63,7 +63,7 @@ MultipleHandles.storyName = 'Multiple handles'
 
 MultipleHandles.parameters = disableColorContrastRule
 
-export const SingleThreshold: Story<RangeSliderProps> = (props) => (
+export const SingleThreshold: ComponentStory<typeof RangeSlider> = (props) => (
   <div style={{ display: 'flex', height: '5rem' }}>
     <RangeSlider
       {...props}
@@ -80,7 +80,7 @@ SingleThreshold.storyName = 'Single threshold'
 
 SingleThreshold.parameters = disableColorContrastRule
 
-export const DoubleThreshold: Story<RangeSliderProps> = (props) => (
+export const DoubleThreshold: ComponentStory<typeof RangeSlider> = (props) => (
   <div style={{ display: 'flex', height: '5rem' }}>
     <RangeSlider
       {...props}
@@ -97,7 +97,9 @@ DoubleThreshold.storyName = 'Double threshold'
 
 DoubleThreshold.parameters = disableColorContrastRule
 
-export const CustomValueFormatter: Story<RangeSliderProps> = (props) => (
+export const CustomValueFormatter: ComponentStory<typeof RangeSlider> = (
+  props
+) => (
   <div style={{ display: 'flex', height: '5rem' }}>
     <RangeSlider
       {...props}
@@ -115,7 +117,7 @@ CustomValueFormatter.storyName = 'Custom value formatter'
 
 CustomValueFormatter.parameters = disableColorContrastRule
 
-export const Stepped: Story<RangeSliderProps> = (props) => (
+export const Stepped: ComponentStory<typeof RangeSlider> = (props) => (
   <div style={{ display: 'flex', height: '5rem' }}>
     <RangeSlider
       {...props}
@@ -133,7 +135,7 @@ Stepped.storyName = 'Stepped'
 
 Stepped.parameters = disableColorContrastRule
 
-export const WithPercentage: Story<RangeSliderProps> = (props) => (
+export const WithPercentage: ComponentStory<typeof RangeSlider> = (props) => (
   <div style={{ display: 'flex', height: '5rem' }}>
     <RangeSlider
       {...props}
@@ -152,7 +154,7 @@ WithPercentage.storyName = 'With percentage'
 
 WithPercentage.parameters = disableColorContrastRule
 
-export const WithIcons: Story<RangeSliderProps> = (props) => (
+export const WithIcons: ComponentStory<typeof RangeSlider> = (props) => (
   <div style={{ display: 'flex', height: '5rem' }}>
     <RangeSlider
       {...props}
@@ -172,7 +174,7 @@ WithIcons.storyName = 'With icons'
 
 WithIcons.parameters = disableColorContrastRule
 
-export const WithLabels: Story<RangeSliderProps> = (props) => (
+export const WithLabels: ComponentStory<typeof RangeSlider> = (props) => (
   <div style={{ display: 'flex', height: '5rem' }}>
     <RangeSlider
       {...props}
@@ -191,7 +193,7 @@ WithLabels.storyName = 'With labels'
 
 WithLabels.parameters = disableColorContrastRule
 
-export const ReversedScale: Story<RangeSliderProps> = (props) => (
+export const ReversedScale: ComponentStory<typeof RangeSlider> = (props) => (
   <div style={{ display: 'flex', height: '5rem' }}>
     <RangeSlider
       {...props}
@@ -211,7 +213,7 @@ ReversedScale.storyName = 'Reversed scale'
 
 ReversedScale.parameters = disableColorContrastRule
 
-export const Disabled: Story<RangeSliderProps> = (props) => (
+export const Disabled: ComponentStory<typeof RangeSlider> = (props) => (
   <div style={{ display: 'flex', height: '5rem' }}>
     <RangeSlider
       {...props}

--- a/packages/react-component-library/src/components/RangeSliderE/RangeSliderE.stories.tsx
+++ b/packages/react-component-library/src/components/RangeSliderE/RangeSliderE.stories.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import {
   IconBrightnessLow,
   IconBrightnessHigh,
 } from '@defencedigital/icon-library'
-import { RangeSliderE, RangeSliderEProps } from './index'
+import { RangeSliderE } from './index'
 
 export default {
   component: RangeSliderE,
@@ -14,7 +14,7 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof RangeSliderE>
 
 const disableColorContrastRule = {
   a11y: {
@@ -35,7 +35,7 @@ const StyledWrapper = styled.div`
   padding: 0 1.5rem;
 `
 
-const Template: Story<RangeSliderEProps> = (props) => (
+const Template: ComponentStory<typeof RangeSliderE> = (props) => (
   <StyledWrapper>
     <RangeSliderE {...props} />
   </StyledWrapper>

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { IconAnchor } from '@defencedigital/icon-library'
 
-import { Select, SelectProps } from './index'
+import { Select } from './index'
 
 const options = [
   { value: 'chocolate', label: 'Chocolate', badge: 100 },
@@ -22,9 +22,9 @@ export default {
       },
     },
   },
-} as Meta
+} as ComponentMeta<typeof Select>
 
-const Template: Story<SelectProps> = (args) => (
+const Template: ComponentStory<typeof Select> = (args) => (
   <div style={{ height: args.isDisabled ? 'initial' : '10rem' }}>
     <Select {...args} />
   </div>

--- a/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react/types-6-0'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
 import {
   IconAgriculture,
   IconAnchor,
@@ -7,7 +7,6 @@ import {
   IconRemove,
 } from '@defencedigital/icon-library'
 
-import { SelectBaseProps } from '../SelectBase'
 import { SelectE } from './index'
 import { SelectEOption } from './SelectEOption'
 
@@ -26,9 +25,9 @@ export default {
       enableShortcuts: false,
     },
   },
-} as Meta
+} as ComponentMeta<typeof SelectE>
 
-const Template: Story<SelectBaseProps> = (args) => (
+const Template: ComponentStory<typeof SelectE> = (args) => (
   <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
     <SelectE label="Some label" {...args}>
       <SelectEOption value="one">One</SelectEOption>
@@ -39,7 +38,7 @@ const Template: Story<SelectBaseProps> = (args) => (
   </div>
 )
 
-const TemplateWIthIconsAndBadges: Story<SelectBaseProps> = (args) => (
+const TemplateWIthIconsAndBadges: ComponentStory<typeof SelectE> = (args) => (
   <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
     <SelectE label="Some label" {...args}>
       <SelectEOption badge={100} icon={<IconAnchor />} value="one">

--- a/packages/react-component-library/src/components/Switch/Switch.stories.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.stories.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
 import { Field, Formik, Form } from 'formik'
 import { withFormik } from '../../enhancers/withFormik'
 import { Button } from '../Button'
 
-import { ResponsiveSwitch, Switch, SwitchProps, SWITCH_SIZE } from '.'
+import { ResponsiveSwitch, Switch, SWITCH_SIZE } from '.'
 
 export default {
   component: Switch,
@@ -15,7 +15,7 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof Switch>
 
 const options = [
   { label: 'One', value: '1' },
@@ -24,14 +24,16 @@ const options = [
   { label: 'Four', value: '4' },
 ]
 
-export const Default: Story<SwitchProps> = (props) => <Switch {...props} />
+export const Default: ComponentStory<typeof Switch> = (props) => (
+  <Switch {...props} />
+)
 
 Default.args = {
   name: 'switch-default',
   options,
 }
 
-export const WithLegend: Story<SwitchProps> = (props) => (
+export const WithLegend: ComponentStory<typeof Switch> = (props) => (
   <Switch
     {...props}
     name="switch-legend"
@@ -42,19 +44,19 @@ export const WithLegend: Story<SwitchProps> = (props) => (
 
 WithLegend.storyName = 'With legend'
 
-export const Responsive: Story<SwitchProps> = (props) => (
+export const Responsive: ComponentStory<typeof Switch> = (props) => (
   <ResponsiveSwitch {...props} name="switch-responsive" options={options} />
 )
 
 Responsive.storyName = 'Responsive'
 
-export const SelectedValue: Story<SwitchProps> = (props) => (
+export const SelectedValue: ComponentStory<typeof Switch> = (props) => (
   <Switch {...props} name="switch-selected-value" options={options} value="2" />
 )
 
 SelectedValue.storyName = 'With value selected'
 
-export const Small: Story<SwitchProps> = (props) => (
+export const Small: ComponentStory<typeof Switch> = (props) => (
   <Switch
     {...props}
     name="switch-small"
@@ -65,7 +67,7 @@ export const Small: Story<SwitchProps> = (props) => (
 
 Small.storyName = 'Small'
 
-export const Large: Story<SwitchProps> = (props) => (
+export const Large: ComponentStory<typeof Switch> = (props) => (
   <Switch
     {...props}
     name="switch-large"
@@ -76,7 +78,7 @@ export const Large: Story<SwitchProps> = (props) => (
 
 Large.storyName = 'Large'
 
-export const WithFormik: Story<SwitchProps> = (props) => {
+export const WithFormik: ComponentStory<typeof Switch> = (props) => {
   interface Data {
     'switch-formik': string
   }

--- a/packages/react-component-library/src/components/SwitchE/SwitchE.stories.tsx
+++ b/packages/react-component-library/src/components/SwitchE/SwitchE.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { SwitchE, SwitchEOption, SwitchEProps } from '.'
+import { SwitchE, SwitchEOption } from '.'
 import { COMPONENT_SIZE } from '../Forms'
 
 export default {
@@ -11,9 +11,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof SwitchE>
 
-const Template: Story<SwitchEProps> = (props) => (
+const Template: ComponentStory<typeof SwitchE> = (props) => (
   <SwitchE {...props}>
     <SwitchEOption label="Day" value="1" />
     <SwitchEOption label="Week" value="2" />

--- a/packages/react-component-library/src/components/TabNav/TabNav.stories.tsx
+++ b/packages/react-component-library/src/components/TabNav/TabNav.stories.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { Link } from '../Link'
 import { TabNav, TabNavItem } from '.'
-import { Nav, NavItem } from '../../common/Nav'
 
 export default {
   component: TabNav,
@@ -12,9 +11,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof TabNav>
 
-export const Default: Story<Nav<NavItem>> = (props) => (
+export const Default: ComponentStory<typeof TabNav> = (props) => (
   <TabNav {...props}>
     <TabNavItem link={<Link href="#">Example Tab 1</Link>} isActive />
     <TabNavItem link={<Link href="#">Example Tab 2</Link>} />

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { Story, ComponentMeta } from '@storybook/react'
 
-import { Tab, TabSet, TabSetProps, ScrollableTabSetProps } from '.'
+import { ScrollableTabSetProps, Tab, TabSet, TabSetProps } from '.'
 
 export default {
   component: TabSet,
@@ -11,7 +11,7 @@ export default {
     actions: { argTypesRegex: '^on.*' },
     layout: 'fullscreen',
   },
-} as Meta
+} as ComponentMeta<typeof TabSet>
 
 export const Default: Story<TabSetProps> = (props) => (
   <TabSet {...props}>

--- a/packages/react-component-library/src/components/Table/Table.stories.tsx
+++ b/packages/react-component-library/src/components/Table/Table.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { Badge, BADGE_COLOR_VARIANT, BADGE_COLOR } from '../Badge'
-import { Table, TableProps, TableColumn } from '.'
+import { Table, TableColumn } from '.'
 
 export default {
   component: Table,
@@ -12,7 +12,7 @@ export default {
     actions: { argTypesRegex: '^on.*' },
     layout: 'fullscreen',
   },
-} as Meta
+} as ComponentMeta<typeof Table>
 
 const tableData = [
   {
@@ -33,7 +33,7 @@ const tableData = [
   },
 ]
 
-export const Default: Story<TableProps> = (props) => {
+export const Default: ComponentStory<typeof Table> = (props) => {
   return (
     <Table {...props}>
       <TableColumn field="first">First column</TableColumn>
@@ -76,7 +76,7 @@ const tableDataArbitraryCellContent = [
   },
 ]
 
-export const ArbitraryCellContent: Story<TableProps> = (props) => (
+export const ArbitraryCellContent: ComponentStory<typeof Table> = (props) => (
   <Table {...props} data={tableDataArbitraryCellContent}>
     <TableColumn field="first">First column</TableColumn>
     <TableColumn field="second">Status</TableColumn>
@@ -85,7 +85,7 @@ export const ArbitraryCellContent: Story<TableProps> = (props) => (
 
 ArbitraryCellContent.storyName = 'Arbitrary cell content'
 
-export const Sortable: Story<TableProps> = (props) => {
+export const Sortable: ComponentStory<typeof Table> = (props) => {
   const tableDataSortable = [
     {
       id: 'a',
@@ -124,7 +124,7 @@ export const Sortable: Story<TableProps> = (props) => {
 
 Sortable.storyName = 'Sortable'
 
-export const WithCaption: Story<TableProps> = (props) => {
+export const WithCaption: ComponentStory<typeof Table> = (props) => {
   const tableDataWithCaption = [
     {
       id: 'a',

--- a/packages/react-component-library/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'
 
 import { Button } from '../Button'
-import { TextArea, TextAreaInputProps } from '.'
+import { TextArea } from '.'
 
 import { withFormik } from '../../enhancers/withFormik'
 
@@ -15,9 +15,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof TextArea>
 
-export const Default: Story<TextAreaInputProps> = (props) => (
+export const Default: ComponentStory<typeof TextArea> = (props) => (
   <TextArea {...props} />
 )
 
@@ -26,25 +26,25 @@ Default.args = {
   label: 'Example label',
 }
 
-export const WithLabel: Story<TextAreaInputProps> = (props) => (
+export const WithLabel: ComponentStory<typeof TextArea> = (props) => (
   <TextArea {...props} label="Example label" />
 )
 
 WithLabel.storyName = 'With label'
 
-export const WithFootnote: Story<TextAreaInputProps> = (props) => (
+export const WithFootnote: ComponentStory<typeof TextArea> = (props) => (
   <TextArea {...props} label="Example label" footnote="Example footnote" />
 )
 
 WithFootnote.storyName = 'With footnote'
 
-export const Disabled: Story<TextAreaInputProps> = (props) => (
+export const Disabled: ComponentStory<typeof TextArea> = (props) => (
   <TextArea {...props} label="Example label" isDisabled />
 )
 
 Disabled.storyName = 'Disabled'
 
-export const WithFormik: Story<TextAreaInputProps> = (props) => {
+export const WithFormik: ComponentStory<typeof TextArea> = (props) => {
   interface Data {
     'textarea-formik': string
   }

--- a/packages/react-component-library/src/components/TextAreaE/TextAreaE.stories.tsx
+++ b/packages/react-component-library/src/components/TextAreaE/TextAreaE.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { TextAreaE, TextAreaEProps } from '.'
+import { TextAreaE } from '.'
 
 export default {
   component: TextAreaE,
@@ -9,9 +9,9 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof TextAreaE>
 
-export const Default: Story<TextAreaEProps> = (props) => (
+export const Default: ComponentStory<typeof TextAreaE> = (props) => (
   <TextAreaE {...props} />
 )
 
@@ -20,13 +20,13 @@ Default.args = {
   label: 'Example label',
 }
 
-export const Disabled: Story<TextAreaEProps> = (props) => (
+export const Disabled: ComponentStory<typeof TextAreaE> = (props) => (
   <TextAreaE {...props} isDisabled label="Example label" />
 )
 
 Disabled.storyName = 'Disabled'
 
-export const WithError: Story<TextAreaEProps> = (props) => (
+export const WithError: ComponentStory<typeof TextAreaE> = (props) => (
   <TextAreaE {...props} isInvalid label="Example label" />
 )
 

--- a/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Field, Formik, Form } from 'formik'
 import * as yup from 'yup'
 
 import { IconSearch } from '@defencedigital/icon-library'
 import { Button } from '../Button'
-import { TextInput, TextInputProps } from '.'
+import { TextInput } from '.'
 
 import { withFormik } from '../../enhancers/withFormik'
 
@@ -14,9 +14,9 @@ export default {
   component: TextInput,
   title: 'Text Input',
   argTypes: { onBlur: { action: 'onBlur' } },
-} as Meta
+} as ComponentMeta<typeof TextInput>
 
-export const Default: Story<TextInputProps> = (props) => (
+export const Default: ComponentStory<typeof TextInput> = (props) => (
   <TextInput {...props} />
 )
 
@@ -25,13 +25,13 @@ Default.args = {
   label: 'Example label',
 }
 
-export const WithLabel: Story<TextInputProps> = (props) => (
+export const WithLabel: ComponentStory<typeof TextInput> = (props) => (
   <TextInput {...props} name="text-input-label" label="Example label" />
 )
 
 WithLabel.storyName = 'With label'
 
-export const Disabled: Story<TextInputProps> = (props) => (
+export const Disabled: ComponentStory<typeof TextInput> = (props) => (
   <TextInput
     {...props}
     name="text-input-disabled"
@@ -42,7 +42,7 @@ export const Disabled: Story<TextInputProps> = (props) => (
 
 Disabled.storyName = 'Disabled'
 
-export const WithStartAdornment: Story<TextInputProps> = (props) => (
+export const WithStartAdornment: ComponentStory<typeof TextInput> = (props) => (
   <TextInput
     {...props}
     name="text-input-start-adornment"
@@ -53,7 +53,7 @@ export const WithStartAdornment: Story<TextInputProps> = (props) => (
 
 WithStartAdornment.storyName = 'With start adornment'
 
-export const WithEndAdornment: Story<TextInputProps> = (props) => (
+export const WithEndAdornment: ComponentStory<typeof TextInput> = (props) => (
   <TextInput
     {...props}
     name="text-input-end-adornment"
@@ -64,7 +64,7 @@ export const WithEndAdornment: Story<TextInputProps> = (props) => (
 
 WithEndAdornment.storyName = 'With end adornment'
 
-export const WithFormik: Story<TextInputProps> = (props) => {
+export const WithFormik: ComponentStory<typeof TextInput> = (props) => {
   interface Data {
     'text-input-formik': string
   }

--- a/packages/react-component-library/src/components/TextInputE/TextInputE.stories.tsx
+++ b/packages/react-component-library/src/components/TextInputE/TextInputE.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { IconSearch } from '@defencedigital/icon-library'
-import { TextInputE, TextInputEProps } from '.'
+import { TextInputE } from '.'
 
 export default {
   component: TextInputE,
@@ -10,9 +10,9 @@ export default {
   parameters: {
     argTypes: { onBlur: { action: 'onBlur' } },
   },
-} as Meta
+} as ComponentMeta<typeof TextInputE>
 
-export const Default: Story<TextInputEProps> = (props) => (
+export const Default: ComponentStory<typeof TextInputE> = (props) => (
   <TextInputE {...props} />
 )
 
@@ -21,7 +21,7 @@ Default.args = {
   label: 'Example label',
 }
 
-export const Disabled: Story<TextInputEProps> = (props) => (
+export const Disabled: ComponentStory<typeof TextInputE> = (props) => (
   <TextInputE
     {...props}
     name="text-input-disabled"
@@ -32,7 +32,9 @@ export const Disabled: Story<TextInputEProps> = (props) => (
 
 Disabled.storyName = 'Disabled'
 
-export const WithStartAdornment: Story<TextInputEProps> = (props) => (
+export const WithStartAdornment: ComponentStory<typeof TextInputE> = (
+  props
+) => (
   <TextInputE
     {...props}
     name="text-input-start-adornment"
@@ -43,7 +45,7 @@ export const WithStartAdornment: Story<TextInputEProps> = (props) => (
 
 WithStartAdornment.storyName = 'With start adornment'
 
-export const WithEndAdornment: Story<TextInputEProps> = (props) => (
+export const WithEndAdornment: ComponentStory<typeof TextInputE> = (props) => (
   <TextInputE
     {...props}
     name="text-input-end-adornment"
@@ -54,7 +56,7 @@ export const WithEndAdornment: Story<TextInputEProps> = (props) => (
 
 WithEndAdornment.storyName = 'With end adornment'
 
-export const WithError: Story<TextInputEProps> = (props) => (
+export const WithError: ComponentStory<typeof TextInputE> = (props) => (
   <TextInputE
     {...props}
     isInvalid

--- a/packages/react-component-library/src/components/ThemedExample/ThemedExample.stories.tsx
+++ b/packages/react-component-library/src/components/ThemedExample/ThemedExample.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { ComponentWithClass } from '../../common/ComponentWithClass'
 import {
   CustomTokenSets as CustomTokenSetsExample,
   StyledTheming as StyledThemingExample,
@@ -22,18 +21,18 @@ export default {
       },
     },
   },
-} as Meta
+} as ComponentMeta<typeof CustomTokenSetsExample>
 
-export const Default: Story<ComponentWithClass> = () => (
+export const Default: ComponentStory<typeof CustomTokenSetsExample> = () => (
   <CustomTokenSetsExample />
 )
 
 Default.args = {}
 Default.storyName = 'Custom Token Sets'
 
-export const StyledTheming: Story<ComponentWithClass> = () => (
-  <StyledThemingExample />
-)
+export const StyledTheming: ComponentStory<
+  typeof CustomTokenSetsExample
+> = () => <StyledThemingExample />
 
 StyledTheming.args = {}
 StyledTheming.storyName = 'Styled Theming'

--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { css, CSSProp } from 'styled-components'
 import { format } from 'date-fns'
 import {
@@ -10,7 +10,6 @@ import {
 
 import {
   Timeline,
-  TimelineProps,
   TimelineEvent,
   TimelineEvents,
   TimelineHours,
@@ -66,7 +65,7 @@ export default {
       },
     },
   },
-} as Meta
+} as ComponentMeta<typeof Timeline>
 
 const disableScrollableRegionFocusableRule = {
   a11y: {
@@ -81,7 +80,7 @@ const disableScrollableRegionFocusableRule = {
   },
 }
 
-const Template: Story<TimelineProps> = (args) => (
+const Template: ComponentStory<typeof Timeline> = (args) => (
   <Timeline {...args}>
     <TimelineTodayMarker />
     <TimelineMonths />
@@ -108,7 +107,7 @@ BoundByFixedDates.args = {
 BoundByFixedDates.parameters = disableScrollableRegionFocusableRule
 BoundByFixedDates.storyName = 'Bound by fixed dates'
 
-export const WithData: Story<TimelineProps> = (props) => (
+export const WithData: ComponentStory<typeof Timeline> = (props) => (
   <Timeline
     {...props}
     startDate={new Date(2020, 9, 1)}
@@ -146,7 +145,7 @@ export const WithData: Story<TimelineProps> = (props) => (
 WithData.parameters = disableScrollableRegionFocusableRule
 WithData.storyName = 'With data'
 
-export const WithSidebar: Story<TimelineProps> = (props) => (
+export const WithSidebar: ComponentStory<typeof Timeline> = (props) => (
   <Timeline
     {...props}
     hasSide
@@ -196,7 +195,7 @@ WithSidebar.parameters = disableScrollableRegionFocusableRule
 
 WithSidebar.storyName = 'With sidebar'
 
-export const WithHours: Story<TimelineProps> = (props) => (
+export const WithHours: ComponentStory<typeof Timeline> = (props) => (
   <Timeline
     {...props}
     hasSide
@@ -237,7 +236,7 @@ WithHours.parameters = disableScrollableRegionFocusableRule
 
 WithHours.storyName = 'With hours'
 
-export const WithCustomMonths: Story<TimelineProps> = (props) => {
+export const WithCustomMonths: ComponentStory<typeof Timeline> = (props) => {
   const CustomTimelineMonth = (
     index: number,
     dayWidth: number,
@@ -281,7 +280,7 @@ WithCustomMonths.parameters = disableScrollableRegionFocusableRule
 
 WithCustomMonths.storyName = 'With custom months'
 
-export const WithCustomWeeks: Story<TimelineProps> = (props) => {
+export const WithCustomWeeks: ComponentStory<typeof Timeline> = (props) => {
   const CustomTimelineWeek = (
     index: number,
     isOddNumber: boolean,
@@ -330,7 +329,7 @@ WithCustomWeeks.parameters = disableScrollableRegionFocusableRule
 
 WithCustomWeeks.storyName = 'With custom weeks'
 
-export const WithCustomDays: Story<TimelineProps> = (props) => {
+export const WithCustomDays: ComponentStory<typeof Timeline> = (props) => {
   const CustomTimelineDays = (index: number, dayWidth: number, date: Date) => {
     return (
       <span
@@ -367,7 +366,7 @@ WithCustomDays.parameters = disableScrollableRegionFocusableRule
 
 WithCustomDays.storyName = 'With custom days'
 
-export const WithCustomHours: Story<TimelineProps> = (props) => {
+export const WithCustomHours: ComponentStory<typeof Timeline> = (props) => {
   const CustomTimelineHours = (width: number, time: string) => {
     return (
       <div
@@ -405,7 +404,9 @@ WithCustomHours.parameters = disableScrollableRegionFocusableRule
 
 WithCustomHours.storyName = 'With custom hours'
 
-export const WithCustomTodayMarker: Story<TimelineProps> = (props) => {
+export const WithCustomTodayMarker: ComponentStory<typeof Timeline> = (
+  props
+) => {
   const CustomTodayMarker = (date: Date, offset: string) => {
     return (
       <span
@@ -447,7 +448,7 @@ WithCustomTodayMarker.parameters = disableScrollableRegionFocusableRule
 
 WithCustomTodayMarker.storyName = 'With custom today marker'
 
-export const WithCustomColumns: Story<TimelineProps> = (props) => {
+export const WithCustomColumns: ComponentStory<typeof Timeline> = (props) => {
   const CustomTimelineColumn = (
     index: number,
     isOddNumber: boolean,
@@ -508,7 +509,7 @@ WithCustomColumns.parameters = disableScrollableRegionFocusableRule
 
 WithCustomColumns.storyName = 'With custom columns'
 
-export const WithCustomRowCss: Story<TimelineProps> = (props) => {
+export const WithCustomRowCss: ComponentStory<typeof Timeline> = (props) => {
   const rowCss: CSSProp = css`
     height: 40px;
   `
@@ -561,7 +562,9 @@ WithCustomRowCss.parameters = disableScrollableRegionFocusableRule
 
 WithCustomRowCss.storyName = 'With custom row CSS'
 
-export const WithCustomEventBarColor: Story<TimelineProps> = (props) => {
+export const WithCustomEventBarColor: ComponentStory<typeof Timeline> = (
+  props
+) => {
   return (
     <Timeline
       {...props}
@@ -594,7 +597,9 @@ WithCustomEventBarColor.parameters = disableScrollableRegionFocusableRule
 
 WithCustomEventBarColor.storyName = 'With custom event bar color'
 
-export const WithCustomEventContent: Story<TimelineProps> = (props) => {
+export const WithCustomEventContent: ComponentStory<typeof Timeline> = (
+  props
+) => {
   const CustomEvent = ({
     children,
     startDate,
@@ -710,7 +715,7 @@ WithCustomEventContent.parameters = disableScrollableRegionFocusableRule
 
 WithCustomEventContent.storyName = 'With custom event content'
 
-export const WithCustomDayWidth: Story<TimelineProps> = (props) => {
+export const WithCustomDayWidth: ComponentStory<typeof Timeline> = (props) => {
   return (
     <Timeline
       {...props}
@@ -753,7 +758,7 @@ WithCustomDayWidth.parameters = disableScrollableRegionFocusableRule
 
 WithCustomDayWidth.storyName = 'With custom day width'
 
-export const WithCustomRange: Story<TimelineProps> = (props) => {
+export const WithCustomRange: ComponentStory<typeof Timeline> = (props) => {
   return (
     <Timeline
       {...props}
@@ -796,7 +801,7 @@ WithCustomRange.parameters = disableScrollableRegionFocusableRule
 
 WithCustomRange.storyName = 'With custom range'
 
-export const NoVisibleCells: Story<TimelineProps> = (props) => (
+export const NoVisibleCells: ComponentStory<typeof Timeline> = (props) => (
   <Timeline
     {...props}
     startDate={new Date(2020, 0, 1)}
@@ -825,7 +830,7 @@ NoVisibleCells.parameters = disableScrollableRegionFocusableRule
 
 NoVisibleCells.storyName = 'No visible cells'
 
-export const HiddenToolbar: Story<TimelineProps> = (props) => (
+export const HiddenToolbar: ComponentStory<typeof Timeline> = (props) => (
   <Timeline
     {...props}
     hideToolbar
@@ -865,7 +870,7 @@ HiddenToolbar.parameters = disableScrollableRegionFocusableRule
 
 HiddenToolbar.storyName = 'Hidden toolbar'
 
-export const HiddenScaling: Story<TimelineProps> = (props) => (
+export const HiddenScaling: ComponentStory<typeof Timeline> = (props) => (
   <Timeline
     {...props}
     hideScaling

--- a/packages/react-component-library/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta, Story } from '@storybook/react'
 import { useToasts, Options } from 'react-toast-notifications'
 
-import { ToastProvider, Toast, ToastProps } from '.'
+import { ToastProvider, Toast } from '.'
 import { Button } from '../Button'
 
 export default {
@@ -18,7 +18,7 @@ export default {
       },
     },
   },
-} as Meta
+} as ComponentMeta<typeof Toast>
 
 const LABEL = 'Example label'
 const DESCRIPTION = 'This is an example toast message'
@@ -90,7 +90,7 @@ export const AutoDismiss: Story<Options> = (props) => {
 
 AutoDismiss.storyName = 'Auto dismiss'
 
-export const ComponentOnly: Story<ToastProps> = (props) => (
+export const ComponentOnly: ComponentStory<typeof Toast> = (props) => (
   <Toast
     {...props}
     appearance="info"
@@ -109,7 +109,7 @@ export const ComponentOnly: Story<ToastProps> = (props) => (
 
 ComponentOnly.storyName = 'Component only'
 
-export const Danger: Story<ToastProps> = (props) => (
+export const Danger: ComponentStory<typeof Toast> = (props) => (
   <Toast
     {...props}
     appearance="error"
@@ -128,7 +128,7 @@ export const Danger: Story<ToastProps> = (props) => (
 
 Danger.storyName = 'Danger'
 
-export const Success: Story<ToastProps> = (props) => (
+export const Success: ComponentStory<typeof Toast> = (props) => (
   <Toast
     {...props}
     appearance="success"
@@ -147,7 +147,7 @@ export const Success: Story<ToastProps> = (props) => (
 
 Success.storyName = 'Success'
 
-export const Warning: Story<ToastProps> = (props) => (
+export const Warning: ComponentStory<typeof Toast> = (props) => (
   <Toast
     {...props}
     appearance="warning"

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Tooltip, TooltipProps } from '.'
+import { Tooltip } from '.'
 
 export default {
   component: Tooltip,
@@ -9,9 +9,12 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
-} as Meta
+} as ComponentMeta<typeof Tooltip>
 
-export const Default: Story<TooltipProps> = ({ children, ...rest }) => (
+export const Default: ComponentStory<typeof Tooltip> = ({
+  children,
+  ...rest
+}) => (
   <div style={{ height: '4rem' }}>
     <Tooltip {...rest}>{children}</Tooltip>
   </div>
@@ -21,7 +24,7 @@ Default.args = {
   children: 'Hello, World!',
 }
 
-export const WithTitle: Story<TooltipProps> = (props) => (
+export const WithTitle: ComponentStory<typeof Tooltip> = (props) => (
   <div style={{ height: '4rem' }}>
     <Tooltip {...props} title="Example title">
       This tooltip has a title!

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 import {
   IconChatBubble,
   IconExitToApp,
@@ -11,7 +11,6 @@ import {
 import { Link } from '../../Link'
 import {
   Masthead,
-  MastheadProps,
   MastheadNav,
   MastheadNavItem,
   MastheadUser,
@@ -34,9 +33,9 @@ export default {
     actions: { argTypesRegex: '^on.*' },
     layout: 'fullscreen',
   },
-} as Meta
+} as ComponentMeta<typeof Masthead>
 
-export const Default: Story<MastheadProps> = (props) => {
+export const Default: ComponentStory<typeof Masthead> = (props) => {
   const notifications = (
     <Notifications link={<Link href="#" />}>
       <Notification
@@ -113,7 +112,7 @@ Default.args = {
   hasUnreadNotification: true,
 }
 
-export const CustomLogo: Story<MastheadProps> = (props) => (
+export const CustomLogo: ComponentStory<typeof Masthead> = (props) => (
   <Masthead {...props} title="Defence Digital Design System" Logo={IconHome} />
 )
 
@@ -122,7 +121,7 @@ CustomLogo.args = {
   onSearch: null,
 }
 
-export const WithoutLogo: Story<MastheadProps> = (props) => (
+export const WithoutLogo: ComponentStory<typeof Masthead> = (props) => (
   <Masthead
     {...props}
     title="Defence Digital Design System"
@@ -135,7 +134,7 @@ WithoutLogo.args = {
   onSearch: null,
 }
 
-export const WithSearch: Story<MastheadProps> = (props) => (
+export const WithSearch: ComponentStory<typeof Masthead> = (props) => (
   <Masthead
     {...props}
     searchPlaceholder="Search..."
@@ -145,7 +144,7 @@ export const WithSearch: Story<MastheadProps> = (props) => (
 
 WithSearch.storyName = 'With search'
 
-export const WithAvatarLinks: Story<MastheadProps> = (props) => {
+export const WithAvatarLinks: ComponentStory<typeof Masthead> = (props) => {
   const user = (
     <MastheadUser initials="RN">
       <MastheadUserItem
@@ -177,7 +176,7 @@ WithAvatarLinks.args = {
   onSearch: null,
 }
 
-export const WithNavigation: Story<MastheadProps> = (props) => {
+export const WithNavigation: ComponentStory<typeof Masthead> = (props) => {
   const nav = (
     <MastheadNav>
       <MastheadNavItem link={<Link href="#">Get started</Link>} isActive />
@@ -202,7 +201,7 @@ WithNavigation.args = {
   onSearch: null,
 }
 
-export const WithNotifications: Story<MastheadProps> = (props) => {
+export const WithNotifications: ComponentStory<typeof Masthead> = (props) => {
   const notifications = (
     <Notifications link={<Link href="#" />}>
       <Notification

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
@@ -1,16 +1,10 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { Graph, House, Tools } from '../../../icons'
 import { Link } from '../../Link'
 import { Notification, Notifications } from '../NotificationPanel'
-import {
-  Sidebar,
-  SidebarProps,
-  SidebarNav,
-  SidebarNavItem,
-  SidebarUser,
-} from './index'
+import { Sidebar, SidebarNav, SidebarNavItem, SidebarUser } from './index'
 
 export default {
   component: Sidebar,
@@ -32,9 +26,9 @@ export default {
     },
     layout: 'fullscreen',
   },
-} as Meta
+} as ComponentMeta<typeof Sidebar>
 
-export const Default: Story<SidebarProps> = (props) => {
+export const Default: ComponentStory<typeof Sidebar> = (props) => {
   const nav = (
     <SidebarNav>
       <SidebarNavItem Image={House} link={<Link href="#">Home</Link>} />
@@ -52,7 +46,7 @@ export const Default: Story<SidebarProps> = (props) => {
 
 Default.args = {}
 
-export const WithUser: Story<SidebarProps> = (props) => {
+export const WithUser: ComponentStory<typeof Sidebar> = (props) => {
   const user = <SidebarUser initials="XT" link={<Link href="#" />} />
 
   const nav = (
@@ -79,7 +73,7 @@ export const WithUser: Story<SidebarProps> = (props) => {
 
 WithUser.storyName = 'With user'
 
-export const WithNotifications: Story<SidebarProps> = (props) => {
+export const WithNotifications: ComponentStory<typeof Sidebar> = (props) => {
   const notifications = (
     <Notifications link={<Link href="#" />}>
       <Notification

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarE.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import {
   IconHome,
@@ -14,7 +14,6 @@ import {
 
 import {
   SidebarE,
-  SidebarEProps,
   SidebarNavE,
   SidebarNavItemE,
   SidebarUserE,
@@ -57,13 +56,13 @@ export default {
     },
     layout: 'fullscreen',
   },
-} as Meta
+} as ComponentMeta<typeof SidebarE>
 
 const StyledSidebarE = styled(SidebarE)`
   max-height: 30rem;
 `
 
-export const Default: Story<SidebarEProps> = (props) => {
+export const Default: ComponentStory<typeof SidebarE> = (props) => {
   const sidebarNav = (
     <SidebarNavE>
       <SidebarNavItemE
@@ -114,7 +113,7 @@ export const Default: Story<SidebarEProps> = (props) => {
 
 Default.args = {}
 
-export const InitiallyOpen: Story<SidebarEProps> = (props) => {
+export const InitiallyOpen: ComponentStory<typeof SidebarE> = (props) => {
   const sidebarNav = (
     <SidebarNavE>
       <SidebarNavItemE
@@ -171,7 +170,7 @@ InitiallyOpen.parameters = disableColorContrastRule
 
 InitiallyOpen.storyName = 'Initially open'
 
-export const WithSubNavigation: Story<SidebarEProps> = (props) => {
+export const WithSubNavigation: ComponentStory<typeof SidebarE> = (props) => {
   const sidebarNavWithSub = (
     <SidebarNavE>
       <SidebarNavItemE
@@ -243,7 +242,7 @@ export const WithSubNavigation: Story<SidebarEProps> = (props) => {
 
 WithSubNavigation.storyName = 'With sub-navigation'
 
-export const WithHeader: Story<SidebarEProps> = (props) => {
+export const WithHeader: ComponentStory<typeof SidebarE> = (props) => {
   const sidebarNav = (
     <SidebarNavE>
       <SidebarNavItemE
@@ -300,7 +299,7 @@ export const WithHeader: Story<SidebarEProps> = (props) => {
 
 WithHeader.storyName = 'With header'
 
-export const WithUserMenu: Story<SidebarEProps> = (props) => {
+export const WithUserMenu: ComponentStory<typeof SidebarE> = (props) => {
   const userWithLinks = (
     <SidebarUserE
       initials="HN"
@@ -362,7 +361,7 @@ export const WithUserMenu: Story<SidebarEProps> = (props) => {
 
 WithUserMenu.storyName = 'With user menu'
 
-export const WithNotifications: Story<SidebarEProps> = (props) => {
+export const WithNotifications: ComponentStory<typeof SidebarE> = (props) => {
   const notifications = (
     <Notifications link={<Link href="#" />}>
       <Notification

--- a/packages/react-component-library/src/primitives/Container/Container.stories.tsx
+++ b/packages/react-component-library/src/primitives/Container/Container.stories.tsx
@@ -1,17 +1,18 @@
 import React from 'react'
-import { Story, Meta } from '@storybook/react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { Container, ContainerProps } from '.'
+import { Container } from '.'
 
 export default {
   component: Container,
   parameters: { layout: 'fullscreen' },
   title: 'Container',
-} as Meta
+} as ComponentMeta<typeof Container>
 
-export const Default: Story<ContainerProps> = ({ children, ...rest }) => (
-  <Container {...rest}>{children}</Container>
-)
+export const Default: ComponentStory<typeof Container> = ({
+  children,
+  ...rest
+}) => <Container {...rest}>{children}</Container>
 
 Default.args = {
   children: 'Arbitrary JSX',

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
@@ -11,7 +11,7 @@ export default {
     actions: { argTypesRegex: '^on.*' },
     layout: 'fullscreen',
   },
-} as Meta
+} as Meta<FloatingBoxWithEmbeddedTargetProps>
 
 export const Default: Story<FloatingBoxWithEmbeddedTargetProps> = (props) => (
   <FloatingBox isVisible renderTarget={<div />} {...props}>


### PR DESCRIPTION
## Related issue

Resolves #2961

## Overview

This updates stories to use the new `ComponentStory` and `ComponentMeta` types added in Storybook 6.3 (and used in their code samples) where possible.

## Link to preview

https://5e25c277526d380020b5e418-mgkgifavsh.chromatic.com/

## Reason

To stay up-to-date and be consistent with official Storybook code samples.

## Work carried out

- [x] Update to `ComponentStory` and `ComponentMeta` types where possible

## Developer notes

There is some information about the new types here: https://github.com/storybookjs/storybook/blob/86a34fac51307b5d4d3add7d6fac0abb147d062b/app/react/src/client/preview/types-6-3.ts

Note that there were a a few cases where it wasn't possible to update to the new types. These are mainly where the type of the component's props is a union, and it didn't know which member of the union was meant. We could decide to stick with `Story` and `Meta` everywhere if we wanted as they are still supported (but we should be passing the props to `Meta` as well if we did that).
