### PR TITLE
Fix various strict null type errors

### DIFF
--- a/packages/react-component-library/src/common/FieldProps.ts
+++ b/packages/react-component-library/src/common/FieldProps.ts
@@ -2,5 +2,5 @@ export interface FieldProps {
   name: string
   value: string
   onChange: (e: React.SyntheticEvent) => void
-  onBlur: (e: React.SyntheticEvent) => void
+  onBlur?: (e: React.SyntheticEvent) => void
 }

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -64,49 +64,48 @@ export const Alert: React.FC<AlertProps> = ({
 }) => {
   const { open, handleOnClose } = useOpenClose(true, onClose)
 
-  const titleId = title ? getId('alert-title') : null
+  const titleId = title ? getId('alert-title') : undefined
   const descriptionId = getId('alert-description')
 
+  if (!open) {
+    return null
+  }
+
   return (
-    open && (
-      <StyledAlert
+    <StyledAlert
+      $variant={variant}
+      aria-describedby={descriptionId}
+      aria-labelledby={titleId}
+      data-testid="alert"
+      role="alert"
+      {...rest}
+    >
+      <StyledIcon
         $variant={variant}
-        aria-describedby={descriptionId}
-        aria-labelledby={titleId}
-        data-testid="alert"
-        role="alert"
-        {...rest}
+        aria-hidden="true"
+        data-testid="state-icon"
       >
-        <StyledIcon
-          $variant={variant}
-          aria-hidden="true"
-          data-testid="state-icon"
-        >
-          {VARIANT_ICON_MAP[variant]}
-        </StyledIcon>
-        <StyledContent data-testid="content">
-          {title && (
-            <StyledTitle
-              $variant={variant}
-              data-testid="content-title"
-              id={titleId}
-            >
-              {title}
-            </StyledTitle>
-          )}
-          <StyledDescription
-            data-testid="content-description"
-            id={descriptionId}
+        {VARIANT_ICON_MAP[variant]}
+      </StyledIcon>
+      <StyledContent data-testid="content">
+        {title && (
+          <StyledTitle
+            $variant={variant}
+            data-testid="content-title"
+            id={titleId}
           >
-            {children}
-          </StyledDescription>
-          <StyledFooter>
-            <StyledCloseButton onClick={handleOnClose} data-testid="close">
-              Dismiss
-            </StyledCloseButton>
-          </StyledFooter>
-        </StyledContent>
-      </StyledAlert>
-    )
+            {title}
+          </StyledTitle>
+        )}
+        <StyledDescription data-testid="content-description" id={descriptionId}>
+          {children}
+        </StyledDescription>
+        <StyledFooter>
+          <StyledCloseButton onClick={handleOnClose} data-testid="close">
+            Dismiss
+          </StyledCloseButton>
+        </StyledFooter>
+      </StyledContent>
+    </StyledAlert>
   )
 }

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -146,4 +146,8 @@ describe('Breadcrumbs', () => {
       expect(wrapper.queryByText('Home')).toHaveAttribute('href', '#home')
     })
   })
