### PR TITLE
Remove `isValid`

### DIFF
--- a/packages/react-component-library/src/common/InputValidationProps.ts
+++ b/packages/react-component-library/src/common/InputValidationProps.ts
@@ -1,9 +1,5 @@
 export interface InputValidationProps {
   /**
-   * Denotes that the form field is valid.
-   */
-  isValid?: boolean
-  /**
    * Denotes that the form field is invalid.
    */
   isInvalid?: boolean

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -879,19 +879,6 @@ describe('DatePicker', () => {
   })
 
   describe('when form validation classes are provided', () => {
-    describe('when the field is valid', () => {
-      beforeEach(() => {
-        wrapper = render(<DatePicker className="is-valid" />)
-      })
-
-      it('should set the border on the outer wrapper', () => {
-        expect(wrapper.getByTestId('datepicker-outer-wrapper')).toHaveStyleRule(
-          'border',
-          `1px solid ${ColorSuccess600}`
-        )
-      })
-    })
-
     describe('when the field is invalid', () => {
       beforeEach(() => {
         wrapper = render(<DatePicker className="is-invalid" />)

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -117,7 +117,6 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   isDisabled,
   isInvalid,
   isRange,
-  isValid,
   label = 'Select Date',
   onChange,
   onCalendarFocus,
@@ -196,7 +195,6 @@ export const DatePicker: React.FC<DatePickerProps> = ({
           data-testid="datepicker-outer-wrapper"
           $hasFocus={open}
           $isInvalid={hasError}
-          $isValid={isValid || hasClass(className, 'is-valid')}
         >
           <StyledInputWrapper>
             <StyledLabel

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -140,7 +140,6 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   isCondensed,
   isDisabled = false,
   isInvalid,
-  isValid,
   label,
   max,
   min,
@@ -190,7 +189,6 @@ export const NumberInput: React.FC<NumberInputProps> = ({
       <StyledNumberInputOuterWrapper
         $hasFocus={hasFocus}
         $isInvalid={isInvalid || hasClass(className, 'is-invalid')}
-        $isValid={isValid || hasClass(className, 'is-valid')}
       >
         <StartAdornment>{startAdornment}</StartAdornment>
 
@@ -200,7 +198,6 @@ export const NumberInput: React.FC<NumberInputProps> = ({
           id={id}
           isDisabled={isDisabled}
           isCondensed={isCondensed}
-          isValid={isValid || hasClass(className, 'is-valid')}
           isInvalid={isInvalid || hasClass(className, 'is-invalid')}
           label={label}
           name={name}

--- a/packages/react-component-library/src/styled-components/input.ts
+++ b/packages/react-component-library/src/styled-components/input.ts
@@ -6,11 +6,10 @@ const { color, spacing } = selectors
 export interface StyledOuterWrapperProps {
   $hasFocus?: boolean
   $isInvalid?: boolean
-  $isValid?: boolean
 }
 
 function getBorderColor(
-  { $hasFocus, $isInvalid, $isValid }: StyledOuterWrapperProps,
+  { $hasFocus, $isInvalid }: StyledOuterWrapperProps,
   borderColorDefault: string
 ) {
   if ($isInvalid) {
@@ -19,10 +18,6 @@ function getBorderColor(
 
   if ($hasFocus) {
     return color('action', '600')
-  }
-
-  if ($isValid) {
-    return color('success', '600')
   }
 
   return borderColorDefault


### PR DESCRIPTION
## Related issue
Closes #3029 

## Overview
Removes the use of `isValid`.

## Reason
This is no longer a presentational state for our components.

## Work carried out
- [x] Remove `isValid`