### PR TITLE
fix(Breadcrumbs): Fix last item alignment in Firefox

### DIFF
--- a/packages/react-component-library/src/components/Breadcrumbs/partials/StyledEndTitle.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/partials/StyledEndTitle.tsx
@@ -3,4 +3,8 @@ import styled from 'styled-components'
 export const StyledEndTitle = styled.span`
   font-weight: 700;
   cursor: default;
+
+  @-moz-document url-prefix() {
+    transform: translateY(-1px);
+  }
 `


### PR DESCRIPTION
## Overview

Resolve visual alignment issue with last breadcrumb item in Firefox.

## Link to preview

https://61e94f61c979b00fe2fd5aad--determined-goldberg-40ba6c.netlify.app

## Reason

>The last item was misaligned due to increased `font-weight`. This is only an issue in Firefox.

## Work carried out

- [x] Add some browser specific styles

## Screenshot

![Screenshot 2022-01-20 at 12 02 05](https://user-images.githubusercontent.com/48086589/150335127-e943f9d4-b1be-497f-bdec-5db2e545e740.png)
