### PR TITLE
fix(RadioE): Fix disabled styling and Firefox border glitch

### DIFF
--- a/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
@@ -23,7 +23,14 @@ Default.args = {
   id: undefined,
   label: 'Default radio',
   name: 'default',
+}
+
+export const Checked = Template.bind({})
+Checked.args = {
+  id: undefined,
   defaultChecked: true,
+  label: 'Checked radio',
+  name: 'checked',
 }
 
 export const Disabled = Template.bind({})

--- a/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
@@ -41,6 +41,16 @@ Disabled.args = {
   name: 'disabled',
 }
 
+export const DisabledChecked = Template.bind({})
+DisabledChecked.storyName = 'Disabled, checked'
+DisabledChecked.args = {
+  id: undefined,
+  isDisabled: true,
+  defaultChecked: true,
+  label: 'Disabled, checked radio',
+  name: 'disabled-checked',
+}
+
 export const Invalid = Template.bind({})
 Invalid.args = {
   id: undefined,

--- a/packages/react-component-library/src/components/RadioE/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledCheckmark.tsx
@@ -13,9 +13,16 @@ export const StyledCheckmark = styled.span`
   background-color: ${color('neutral', 'white')};
   border-radius: 999px;
   border: 1px solid ${color('neutral', '200')};
+  outline: none;
 
-  &::after {
+  &::after,
+  &::before {
     content: '';
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-radius: 999px;
     position: absolute;
     display: none;
   }

--- a/packages/react-component-library/src/components/RadioE/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledCheckmark.tsx
@@ -10,7 +10,6 @@ export const StyledCheckmark = styled.span`
   transform: translateY(-50%);
   height: 16px;
   width: 16px;
-  background-color: ${color('neutral', 'white')};
   border-radius: 999px;
   border: 1px solid ${color('neutral', '200')};
   outline: none;

--- a/packages/react-component-library/src/components/RadioE/partials/StyledRadio.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledRadio.tsx
@@ -10,7 +10,7 @@ interface StyledRadioProps {
   $isChecked?: boolean
 }
 
-const RADIO_FOCUS_WIDTH = '0.1rem'
+const RADIO_ACTIVE_BORDER_WIDTH = '2px'
 
 const { spacing, fontSize, color, animation } = selectors
 
@@ -37,37 +37,36 @@ export const StyledRadio = styled.div<StyledRadioProps>`
       0 0 0 5px ${color('action', '100')};
   }
 
-  /* Active state, light blue outline */
-
-  &:hover ${StyledCheckmark}, ${StyledInput}:active ~ ${StyledCheckmark} {
-    border: 1px solid ${color('action', '500')};
-    outline: none;
-    box-shadow: 0 0 0 ${RADIO_FOCUS_WIDTH} ${color('action', '500')};
+  ${StyledCheckmark}::before {
+    display: block;
+    box-shadow: 0 0 0 0 transparent;
     transition: all ${animation('default')};
   }
 
-  /* Checked state, blue border */
+  /* Checkmark hover and active states, blue border */
+
+  &:hover ${StyledCheckmark}, ${StyledInput}:active ~ ${StyledCheckmark} {
+    &::before {
+      box-shadow: 0 0 0 ${RADIO_ACTIVE_BORDER_WIDTH} ${color('action', '500')};
+    }
+  }
+
+  /* Checkmark checked state */
 
   ${StyledInput}:checked ~ ${StyledCheckmark} {
     background-color: ${color('neutral', 'white')};
-    border: 1px solid ${color('action', '500')};
-    box-shadow: 0 0 0 ${RADIO_FOCUS_WIDTH} ${color('action', '500')};
-  }
 
-  ${StyledInput}:checked ~ ${StyledCheckmark}:after {
-    display: block;
-  }
+    /* Blue border */
+    &::before {
+      box-shadow: 0 0 0 ${RADIO_ACTIVE_BORDER_WIDTH} ${color('action', '500')};
+    }
 
-  /* Checkmark, blue dot */
-
-  ${StyledCheckmark}::after {
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    border-radius: 999px;
-    background: ${color('action', '500')};
-    border: 2px solid ${color('neutral', 'white')};
+    /* Central blue dot */
+    &::after {
+      display: block;
+      background: ${color('action', '500')};
+      border: 2px solid ${color('neutral', 'white')};
+    }
   }
 
   ${({ $isDisabled }) =>
@@ -84,10 +83,13 @@ export const StyledRadio = styled.div<StyledRadioProps>`
         border: 1px solid ${color('neutral', '100')};
       }
 
