### PR TITLE
fix(DatePickerE): Allow state to be held externally

### DIFF
--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.stories.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.stories.tsx
@@ -2,12 +2,12 @@ import { action } from '@storybook/addon-actions'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { parseISO } from 'date-fns'
 import { Field, Form, Formik } from 'formik'
-import React from 'react'
+import React, { useState } from 'react'
 import * as yup from 'yup'
 
 import { withFormik } from '../../enhancers'
 import { ButtonE } from '../ButtonE'
-import { DatePickerE } from '.'
+import { DatePickerE, DatePickerEOnChangeData } from '.'
 
 export default {
   component: DatePickerE,
@@ -33,17 +33,17 @@ const Template: ComponentStory<typeof DatePickerE> = (args) => (
 
 export const Default = Template.bind({})
 
-export const WithExistingValue = Template.bind({})
-WithExistingValue.storyName = 'With existing value'
-WithExistingValue.args = {
-  startDate: parseISO('2021-12-15'),
+export const WithInitialValue = Template.bind({})
+WithInitialValue.storyName = 'With initial value'
+WithInitialValue.args = {
+  initialStartDate: parseISO('2021-12-15'),
 }
 
 export const CustomFormat = Template.bind({})
 CustomFormat.storyName = 'Custom format'
 CustomFormat.args = {
   format: 'yyyy/MM/dd',
-  startDate: parseISO('2021-01-11'),
+  initialStartDate: parseISO('2021-01-11'),
 }
 
 export const CustomInitialMonth = Template.bind({})
@@ -66,7 +66,7 @@ Disabled.args = {
 export const DisabledDays = Template.bind({})
 DisabledDays.storyName = 'Disabled days'
 DisabledDays.args = {
-  startDate: parseISO('2021-04-01'),
+  initialStartDate: parseISO('2021-04-01'),
   disabledDays: [
     parseISO('2021-04-12'),
     parseISO('2021-04-02'),
@@ -82,26 +82,25 @@ Range.args = {
   isRange: true,
 }
 
-export const RangeWithExistingValue = Template.bind({})
-RangeWithExistingValue.storyName = 'Range, with existing value'
-RangeWithExistingValue.args = {
+export const RangeWithInitialValue = Template.bind({})
+RangeWithInitialValue.storyName = 'Range, with initial values'
+RangeWithInitialValue.args = {
   isRange: true,
-  startDate: parseISO('2021-12-05'),
-  endDate: parseISO('2021-12-15'),
+  initialStartDate: parseISO('2021-12-05'),
+  initialEndDate: parseISO('2021-12-15'),
 }
 
 export const WithFormik: ComponentStory<typeof DatePickerE> = (props) => {
   interface Data {
     startDate: Date
     endDate: Date
-    anotherStartDate: Date | null
     andAnotherStartDate: Date | null
   }
 
   const errorText = 'Something went wrong!'
 
   const validationSchema = yup.object().shape({
-    andAnotherStartDate: yup.date().required(errorText),
+    andAnotherStartDate: yup.date().nullable().required(errorText),
   })
 
   const FormikDatePicker = withFormik(DatePickerE)
@@ -109,7 +108,6 @@ export const WithFormik: ComponentStory<typeof DatePickerE> = (props) => {
   const initialValues: Data = {
     startDate: new Date(2020, 0, 1),
     endDate: new Date(2020, 4, 1),
-    anotherStartDate: null,
     andAnotherStartDate: null,
   }
 
@@ -121,27 +119,28 @@ export const WithFormik: ComponentStory<typeof DatePickerE> = (props) => {
       onSubmit={action('onSubmit')}
       validationSchema={validationSchema}
     >
-      {({ setFieldValue }) => (
+      {({ setFieldValue, values }) => (
         <Form>
           <Field
             {...props}
             name="date"
             component={FormikDatePicker}
             isRange
-            onChange={({ startDate, endDate }: any) => {
+            onChange={({ startDate, endDate }: DatePickerEOnChangeData) => {
               setFieldValue('startDate', startDate)
               setFieldValue('endDate', endDate)
             }}
-            startDate={initialValues.startDate}
-            endDate={initialValues.endDate}
+            startDate={values.startDate}
+            endDate={values.endDate}
           />
           <Field
             name="andAnotherStartDate"
             label="And another date"
             component={FormikDatePicker}
-            onChange={({ startDate }: any) => {
+            onChange={({ startDate }: DatePickerEOnChangeData) => {
               setFieldValue('andAnotherStartDate', startDate)
             }}
+            startDate={values.andAnotherStartDate}
           />
           <ButtonE type="submit">Submit</ButtonE>
         </Form>

--- a/packages/react-component-library/src/components/DatePickerE/types.ts
+++ b/packages/react-component-library/src/components/DatePickerE/types.ts
@@ -1,4 +1,32 @@
-export interface StateObject {
+export interface DatePickerEState {
   from?: Date
   to?: Date
+  inputValue: string
+  datePickerFormat: string
 }
+
+export const DATEPICKER_E_ACTION = {
+  RESET: 'reset',
+  UPDATE: 'update',
+  REFRESH_INPUT_VALUE: 'refreshInputValue',
+} as const
+
+interface ResetAction {
+  type: typeof DATEPICKER_E_ACTION.RESET
+  data: Omit<DatePickerEState, 'inputValue'>
+}
+
+interface UpdateAction {
+  type: typeof DATEPICKER_E_ACTION.UPDATE
+  data: Partial<DatePickerEState>
+}
+
+interface RefreshInputValueAction {
+  type: typeof DATEPICKER_E_ACTION.REFRESH_INPUT_VALUE
+  data?: never
+}
+
+export type DatePickerEAction =
+  | ResetAction
+  | UpdateAction
+  | RefreshInputValueAction

--- a/packages/react-component-library/src/components/DatePickerE/useDatePickerEReducer.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useDatePickerEReducer.ts
@@ -1,0 +1,110 @@
+import { isEqual, isValid } from 'date-fns'
+import React, { useEffect, useReducer } from 'react'
+
+import { formatDatesForInput } from './formatDatesForInput'
+import {
+  DATEPICKER_E_ACTION,
+  DatePickerEAction,
+  DatePickerEState,
+} from './types'
+
+function init({
+  from,
+  to,
+  datePickerFormat,
+}: Omit<DatePickerEState, 'inputValue'>) {
+  return {
+    from,
+    to,
+    datePickerFormat,
+    inputValue: formatDatesForInput(from, to, datePickerFormat),
+  }
+}
+
+function reducer(
+  state: DatePickerEState,
+  action: DatePickerEAction
+): DatePickerEState {
+  switch (action.type) {
+    case DATEPICKER_E_ACTION.RESET:
+      return init(action.data)
+    case DATEPICKER_E_ACTION.UPDATE:
+      return { ...state, ...action.data }
+    case DATEPICKER_E_ACTION.REFRESH_INPUT_VALUE:
+      if (state.from && !isValid(state.from)) {
+        return state
+      }
+
+      return {
+        ...state,
+        inputValue: formatDatesForInput(
+          state.from,
+          state.to,
+          state.datePickerFormat
+        ),
+      }
+    default:
+      throw new Error('Unknown reducer action type')
+  }
+}
+
+function areDatesEqual(dateLeft: Date | null, dateRight: Date | null): boolean {
+  const bothDatesInvalid =
+    dateLeft && dateRight && !isValid(dateLeft) && !isValid(dateRight)
+
+  return (
+    dateLeft === dateRight || bothDatesInvalid || isEqual(dateLeft, dateRight)
+  )
+}
+
+function shouldReset(
+  state: DatePickerEState,
+  startDate: Date | undefined,
+  endDate: Date | undefined,
+  datePickerFormat: string,
+  isRange: boolean
+): boolean {
+  if (startDate === undefined && endDate === undefined) {
+    return false
+  }
+
+  return (
+    !areDatesEqual(state.from, startDate) ||
+    (isRange && !areDatesEqual(state.to, endDate)) ||
+    datePickerFormat !== state.datePickerFormat
+  )
+}
+
+export function useDatePickerEReducer(
+  startDate: Date | undefined,
+  endDate: Date | undefined,
+  initialStartDate: Date | undefined,
+  initialEndDate: Date | undefined,
+  datePickerFormat: string,
+  isRange: boolean
+): [DatePickerEState, React.Dispatch<DatePickerEAction>] {
+  const [state, dispatch] = useReducer(
+    reducer,
+    {
+      from: startDate === undefined ? initialStartDate : startDate,
+      to: endDate === undefined ? initialEndDate : endDate,
+      datePickerFormat,
+    },
+    init
+  )
+
+  useEffect(() => {
+    if (shouldReset(state, startDate, endDate, datePickerFormat, isRange)) {
+      dispatch({
+        type: DATEPICKER_E_ACTION.RESET,
+        data: {
+          from: startDate,
+          to: endDate,
+          datePickerFormat,
+        },
+      })
+    }
+  }, [datePickerFormat, endDate, isRange, startDate, state])
+
+  return [state, dispatch]
+}

--- a/packages/react-component-library/src/components/DatePickerE/useInput.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useInput.ts
@@ -1,9 +1,12 @@
 import { addHours, isValid, parse } from 'date-fns'
-import { useCallback } from 'react'
+import React, { useCallback } from 'react'
 
-import { StateObject } from './types'
-import { formatDatesForInput } from './formatDatesForInput'
 import { RETURN } from '../../utils/keyCodes'
+import {
+  DATEPICKER_E_ACTION,
+  DatePickerEAction,
+  DatePickerEState,
+} from './types'
 
 function parseDate(datePickerFormat: string, value: string) {
   if (!value) {
@@ -23,9 +26,9 @@ export function useInput(
   datePickerFormat: string,
   isRange: boolean,
   handleDayClick: (date: Date) => void,
-  state: StateObject,
+  state: DatePickerEState,
   setHasError: React.Dispatch<React.SetStateAction<boolean>>,
-  setInputValue: React.Dispatch<React.SetStateAction<string>>
+  dispatch: React.Dispatch<DatePickerEAction>
 ) {
   const { from } = state
 
@@ -35,11 +38,9 @@ export function useInput(
         return
       }
 
-      if (isValid(from)) {
-        setInputValue(formatDatesForInput(from, null, datePickerFormat))
-      }
+      dispatch({ type: DATEPICKER_E_ACTION.REFRESH_INPUT_VALUE })
     },
-    [datePickerFormat, from, isRange, setInputValue]
+    [dispatch, isRange]
   )
 
   const handleInputBlur = useCallback(() => {
@@ -47,12 +48,10 @@ export function useInput(
       return
     }
 
-    if (isValid(from)) {
-      setInputValue(formatDatesForInput(from, null, datePickerFormat))
-    }
+    dispatch({ type: DATEPICKER_E_ACTION.REFRESH_INPUT_VALUE })
 
     setHasError(from && !isValid(from))
-  }, [datePickerFormat, from, isRange, setHasError, setInputValue])
+  }, [dispatch, from, isRange, setHasError])
 
   const handleInputChange = useCallback(
     (event) => {
@@ -60,7 +59,13 @@ export function useInput(
         return
       }
 
-      setInputValue(event.currentTarget.value)
+      dispatch({
+        type: DATEPICKER_E_ACTION.UPDATE,
+        data: {
+          inputValue: event.currentTarget.value,
+        },
+      })
+
       const date = parseDate(datePickerFormat, event.currentTarget.value)
       handleDayClick(date)
 
@@ -68,7 +73,7 @@ export function useInput(
         setHasError(false)
       }
     },
-    [isRange, datePickerFormat, handleDayClick, setHasError, setInputValue]
+    [isRange, dispatch, datePickerFormat, handleDayClick, setHasError]
   )
 
   return {

--- a/packages/react-component-library/src/components/Timeline/context/reducer.ts
+++ b/packages/react-component-library/src/components/Timeline/context/reducer.ts
@@ -142,6 +142,6 @@ export function reducer(
         ),
       }
     default:
-      throw new Error('Unknown action type')
+      throw new Error('Unknown reducer action type')
   }
 }

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -202,6 +202,7 @@ export const Example: React.FC<unknown> = () => {
               name="exampleDatePicker"
               component={FormikDatePickerE}
               disabledDays={{ before: MINIMUM_DATE }}
+              startDate={values.exampleDatePicker}
               onChange={({ startDate }: DatePickerEOnChangeData) => {
                 setFieldValue('exampleDatePicker', startDate)
               }}

--- a/packages/react-component-library/src/forms/native/native.stories.tsx
+++ b/packages/react-component-library/src/forms/native/native.stories.tsx
@@ -187,6 +187,7 @@ export const Example: React.FC<unknown> = () => {
           data-testid="form-example-NumberInputE"
         />
         <DatePickerE
+          disabledDays={{ before: MINIMUM_DATE }}
           onChange={({ startDate }) => {
             handleChange({
               currentTarget: {
@@ -195,7 +196,7 @@ export const Example: React.FC<unknown> = () => {
               },
             })
           }}
-          disabledDays={{ before: MINIMUM_DATE }}
+          startDate={formState.exampleDatePicker}
         />
         {formErrors.exampleDatePicker && (
           <span>{formErrors.exampleDatePicker}</span>

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -185,13 +185,14 @@ export const Example: React.FC<unknown> = () => {
               return true
             },
           }}
-          render={({ onChange }) => {
+          render={({ onChange, value }) => {
             return (
               <DatePickerE
+                disabledDays={{ before: MINIMUM_DATE }}
                 onChange={({ startDate }) => {
                   onChange(startDate)
                 }}
-                disabledDays={{ before: MINIMUM_DATE }}
+                startDate={value}
               />
             )
           }}


### PR DESCRIPTION
## Related issue

Resovles #2971

## Overview

The makes DatePickerE compatible with use cases where the state is held in the parent component (e.g. a form library) and passed back to the component.

## Link to preview

https://5e25c277526d380020b5e418-vgnydmrmpy.chromatic.com/?path=/docs/date-picker-experimental--default

## Reason

This scenario should work as it's a common pattern when using forms.

## Work carried out

- [x] Split `startDate` and `endDate` props into `intialStartDate`, `intialEndDate`, `startDate` and `endDate`
- [x] Refactor the component to use the `useReducer` hook
- [x] Add stories demonstrating state being kept externally

## Developer notes

`initialStartDate` and `initialEndDate` are analogous to `defaultValue` in `<input>`, while `startDate` and `endDate` are analogous to `value` in `<input>`.

If `startDate` and `endDate` are used it is expected that the parent component keeps them updated using the onChange callback (same as `value` for `<input>`).

See the updated stories for examples.

Some further tidying up has been split into a separate PR:

- #3005
