### PR TITLE
fix(CheckboxE): Fix unchecked disabled styles and Firefox border glitch 

### DIFF
--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
@@ -27,13 +27,31 @@ Default.args = {
   name: 'default',
 }
 
-export const Disabled = Template.bind({})
-Disabled.args = {
+export const Checked = Template.bind({})
+Checked.args = {
+  id: undefined,
+  defaultChecked: true,
+  label: 'Checked',
+  name: 'checked',
+}
+
+export const DisabledUnchecked = Template.bind({})
+DisabledUnchecked.storyName = 'Disabled, unchecked'
+DisabledUnchecked.args = {
   id: undefined,
   isDisabled: true,
-  label: 'Disabled checkbox',
+  label: 'Disabled, unchecked',
   name: 'disabled',
-  checked: true,
+}
+
+export const DisabledChecked = Template.bind({})
+DisabledChecked.storyName = 'Disabled, checked'
+DisabledChecked.args = {
+  id: undefined,
+  defaultChecked: true,
+  isDisabled: true,
+  label: 'Disabled, checked',
+  name: 'disabled',
 }
 
 export const Invalid = Template.bind({})

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
@@ -106,7 +106,6 @@ export const CheckboxE = React.forwardRef<HTMLInputElement, CheckboxEProps>(
             <StyledLabel htmlFor={id} data-testid="checkbox-label">
               <StyledInput
                 ref={mergeRefs([localRef, ref])}
-                $isDisabled={isDisabled}
                 id={id}
                 type="checkbox"
                 name={name}

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckbox.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckbox.tsx
@@ -1,8 +1,6 @@
 import { selectors } from '@defencedigital/design-tokens'
 import styled, { css } from 'styled-components'
 
-import { StyledCheckmark } from './StyledCheckmark'
-
 const { color, fontSize } = selectors
 
 export interface StyledCheckboxProps {
@@ -32,13 +30,6 @@ export const StyledCheckbox = styled.div<StyledCheckboxProps>`
       0 0 0 5px ${color('action', '100')};
   }
 
-  &:hover ${StyledCheckmark}, &:active ${StyledCheckmark} {
-    border: 1px solid ${color('action', '500')};
-    outline: none;
-    box-shadow: 0 0 0 1px ${color('action', '500')};
-    transition: all 0.2s;
-  }
-
   ${({ $isInvalid }) =>
     $isInvalid &&
     css`
@@ -59,12 +50,6 @@ export const StyledCheckbox = styled.div<StyledCheckboxProps>`
 
       * {
         cursor: not-allowed;
-      }
-
-      &&& ${StyledCheckmark} {
-        background-color: ${color('neutral', '200')};
-        border-color: ${color('neutral', '200')};
-        box-shadow: none;
       }
 
       background-color: ${color('neutral', '000')};

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckmark.tsx
@@ -1,9 +1,10 @@
+import { position } from 'polished'
 import styled from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
 import { StyledCheckbox } from './StyledCheckbox'
 
-const { color } = selectors
+const { animation, color } = selectors
 
 export const StyledCheckmark = styled.div`
   position: absolute;
@@ -16,6 +17,12 @@ export const StyledCheckmark = styled.div`
   border: 1px solid ${color('neutral', '200')};
   border-radius: 3px;
 
+  &::before {
+    content: '';
+    ${position('absolute', 0, 0, 0, 0)};
+    border-radius: 2px;
+  }
+
   &::after {
     content: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIiAvPgogICAgPHBhdGggdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMywgNCkiIGQ9Ik04LjgyMiAwYzEuMDUtLjAyNyAxLjU3NCAxLjMwNC44MjcgMi4wOEw0LjI5OCA3Ljc0YS44My44MyAwIDAgMS0xLjIwNyAwTC4zNzYgNC44NTVDLS43NTIgMy43MTguOTE0IDEuOTU2IDEuOTkgMy4xNDlsMS41MDggMS41OTVjLjEwNS4xMS4yODguMTEuNDA3IDBsNC4xMy00LjM3QTEuMSAxLjEgMCAwIDEgOC44MjMgMHoiCiAgICAgICAgICBmaWxsPSIjRkZGIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KPC9zdmc+Cg==);
     border-radius: 2px;
@@ -23,10 +30,10 @@ export const StyledCheckmark = styled.div`
   }
 
   ${StyledCheckbox}:hover &, ${StyledCheckbox}:active & {
-    border: 1px solid ${color('action', '500')};
-    outline: none;
-    box-shadow: 0 0 0 1px ${color('action', '500')};
-    transition: all 0.2s;
+    &::before {
+      box-shadow: 0 0 0 2px ${color('action', '500')};
+      transition: all ${animation('default')};
+    }
   }
 
   ${StyledCheckbox} input:checked ~ & {
@@ -42,6 +49,9 @@ export const StyledCheckmark = styled.div`
   ${StyledCheckbox} input:disabled ~ & {
     background-color: ${color('neutral', '200')};
     border-color: ${color('neutral', '200')};
-    box-shadow: none;
+
+    &::before {
+      box-shadow: none;
+    }
   }
 `

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckmark.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
+import { StyledCheckbox } from './StyledCheckbox'
+
 const { color } = selectors
 
 export const StyledCheckmark = styled.div`
@@ -18,5 +20,28 @@ export const StyledCheckmark = styled.div`
     content: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIiAvPgogICAgPHBhdGggdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMywgNCkiIGQ9Ik04LjgyMiAwYzEuMDUtLjAyNyAxLjU3NCAxLjMwNC44MjcgMi4wOEw0LjI5OCA3Ljc0YS44My44MyAwIDAgMS0xLjIwNyAwTC4zNzYgNC44NTVDLS43NTIgMy43MTguOTE0IDEuOTU2IDEuOTkgMy4xNDlsMS41MDggMS41OTVjLjEwNS4xMS4yODguMTEuNDA3IDBsNC4xMy00LjM3QTEuMSAxLjEgMCAwIDEgOC44MjMgMHoiCiAgICAgICAgICBmaWxsPSIjRkZGIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KPC9zdmc+Cg==);
     border-radius: 2px;
     color: ${color('neutral', 'white')};
+  }
+
+  ${StyledCheckbox}:hover &, ${StyledCheckbox}:active & {
+    border: 1px solid ${color('action', '500')};
+    outline: none;
+    box-shadow: 0 0 0 1px ${color('action', '500')};
+    transition: all 0.2s;
+  }
+
+  ${StyledCheckbox} input:checked ~ & {
+    background-color: ${color('action', '500')};
+    border: 1px solid ${color('action', '500')};
+    text-align: center;
+
+    &::after {
+      display: block;
+    }
+  }
+
+  ${StyledCheckbox} input:disabled ~ & {
+    background-color: ${color('neutral', '200')};
+    border-color: ${color('neutral', '200')};
+    box-shadow: none;
   }
 `

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckmark.tsx
@@ -25,6 +25,7 @@ export const StyledCheckmark = styled.div`
 
   &::after {
     content: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIiAvPgogICAgPHBhdGggdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMywgNCkiIGQ9Ik04LjgyMiAwYzEuMDUtLjAyNyAxLjU3NCAxLjMwNC44MjcgMi4wOEw0LjI5OCA3Ljc0YS44My44MyAwIDAgMS0xLjIwNyAwTC4zNzYgNC44NTVDLS43NTIgMy43MTguOTE0IDEuOTU2IDEuOTkgMy4xNDlsMS41MDggMS41OTVjLjEwNS4xMS4yODguMTEuNDA3IDBsNC4xMy00LjM3QTEuMSAxLjEgMCAwIDEgOC44MjMgMHoiCiAgICAgICAgICBmaWxsPSIjRkZGIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KPC9zdmc+Cg==);
+    display: none;
     border-radius: 2px;
     color: ${color('neutral', 'white')};
   }
