### PR TITLE
refactor(TabSet): Rename child component

### DIFF
--- a/packages/react-component-library/src/components/TabSet/TabContent.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabContent.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
 import { StyledContent } from './partials/StyledContent'
-import { TabProps } from '.'
+import { TabSetItemProps } from '.'
 
 interface TabContentProps {
   tabId: string
   isActive: boolean
-  children: React.ReactElement<TabProps>
+  children: React.ReactElement<TabSetItemProps>
 }
 
 export const TabContent: React.FC<TabContentProps> = ({

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Story, ComponentMeta } from '@storybook/react'
 
-import { ScrollableTabSetProps, Tab, TabSet, TabSetProps } from '.'
+import { ScrollableTabSetProps, TabSetItem, TabSet, TabSetProps } from '.'
 
 export default {
   component: TabSet,
-  subcomponents: { Tab },
+  subcomponents: { TabSetItem },
   title: 'Tab Set',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
@@ -15,15 +15,15 @@ export default {
 
 export const Default: Story<TabSetProps> = (props) => (
   <TabSet {...props}>
-    <Tab title="Example Tab 1">
+    <TabSetItem title="Example Tab 1">
       <p>Example tab 1 content</p>
-    </Tab>
-    <Tab title="Example Tab 2">
+    </TabSetItem>
+    <TabSetItem title="Example Tab 2">
       <p>Example tab 2 content</p>
-    </Tab>
-    <Tab title="Example Tab 3">
+    </TabSetItem>
+    <TabSetItem title="Example Tab 3">
       <p>Example tab 3 content</p>
-    </Tab>
+    </TabSetItem>
   </TabSet>
 )
 
@@ -31,15 +31,15 @@ Default.args = {}
 
 export const InitialActiveTab: Story<TabSetProps> = (props) => (
   <TabSet {...props}>
-    <Tab title="Example Tab 1">
+    <TabSetItem title="Example Tab 1">
       <p>Example tab 1 content</p>
-    </Tab>
-    <Tab title="Example Tab 2" isActive>
+    </TabSetItem>
+    <TabSetItem title="Example Tab 2" isActive>
       <p>Example tab 2 content</p>
-    </Tab>
-    <Tab title="Example Tab 3">
+    </TabSetItem>
+    <TabSetItem title="Example Tab 3">
       <p>Example tab 3 content</p>
-    </Tab>
+    </TabSetItem>
   </TabSet>
 )
 
@@ -47,12 +47,12 @@ InitialActiveTab.storyName = 'Initial active tab'
 
 export const FullWidth: Story<TabSetProps> = (props) => (
   <TabSet {...props} isFullWidth>
-    <Tab title="Example Tab 1">
+    <TabSetItem title="Example Tab 1">
       <p>Example tab 1 content</p>
-    </Tab>
-    <Tab title="Example Tab 2">
+    </TabSetItem>
+    <TabSetItem title="Example Tab 2">
       <p>Example tab 2 content</p>
-    </Tab>
+    </TabSetItem>
   </TabSet>
 )
 
@@ -61,7 +61,7 @@ FullWidth.storyName = 'Full width'
 export const ScrollableBody: Story<TabSetProps> = (props) => (
   <div style={{ height: '200px' }}>
     <TabSet {...props}>
-      <Tab title="Example Tab 1">
+      <TabSetItem title="Example Tab 1">
         <>
           <p>Scrollable tab 1 content</p>
           <p>Scrollable tab 1 content</p>
@@ -72,8 +72,8 @@ export const ScrollableBody: Story<TabSetProps> = (props) => (
           <p>Scrollable tab 1 content</p>
           <p>Scrollable tab 1 content</p>
         </>
-      </Tab>
-      <Tab title="Example Tab 2">
+      </TabSetItem>
+      <TabSetItem title="Example Tab 2">
         <>
           <p>Scrollable tab 2 content</p>
           <p>Scrollable tab 2 content</p>
@@ -84,7 +84,7 @@ export const ScrollableBody: Story<TabSetProps> = (props) => (
           <p>Scrollable tab 2 content</p>
           <p>Scrollable tab 2 content</p>
         </>
-      </Tab>
+      </TabSetItem>
     </TabSet>
   </div>
 )
@@ -105,66 +105,66 @@ const TabTitle: React.FC<TabTitleProps> = ({ year, children }) => (
 
 export const Scrollable: Story<ScrollableTabSetProps> = (props) => (
   <TabSet {...props} isScrollable>
-    <Tab title={<TabTitle year={2019}>01/02</TabTitle>}>
+    <TabSetItem title={<TabTitle year={2019}>01/02</TabTitle>}>
       <p>Example tab 1 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>02/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>02/02</TabTitle>}>
       <p>Example tab 2 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>03/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>03/02</TabTitle>}>
       <p>Example tab 3 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>04/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>04/02</TabTitle>}>
       <p>Example tab 4 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>05/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>05/02</TabTitle>}>
       <p>Example tab 5 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>06/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>06/02</TabTitle>}>
       <p>Example tab 6 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>07/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>07/02</TabTitle>}>
       <p>Example tab 7 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>08/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>08/02</TabTitle>}>
       <p>Example tab 8 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>09/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>09/02</TabTitle>}>
       <p>Example tab 9 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>10/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>10/02</TabTitle>}>
       <p>Example tab 10 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>11/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>11/02</TabTitle>}>
       <p>Example tab 11 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>12/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>12/02</TabTitle>}>
       <p>Example tab 12 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>13/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>13/02</TabTitle>}>
       <p>Example tab 13 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>14/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>14/02</TabTitle>}>
       <p>Example tab 14 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>15/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>15/02</TabTitle>}>
       <p>Example tab 15 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>16/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>16/02</TabTitle>}>
       <p>Example tab 16 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>17/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>17/02</TabTitle>}>
       <p>Example tab 17 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>18/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>18/02</TabTitle>}>
       <p>Example tab 18 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>19/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>19/02</TabTitle>}>
       <p>Example tab 19 content</p>
