### PR TITLE
fix(CheckboxE): Fix inability to use space to toggle state in Firefox

### DIFF
--- a/packages/react-component-library/cypress/selectors/CheckboxE.ts
+++ b/packages/react-component-library/cypress/selectors/CheckboxE.ts
@@ -1,0 +1,4 @@
+export default {
+  input: '[data-testid="checkbox-input"]',
+  wrapper: '[data-testid="checkbox"]',
+}

--- a/packages/react-component-library/cypress/selectors/index.ts
+++ b/packages/react-component-library/cypress/selectors/index.ts
@@ -1,4 +1,5 @@
 import autocompleteE from './AutocompleteE'
+import checkboxE from './CheckboxE'
 import contextMenu from './ContextMenu'
 import datePicker from './DatePicker'
 import form from './form'
@@ -9,6 +10,7 @@ import timeline from './timeline'
 
 export default {
   autocompleteE,
+  checkboxE,
   contextMenu,
   datePicker,
   form,

--- a/packages/react-component-library/cypress/specs/CheckboxE/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/CheckboxE/index.spec.ts
@@ -1,0 +1,46 @@
+/// <reference types="cypress-plugin-tab/src" />
+import { beforeEach, cy, describe, it } from 'local-cypress'
+
+import selectors from '../../selectors'
+
+describe('CheckboxE', () => {
+  beforeEach(() => {
+    cy.visit('/iframe.html?id=checkbox-experimental--default&viewMode=story')
+  })
+
+  it('does not check the input by default', () => {
+    cy.get(selectors.checkboxE.input).should('not.be.checked')
+  })
+
+  describe(`when the component is clicked on`, () => {
+    beforeEach(() => {
+      cy.get(selectors.checkboxE.wrapper).click()
+    })
+
+    it('checks the input', () => {
+      cy.get(selectors.checkboxE.input).should('be.checked')
+    })
+
+    describe(`and the component is clicked on again`, () => {
+      beforeEach(() => {
+        cy.get(selectors.checkboxE.wrapper).click()
+      })
+
+      it('unchecks the input', () => {
+        cy.get(selectors.checkboxE.input).should('not.be.checked')
+      })
+    })
+  })
+
+  describe('when tab is pressed', () => {
+    beforeEach(() => {
+      // Make sure the component has rendered before tabbing
+      cy.get(selectors.checkboxE.input)
+      cy.get('body').tab()
+    })
+
+    it('focuses the input', () => {
+      cy.get(selectors.checkboxE.input).should('be.focused')
+    })
+  })
+})

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.test.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.test.tsx
@@ -58,9 +58,7 @@ describe('Checkbox', () => {
     })
 
     it('should not initially render as checked', () => {
-      expect(checkbox.getByTestId('checkbox-input')).not.toHaveAttribute(
-        'checked'
-      )
+      expect(checkbox.getByTestId('checkbox-input')).not.toBeChecked()
     })
   })
 
@@ -81,7 +79,7 @@ describe('Checkbox', () => {
     })
 
     it('should initially render as checked', () => {
-      expect(checkbox.getByTestId('checkbox-input')).toHaveAttribute('checked')
+      expect(checkbox.getByTestId('checkbox-input')).toBeChecked()
     })
   })
 
@@ -102,7 +100,7 @@ describe('Checkbox', () => {
     })
 
     it('should initially render as checked', () => {
-      expect(checkbox.getByTestId('checkbox-input')).toHaveAttribute('checked')
+      expect(checkbox.getByTestId('checkbox-input')).toBeChecked()
     })
   })
 

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.test.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { CheckboxE } from '.'
 import { FieldProps } from '../../common/FieldProps'
