### PR TITLE
feat(DatePicker): Migrate to react-day-picker v8

### DIFF
--- a/packages/react-component-library/cypress/e2e/DatePicker/index.cy.ts
+++ b/packages/react-component-library/cypress/e2e/DatePicker/index.cy.ts
@@ -2,10 +2,10 @@ import { describe, cy, it, before } from 'local-cypress'
 import { addDays, startOfMonth, format } from 'date-fns'
 import { ColorNeutral200 } from '@defencedigital/design-tokens'
 
+import { formatDatesForInput } from '../../../src/components/DatePicker/utils'
 import { DATE_FORMAT } from '../../../src/constants'
 import { hexToRgb } from '../../helpers'
 import selectors from '../../selectors'
-import { formatDatesForInput } from '../../../src/components/DatePicker/utils/formatDatesForInput'
 
 describe('DatePicker', () => {
   describe('when a day is selected', () => {
@@ -23,9 +23,7 @@ describe('DatePicker', () => {
 
     describe('and the first day is clicked', () => {
       before(() => {
-        cy.get(selectors.datePicker.day.inside)
-          .contains('1')
-          .click({ force: true })
+        cy.get(selectors.datePicker.day).contains('1').click({ force: true })
       })
 
       it('should set the value of the input to the date', () => {
@@ -47,7 +45,7 @@ describe('DatePicker', () => {
 
   describe('when a range is selected', () => {
     before(() => {
-      cy.visit('/iframe.html?id=date-picker--range&viewMode=story')
+      cy.visit('/iframe.html?id=date-picker-experimental--range&viewMode=story')
 
       cy.get(selectors.datePicker.input).click()
     })
@@ -58,7 +56,7 @@ describe('DatePicker', () => {
 
     describe('and the `from` day is clicked', () => {
       before(() => {
-        cy.get(selectors.datePicker.day.inside).contains('1').click()
+        cy.get(selectors.datePicker.day).contains('1').click()
       })
 
       it('should set the value of the input to the date', () => {
@@ -72,7 +70,7 @@ describe('DatePicker', () => {
 
       describe('and the `to` day is clicked', () => {
         before(() => {
-          cy.get(selectors.datePicker.day.inside).contains('10').click()
+          cy.get(selectors.datePicker.day).contains('10').click()
         })
 
         it('should set the value of the input to the range', () => {

--- a/packages/react-component-library/cypress/selectors/DatePicker.ts
+++ b/packages/react-component-library/cypress/selectors/DatePicker.ts
@@ -1,8 +1,6 @@
 export default {
   button: '[data-testid="datepicker-input-button"]',
-  day: {
-    inside: '.DayPicker-Day:not(.DayPicker-Day--outside)',
-  },
+  day: '.rdp_day',
   floatingBox: '[data-testid="floating-box"]',
   input: '[data-testid="datepicker-input"]',
   outerWrapper: '[data-testid="datepicker-outer-wrapper"]',

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -157,7 +157,7 @@
     "lodash": "^4.17.21",
     "polished": "^4.0.3",
     "react-compound-slider": "^3.3.1",
-    "react-day-picker": "^7.4.8",
+    "react-day-picker": "^8.0.4",
     "react-merge-refs": "^1.1.0",
     "react-popper": "^2.2.5",
     "react-select": "^4.1.0",

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -830,6 +830,19 @@ describe('DatePicker', () => {
             })
           ).toHaveLength(0)
         })
+
+        describe('and then presses the tab key', () => {
+          beforeEach(() => {
+            userEvent.tab()
+          })
+
+          it('clears the range and removes the shading', () => {
+            // The start date still has the modifier
+            expect(
+              wrapper.container.querySelectorAll('.rdp-day_selected')
+            ).toHaveLength(1)
+          })
+        })
       })
 
       describe('and clicks on a second date', () => {

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -612,6 +612,22 @@ describe('DatePicker', () => {
     })
   })
 
+  describe('when a single date picker with a value is rendered and the picker is opened', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <DatePicker startDate={new Date('2022-01-18T00:00:00Z')} />
+      )
+
+      return user.click(wrapper.getByTestId('datepicker-input-button'))
+    })
+
+    it('focuses the current date', () => {
+      expect(
+        wrapper.getByRole('button', { name: '18th January (Tuesday)' })
+      ).toHaveFocus()
+    })
+  })
+
   describe('when a single date picker is rendered and the picker is opened', () => {
     beforeEach(() => {
       wrapper = render(<DatePicker />)
@@ -623,12 +639,10 @@ describe('DatePicker', () => {
       expect(wrapper.getByText('December 2019')).toBeInTheDocument()
     })
 
-    it('focuses the previous month button', () => {
-      return waitFor(() =>
-        expect(
-          wrapper.getByLabelText(PREVIOUS_MONTH_BUTTON_LABEL)
-        ).toHaveFocus()
-      )
+    it('focuses the current date', () => {
+      expect(
+        wrapper.getByRole('button', { name: '5th December (Thursday)' })
+      ).toHaveFocus()
     })
 
     describe('when Shift-Tab is pressed once', () => {
@@ -638,7 +652,7 @@ describe('DatePicker', () => {
 
       it('traps the focus within the picker', () => {
         expect(
-          wrapper.getByRole('button', { name: '5th December (Thursday)' })
+          wrapper.getByLabelText(PREVIOUS_MONTH_BUTTON_LABEL)
         ).toHaveFocus()
       })
 
@@ -649,7 +663,7 @@ describe('DatePicker', () => {
 
         it('still traps the focus within the picker', () => {
           expect(
-            wrapper.getByLabelText(PREVIOUS_MONTH_BUTTON_LABEL)
+            wrapper.getByRole('button', { name: '5th December (Thursday)' })
           ).toHaveFocus()
         })
       })

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -209,9 +209,8 @@ export const DatePicker: React.FC<DatePickerProps> = ({
 
   const {
     rangeHoverOrFocusDate,
-    handleDayFocus,
-    handleDayMouseEnter,
-    handleDayMouseLeave,
+    handleDayFocusOrMouseEnter,
+    handleDayBlurOrMouseLeave,
   } = useRangeHoverOrFocusDate(isRange)
 
   const { handleKeyDown, handleInputBlur, handleInputChange } = useInput(
@@ -351,9 +350,10 @@ export const DatePicker: React.FC<DatePickerProps> = ({
               }}
               defaultMonth={replaceInvalidDate(startDate) || initialMonth}
               disabled={disabledDays}
-              onDayMouseEnter={handleDayMouseEnter}
-              onDayMouseLeave={handleDayMouseLeave}
-              onDayFocus={handleDayFocus}
+              onDayMouseEnter={handleDayFocusOrMouseEnter}
+              onDayMouseLeave={handleDayBlurOrMouseLeave}
+              onDayFocus={handleDayFocusOrMouseEnter}
+              onDayBlur={handleDayBlurOrMouseLeave}
             />
           </div>
         </FocusTrap>

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -354,6 +354,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
               onDayMouseLeave={handleDayBlurOrMouseLeave}
               onDayFocus={handleDayFocusOrMouseEnter}
               onDayBlur={handleDayBlurOrMouseLeave}
+              initialFocus
             />
           </div>
         </FocusTrap>

--- a/packages/react-component-library/src/components/DatePicker/constants.ts
+++ b/packages/react-component-library/src/components/DatePicker/constants.ts
@@ -1,13 +1,7 @@
-const LOCALE = {
-  UK: 'en-GB',
-}
-
-const WEEKDAY_TITLES = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
-
 const DATE_VALIDITY = {
   VALID: 'valid',
   INVALID: 'invalid',
   DISABLED: 'disabled',
 } as const
 
-export { DATE_VALIDITY, LOCALE, WEEKDAY_TITLES }
+export { DATE_VALIDITY }

--- a/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
@@ -1,4 +1,4 @@
-import DayPicker from 'react-day-picker'
+import { DayPicker } from 'react-day-picker'
 import { selectors } from '@defencedigital/design-tokens'
 import styled, { css } from 'styled-components'
 
@@ -9,27 +9,25 @@ import { isIE11 } from '../../../helpers'
 
 const { color, spacing, fontSize } = selectors
 
-interface StyledDayPickerProps {
-  $isRange: boolean
-  $isVisible: boolean
-}
-
 const DAY_SIZE = '34px'
 
-export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
-  pointer-events: none;
-
-  ${({ $isVisible }) =>
-    $isVisible &&
-    css`
-      pointer-events: all;
-    `}
-
-  .DayPicker {
-    display: inline-block;
+export const StyledDayPicker = styled(DayPicker)`
+  .rdp-vhidden {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    box-sizing: border-box;
+    clip: rect(1px, 1px, 1px, 1px);
+    height: 1px;
+    overflow: hidden;
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    top: 0;
+    width: 1px;
   }
 
-  .DayPicker-wrapper {
+  .rdp-months {
     position: relative;
     flex-direction: row;
     padding-bottom: ${spacing('8')};
@@ -38,22 +36,19 @@ export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
     outline: none;
   }
 
-  .DayPicker-Months {
+  .rdp-months {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
   }
 
-  .DayPicker-Month {
-    display: table;
+  .rdp-month {
     margin: 0 ${spacing('6')};
     margin-top: ${spacing('8')};
-    border-spacing: 0;
-    border-collapse: collapse;
     user-select: none;
   }
 
-  .DayPicker-NavButton {
+  .rdp-nav_button {
     ${getButtonStyles({
       $size: COMPONENT_SIZE.SMALL,
       $variant: BUTTON_VARIANT.TERTIARY,
@@ -64,43 +59,40 @@ export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
     background-position: center;
     background-size: 18px;
     background-repeat: no-repeat;
+
+    svg {
+      display: none;
+    }
   }
 
-  .DayPicker-NavButton--prev {
+  .rdp-nav_button_previous {
     left: ${spacing('6')};
     background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg width='16px' height='16px' viewBox='0 0 16 16' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Ctitle%3EIcons/Navigation/chevron-left%3C/title%3E%3Cdefs%3E%3Cpolygon id='path-1' points='10.2755556 4.9422222 9.33333334 3.99999998 5.33333332 8 9.33333334 12 10.2755556 11.0577778 7.21777777 8'%3E%3C/polygon%3E%3C/defs%3E%3Cg id='Icons/Navigation/chevron-left' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cmask id='mask-2' fill='white'%3E%3Cuse xlink:href='%23path-1'%3E%3C/use%3E%3C/mask%3E%3Cuse id='Icons/Navigation/ic_chevron_left_18px' fill='%23233745' fill-rule='nonzero' xlink:href='%23path-1'%3E%3C/use%3E%3C/g%3E%3C/svg%3E");
   }
 
-  .DayPicker-NavButton--next {
+  .rdp-nav_button_next {
     right: ${spacing('6')};
     background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg width='16px' height='16px' viewBox='0 0 16 16' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Ctitle%3EIcons/Navigation/chevron-right%3C/title%3E%3Cdefs%3E%3Cpolygon id='path-1' points='6.66666666 3.99999998 5.72444443 4.9422222 8.78222223 8 5.72444443 11.0577778 6.66666666 12 10.6666667 8'%3E%3C/polygon%3E%3C/defs%3E%3Cg id='Icons/Navigation/chevron-right' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cmask id='mask-2' fill='white'%3E%3Cuse xlink:href='%23path-1'%3E%3C/use%3E%3C/mask%3E%3Cuse id='Icons/Navigation/ic_chevron_right_18px' fill='%23233745' fill-rule='nonzero' xlink:href='%23path-1'%3E%3C/use%3E%3C/g%3E%3C/svg%3E");
   }
 
-  .DayPicker-NavButton--interactionDisabled {
-    display: none;
-  }
-
-  .DayPicker-Caption {
-    display: table-caption;
+  .rdp-caption_label {
+    width: 100%;
     margin-bottom: ${spacing('8')};
     height: 1.5rem;
     color: ${color('neutral', '600')};
     font-size: ${fontSize('base')};
+    font-weight: 400;
     line-height: 1.5rem;
     text-align: center;
     white-space: nowrap;
   }
 
-  .DayPicker-Weekdays {
-    display: table-header-group;
-    margin-top: ${spacing('8')};
+  .rdp-table {
+    border-spacing: 0;
+    border-collapse: collapse;
   }
 
-  .DayPicker-WeekdaysRow {
-    display: table-row;
-  }
-
-  .DayPicker-Weekday {
+  .rdp-head_cell {
     display: table-cell;
     padding: 0 ${spacing('2')} ${spacing('4')};
     text-align: center;
@@ -110,31 +102,35 @@ export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
     font-weight: 600;
   }
 
-  .DayPicker-Weekday abbr[title] {
-    border-bottom: none;
-    text-decoration: none;
+  .rdp-cell {
+    padding: 0;
+    height: ${DAY_SIZE};
+    width: ${DAY_SIZE};
+
+    &:not(:empty) {
+      border: 1px solid ${color('neutral', '000')};
+    }
   }
 
-  .DayPicker-Body {
-    display: table-row-group;
-  }
-
-  .DayPicker-Week {
-    display: table-row;
-  }
-
-  .DayPicker-Day {
+  .rdp-day {
     position: relative;
     display: table-cell;
-    border: 1px solid ${color('neutral', '000')};
+    border: none;
     font-size: ${fontSize('m')};
     font-weight: 400;
+    background: transparent;
     color: ${color('neutral', '500')};
     text-align: center;
     vertical-align: middle;
-    height: ${DAY_SIZE};
-    width: ${DAY_SIZE};
+    height: 100%;
+    width: 100%;
     cursor: pointer;
+
+    ${isIE11() &&
+    css`
+      height: ${`math(${DAY_SIZE} - 1px)`};
+      width: ${`math(${DAY_SIZE} - 1px)`};
+    `}
 
     &:focus {
       outline: none;
@@ -161,39 +157,27 @@ export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
     }
   }
 
-  .DayPicker-Day--outside {
-    border: none;
-    visibility: hidden;
-  }
-
-  &.DayPicker--interactionDisabled .DayPicker-Day,
-  .DayPicker-Day--outside {
-    cursor: default;
-  }
-
-  .DayPicker-Day:not(.DayPicker-Day--outside) {
-    &.DayPicker-Day--today {
+  .rdp-day {
+    &.rdp-day_today {
       color: ${color('warning', '800')};
     }
 
-    &.DayPicker-Day--selected {
+    &.rdp-day_selected {
       background-color: ${color('action', '000')};
     }
 
-    &.DayPicker-Day--start,
-    &.DayPicker-Day--end {
+    &.rdp-day_start,
+    &.rdp-day_end {
       color: ${color('neutral', 'white')};
       background-color: ${color('action', '700')};
     }
   }
 
-  &:not(.DayPicker--interactionDisabled) {
-    .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--start):not(.DayPicker-Day--end):not(.DayPicker-Day--outside):hover {
-      background-color: ${color('neutral', '100')};
-    }
+  .rdp-day:not(.rdp-day_disabled):not(.rdp-day_start):not(.rdp-day_end):hover {
+    background-color: ${color('neutral', '100')};
   }
 
-  .DayPicker-Day--disabled {
+  .rdp-day_disabled {
     color: ${color('neutral', '200')};
     pointer-events: none;
   }

--- a/packages/react-component-library/src/components/DatePicker/useFocusTrapOptions.ts
+++ b/packages/react-component-library/src/components/DatePicker/useFocusTrapOptions.ts
@@ -21,6 +21,7 @@ export function useFocusTrapOptions(
         isEventTargetDescendantOf(event, clickAllowedElementRefs),
       clickOutsideDeactivates: (event) =>
         !isEventTargetDescendantOf(event, clickAllowedElementRefs),
+      initialFocus: false,
       onDeactivate: close,
     }),
     [clickAllowedElementRefs, close]

--- a/packages/react-component-library/src/components/DatePicker/useFocusTrapOptions.ts
+++ b/packages/react-component-library/src/components/DatePicker/useFocusTrapOptions.ts
@@ -21,9 +21,6 @@ export function useFocusTrapOptions(
         isEventTargetDescendantOf(event, clickAllowedElementRefs),
       clickOutsideDeactivates: (event) =>
         !isEventTargetDescendantOf(event, clickAllowedElementRefs),
-      // Temporary workaround until we update to react-day-picker v8, which has a way
-      // to set the initial focus to the selected date (or today if no date selected)
-      initialFocus: '[role="button"]',
       onDeactivate: close,
     }),
     [clickAllowedElementRefs, close]

--- a/packages/react-component-library/src/components/DatePicker/useInput.ts
+++ b/packages/react-component-library/src/components/DatePicker/useInput.ts
@@ -14,7 +14,7 @@ function parseDate(datePickerFormat: string, value: string) {
     return new Date(NaN)
   }
 
-  return addHours(date, 12)
+  return date
 }
 
 export function useInput(

--- a/packages/react-component-library/src/components/DatePicker/useRangeHoverOrFocusDate.ts
+++ b/packages/react-component-library/src/components/DatePicker/useRangeHoverOrFocusDate.ts
@@ -3,14 +3,11 @@ import { useCallback, useState } from 'react'
 /**
  * Hook to keep track of the date being hovered over or focused
  * when in range mode.
- *
- * @todo Add handleDayBlur after upgrading to react-day-picker v8.
  */
 export function useRangeHoverOrFocusDate(isRange: boolean): {
   rangeHoverOrFocusDate: Date | null
-  handleDayFocus: (date: Date) => void
-  handleDayMouseEnter: (date: Date) => void
-  handleDayMouseLeave: () => void
+  handleDayFocusOrMouseEnter: (date: Date) => void
+  handleDayBlurOrMouseLeave: () => void
 } {
   const [rangeHoverOrFocusDate, setRangeHoverOrFocusDate] =
     useState<Date | null>(null)
@@ -24,7 +21,7 @@ export function useRangeHoverOrFocusDate(isRange: boolean): {
     [isRange]
   )
 
-  const handleDayMouseLeave = useCallback(() => {
+  const handleDayBlurOrMouseLeave = useCallback(() => {
     if (isRange) {
       setRangeHoverOrFocusDate(null)
     }
@@ -32,8 +29,7 @@ export function useRangeHoverOrFocusDate(isRange: boolean): {
 
   return {
     rangeHoverOrFocusDate,
-    handleDayFocus: handleDayFocusOrMouseEnter,
-    handleDayMouseEnter: handleDayFocusOrMouseEnter,
-    handleDayMouseLeave,
+    handleDayFocusOrMouseEnter,
+    handleDayBlurOrMouseLeave,
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3203,6 +3203,22 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
   integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
+"@reach/auto-id@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.16.0.tgz#dfabc3227844e8c04f8e6e45203a8e14a8edbaed"
+  integrity sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==
+  dependencies:
+    "@reach/utils" "0.16.0"
+    tslib "^2.3.0"
+
+"@reach/utils@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
+  integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==
+  dependencies:
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
 "@sinclair/typebox@^0.23.3":
   version "0.23.4"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.23.4.tgz#6ff93fd2585ce44f7481c9ff6af610fbb5de98a4"
@@ -14224,12 +14240,12 @@ react-compound-slider@^3.3.1:
     d3-array "^2.8.0"
     warning "^4.0.3"
 
-react-day-picker@^7.4.8:
-  version "7.4.10"
-  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.4.10.tgz#d3928fa65c04379ad28c76de22aa85374a8361e1"
-  integrity sha512-/QkK75qLKdyLmv0kcVzhL7HoJPazoZXS8a6HixbVoK6vWey1Od1WRLcxfyEiUsRfccAlIlf6oKHShqY2SM82rA==
+react-day-picker@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-8.0.4.tgz#1d6f2627ecec30752bbfd706edd6e664b1a04ed1"
+  integrity sha512-RaGClmZjCgDl0O8OlgMnhtUBZgmSWNTv6p5TUXo8E9VudMPL9azAR9UCqF0JQxcDPLbjLgeMZnm53K0rWtRLCQ==
   dependencies:
-    prop-types "^15.6.2"
+    "@reach/auto-id" "^0.16.0"
 
 react-docgen-typescript@^2.1.1:
   version "2.2.2"
@@ -16231,7 +16247,7 @@ tiny-invariant@^1.1.0:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
   integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
 
-tiny-warning@^1.0.2:
+tiny-warning@^1.0.2, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==


### PR DESCRIPTION
## Related issue

#2871
#2872 

## Overview

Work in progress PR to migrate DatePicker to react-day-picker v8.

## Link to preview

todo

## Reason

To resolve various accessibility and keyboard navigation problems.

## Work carried out

- [x] Migrate DatePicker to react-day-picker v8
- [x] Fix bug with shading of keyboard range selection when second date is blurred
- [x] Focus selected date or current date on open

## Demo

todo

## Developer notes

todo