-      &:hover ${StyledCheckmark}, ${StyledInput}:active ~ .rn-radio__checkmark {
+      &:hover ${StyledCheckmark}, ${StyledInput}:active ~ ${StyledCheckmark} {
         border: 1px solid ${color('neutral', '100')};
-        box-shadow: none;
         cursor: not-allowed;
+
+        &::before {
+          box-shadow: none;
+        }
       }
 
       background-color: ${color('neutral', '000')};

--- a/packages/react-component-library/src/components/RadioE/partials/StyledRadio.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledRadio.tsx
@@ -14,6 +14,21 @@ const RADIO_ACTIVE_BORDER_WIDTH = '2px'
 
 const { spacing, fontSize, color, animation } = selectors
 
+const BackgroundColor = css<StyledRadioProps>`
+  ${({ $isDisabled }) =>
+    $isDisabled ? color('neutral', '000') : color('neutral', 'white')}
+`
+
+const CheckmarkActiveBorderColor = css<StyledRadioProps>`
+  ${({ $isDisabled }) =>
+    $isDisabled ? color('neutral', '200') : color('action', '500')}
+`
+
+const CheckmarkCheckedFillColor = css<StyledRadioProps>`
+  ${({ $isDisabled }) =>
+    $isDisabled ? color('neutral', '200') : color('action', '500')}
+`
+
 export const StyledRadio = styled.div<StyledRadioProps>`
   display: inline-flex;
   position: relative;
@@ -21,6 +36,7 @@ export const StyledRadio = styled.div<StyledRadioProps>`
   cursor: pointer;
   font-size: ${fontSize('base')};
   user-select: none;
+  background: ${BackgroundColor};
 
   * {
     cursor: pointer;
@@ -37,35 +53,45 @@ export const StyledRadio = styled.div<StyledRadioProps>`
       0 0 0 5px ${color('action', '100')};
   }
 
-  ${StyledCheckmark}::before {
-    display: block;
-    box-shadow: 0 0 0 0 transparent;
-    transition: all ${animation('default')};
+  ${StyledCheckmark} {
+    background: ${BackgroundColor};
+
+    &::before {
+      display: block;
+      box-shadow: 0 0 0 0 transparent;
+      transition: all ${animation('default')};
+    }
   }
 
   /* Checkmark hover and active states, blue border */
 
-  &:hover ${StyledCheckmark}, ${StyledInput}:active ~ ${StyledCheckmark} {
-    &::before {
-      box-shadow: 0 0 0 ${RADIO_ACTIVE_BORDER_WIDTH} ${color('action', '500')};
-    }
-  }
+  ${({ $isDisabled }) =>
+    !$isDisabled &&
+    css`
+      &:hover ${StyledCheckmark}, ${StyledInput}:active ~ ${StyledCheckmark} {
+        &::before {
+          box-shadow: 0 0 0 ${RADIO_ACTIVE_BORDER_WIDTH}
+            ${color('action', '500')};
+        }
+      }
+    `}
 
   /* Checkmark checked state */
 
   ${StyledInput}:checked ~ ${StyledCheckmark} {
     background-color: ${color('neutral', 'white')};
 
-    /* Blue border */
+    /* Blue border (grey if disabled) */
     &::before {
-      box-shadow: 0 0 0 ${RADIO_ACTIVE_BORDER_WIDTH} ${color('action', '500')};
+      box-shadow: 0 0 0 ${RADIO_ACTIVE_BORDER_WIDTH}
+        ${CheckmarkActiveBorderColor};
     }
 
-    /* Central blue dot */
+    /* Central blue dot (grey dot if disabled) */
     &::after {
       display: block;
-      background: ${color('action', '500')};
-      border: 2px solid ${color('neutral', 'white')};
+      background: ${CheckmarkCheckedFillColor};
+      border: 2px solid ${BackgroundColor};
     }
   }
 
@@ -78,21 +104,6 @@ export const StyledRadio = styled.div<StyledRadioProps>`
         cursor: not-allowed;
       }
 
-      ${StyledInput} ~ ${StyledCheckmark} {
-        background-color: ${color('neutral', '200')};
-        border: 1px solid ${color('neutral', '100')};
-      }
-
-      &:hover ${StyledCheckmark}, ${StyledInput}:active ~ ${StyledCheckmark} {
-        border: 1px solid ${color('neutral', '100')};
-        cursor: not-allowed;
-
-        &::before {
-          box-shadow: none;
-        }
-      }
-
-      background-color: ${color('neutral', '000')};
       border-color: transparent;
 
       &:focus-within,


### PR DESCRIPTION
## Related issue

#3007
Resolves #3052 

## Overview

This:

- fixes a glitch with the hover and checked border in Firefox
- adjusts the size of that border to 2px
- corrects the disabled styles for both checked and unchecked states

## Link to preview

- [Storybook](https://5e25c277526d380020b5e418-jrrxzijbql.chromatic.com/?path=/docs/radio-experimental--default)
- [Non-Storybook](https://red-playground.netlify.app/)

## Reason

Make the component better and make the component line up with the design spec.

## Work carried out

- [x] Rework hover/checked border
- [x] Correct various disabled styles
- [x] Update stories

## Screenshot

### Checked

<details>
<summary>Before and after animation</summary>

![checked](https://user-images.githubusercontent.com/66470099/152199069-6bba4403-de36-4f28-a7de-c0daddae7ba9.gif)

</details>

<details>
<summary>Firefox, before</summary>

![checked-firefox-before](https://user-images.githubusercontent.com/66470099/152197704-955076f6-4b09-4649-af45-18a3c6c60bbc.png)

</details>

<details>
<summary>Firefox, after</summary>

![checked-firefox-after](https://user-images.githubusercontent.com/66470099/152197758-949d9cca-19ed-430d-b157-ff934713e75b.png)

</details>

### Disabled, unchecked

#### Before

![disabled-before](https://user-images.githubusercontent.com/66470099/152199809-b1843f3e-a311-4922-8c52-e7443e7037a9.png)

#### After

![Screenshot 2022-02-02 at 16-50-53 Radio (Experimental) - Disabled ⋅ Storybook](https://user-images.githubusercontent.com/66470099/152199535-9cb8ea86-2065-4aac-beec-189dc2c385b7.png)

### Disabled, checked

#### Before

![disabled-checked-before](https://user-images.githubusercontent.com/66470099/152199890-c24ac8c8-be14-4f80-8276-15083a92b1a5.png)

#### After

![disabled-checked-after](https://user-images.githubusercontent.com/66470099/152200197-9eeab74a-f20e-4229-94b0-5a148a2c4ed4.png)

## Developer notes

Note: I'd recommend using the browser zoom instead of the Storybook zoom in Firefox to check this – Storybook uses a `transform` to zoom and it seems this causes glitches with a round box-shadow in Firefox.

The original Firefox glitch in the issue was due to half the border being a border and the other half being a box-shadow.

One follow-up issue has been created:

- #3056

The same Firefox glitch for CheckboxE will be resolved in a separate PR.