### PR TITLE
feat(SelectE): Truncate overflowing options and display tooltip

### DIFF
--- a/packages/react-component-library/cypress/selectors/SelectE.ts
+++ b/packages/react-component-library/cypress/selectors/SelectE.ts
@@ -4,4 +4,5 @@ export default {
   label: '[data-testid="select-label"]',
   option: '[data-testid="select-option"]',
   outerWrapper: '[data-testid="select-outer-wrapper"]',
+  tooltip: '[data-testid="floating-box"]',
 }

--- a/packages/react-component-library/cypress/specs/SelectE/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/SelectE/index.spec.ts
@@ -18,11 +18,25 @@ describe('SelectE', () => {
 
     describe('and `th` is typed', () => {
       before(() => {
-        cy.get(selectors.selectE.outerWrapper).type('th{enter}')
+        cy.get(selectors.selectE.outerWrapper).type('Th{enter}')
+        cy.get('body').click()
       })
 
       it('sets the value as the item', () => {
-        cy.get(selectors.selectE.input).should('have.value', 'Three')
+        cy.get(selectors.selectE.input).should(
+          'have.value',
+          'This is a really, really long select option label that overflows the container when selected'
+        )
+      })
+
+      describe('and the user hovers on the input', () => {
+        beforeEach(() => {
+          cy.get(selectors.selectE.input).trigger('mouseover')
+        })
+
+        it('displays a tooltip', () => {
+          cy.get(selectors.selectE.tooltip).should('be.visible')
+        })
       })
     })
   })

--- a/packages/react-component-library/src/components/AutocompleteE/AutocompleteE.tsx
+++ b/packages/react-component-library/src/components/AutocompleteE/AutocompleteE.tsx
@@ -109,6 +109,7 @@ export const AutocompleteE: React.FC<AutocompleteEProps> = ({
             }),
             inputValue,
             isHighlighted: highlightedIndex === index,
+            title: child.props.children,
           })
         })}
       {inputValue && !items.length && <NoResults>{inputValue}</NoResults>}

--- a/packages/react-component-library/src/components/SelectBase/SelectBaseOption.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectBaseOption.tsx
@@ -11,6 +11,7 @@ export interface SelectBaseOptionBaseProps extends ComponentWithClass {
   icon?: React.ReactNode
   isHighlighted?: boolean
   value: string
+  title?: string
 }
 
 export interface SelectBaseOptionAsArrayProps
@@ -30,7 +31,7 @@ export type SelectBaseOptionProps =
 export const SelectBaseOption = React.forwardRef<
   HTMLLIElement,
   SelectBaseOptionProps