@@ -12,14 +13,16 @@ describe('Checkbox', () => {
   let form: FormProps
   let label: string
   let checkbox: RenderResult
+  let onChangeSpy: jest.Mock
 
   beforeEach(() => {
     label = ''
+    onChangeSpy = jest.fn()
 
     field = {
       name: 'example1',
       value: 'false',
-      onChange: jest.fn(),
+      onChange: onChangeSpy,
       onBlur: jest.fn(),
     }
 
@@ -30,6 +33,8 @@ describe('Checkbox', () => {
   })
 
   describe('when a field has no errors, a label and a value', () => {
+    let input: HTMLElement
+
     beforeEach(() => {
       label = 'My Label 1'
       field.value = 'false'
@@ -42,6 +47,8 @@ describe('Checkbox', () => {
           onChange={field.onChange}
         />
       )
+
+      input = checkbox.getByTestId('checkbox-input')
     })
 
     it('should render a field with a label', () => {
@@ -51,14 +58,50 @@ describe('Checkbox', () => {
     })
 
     it('should populate the field value', () => {
-      expect(checkbox.queryByTestId('checkbox-input')).toHaveAttribute(
-        'value',
-        'false'
-      )
+      expect(input).toHaveAttribute('value', 'false')
     })
 
     it('should not initially render as checked', () => {
-      expect(checkbox.getByTestId('checkbox-input')).not.toBeChecked()
+      expect(input).not.toBeChecked()
+    })
+
+    describe('and tab is pressed', () => {
+      beforeEach(() => {
+        userEvent.tab()
+      })
+
+      it('focuses the input', () => {
+        expect(input).toHaveFocus()
+      })
+
+      describe('and space is pressed', () => {
+        beforeEach(() => {
+          userEvent.keyboard('[Space]')
+        })
+
+        it('checks the input', () => {
+          expect(input).toBeChecked()
+        })
+
+        it('calls onChange once', () => {
+          expect(field.onChange).toHaveBeenCalledTimes(1)
+        })
+
+        describe('and space is pressed again', () => {
+          beforeEach(() => {
+            onChangeSpy.mockReset()
+            userEvent.keyboard('[Space]')
+          })
+
+          it('unchecks the input', () => {
+            expect(input).not.toBeChecked()
+          })
+
+          it('calls onChange once', () => {
+            expect(field.onChange).toHaveBeenCalledTimes(1)
+          })
+        })
+      })
     })
   })
 

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
@@ -73,8 +73,10 @@ export const CheckboxE = React.forwardRef<HTMLInputElement, CheckboxEProps>(
     const localRef = useRef<HTMLInputElement>(null)
     const [isChecked, setIsChecked] = useState(defaultChecked || checked)
 
-    const handleClick = (_: React.MouseEvent<HTMLDivElement>) => {
-      localRef.current.click()
+    const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.target !== localRef.current) {
+        localRef.current.click()
+      }
     }
 
     const handleKeyUp = (_: React.KeyboardEvent) => {

--- a/packages/react-component-library/src/components/RadioE/RadioE.test.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { FieldProps } from '../../common/FieldProps'
 import { FormProps } from '../../common/FormProps'
@@ -30,6 +31,8 @@ describe('RadioE', () => {
   })
 
   describe('when the field has no errors, a label and a value', () => {
+    let input: HTMLElement
+
     beforeEach(() => {
       label = 'My Label 1'
       field.value = 'option1'
@@ -42,6 +45,8 @@ describe('RadioE', () => {
           label={label}
         />
       )
+
+      input = radio.getByTestId('radio-input')
     })
 
     it('should render a field with a label', () => {
@@ -49,10 +54,31 @@ describe('RadioE', () => {
     })
 
     it('should populate the field value', () => {
-      expect(radio.queryByTestId('radio-input')).toHaveAttribute(
-        'value',
-        'option1'
-      )
+      expect(input).toHaveAttribute('value', 'option1')
+    })
+
+    describe('and tab is pressed', () => {
+      beforeEach(() => {
+        userEvent.tab()
+      })
+
+      it('focuses the input', () => {
+        expect(input).toHaveFocus()
+      })
+
+      describe('and space is pressed', () => {
+        beforeEach(() => {
+          userEvent.keyboard('[Space]')
+        })
+
+        it('checks the input', () => {
+          expect(input).toBeChecked()
+        })
+
+        it('calls onChange once', () => {
+          expect(field.onChange).toHaveBeenCalledTimes(1)
+        })
+      })
     })
   })
 

--- a/packages/react-component-library/src/components/RadioE/RadioE.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.tsx
@@ -65,8 +65,10 @@ export const RadioE = React.forwardRef<HTMLInputElement, RadioEProps>(
   ) => {
     const localRef = useRef<HTMLInputElement>(null)
 
-    const handleClick = (_: React.MouseEvent<HTMLDivElement>) => {
-      localRef.current.click()
+    const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.target !== localRef.current) {
+        localRef.current.click()
+      }
     }
 
     const handleKeyUp = (_: React.KeyboardEvent) => {


### PR DESCRIPTION
## Related issue

Resolves #3012

## Overview

This fixes a bug with CheckboxE where the space key would double-toggle the input.

## Link to preview

CheckboxE:

https://5e25c277526d380020b5e418-jyjeyhqiwf.chromatic.com/?path=/docs/checkbox-experimental--default

RadioE (behaviour should be unchanged):

https://5e25c277526d380020b5e418-jyjeyhqiwf.chromatic.com/?path=/docs/radio-experimental--default

## Reason

To make sure the component works correctly using the keyboard.

## Work carried out

- [x] Add Cypress tests
- [x] Fix bug
- [x] Tidy up tests slightly
- [x] Copy fix to RadioE

## Demo

### Before

![Screencast_21-01-22_15:48:12](https://user-images.githubusercontent.com/66470099/150557673-dba95ff0-20b0-4c1c-97db-6985c910ab40.gif)

### After

![Screencast_28-01-22_10:51:47](https://user-images.githubusercontent.com/66470099/151534545-ca92edd4-c092-4542-8102-ff8d0bf9d1f0.gif)

## Developer notes

RadioE shouldn't have the same problem in practice as the space key only checks the input (rather than toggles it like it does for a checkbox), and so an extra click has no effect. However, I've changed the code there as well for consistency.
