### PR TITLE
fix(Select): Handle overflowing option label

### DIFF
--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -8,6 +8,11 @@ const options = [
   { value: 'chocolate', label: 'Chocolate', badge: 100 },
   { value: 'melon', label: 'Melon' },
   { value: 'strawberry', label: 'Strawberry' },
+  {
+    value: 'foo',
+    label:
+      'This is a really, really long select option label that overflows the container when selected',
+  },
 ]
 
 export default {
@@ -25,7 +30,12 @@ export default {
 } as ComponentMeta<typeof Select>
 
 const Template: ComponentStory<typeof Select> = (args) => (
-  <div style={{ height: args.isDisabled ? 'initial' : '10rem' }}>
+  <div
+    style={{
+      height: args.isDisabled ? 'initial' : '13rem',
+      maxWidth: '25rem',
+    }}
+  >
     <Select {...args} />
   </div>
 )

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
 } from '@testing-library/react'
 import { IconAnchor } from '@defencedigital/icon-library'
+import userEvent from '@testing-library/user-event'
 
 import { Select } from '.'
 import { Button } from '../Button'
@@ -288,6 +289,47 @@ describe('Select', () => {
         expect(
           wrapper.getByTestId('select-single-value-label')
         ).toHaveTextContent('Option 3')
+      })
+    })
+  })
+
+  describe('when an option value is selected that overflows', () => {
+    const label =
+      'This is a really, really long select option label that overflows the container when selected'
+
+    beforeEach(() => {
+      wrapper = render(
+        <Select
+          options={[
+            ...options,
+            {
+              label,
+              value: 'foo',
+            },
+          ]}
+        />
+      )
+
+      const input = wrapper.getByTestId('react-select-vendor-input')
+      fireEvent.focus(input)
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown',
+        code: 40,
+      })
+
+      userEvent.click(wrapper.getByText(label))
+    })
+
+    describe('when the user hovers over the label', () => {
+      beforeEach(() => {
+        userEvent.hover(wrapper.getByText(label))
+      })
+
+      it('displays the Tooltip with the label content', () => {
+        expect(wrapper.getByTestId('floating-box')).toBeInTheDocument()
+        expect(wrapper.getByTestId('floating-box-content')).toHaveTextContent(
+          label
+        )
       })
     })
   })

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -333,4 +333,31 @@ describe('Select', () => {
       })
     })
   })
