### PR TITLE
refactor(ReactComponentLibrary): Remove margins

### DIFF
--- a/packages/react-component-library/src/components/CheckboxEnhanced/partials/StyledCheckboxEnhanced.tsx
+++ b/packages/react-component-library/src/components/CheckboxEnhanced/partials/StyledCheckboxEnhanced.tsx
@@ -14,7 +14,6 @@ export const StyledCheckboxEnhanced = styled.div`
   flex-direction: column;
   width: 22rem;
   padding: ${spacing('10')};
-  margin: ${spacing('4')};
   border-radius: 4px;
   border: 1px solid ${color('neutral', '100')};
   outline: none;

--- a/packages/react-component-library/src/components/DatePickerE/partials/StyledDatePickerEInput.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/partials/StyledDatePickerEInput.tsx
@@ -1,9 +1,6 @@
 import styled, { css } from 'styled-components'
-import { selectors } from '@defencedigital/design-tokens'
 
 import { StyledInput } from '../../TextInputE/partials/StyledInput'
-
-const { spacing } = selectors
 
 interface StyledDatePickerInputProps {
   $isDisabled?: boolean
@@ -14,7 +11,6 @@ export const StyledDatePickerEInput = styled.div<StyledDatePickerInputProps>`
   flex-direction: column;
   position: relative;
   z-index: 0;
-  margin: ${spacing('6')} 0;
   padding: 0;
   border: 0;
   vertical-align: top;

--- a/packages/react-component-library/src/components/DescriptionList/partials/StyledDescriptionList.tsx
+++ b/packages/react-component-library/src/components/DescriptionList/partials/StyledDescriptionList.tsx
@@ -8,6 +8,7 @@ export interface StyledDescriptionListProps {
 export const StyledDescriptionList = styled.dl<StyledDescriptionListProps>`
   overflow: hidden;
   transition: 200ms max-height linear;
+  margin-block: 0;
 
   ${({ $isCollapsible }) =>
     $isCollapsible &&

--- a/packages/react-component-library/src/components/NumberInputE/partials/StyledNumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/partials/StyledNumberInput.tsx
@@ -1,13 +1,9 @@
-import { selectors } from '@defencedigital/design-tokens'
 import styled from 'styled-components'
-
-const { spacing } = selectors
 
 export const StyledNumberInput = styled.div`
   display: inline-flex;
   flex-direction: column;
   position: relative;
-  margin: ${spacing('6')} 0;
   padding: 0;
   border: 0;
   vertical-align: top;

--- a/packages/react-component-library/src/components/TextInputE/partials/StyledTextInput.tsx
+++ b/packages/react-component-library/src/components/TextInputE/partials/StyledTextInput.tsx
@@ -1,13 +1,9 @@
 import styled from 'styled-components'
-import { selectors } from '@defencedigital/design-tokens'
-
-const { spacing } = selectors
 
 export const StyledTextInput = styled.div`
   display: inline-flex;
   flex-direction: column;
   position: relative;
-  margin: ${spacing('6')} 0;
   padding: 0;
   border: 0;
   vertical-align: top;


### PR DESCRIPTION
## Related issue
Closes #748 

## Overview
Removes margins from components.

## Reason
Appearance can be unpredictable for consumers.

## Work carried out
- [x] `DatePickerE`
- [x] `DescriptionList`
- [x] `NumberInputE`
- [x] `TextInputE`

## Developer notes
`CheckboxEnhanced` and `RadioEnhanced` will be removed so these margins have been left.
