### PR TITLE
feat(GlobalStyleProvider): Remove root font-size breakpoints

### DIFF
--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -21,7 +21,7 @@ The reccomended way to access tokens is using the supplied selector functions.
 Simply import the selector object and then destructure the selectors you want to use out of this.
 
 ```javascript
-import { selectors } from "@defencedigital/design-tokens";
+import { selectors } from '@defencedigital/design-tokens'
 
 const { color, spacing, mediaQuery } = selectors
 
@@ -34,19 +34,19 @@ const StyledExample = styled.div`
     // @media and (min-width:576px) and (max-width:1400px)
     color: black;
   `}
-`;
+`
 ```
 
-| Selector   | Alias | Example Return Value                               | Description                                                       |
-|------------|-------|----------------------------------------------------|-------------------------------------------------------------------|
-| animation  |       | `0.2s`                                             | Animation timing values.                                          |
-| breakpoint |       | `{   breakpoint: '768px',   baseFontSize: '96%' }` | Raw object containing `breakpoint` and associated `baseFontSize`. |
-| mediaQuery | mq    |  See usage example above.                                                  | Tagged template literal that generates a media query string.      |
-| color      |       | `#FFFFFF`                                          | A color value as a hex string.                                    |
-| shadow     |       | `0 1px 3px rgba(0, 0, 0, 0.04)`                    | Preset `box-shadow` values.                                       |
-| spacing    |       | `0.5rem`                                           | Fixed spacing value in REMs.                                      |
-| fontSize   |       | `0.5rem`                                           | Fixed `font-size` value in REMs.                                  |
-| zIndex     |       | `6001`                                             | Scoped `z-index` value with optional modifier.                    |
+| Selector   | Alias | Example Return Value            | Description                                                  |
+| ---------- | ----- | ------------------------------- | ------------------------------------------------------------ |
+| animation  |       | `0.2s`                          | Animation timing values.                                     |
+| breakpoint |       | `{ breakpoint: '768px' }`       | Raw object containing `breakpoint`.                          |
+| mediaQuery | mq    | See usage example above.        | Tagged template literal that generates a media query string. |
+| color      |       | `#FFFFFF`                       | A color value as a hex string.                               |
+| shadow     |       | `0 1px 3px rgba(0, 0, 0, 0.04)` | Preset `box-shadow` values.                                  |
+| spacing    |       | `0.5rem`                        | Fixed spacing value in REMs.                                 |
+| fontSize   |       | `0.5rem`                        | Fixed `font-size` value in REMs.                             |
+| zIndex     |       | `6001`                          | Scoped `z-index` value with optional modifier.               |
 
 The selectors are typed. We reccomend using the hinting in your IDE to see the signatures and available arguments for each selector. Alternatively, you can see the raw tokens [here on GitHub](https://github.com/defencedigital/mod-uk-design-system/tree/master/packages/design-tokens/src/tokens).
 
@@ -65,7 +65,7 @@ import { ColorNeutral100 } from '@defencedigital/design-tokens'
 ### SASS
 
 ```css
-@use '@defencedigital/design-tokens' as $vars
+@use '@defencedigital/design-tokens' as $vars;
 ```
 
 ## Questions
@@ -78,7 +78,7 @@ The [documentation website](https://docs.royalnavy.io/) contains all the informa
 
 ## Contributing
 
-The [contributing guide](https://github.com/defencedigital/mod-uk-design-system/blob/master/docs/contributing.md) resource presents information about our development process. 
+The [contributing guide](https://github.com/defencedigital/mod-uk-design-system/blob/master/docs/contributing.md) resource presents information about our development process.
 
 ## Changelog
 

--- a/packages/design-tokens/src/__tests__/selectors.test.tsx
+++ b/packages/design-tokens/src/__tests__/selectors.test.tsx
@@ -123,7 +123,7 @@ describe('mediaQuery / mq', () => {
 describe('breakpoint', () => {
   const StyledComponent = styled.div`
     @media only screen and (min-width: ${breakpoint('xs').breakpoint}) {
-      font-size: ${breakpoint('xs').baseFontSize};
+      font-size: 14px;
     }
   `
 
@@ -134,7 +134,7 @@ describe('breakpoint', () => {
   it('should set styles correctly', () => {
     expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
       'font-size',
-      '94%',
+      '14px',
       {
         media: 'only screen and (min-width:576px)',
       }

--- a/packages/design-tokens/src/getters.ts
+++ b/packages/design-tokens/src/getters.ts
@@ -31,14 +31,8 @@ export function getBreakpoint(
     `breakpoint[${size}].breakpoint.value`
   )
 
-  const baseFontSize = get(
-    breakpointsTokens,
-    `breakpoint[${size}].baseFontSize.value`
-  )
-
   return {
     breakpoint,
-    baseFontSize,
   }
 }
 

--- a/packages/design-tokens/src/tokens/dark/breakpoints.json
+++ b/packages/design-tokens/src/tokens/dark/breakpoints.json
@@ -3,57 +3,36 @@
     "root": {
       "breakpoint": {
         "value": "0"
-      },
-      "baseFontSize": {
-        "value": "100%"
       }
     },
     "xs": {
       "breakpoint": {
         "value": "576px"
-      },
-      "baseFontSize": {
-        "value": "94%"
       }
     },
     "s": {
       "breakpoint": {
         "value": "768px"
-      },
-      "baseFontSize": {
-        "value": "96%"
       }
     },
     "m": {
       "breakpoint": {
         "value": "1024px"
-      },
-      "baseFontSize": {
-        "value": "98%"
       }
     },
     "l": {
       "breakpoint": {
         "value": "1200px"
-      },
-      "baseFontSize": {
-        "value": "100%"
       }
     },
     "xl": {
       "breakpoint": {
         "value": "1400px"
-      },
-      "baseFontSize": {
-        "value": "103%"
       }
     },
     "xxl": {
       "breakpoint": {
         "value": "1600px"
-      },
-      "baseFontSize": {
-        "value": "106%"
       }
     }
   }

--- a/packages/design-tokens/src/tokens/light/breakpoints.json
+++ b/packages/design-tokens/src/tokens/light/breakpoints.json
@@ -3,57 +3,36 @@
     "root": {
       "breakpoint": {
         "value": "0"
-      },
-      "baseFontSize": {
-        "value": "100%"
       }
     },
     "xs": {
       "breakpoint": {
         "value": "576px"
-      },
-      "baseFontSize": {
-        "value": "94%"
       }
     },
     "s": {
       "breakpoint": {
         "value": "768px"
-      },
-      "baseFontSize": {
-        "value": "96%"
       }
     },
     "m": {
       "breakpoint": {
         "value": "1024px"
-      },
-      "baseFontSize": {
-        "value": "98%"
       }
     },
     "l": {
       "breakpoint": {
         "value": "1200px"
-      },
-      "baseFontSize": {
-        "value": "100%"
       }
     },
     "xl": {
       "breakpoint": {
         "value": "1400px"
-      },
-      "baseFontSize": {
-        "value": "103%"
       }
     },
     "xxl": {
       "breakpoint": {
         "value": "1600px"
-      },
-      "baseFontSize": {
-        "value": "106%"
       }
     }
   }

--- a/packages/design-tokens/src/types.ts
+++ b/packages/design-tokens/src/types.ts
@@ -35,13 +35,23 @@ export type BreakpointSize = keyof Tokens['breakpointsTokens']['breakpoint']
 
 export type Breakpoint = {
   breakpoint: string
-  baseFontSize: string
 }
 
 export type ColorGroup = keyof Tokens['colorsTokens']['color']
 
 export type ColorShade =
-  'black' | 'white' | '000' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900'
+  | 'black'
+  | 'white'
+  | '000'
+  | '100'
+  | '200'
+  | '300'
+  | '400'
+  | '500'
+  | '600'
+  | '700'
+  | '800'
+  | '900'
 
 export type ShadowWeight = keyof Tokens['shadowsTokens']['shadow']
 

--- a/packages/react-component-library/src/styled-components/GlobalStyle.tsx
+++ b/packages/react-component-library/src/styled-components/GlobalStyle.tsx
@@ -1,11 +1,7 @@
 import React, { createContext } from 'react'
 import { createGlobalStyle, ThemeProvider } from 'styled-components'
 import { Normalize } from 'styled-normalize'
-import {
-  selectors,
-  BreakpointSize,
-  lightTheme,
-} from '@defencedigital/design-tokens'
+import { selectors, lightTheme } from '@defencedigital/design-tokens'
 
 export interface GlobalStyleContextDefaults {
   theme?: Record<string, any>
@@ -16,9 +12,7 @@ export interface GlobalStyleProviderProps {
   theme?: Record<string, any>
 }
 
-const breakpoints: BreakpointSize[] = ['s', 'xs', 'm', 'l', 'xl', 'xxl']
-
-const { mq, breakpoint, fontSize } = selectors
+const { fontSize } = selectors
 
 /**
  * Globally setting `border-box`
@@ -43,14 +37,7 @@ const BoxSizing = createGlobalStyle`
 const Fonts = createGlobalStyle`
   html {
     font-family: "lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-
-    ${breakpoints
-      .map((bp) => {
-        return mq({ gte: bp })`
-          font-size: ${breakpoint(bp).baseFontSize};
-        `
-      })
-      .join('\n\n')}
+    font-size: ${fontSize('base')};
   }
 
   h1,


### PR DESCRIPTION
## Related issue

Closes #2761

## Overview

Remove redundant font-size breakpoints in `GlobalStyleProvider`.

## Reason

>These are redundant and cause weird visual issues in the majority of applications. Some downstream teams are already writing overrides to turn it off.

## Work carried out

- [x] Remove redundant breakpoints