+
+  describe('when the optional `onChange` callback is not provided and the user selects an item', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Select
+          options={[
+            ...options,
+            {
+              label: 'Foo',
+              value: 'foo',
+            },
+          ]}
+        />
+      )
+
+      const input = wrapper.getByTestId('react-select-vendor-input')
+      fireEvent.focus(input)
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown',
+        code: 40,
+      })
+    })
+
+    it('should not attempt to invoke the `onChange` callback', () => {
+      expect(() => userEvent.click(wrapper.getByText('Foo'))).not.toThrow()
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import ReactSelect, { Props as ReactSelectProps } from 'react-select'
 
 import { DropdownIndicator } from '../Dropdown/DropdownIndicator'

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -61,12 +61,14 @@ export const Select: React.FC<SelectProps> = ({
       option && option.value !== undefined ? option.value : null
     setSelectedValue(selectedValue)
 
-    onChange({
-      target: {
-        name,
-        value: selectedValue,
-      },
-    })
+    if (onChange) {
+      onChange({
+        target: {
+          name,
+          value: selectedValue,
+        },
+      })
+    }
   }
 
   return (

--- a/packages/react-component-library/src/components/Select/SingleValue.tsx
+++ b/packages/react-component-library/src/components/Select/SingleValue.tsx
@@ -1,20 +1,43 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { SingleValueProps } from 'react-select/src/components/SingleValue'
 
 import { BADGE_SIZE } from '../Badge'
 import { StyledBadge } from './partials/StyledBadge'
 import { SelectOptionWithBadgeType } from './Option'
 import { StyledSingleValue } from './partials/StyledSingleValue'
+import { StyledSingleValueLabel } from './partials/StyledSingleValueLabel'
+import { FloatingBox } from '../../primitives/FloatingBox'
+import { useStatefulRef } from '../../hooks/useStatefulRef'
+import { StyledTooltip } from './partials/StyledTooltip'
 
 export const SingleValue: React.FC<
   SingleValueProps<SelectOptionWithBadgeType>
 > = ({ children, ...props }) => {
+  const [floatingBoxTarget, setFloatingBoxTarget] = useStatefulRef()
+  const [showTooltip, setShowTooltip] = useState<boolean>(false)
   const { badge } = props.data
 
   return (
-    <StyledSingleValue data-testid="select-single-value" {...props}>
-      <span data-testid="select-single-value-label">{children}</span>
-      {badge && <StyledBadge size={BADGE_SIZE.XSMALL}>{badge}</StyledBadge>}
-    </StyledSingleValue>
+    <>
+      <StyledSingleValue data-testid="select-single-value" {...props}>
+        <StyledSingleValueLabel
+          data-testid="select-single-value-label"
+          onMouseEnter={(_) => setShowTooltip(true)}
+          onMouseLeave={(_) => setShowTooltip(false)}
+          ref={setFloatingBoxTarget}
+        >
+          {children}
+        </StyledSingleValueLabel>
+        {badge && <StyledBadge size={BADGE_SIZE.XSMALL}>{badge}</StyledBadge>}
+      </StyledSingleValue>
+      <FloatingBox
+        placement="bottom"
+        scheme="dark"
+        isVisible={showTooltip}
+        targetElement={floatingBoxTarget}
+      >
+        <StyledTooltip>{children}</StyledTooltip>
+      </FloatingBox>
+    </>
   )
 }

--- a/packages/react-component-library/src/components/Select/partials/StyledSingleValue.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledSingleValue.tsx
@@ -5,10 +5,13 @@ import styled from 'styled-components'
 const { fontSize, spacing } = selectors
 
 export const StyledSingleValue = styled(components.SingleValue)`
-  font-size: ${fontSize('base')};
-  overflow: visible;
-
   &&& {
     margin: ${spacing('4')} 0 0 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: ${fontSize('base')};
+    max-width: calc(100% - 95px);
+    overflow: visible;
   }
 `

--- a/packages/react-component-library/src/components/Select/partials/StyledSingleValueLabel.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledSingleValueLabel.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+export const StyledSingleValueLabel = styled.span`
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 6px 0;
+`

--- a/packages/react-component-library/src/components/Select/partials/StyledTooltip.tsx
+++ b/packages/react-component-library/src/components/Select/partials/StyledTooltip.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+import { selectors } from '@defencedigital/design-tokens'
+
+const { fontSize, spacing } = selectors
+
+export const StyledTooltip = styled.span`
+  display: inline-flex;
+  font-size: ${fontSize('base')};
+  padding: ${spacing('6')} ${spacing('8')};
+`


### PR DESCRIPTION
## Related issue

Closes #2951

## Overview

Truncate and add ellipses to overflowing select label content. Also add Tooltip to the selected option label that displays on hover.

## Link to preview

https://61f2771ee6b8899f7e9c826a--infallible-meitner-a1d8bb.netlify.app

## Reason

>When a select element contains text that does not fit it overflows the component, blocking the "X" and drop down icon.

## Work carried out

- [x] Remove some unsued imports
- [x] Handle overflowing selected values
- [x] Check optional onChange callback exists before invoking to avoid error

## Screenshot

![2022-01-25 12 25 22](https://user-images.githubusercontent.com/48086589/150979761-96e09838-a80b-4ef8-bb18-46785a57a92b.gif)

## Developer notes

This component is about to be superseeded by the new `3.x.x` implementation. I've created a [seperate issue](https://github.com/defencedigital/mod-uk-design-system/issues/3023) to look into the behaviour there as it doesn't appear to handle this scenario yet.