->(({ badge, icon, children, isHighlighted, ...rest }, ref) => {
+>(({ badge, icon, children, isHighlighted, title, ...rest }, ref) => {
   return (
     <StyledOption
       $isHighlighted={isHighlighted}
@@ -39,7 +40,7 @@ export const SelectBaseOption = React.forwardRef<
       {...rest}
     >
       {icon}
-      <StyledOptionText>{children}</StyledOptionText>
+      <StyledOptionText title={title}>{children}</StyledOptionText>
       {badge && (
         <StyledOptionBadge
           data-testid="select-badge"

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -1,9 +1,11 @@
-import React, { useMemo, useState } from 'react'
 import { UseSelectReturnValue, UseComboboxReturnValue } from 'downshift'
+import React, { useMemo, useState } from 'react'
+import mergeRefs from 'react-merge-refs'
 
 import { ArrowButton } from '../SelectE/ArrowButton'
 import { ClearButton } from '../SelectE/ClearButton'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { FloatingBox } from '../../primitives/FloatingBox'
 import { getId } from '../../helpers'
 import { SelectChildWithStringType } from './types'
 import { StyledInlineButtons } from './partials/StyledInlineButtons'
@@ -15,6 +17,8 @@ import { StyledOptionsWrapper } from './partials/StyledOptionsWrapper'
 import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
 import { StyledSelect } from './partials/StyledSelect'
 import { StyledTextInput } from './partials/StyledTextInput'
+import { StyledTooltip } from './partials/StyledTooltip'
+import { useStatefulRef } from '../../hooks/useStatefulRef'
 
 type ComboboxReturnValueType = UseComboboxReturnValue<SelectChildWithStringType>
 type SelectReturnValueType = UseSelectReturnValue<SelectChildWithStringType>
@@ -40,6 +44,10 @@ export interface SelectLayoutProps extends ComponentWithClass {
   value?: string
 }
 
+const isEllipsisActive = (el: HTMLInputElement): boolean => {
+  return el.offsetWidth < el.scrollWidth
+}
+
 export const SelectLayout: React.FC<SelectLayoutProps> = ({
   children,
   hasLabelFocus,
@@ -59,66 +67,80 @@ export const SelectLayout: React.FC<SelectLayoutProps> = ({
 }) => {
   const [hasHover, setHasHover] = useState<boolean>(false)
   const labelId = useMemo(() => getId('label'), [])
+  const [floatingBoxTarget, setFloatingBoxTarget] =
+    useStatefulRef<HTMLInputElement>()
+  const { ref, ...inputPropsRest } = inputProps
 
   return (
-    <StyledSelect data-testid="select" aria-labelledby={labelId}>
-      <StyledTextInput data-testid="text-input-container">
-        <StyledOuterWrapper
-          $hasFocus={isOpen}
-          $isDisabled={isDisabled}
-          $isInvalid={isInvalid}
-          data-testid="select-outer-wrapper"
-        >
-          <StyledInputWrapper
-            data-testid="text-input-input-wrapper"
-            {...inputWrapperProps}
+    <>
+      <StyledSelect data-testid="select" aria-labelledby={labelId}>
+        <StyledTextInput data-testid="text-input-container">
+          <StyledOuterWrapper
+            $hasFocus={isOpen}
+            $isDisabled={isDisabled}
+            $isInvalid={isInvalid}
+            data-testid="select-outer-wrapper"
           >
-            <StyledLabel
-              $hasContent={hasSelectedItem}
-              $hasFocus={hasLabelFocus}
-              htmlFor={id}
-              id={labelId}
-              data-testid="select-label"
+            <StyledInputWrapper
+              data-testid="text-input-input-wrapper"
+              {...inputWrapperProps}
             >
-              {label}
-            </StyledLabel>
-            <StyledInput
-              $hasLabel
-              data-testid="select-input"
-              disabled={isDisabled}
-              value={value}
-              onMouseEnter={() => {
-                if (!isDisabled) {
-                  setHasHover(true)
-                }
-              }}
-              onMouseLeave={() => setHasHover(false)}
-              {...rest}
-              {...inputProps}
-              aria-labelledby={labelId}
-              id={id}
-            />
-          </StyledInputWrapper>
-          <StyledInlineButtons>
-            {hasSelectedItem && (
-              <ClearButton
-                isDisabled={isDisabled}
-                onClick={onClearButtonClick}
+              <StyledLabel
+                $hasContent={hasSelectedItem}
+                $hasFocus={hasLabelFocus}
+                htmlFor={id}
+                id={labelId}
+                data-testid="select-label"
+              >
+                {label}
+              </StyledLabel>
+              <StyledInput
+                ref={mergeRefs([setFloatingBoxTarget, ref])}
+                $hasLabel
+                data-testid="select-input"
+                disabled={isDisabled}
+                value={value}
+                onMouseEnter={() => {
+                  if (!isDisabled) {
+                    setHasHover(true)
+                  }
+                }}
+                onMouseLeave={() => setHasHover(false)}
+                {...rest}
+                {...inputPropsRest}
+                aria-labelledby={labelId}
+                id={id}
               />
-            )}
-            <ArrowButton
-              hasHover={hasHover}
-              isDisabled={isDisabled}
-              isOpen={isOpen}
-              {...toggleButtonProps}
-            />
-          </StyledInlineButtons>
-        </StyledOuterWrapper>
-      </StyledTextInput>
-      <StyledOptionsWrapper $isVisible={isOpen}>
-        <StyledOptions {...menuProps}>{children}</StyledOptions>
-      </StyledOptionsWrapper>
-    </StyledSelect>
+            </StyledInputWrapper>
+            <StyledInlineButtons>
+              {hasSelectedItem && (
+                <ClearButton
+                  isDisabled={isDisabled}
+                  onClick={onClearButtonClick}
+                />
+              )}
+              <ArrowButton
+                hasHover={hasHover}
+                isDisabled={isDisabled}
+                isOpen={isOpen}
+                {...toggleButtonProps}
+              />
+            </StyledInlineButtons>
+          </StyledOuterWrapper>
+        </StyledTextInput>
+        <StyledOptionsWrapper $isVisible={isOpen}>
+          <StyledOptions {...menuProps}>{children}</StyledOptions>
+        </StyledOptionsWrapper>
+      </StyledSelect>
+      <FloatingBox
+        placement="bottom"
+        scheme="dark"
+        isVisible={hasHover && isEllipsisActive(floatingBoxTarget)}
+        targetElement={floatingBoxTarget}
+      >
+        <StyledTooltip>{value}</StyledTooltip>
+      </FloatingBox>
+    </>
   )
 }
 

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledInput.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledInput.tsx
@@ -6,6 +6,11 @@ import {
 } from '../../TextInputE/partials/StyledInput'
 
 export const StyledInput = styled(StyledTextInputInput)<StyledInputProps>`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 0;
+
   &:enabled {
     cursor: pointer;
   }

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledOptionText.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledOptionText.tsx
@@ -2,4 +2,7 @@ import styled from 'styled-components'
 
 export const StyledOptionText = styled.span`
   flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 `

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledTooltip.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledTooltip.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+import { selectors } from '@defencedigital/design-tokens'
+
+const { fontSize, spacing } = selectors
+
+export const StyledTooltip = styled.span`
+  display: inline-flex;
+  font-size: ${fontSize('base')};
+  padding: ${spacing('6')} ${spacing('8')};
+`

--- a/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.stories.tsx
@@ -28,9 +28,14 @@ export default {
 } as ComponentMeta<typeof SelectE>
 
 const Template: ComponentStory<typeof SelectE> = (args) => (
-  <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
+  <div
+    style={{ height: args.isDisabled ? 'initial' : '18rem', maxWidth: '20rem' }}
+  >
     <SelectE label="Some label" {...args}>
-      <SelectEOption value="one">One</SelectEOption>
+      <SelectEOption value="one">
+        This is a really, really long select option label that overflows the
+        container when selected
+      </SelectEOption>
       <SelectEOption value="two">Two</SelectEOption>
       <SelectEOption value="three">Three</SelectEOption>
       <SelectEOption value="four">Four</SelectEOption>
@@ -39,7 +44,9 @@ const Template: ComponentStory<typeof SelectE> = (args) => (
 )
 
 const TemplateWIthIconsAndBadges: ComponentStory<typeof SelectE> = (args) => (
-  <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
+  <div
+    style={{ height: args.isDisabled ? 'initial' : '18rem', maxWidth: '20rem' }}
+  >
     <SelectE label="Some label" {...args}>
       <SelectEOption badge={100} icon={<IconAnchor />} value="one">
         One

--- a/packages/react-component-library/src/components/SelectE/SelectE.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.tsx
@@ -82,6 +82,7 @@ export const SelectE: React.FC<SelectBaseProps> = ({
                 key: `select-option-${child.props.children}`,
               }),
               isHighlighted: highlightedIndex === index,
+              title: child.props.children,
             })
           }
         )}

--- a/packages/react-component-library/src/components/SelectE/SelectEOption.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectEOption.tsx
@@ -3,7 +3,8 @@ import React from 'react'
 import { SelectBaseOption, SelectBaseOptionAsStringProps } from '../SelectBase'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SelectEOptionProps extends SelectBaseOptionAsStringProps {}
+export interface SelectEOptionProps
+  extends Omit<SelectBaseOptionAsStringProps, 'title'> {}
 
 export const SelectEOption = React.forwardRef<
   HTMLLIElement,

--- a/yarn.lock
+++ b/yarn.lock
@@ -18578,9 +18578,9 @@ write-pkg@^4.0.0:
     write-json-file "^3.2.0"
 
 ws@8.2.3, ws@^7.3.1, ws@^7.4.6, ws@^8.2.3, ws@^8.4.2:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.2.tgz#18e749868d8439f2268368829042894b6907aa0b"
-  integrity sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
+  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
 
 x-default-browser@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Related issue

Closes #3023

## Overview

Handle long option labels elegantly (truncate, ellipsis and tooltip).

## Link to preview

https://62024fc275c9b4a9bf04d695--angry-villani-87949f.netlify.app

## Reason

>This functionality was recently added to the legacy component. The new experimental implementation needs to include this to reach feature parity.

## Work carried out

- [x] Truncate and ellipsis overflowing labels
- [x] Display Tooltip on hover only if truncated
- [x] Compliment with Cypress test

## Screenshot

![2022-02-08 11 10 25](https://user-images.githubusercontent.com/48086589/152975799-6a2a84cb-129d-4705-8853-40c559b64001.gif)

## Developer notes

The added Cypress eventing library plays nice with Chrome but not Firefox - added skip for that browser.