+
+  it('does not throw an error if there are no children', () => {
+    expect(() => render(<Breadcrumbs />)).not.toThrowError()
+  })
 })

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -10,7 +10,7 @@ export const Breadcrumbs: React.FC<Nav<BreadcrumbsItemProps>> = ({
   ...rest
 }) => {
   const mapped = React.Children.map(
-    children,
+    children ?? [],
     (child: React.ReactElement<BreadcrumbsItemProps>, index: number) => {
       warnIfOverwriting(child.props, 'isFirst', BreadcrumbsItem.name)
       warnIfOverwriting(child.props, 'isLast', BreadcrumbsItem.name)

--- a/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -57,7 +57,7 @@ function getText(
 
 export const BreadcrumbsItem: React.FC<BreadcrumbsItemProps> = ({
   isFirst,
-  isLast,
+  isLast = false,
   link,
   href,
   children,

--- a/packages/react-component-library/src/components/ButtonE/ButtonE.stories.tsx
+++ b/packages/react-component-library/src/components/ButtonE/ButtonE.stories.tsx
@@ -60,7 +60,7 @@ PrimaryRightIcon.args = {
 export const IconNoText = Template.bind({})
 IconNoText.storyName = 'Icon, no text'
 IconNoText.args = {
-  children: null,
+  children: undefined,
   icon: <IconBrightnessLow />,
   title: 'Reduce brightness',
 }

--- a/packages/react-component-library/src/components/ButtonE/ButtonE.test.tsx
+++ b/packages/react-component-library/src/components/ButtonE/ButtonE.test.tsx
@@ -17,7 +17,7 @@ describe('Button', () => {
   describe('default props', () => {
     beforeEach(() => {
       wrapper = render(<ButtonE onClick={onClickSpy}>Click me</ButtonE>)
-      button = wrapper.getByText('Click me').parentElement
+      button = wrapper.getByLabelText('Click me')
     })
 
     it('should default the type to "button"', () => {
@@ -42,7 +42,7 @@ describe('Button', () => {
   describe('when the onClick callback has not been specified', () => {
     beforeEach(() => {
       wrapper = render(<ButtonE>Click me</ButtonE>)
-      button = wrapper.getByText('Click me').parentElement
+      button = wrapper.getByLabelText('Click me')
     })
 
     it('does not throw an error when the button is clicked', () => {
@@ -61,7 +61,7 @@ describe('Button', () => {
           Click me
         </ButtonE>
       )
-      button = wrapper.getByText('Click me').parentElement
+      button = wrapper.getByLabelText('Click me')
 
       expect(button).toHaveAttribute('type', expected)
     })

--- a/packages/react-component-library/src/components/ButtonE/ButtonE.tsx
+++ b/packages/react-component-library/src/components/ButtonE/ButtonE.tsx
@@ -81,7 +81,7 @@ export const ButtonE: React.FC<ButtonEProps> = ({
   children,
   className,
   isDisabled,
-  isLoading,
+  isLoading = false,
   icon,
   iconPosition = BUTTON_E_ICON_POSITION.RIGHT,
   onClick,

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -23,7 +23,7 @@ const ClickArea = styled.div`
 `
 
 export const Default: ComponentStory<typeof ContextMenu> = (props) => {
-  const ref = useRef()
+  const ref = useRef<HTMLDivElement>(null)
 
   return (
     <>
@@ -56,7 +56,7 @@ export const Default: ComponentStory<typeof ContextMenu> = (props) => {
 Default.storyName = 'Default'
 
 export const WithIcons: ComponentStory<typeof ContextMenu> = (props) => {
-  const ref = useRef()
+  const ref = useRef<HTMLDivElement>(null)
 
   return (
     <>

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
@@ -27,7 +27,7 @@ describe('ContextMenu', () => {
   describe('With links, no icons and closed', () => {
     beforeEach(() => {
       const ContextExample = () => {
-        const ref = useRef()
+        const ref = useRef<HTMLDivElement>(null)
 
         return (
           <>
@@ -55,7 +55,7 @@ describe('ContextMenu', () => {
   describe('With a clickType of left', () => {
     beforeEach(() => {
       const ContextExample = () => {
-        const ref = useRef()
+        const ref = useRef<HTMLDivElement>(null)
 
         return (
           <>
@@ -133,7 +133,7 @@ describe('ContextMenu', () => {
     }: {
       position: ClickMenuPositionType
     }) => {
-      const ref = useRef()
+      const ref = useRef<HTMLDivElement>(null)
 
       return (
         <>
@@ -279,7 +279,7 @@ describe('ContextMenu', () => {
   describe('With links, no icons and and open', () => {
     beforeEach(() => {
       const ContextExample = () => {
-        const ref = useRef()
+        const ref = useRef<HTMLDivElement>(null)
 
         return (
           <>
@@ -332,7 +332,7 @@ describe('ContextMenu', () => {
       onClickSpy = jest.fn()
 
       const ContextExample = () => {
-        const ref: React.Ref<HTMLDivElement> = useRef()
+        const ref: React.Ref<HTMLDivElement> = useRef(null)
 
         return (
           <>
@@ -365,7 +365,7 @@ describe('ContextMenu', () => {
   describe('With icons and open', () => {
     beforeEach(() => {
       const ContextExample = () => {
-        const ref = useRef()
+        const ref = useRef<HTMLDivElement>(null)
 
         return (
           <>
@@ -399,7 +399,7 @@ describe('ContextMenu', () => {
   describe('With dividers and open', () => {
     beforeEach(() => {
       const ContextExample = () => {
-        const ref = useRef()
+        const ref = useRef<HTMLDivElement>(null)
 
         return (
           <>
@@ -435,7 +435,7 @@ describe('ContextMenu', () => {
       onHideSpy = jest.fn()
 
       const ContextExample = () => {
-        const ref = useRef()
+        const ref = useRef<HTMLDivElement>(null)
 
         return (
           <>
@@ -487,7 +487,7 @@ describe('ContextMenu', () => {
   describe('With arbitrary props', () => {
     beforeEach(() => {
       const ContextExample = () => {
-        const ref = useRef()
+        const ref = useRef<HTMLDivElement>(null)
 
         return (
           <>

--- a/packages/react-component-library/src/components/Drawer/Drawer.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.tsx
@@ -24,7 +24,7 @@ export interface DrawerProps extends ComponentWithClass {
 }
 
 export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
-  ({ children, onClose, isOpen, className, ...rest }, ref) => {
+  ({ children, onClose, isOpen = false, className, ...rest }, ref) => {
     const { handleOnClose, open } = useOpenClose(isOpen, onClose)
 
     return (

--- a/packages/react-component-library/src/components/Popover/Popover.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.tsx
@@ -47,7 +47,7 @@ export const Popover: React.FC<PopoverProps> = ({
   children,
   closeDelay = POPOVER_CLOSE_DELAY,
   content,
-  isClick,
+  isClick = false,
   scheme = FLOATING_BOX_SCHEME.LIGHT,
   placement = FLOATING_BOX_PLACEMENT.RIGHT,
   ...rest

--- a/packages/react-component-library/src/components/TextAreaE/TextAreaE.test.tsx
+++ b/packages/react-component-library/src/components/TextAreaE/TextAreaE.test.tsx
@@ -121,7 +121,7 @@ describe('TextArea', () => {
         field = {
           name: 'colour',
           value: '',
-          onBlur: null,
+          onBlur: undefined,
           onChange: jest.fn(),
         }
         form = {
@@ -161,7 +161,7 @@ describe('TextArea', () => {
         field = {
           name: 'colour',
           value: '',
-          onBlur: null,
+          onBlur: undefined,
           onChange: jest.fn(),
         }
         form = {

--- a/packages/react-component-library/src/components/TextInputE/Input.tsx
+++ b/packages/react-component-library/src/components/TextInputE/Input.tsx
@@ -9,7 +9,7 @@ import { useInputValue } from '../../hooks/useInputValue'
 export interface InputProps extends ComponentWithClass {
   hasFocus: boolean
   id?: string
-  isDisabled: boolean
+  isDisabled?: boolean
   label?: string
   name: string
   onBlur: (event: React.FormEvent) => void

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
@@ -49,7 +49,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   ...rest
 }) => {
   const contentId = getId('tooltip-content')
-  const titleId = title ? getId('tooltip-title') : null
+  const titleId = title ? getId('tooltip-title') : undefined
 
   return (
     <StyledTooltip

--- a/packages/react-component-library/src/components/Tooltip/partials/StyledTooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/partials/StyledTooltip.tsx
@@ -1,14 +1,14 @@
 import styled, { css } from 'styled-components'
 
 interface StyledTooltipProps {
-  $bottom: number
-  $left: number
-  $right: number
-  $top: number
-  $width: number
+  $bottom?: number
+  $left?: number
+  $right?: number
+  $top?: number
+  $width?: number
 }
 
-function getUnitAsPx($unit: number) {
+function getUnitAsPx($unit: number | undefined) {
   return $unit ? `${$unit}px` : 'auto'
 }
 

--- a/packages/react-component-library/src/hooks/__tests__/useInputValue.test.ts
+++ b/packages/react-component-library/src/hooks/__tests__/useInputValue.test.ts
@@ -4,7 +4,7 @@ import { act, renderHook, RenderResult } from '@testing-library/react-hooks'
 import { useInputValue } from '../useInputValue'
 
 describe('useInputValue', () => {
-  let rerender: (props?: unknown) => void
+  let rerender: (value: string | undefined) => void
   let result: RenderResult<{
     committedValue: string
     hasValue: boolean
@@ -12,9 +12,12 @@ describe('useInputValue', () => {
   }>
 
   beforeEach(() => {
-    const render = renderHook((value) => useInputValue(value), {
-      initialProps: undefined,
-    })
+    const render = renderHook(
+      (value: string | undefined) => useInputValue(value),
+      {
+        initialProps: undefined,
+      }
+    )
 
     rerender = render.rerender
     result = render.result

--- a/packages/react-component-library/src/hooks/useDocumentClick.ts
+++ b/packages/react-component-library/src/hooks/useDocumentClick.ts
@@ -19,7 +19,7 @@ const NODE_CURRENT = {
  * to false if the hook needs to be enabled or disabled dynamically
  */
 export function useDocumentClick(
-  nodes: React.MutableRefObject<Element> | React.MutableRefObject<Element>[],
+  nodes: React.RefObject<Element | null> | React.RefObject<Element | null>[],
   onDocumentClick: (event: Event) => void,
   isEnabled = true
 ) {
@@ -29,7 +29,7 @@ export function useDocumentClick(
 
       const nonClickableRef = find(
         nonClickableRefs,
-        (node: React.MutableRefObject<Element>) => {
+        (node: React.RefObject<Element>) => {
           const current = node.current || NODE_CURRENT
           return current.contains(event.target as Element)
         }
@@ -44,7 +44,7 @@ export function useDocumentClick(
 
   useEffect(() => {
     if (!isEnabled) {
-      return null
+      return undefined
     }
 
     document.addEventListener('mousedown', handleDocumentClick)

--- a/packages/react-component-library/src/hooks/useHideShow.ts
+++ b/packages/react-component-library/src/hooks/useHideShow.ts
@@ -4,8 +4,8 @@ import { useDocumentClick } from '.'
 
 export function useHideShow(isClick: boolean, closeDelay: number) {
   const [isVisible, setIsVisible] = useState(false)
-  const timerRef = useRef(null)
-  const floatingBoxChildrenRef = useRef()
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const floatingBoxChildrenRef = useRef(null)
 
   const hideElement = useCallback(() => {
     if (isVisible) {

--- a/packages/react-component-library/src/hooks/useInputValue.ts
+++ b/packages/react-component-library/src/hooks/useInputValue.ts
@@ -3,7 +3,7 @@ import { ChangeEvent, useMemo, useState } from 'react'
 
 const EMPTY_STRING = ''
 
-export function useInputValue(value: string) {
+export function useInputValue(value: string | undefined) {
   const [committedValue, setCommittedValue] = useState<string>(EMPTY_STRING)
 
   useMemo(() => setCommittedValue(value || EMPTY_STRING), [value])


### PR DESCRIPTION
## Related issue

#2755

## Overview

This fixes a subset of type errors on master that were being suppressed by `"strictNullChecks": false`. 

## Link to preview

https://5e25c277526d380020b5e418-ddpqvyfkig.chromatic.com/

## Reason

> Currently, the TypeScript configuation in `packages/react-component-library/tsconfig.json` contains:
> 
> ```
>     "strictNullChecks": false,
> ```
> 
> This means that types implicitly allow null and undefined. This is undesirable as it means:
> 
> - types are misleading
> - there may be hidden bugs (either due to values being null or undefined unintentionally, or due to null or undefined not being handled)
> - there may be missed test cases

## Work carried out

- [x] Resolve a number of strict null errors

## Developer notes

These were a number of straightforward errors that should be safe to fix on master (as opposed to `release/3.0.0`). Just banking these ones to reduce the risk of conflicts – the rest are to follow.
