### PR TITLE
refactor(DatePickerE): Tidy up reducer and related logic

### DIFF
--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.test.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.test.tsx
@@ -22,11 +22,6 @@ const ERROR_BOX_SHADOW = `0 0 0 ${
   BORDER_WIDTH[COMPONENT_SIZE.FORMS]
 } ${ColorDanger800.toUpperCase()}`
 
-function click(element: HTMLElement) {
-  fireEvent.mouseDown(element)
-  fireEvent.click(element)
-}
-
 function formatDate(date: Date | null) {
   return isValid(date) ? format(date, 'dd/MM/yyyy') : ''
 }
@@ -293,7 +288,7 @@ describe('DatePickerE', () => {
 
               describe('and clicks on a day', () => {
                 beforeEach(() => {
-                  click(wrapper.getByText('31'))
+                  userEvent.click(wrapper.getByText('31'))
                 })
 
                 it('set the value of the component to this date', () => {
@@ -399,7 +394,7 @@ describe('DatePickerE', () => {
         describe('and a day is selected', () => {
           beforeEach(() => {
             userEvent.click(wrapper.getByTestId('datepicker-input-button'))
-            click(wrapper.getByText('21'))
+            userEvent.click(wrapper.getByText('21'))
           })
 
           it('set the value of the component to the selected date', () => {
@@ -681,7 +676,7 @@ describe('DatePickerE', () => {
 
       describe('when the first day is clicked', () => {
         beforeEach(() => {
-          click(wrapper.getByText('1'))
+          userEvent.click(wrapper.getByText('1'))
         })
 
         it('updates the input value', () => {
@@ -816,7 +811,7 @@ describe('DatePickerE', () => {
 
       describe('and clicks on a second date', () => {
         beforeEach(() => {
-          click(wrapper.getByText('20'))
+          userEvent.click(wrapper.getByText('20'))
         })
 
         it('closes the day picker', () => {
@@ -854,7 +849,7 @@ describe('DatePickerE', () => {
 
       describe('and clicks on a date less than the first', () => {
         beforeEach(() => {
-          click(wrapper.getByText('9'))
+          userEvent.click(wrapper.getByText('9'))
         })
 
         it('closes the day picker', () => {
@@ -1004,7 +999,9 @@ describe('DatePickerE', () => {
 
     describe('and a disabled day is clicked', () => {
       beforeEach(() => {
-        click(wrapper.getByText('12'))
+        userEvent.click(wrapper.getByText('12'), undefined, {
+          skipPointerEventsCheck: true,
+        })
       })
 
       it('does not set the picker to that day', () => {

--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
@@ -24,9 +24,9 @@ import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
 import { useExternalId } from '../../hooks/useExternalId'
 import { useFocus } from '../../hooks/useFocus'
 import { useFocusTrapOptions } from './useFocusTrapOptions'
+import { useHandleDayClick } from './useHandleDayClick'
 import { useInput } from './useInput'
 import { useRangeHoverOrFocusDate } from './useRangeHoverOrFocusDate'
-import { useSelection } from './useSelection'
 import { useStatefulRef } from '../../hooks/useStatefulRef'
 import { useDatePickerEReducer } from './useDatePickerEReducer'
 
@@ -205,7 +205,7 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
     datePickerFormat,
     isRange
   )
-  const handleDayClick = useSelection(
+  const handleDayClick = useHandleDayClick(
     state,
     dispatch,
     isRange,

--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
@@ -1,7 +1,7 @@
 import { IconEvent } from '@defencedigital/icon-library'
 import { isValid } from 'date-fns'
 import FocusTrap from 'focus-trap-react'
-import React, { useRef, useState } from 'react'
+import React, { useRef } from 'react'
 import { Placement } from '@popperjs/core'
 import { DayModifiers, DayPickerProps } from 'react-day-picker'
 import { useBoolean } from 'usehooks-ts'
@@ -213,10 +213,9 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
     onChange
   )
   const { startDate, endDate } = state
+  const hasError =
+    state.hasError || isInvalid || hasClass(className, 'is-invalid')
 
-  const [hasError, setHasError] = useState<boolean>(
-    isInvalid || hasClass(className, 'is-invalid')
-  )
   const [floatingBoxTarget, setFloatingBoxTarget] = useStatefulRef()
 
   const {
@@ -230,8 +229,6 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
     datePickerFormat,
     isRange,
     handleDayClick,
-    state,
-    setHasError,
     dispatch
   )
 
@@ -343,8 +340,9 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
                 return
               }
 
-              setHasError(false)
               const newState = handleDayClick(day)
+
+              dispatch({ type: DATEPICKER_E_ACTION.REFRESH_HAS_ERROR })
               dispatch({ type: DATEPICKER_E_ACTION.REFRESH_INPUT_VALUE })
 
               if (newState.endDate || !isRange) {

--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
@@ -159,7 +159,7 @@ const replaceInvalidDate = (date: Date) => (isValid(date) ? date : undefined)
 
 export const DatePickerE: React.FC<DatePickerEProps> = ({
   className,
-  endDate,
+  endDate: externalEndDate,
   format: datePickerFormat = DATE_FORMAT.SHORT,
   id: externalId,
   isDisabled,
@@ -168,7 +168,7 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
   label = 'Date',
   onChange,
   onCalendarFocus,
-  startDate,
+  startDate: externalStartDate,
   initialIsOpen,
   disabledDays,
   initialMonth,
@@ -198,8 +198,8 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
   )
 
   const [state, dispatch] = useDatePickerEReducer(
-    startDate,
-    endDate,
+    externalStartDate,
+    externalEndDate,
     initialStartDate,
     initialEndDate,
     datePickerFormat,
@@ -212,6 +212,7 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
     disabledDays,
     onChange
   )
+  const { startDate, endDate } = state
 
   const [hasError, setHasError] = useState<boolean>(
     isInvalid || hasClass(className, 'is-invalid')
@@ -225,7 +226,6 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
     handleDayMouseLeave,
   } = useRangeHoverOrFocusDate(isRange)
 
-  const { from, to } = state
   const { handleKeyDown, handleInputBlur, handleInputChange } = useInput(
     datePickerFormat,
     isRange,
@@ -236,11 +236,11 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
   )
 
   const modifiers = {
-    start: replaceInvalidDate(from),
-    end: replaceInvalidDate(to),
+    start: replaceInvalidDate(startDate),
+    end: replaceInvalidDate(endDate),
   }
 
-  const hasContent = Boolean(from)
+  const hasContent = Boolean(startDate)
 
   const placeholder = !isRange ? datePickerFormat.toLowerCase() : null
 
@@ -333,8 +333,8 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
             weekdaysShort={WEEKDAY_TITLES}
             selectedDays={[
               {
-                from: replaceInvalidDate(from),
-                to: replaceInvalidDate(to) || rangeHoverOrFocusDate,
+                from: replaceInvalidDate(startDate),
+                to: replaceInvalidDate(endDate) || rangeHoverOrFocusDate,
               },
             ]}
             modifiers={modifiers}
@@ -347,11 +347,11 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
               const newState = handleDayClick(day)
               dispatch({ type: DATEPICKER_E_ACTION.REFRESH_INPUT_VALUE })
 
-              if (newState.to || !isRange) {
+              if (newState.endDate || !isRange) {
                 setTimeout(() => close())
               }
             }}
-            initialMonth={replaceInvalidDate(from) || initialMonth}
+            initialMonth={replaceInvalidDate(startDate) || initialMonth}
             disabledDays={disabledDays}
             $isRange={isRange}
             $isVisible={isOpen}

--- a/packages/react-component-library/src/components/DatePickerE/partials/StyledSeparator.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/partials/StyledSeparator.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
-const { color, spacing } = selectors
+const { color } = selectors
 
 export const StyledSeparator = styled.div`
   width: 1px;

--- a/packages/react-component-library/src/components/DatePickerE/types.ts
+++ b/packages/react-component-library/src/components/DatePickerE/types.ts
@@ -1,6 +1,6 @@
 export interface DatePickerEState {
-  from?: Date
-  to?: Date
+  startDate?: Date
+  endDate?: Date
   inputValue: string
   datePickerFormat: string
 }

--- a/packages/react-component-library/src/components/DatePickerE/types.ts
+++ b/packages/react-component-library/src/components/DatePickerE/types.ts
@@ -3,22 +3,29 @@ export interface DatePickerEState {
   endDate?: Date
   inputValue: string
   datePickerFormat: string
+  hasError: boolean
 }
 
 export const DATEPICKER_E_ACTION = {
   RESET: 'reset',
   UPDATE: 'update',
+  REFRESH_HAS_ERROR: 'refreshHasError',
   REFRESH_INPUT_VALUE: 'refreshInputValue',
 } as const
 
 interface ResetAction {
   type: typeof DATEPICKER_E_ACTION.RESET
-  data: Omit<DatePickerEState, 'inputValue'>
+  data: Omit<DatePickerEState, 'hasError' | 'inputValue'>
 }
 
 interface UpdateAction {
   type: typeof DATEPICKER_E_ACTION.UPDATE
   data: Partial<DatePickerEState>
+}
+
+interface RefreshHasErrorAction {
+  type: typeof DATEPICKER_E_ACTION.REFRESH_HAS_ERROR
+  data?: never
 }
 
 interface RefreshInputValueAction {
@@ -29,4 +36,5 @@ interface RefreshInputValueAction {
 export type DatePickerEAction =
   | ResetAction
   | UpdateAction
+  | RefreshHasErrorAction
   | RefreshInputValueAction

--- a/packages/react-component-library/src/components/DatePickerE/useDatePickerEReducer.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useDatePickerEReducer.ts
@@ -12,11 +12,12 @@ function init({
   startDate,
   endDate,
   datePickerFormat,
-}: Omit<DatePickerEState, 'inputValue'>) {
+}: Omit<DatePickerEState, 'hasError' | 'inputValue'>) {
   return {
     startDate,
     endDate,
     datePickerFormat,
+    hasError: false,
     inputValue: formatDatesForInput(startDate, endDate, datePickerFormat),
   }
 }
@@ -30,6 +31,11 @@ function reducer(
       return init(action.data)
     case DATEPICKER_E_ACTION.UPDATE:
       return { ...state, ...action.data }
+    case DATEPICKER_E_ACTION.REFRESH_HAS_ERROR:
+      return {
+        ...state,
+        hasError: state.startDate && !isValid(state.startDate),
+      }
     case DATEPICKER_E_ACTION.REFRESH_INPUT_VALUE:
       if (state.startDate && !isValid(state.startDate)) {
         return state

--- a/packages/react-component-library/src/components/DatePickerE/useDatePickerEReducer.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useDatePickerEReducer.ts
@@ -9,15 +9,15 @@ import {
 } from './types'
 
 function init({
-  from,
-  to,
+  startDate,
+  endDate,
   datePickerFormat,
 }: Omit<DatePickerEState, 'inputValue'>) {
   return {
-    from,
-    to,
+    startDate,
+    endDate,
     datePickerFormat,
-    inputValue: formatDatesForInput(from, to, datePickerFormat),
+    inputValue: formatDatesForInput(startDate, endDate, datePickerFormat),
   }
 }
 
@@ -31,15 +31,15 @@ function reducer(
     case DATEPICKER_E_ACTION.UPDATE:
       return { ...state, ...action.data }
     case DATEPICKER_E_ACTION.REFRESH_INPUT_VALUE:
-      if (state.from && !isValid(state.from)) {
+      if (state.startDate && !isValid(state.startDate)) {
         return state
       }
 
       return {
         ...state,
         inputValue: formatDatesForInput(
-          state.from,
-          state.to,
+          state.startDate,
+          state.endDate,
           state.datePickerFormat
         ),
       }
@@ -69,8 +69,8 @@ function shouldReset(
   }
 
   return (
-    !areDatesEqual(state.from, startDate) ||
-    (isRange && !areDatesEqual(state.to, endDate)) ||
+    !areDatesEqual(state.startDate, startDate) ||
+    (isRange && !areDatesEqual(state.endDate, endDate)) ||
     datePickerFormat !== state.datePickerFormat
   )
 }
@@ -86,8 +86,8 @@ export function useDatePickerEReducer(
   const [state, dispatch] = useReducer(
     reducer,
     {
-      from: startDate === undefined ? initialStartDate : startDate,
-      to: endDate === undefined ? initialEndDate : endDate,
+      startDate: startDate === undefined ? initialStartDate : startDate,
+      endDate: endDate === undefined ? initialEndDate : endDate,
       datePickerFormat,
     },
     init
@@ -98,8 +98,8 @@ export function useDatePickerEReducer(
       dispatch({
         type: DATEPICKER_E_ACTION.RESET,
         data: {
-          from: startDate,
-          to: endDate,
+          startDate,
+          endDate,
           datePickerFormat,
         },
       })

--- a/packages/react-component-library/src/components/DatePickerE/useHandleDayClick.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useHandleDayClick.ts
@@ -13,19 +13,23 @@ import {
   DatePickerEState,
 } from './types'
 
-function getNewState(isRange: boolean, day: Date, state: DatePickerEState) {
+function getNewState(
+  isRange: boolean,
+  day: Date,
+  { startDate, endDate }: DatePickerEState
+) {
   if (!isRange) {
-    return { from: day, to: day }
+    return { startDate: day, endDate: day }
   }
 
-  if (state.from && !state.to) {
+  if (startDate && !endDate) {
     return {
-      from: min([state.from, day]),
-      to: max([state.from, day]),
+      startDate: min([startDate, day]),
+      endDate: max([startDate, day]),
     }
   }
 
-  return { from: day, to: null }
+  return { startDate: day, endDate: null }
 }
 
 function calculateDateValidity(
@@ -53,7 +57,7 @@ export const useHandleDayClick = (
   isRange: boolean,
   disabledDays: DayPickerProps['disabledDays'],
   onChange?: (data: DatePickerEOnChangeData) => void
-): ((day: Date) => { from: Date; to: Date }) => {
+): ((day: Date) => { startDate: Date; endDate: Date }) => {
   function handleDayClick(day: Date) {
     const newState = getNewState(isRange, day, state)
 
@@ -62,14 +66,14 @@ export const useHandleDayClick = (
       data: newState,
     })
 
-    const { from: newFrom, to: newTo } = newState
+    const { startDate, endDate } = newState
 
     if (onChange) {
       onChange({
-        startDate: newFrom,
-        startDateValidity: calculateDateValidity(newFrom, disabledDays),
-        endDate: newTo,
-        endDateValidity: calculateDateValidity(newTo, disabledDays),
+        startDate,
+        startDateValidity: calculateDateValidity(startDate, disabledDays),
+        endDate,
+        endDateValidity: calculateDateValidity(endDate, disabledDays),
       })
     }
 

--- a/packages/react-component-library/src/components/DatePickerE/useHandleDayClick.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useHandleDayClick.ts
@@ -47,7 +47,7 @@ function calculateDateValidity(
   return DATE_VALIDITY.VALID
 }
 
-export const useSelection = (
+export const useHandleDayClick = (
   state: DatePickerEState,
   dispatch: React.Dispatch<DatePickerEAction>,
   isRange: boolean,

--- a/packages/react-component-library/src/components/DatePickerE/useInput.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useInput.ts
@@ -2,11 +2,7 @@ import { addHours, isValid, parse } from 'date-fns'
 import React, { useCallback } from 'react'
 
 import { RETURN } from '../../utils/keyCodes'
-import {
-  DATEPICKER_E_ACTION,
-  DatePickerEAction,
-  DatePickerEState,
-} from './types'
+import { DATEPICKER_E_ACTION, DatePickerEAction } from './types'
 
 function parseDate(datePickerFormat: string, value: string) {
   if (!value) {
@@ -26,12 +22,8 @@ export function useInput(
   datePickerFormat: string,
   isRange: boolean,
   handleDayClick: (date: Date) => void,
-  state: DatePickerEState,
-  setHasError: React.Dispatch<React.SetStateAction<boolean>>,
   dispatch: React.Dispatch<DatePickerEAction>
 ) {
-  const { startDate } = state
-
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
       if (isRange || event.keyCode !== RETURN) {
@@ -48,10 +40,9 @@ export function useInput(
       return
     }
 
+    dispatch({ type: DATEPICKER_E_ACTION.REFRESH_HAS_ERROR })
     dispatch({ type: DATEPICKER_E_ACTION.REFRESH_INPUT_VALUE })
-
-    setHasError(startDate && !isValid(startDate))
-  }, [dispatch, startDate, isRange, setHasError])
+  }, [dispatch, isRange])
 
   const handleInputChange = useCallback(
     (event) => {
@@ -68,12 +59,8 @@ export function useInput(
 
       const date = parseDate(datePickerFormat, event.currentTarget.value)
       handleDayClick(date)
-
-      if (isValid(date)) {
-        setHasError(false)
-      }
     },
-    [isRange, dispatch, datePickerFormat, handleDayClick, setHasError]
+    [isRange, dispatch, datePickerFormat, handleDayClick]
   )
 
   return {

--- a/packages/react-component-library/src/components/DatePickerE/useInput.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useInput.ts
@@ -30,7 +30,7 @@ export function useInput(
   setHasError: React.Dispatch<React.SetStateAction<boolean>>,
   dispatch: React.Dispatch<DatePickerEAction>
 ) {
-  const { from } = state
+  const { startDate } = state
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -50,8 +50,8 @@ export function useInput(
 
     dispatch({ type: DATEPICKER_E_ACTION.REFRESH_INPUT_VALUE })
 
-    setHasError(from && !isValid(from))
-  }, [dispatch, from, isRange, setHasError])
+    setHasError(startDate && !isValid(startDate))
+  }, [dispatch, startDate, isRange, setHasError])
 
   const handleInputChange = useCallback(
     (event) => {


### PR DESCRIPTION
## Related issue

Resolves #2971

## Overview

This tidies up various bits of DatePickerE

## Link to preview

https://5e25c277526d380020b5e418-afotyleznc.chromatic.com/?path=/docs/date-picker-experimental--default

## Reason

Split from #3004 to reduce PR size and noise.

## Work carried out

- [x] Rename useSelection hook
- [x] Rename `from` and `to` state properties to `startDate` and `endDate ` for consistency
- [x] Move `hasError` into the reducer
- [x] Remove redundant `click()` function from tests

## Developer notes

n/a