@@ -47,11 +48,15 @@ export const StyledCheckmark = styled.div`
   }
 
   ${StyledCheckbox} input:disabled ~ & {
-    background-color: ${color('neutral', '200')};
+    background-color: ${color('neutral', '000')};
     border-color: ${color('neutral', '200')};
 
     &::before {
       box-shadow: none;
     }
+  }
+
+  ${StyledCheckbox} input:disabled:checked ~ & {
+    background-color: ${color('neutral', '200')};
   }
 `

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledInput.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledInput.tsx
@@ -1,40 +1,9 @@
-import { selectors } from '@defencedigital/design-tokens'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
-import { StyledCheckboxProps } from './StyledCheckbox'
-import { StyledCheckmark } from './StyledCheckmark'
-
-const { color } = selectors
-
-export const StyledInput = styled.input<StyledCheckboxProps>`
+export const StyledInput = styled.input`
   position: absolute;
   opacity: 0;
   cursor: pointer;
   height: 0;
   width: 0;
-
-  &:checked ~ ${StyledCheckmark} {
-    background-color: ${color('action', '500')};
-    border: 1px solid ${color('action', '500')};
-    text-align: center;
-  }
-
-  &:checked ~ ${StyledCheckmark}:after {
-    display: block;
-  }
-
-  ${({ $isDisabled }) =>
-    $isDisabled &&
-    css`
-      ~ ${StyledCheckmark} {
-        background-color: ${color('neutral', '000')};
-        border: 1px solid ${color('neutral', '100')};
-      }
-
-      &:hover ~ ${StyledCheckmark}, input:active ~ ${StyledCheckmark} {
-        border: 1px solid ${color('neutral', '100')};
-        box-shadow: none;
-        cursor: not-allowed;
-      }
-    `}
 `


### PR DESCRIPTION
## Related issue

Resolves #3007

## Overview

This:

- refactors the CheckboxE StyledCheckbox styles
- fixes a glitch with the active and hover borders in Firefox
- fixes styling for a disabled, unchecked checkbox

## Link to preview

- [Storybook](https://5e25c277526d380020b5e418-bokayohatk.chromatic.com/?path=/docs/checkbox-experimental--default)
- [Non-Storybook](https://red-playground.netlify.app/)

## Reason

To fix rendering in Firefox and make the disabled state worth as expected.

## Work carried out

- [x] Refactor styles
- [x] Fix glitch with active and hover border in Firefox
- [x] Fix unchecked disabled styling and add stories

## Screenshot

### Firefox hover/active

#### Before

![image](https://user-images.githubusercontent.com/66470099/152570132-d3d08078-2a34-4aad-8d67-44a9b401b55c.png)

#### After

![image](https://user-images.githubusercontent.com/66470099/152570004-ee191abb-6538-4cb6-9a88-d37d10b0c308.png)

### Disabled unchecked

#### Before

![image](https://user-images.githubusercontent.com/66470099/152568919-87bb0d2a-8ef2-4f17-9f9a-f01ceb94916e.png)

#### After

![image](https://user-images.githubusercontent.com/66470099/152568834-e906d9c7-8de1-448d-a66e-b48616534009.png)

## Developer notes

Note: Would suggest using the browser zoom to test in Firefox over the Storybook zoom (Storybook uses a transform which causes box-shadow artefacts in Firefox).