-    </Tab>
-    <Tab title={<TabTitle year={2019}>20/02</TabTitle>}>
+    </TabSetItem>
+    <TabSetItem title={<TabTitle year={2019}>20/02</TabTitle>}>
       <p>Example tab 20 content</p>
-    </Tab>
+    </TabSetItem>
   </TabSet>
 )
 

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -9,7 +9,7 @@ import {
 } from '@testing-library/react'
 import { selectors } from '@defencedigital/design-tokens'
 
-import { Tab, TabSet } from '.'
+import { TabSetItem, TabSet } from '.'
 import { SCROLL_DIRECTION } from './constants'
 
 const { color } = selectors
@@ -39,10 +39,10 @@ describe('TabSet', () => {
 
         wrapper = render(
           <TabSet {...props}>
-            <Tab data-arbitrary="arbitrary-tab" title="Title 1">
+            <TabSetItem data-arbitrary="arbitrary-tab" title="Title 1">
               Content 1
-            </Tab>
-            <Tab title="Title 2">Content 2</Tab>
+            </TabSetItem>
+            <TabSetItem title="Title 2">Content 2</TabSetItem>
           </TabSet>
         )
       })
@@ -226,8 +226,8 @@ describe('TabSet', () => {
       beforeEach(() => {
         wrapper = render(
           <TabSet>
-            <Tab title="Title 1">Content 1</Tab>
-            <Tab title="Title 2">Content 2</Tab>
+            <TabSetItem title="Title 1">Content 1</TabSetItem>
+            <TabSetItem title="Title 2">Content 2</TabSetItem>
           </TabSet>
         )
       })
@@ -248,10 +248,10 @@ describe('TabSet', () => {
       beforeEach(() => {
         wrapper = render(
           <TabSet>
-            <Tab title="Title 1">Content 1</Tab>
-            <Tab title="Title 2" isActive>
+            <TabSetItem title="Title 1">Content 1</TabSetItem>
+            <TabSetItem title="Title 2" isActive>
               Content 2
-            </Tab>
+            </TabSetItem>
           </TabSet>
         )
       })
@@ -284,8 +284,8 @@ describe('TabSet', () => {
         wrapper = render(
           <form>
             <TabSet>
-              <Tab title="Title 1">Content 1</Tab>
-              <Tab title="Title 2">Content 2</Tab>
+              <TabSetItem title="Title 1">Content 1</TabSetItem>
+              <TabSetItem title="Title 2">Content 2</TabSetItem>
             </TabSet>
           </form>
         )
@@ -313,12 +313,12 @@ describe('TabSet', () => {
       beforeEach(() => {
         wrapper = render(
           <TabSet>
-            <Tab title={<span>Title 1</span>}>
+            <TabSetItem title={<span>Title 1</span>}>
               <p>Content 1</p>
-            </Tab>
-            <Tab title={<span>Title 2</span>}>
+            </TabSetItem>
+            <TabSetItem title={<span>Title 2</span>}>
               <p>Content 2</p>
-            </Tab>
+            </TabSetItem>
           </TabSet>
         )
       })
@@ -346,9 +346,9 @@ describe('TabSet', () => {
     beforeEach(() => {
       wrapper = render(
         <TabSet isScrollable>
-          <Tab title="Title 1">Content 1</Tab>
-          <Tab title="Title 2">Content 2</Tab>
-          <Tab title="Title 3">Content 3</Tab>
+          <TabSetItem title="Title 1">Content 1</TabSetItem>
+          <TabSetItem title="Title 2">Content 2</TabSetItem>
+          <TabSetItem title="Title 3">Content 3</TabSetItem>
         </TabSet>
       )
 

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -4,25 +4,25 @@ import {
   IconKeyboardArrowRight,
 } from '@defencedigital/icon-library'
 
-import { ComponentWithClass } from '../../common/ComponentWithClass'
-import { Tab, TabContent, TabItem, TabProps } from '.'
-import { useScrollableTabSet } from './useScrollableTabSet'
-import { SCROLL_DIRECTION } from './constants'
-import { getId } from '../../helpers'
 import { ARROW_LEFT, ARROW_RIGHT } from '../../utils/keyCodes'
-import { StyledTabSet } from './partials/StyledTabSet'
+import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { getId } from '../../helpers'
+import { SCROLL_DIRECTION } from './constants'
+import { StyledBody } from './partials/StyledBody'
 import { StyledHeader } from './partials/StyledHeader'
 import { StyledNavigation } from './partials/StyledNavigation'
-import { StyledTabs } from './partials/StyledTabs'
-import { StyledBody } from './partials/StyledBody'
-import { StyledScrollRight } from './partials/StyledScrollRight'
 import { StyledScrollLeft } from './partials/StyledScrollLeft'
+import { StyledScrollRight } from './partials/StyledScrollRight'
+import { StyledTabs } from './partials/StyledTabs'
+import { StyledTabSet } from './partials/StyledTabSet'
+import { TabSetItem, TabContent, TabItem, TabSetItemProps } from '.'
+import { useScrollableTabSet } from './useScrollableTabSet'
 
 export interface TabSetProps extends ComponentWithClass {
   /**
    * Collection of `Tab` components that make up the tab set.
    */
-  children: React.ReactElement<TabProps>[]
+  children: React.ReactElement<TabSetItemProps>[]
   /**
    * Optional handler invoked when the currently selected tab is changed.
    */
@@ -41,7 +41,7 @@ export interface ScrollableTabSetProps extends ComponentWithClass {
   /**
    * Collection of `Tab` components that make up the tab set.
    */
-  children: React.ReactElement<TabProps>[]
+  children: React.ReactElement<TabSetItemProps>[]
   /**
    * Optional handler invoked when the currently selected tab is changed.
    */
@@ -162,7 +162,7 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
       <StyledBody $isScrollable={isScrollable}>
         {Children.map(
           children,
-          (child: React.ReactElement<TabProps>, index: number) => {
+          (child: React.ReactElement<TabSetItemProps>, index: number) => {
             const {
               children: tabChildren,
               title,
@@ -176,7 +176,7 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
                 isActive={index === activeTab}
                 {...tabRest}
               >
-                <Tab title={title}>{tabChildren}</Tab>
+                <TabSetItem title={title}>{tabChildren}</TabSetItem>
               </TabContent>
             )
           }

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -166,7 +166,7 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
             const {
               children: tabChildren,
               title,
-              isActive,
+              isActive: _,
               ...tabRest
             } = child.props
 

--- a/packages/react-component-library/src/components/TabSet/TabSetItem.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSetItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export interface TabProps {
+export interface TabSetItemProps {
   /**
    * Text title to display within the tab.
    */
@@ -15,8 +15,8 @@ export interface TabProps {
   isActive?: boolean
 }
 
-export const Tab: React.FC<TabProps> = ({ children }) => {
+export const TabSetItem: React.FC<TabSetItemProps> = ({ children }) => {
   return <>{children}</>
 }
 
-Tab.displayName = 'Tab'
+TabSetItem.displayName = 'TabSetItem'

--- a/packages/react-component-library/src/components/TabSet/index.ts
+++ b/packages/react-component-library/src/components/TabSet/index.ts
@@ -1,4 +1,4 @@
-export * from './Tab'
+export * from './TabSetItem'
 export * from './TabContent'
 export * from './TabItem'
 export * from './TabSet'

--- a/packages/react-component-library/src/components/TabSet/useScrollableTabSet.ts
+++ b/packages/react-component-library/src/components/TabSet/useScrollableTabSet.ts
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 
-import { TabProps } from './Tab'
+import { TabSetItemProps } from './TabSetItem'
 
 function hasTab(tabIndex: number, itemsRef: Array<HTMLLIElement>) {
   return tabIndex > -1 && tabIndex < itemsRef.length
@@ -22,7 +22,9 @@ function scrollTo(element: HTMLDivElement, left: number): Promise<void> {
   })
 }
 
-export function useScrollableTabSet(items: React.ReactElement<TabProps>[]) {
+export function useScrollableTabSet(
+  items: React.ReactElement<TabSetItemProps>[]
+) {
   const [currentScrollToTab, setCurrentScrollToTab] = useState(0)
   const itemsRef = useRef<Array<HTMLLIElement>>([])
   const tabsRef = useRef<HTMLDivElement>()


### PR DESCRIPTION
## Related issue

Closes #2259

## Overview

Rename child component to match convention used by `TabNav`.

## Reason

>Breaking changes to interfaces ahead of upcoming major release.

## Work carried out

- [x] Rename child component
- [x] Correctly mark a dropped prop
