### PR TITLE
Fix various strict null errors (part 2)

### DIFF
--- a/packages/react-component-library/src/components/AutocompleteE/Autocomplete.test.tsx
+++ b/packages/react-component-library/src/components/AutocompleteE/Autocomplete.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event'
 import { AutocompleteE, AutocompleteEOption } from '.'
 
 describe('AutocompleteE', () => {
-  let onChangeSpy: (value: string) => void
+  let onChangeSpy: (value: string | null) => void
   let wrapper: RenderResult
 
   describe('when using the default prop values', () => {
@@ -16,7 +16,11 @@ describe('AutocompleteE', () => {
       onChangeSpy = jest.fn()
 
       wrapper = render(
-        <AutocompleteE id="autocomplete-id" label="Label" onChange={onChangeSpy}>
+        <AutocompleteE
+          id="autocomplete-id"
+          label="Label"
+          onChange={onChangeSpy}
+        >
           <AutocompleteEOption value="one">One</AutocompleteEOption>
           <AutocompleteEOption value="two">Two</AutocompleteEOption>
           <AutocompleteEOption value="three">Three</AutocompleteEOption>
@@ -162,7 +166,7 @@ describe('AutocompleteE', () => {
     })
   })
 
-  describe('when `value` is set', () => {
+  describe('when `value` is set to a valid value', () => {
     beforeEach(() => {
       wrapper = render(
         <AutocompleteE label="Label" value="two">
@@ -175,6 +179,22 @@ describe('AutocompleteE', () => {
 
     it('sets the value', () => {
       expect(wrapper.getByTestId('select-input')).toHaveValue('Two')
+    })
+  })
+
+  describe.each(['invalid', null])('when `value` is set to `%s`', (value) => {
+    beforeEach(() => {
+      wrapper = render(
+        <AutocompleteE label="Label" value={value}>
+          <AutocompleteEOption value="one">One</AutocompleteEOption>
+          <AutocompleteEOption value="two">Two</AutocompleteEOption>
+          <AutocompleteEOption value="three">Three</AutocompleteEOption>
+        </AutocompleteE>
+      )
+    })
+
+    it('does not set the value', () => {
+      expect(wrapper.getByTestId('select-input')).toHaveValue('')
     })
   })
 })

--- a/packages/react-component-library/src/components/AutocompleteE/AutocompleteE.tsx
+++ b/packages/react-component-library/src/components/AutocompleteE/AutocompleteE.tsx
@@ -20,9 +20,9 @@ export interface AutocompleteEProps extends SelectBaseProps {}
 export const AutocompleteE: React.FC<AutocompleteEProps> = ({
   children,
   id = getId('autocomplete'),
-  isInvalid,
+  isInvalid = false,
   onChange,
-  value,
+  value = null,
   ...rest
 }) => {
   const { hasError, inputRef, items, onInputValueChange, onIsOpenChange } =
@@ -43,7 +43,7 @@ export const AutocompleteE: React.FC<AutocompleteEProps> = ({
     setHighlightedIndex,
     setInputValue,
     toggleMenu,
-  } = useCombobox({
+  } = useCombobox<SelectChildWithStringType>({
     items,
     itemToString,
     onInputValueChange,

--- a/packages/react-component-library/src/components/AutocompleteE/hooks/useAutocomplete.ts
+++ b/packages/react-component-library/src/components/AutocompleteE/hooks/useAutocomplete.ts
@@ -19,7 +19,7 @@ export function useAutocomplete(
   ) => void
 } {
   const [hasError, setHasError] = useState<boolean>(isInvalid)
-  const inputRef = useRef<HTMLInputElement>()
+  const inputRef = useRef<HTMLInputElement>(null)
   const [items, setItems] = useState<SelectChildWithStringType[]>(children)
 
   function onInputValueChange({
@@ -32,7 +32,7 @@ export function useAutocomplete(
           if (!React.isValidElement(item)) {
             return false
           }
-          const filter = inputValue.toLowerCase()
+          const filter = (inputValue as string).toLowerCase()
           return item.props.children.toLowerCase().indexOf(filter) > -1
         })
       )
@@ -41,7 +41,7 @@ export function useAutocomplete(
     }
   }
 
-  function getHasError(inputValue: string): boolean {
+  function getHasError(inputValue: string | undefined): boolean {
     if (!inputValue) {
       return false
     }
@@ -54,7 +54,7 @@ export function useAutocomplete(
     isOpen,
   }: UseComboboxStateChange<SelectChildWithStringType>) {
     if (isOpen) {
-      inputRef.current.focus()
+      inputRef.current?.focus()
     } else {
       const newHasError = getHasError(inputValue)
       setHasError(newHasError)
@@ -63,7 +63,7 @@ export function useAutocomplete(
         setItems(children)
       }
 
-      inputRef.current.blur()
+      inputRef.current?.blur()
     }
   }
 

--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.stories.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.stories.tsx
@@ -97,10 +97,15 @@ export const WithFormik: ComponentStory<typeof DatePickerE> = (props) => {
     andAnotherStartDate: Date | null
   }
 
-  const errorText = 'Something went wrong!'
+  const requiredError = 'Something went wrong!'
+  const invalidError = 'Enter a valid date'
 
   const validationSchema = yup.object().shape({
-    andAnotherStartDate: yup.date().nullable().required(errorText),
+    andAnotherStartDate: yup
+      .date()
+      .nullable()
+      .required(requiredError)
+      .typeError(invalidError),
   })
 
   const FormikDatePicker = withFormik(DatePickerE)
@@ -113,7 +118,7 @@ export const WithFormik: ComponentStory<typeof DatePickerE> = (props) => {
 
   return (
     <Formik
-      initialErrors={{ andAnotherStartDate: errorText }}
+      initialErrors={{ andAnotherStartDate: requiredError }}
       initialTouched={{ andAnotherStartDate: true }}
       initialValues={initialValues}
       onSubmit={action('onSubmit')}

--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.test.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.test.tsx
@@ -1,4 +1,4 @@
-import { format, isValid, parseISO } from 'date-fns'
+import { format, isValid } from 'date-fns'
 import React, { useState } from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { ColorDanger800 } from '@defencedigital/design-tokens'
@@ -23,7 +23,7 @@ const ERROR_BOX_SHADOW = `0 0 0 ${
 } ${ColorDanger800.toUpperCase()}`
 
 function formatDate(date: Date | null) {
-  return isValid(date) ? format(date, 'dd/MM/yyyy') : ''
+  return date && isValid(date) ? format(date, 'dd/MM/yyyy') : ''
 }
 
 describe('DatePickerE', () => {

--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
@@ -1,5 +1,4 @@
 import { IconEvent } from '@defencedigital/icon-library'
-import { isValid } from 'date-fns'
 import FocusTrap from 'focus-trap-react'
 import React, { useRef } from 'react'
 import { Placement } from '@popperjs/core'
@@ -13,6 +12,7 @@ import { DATEPICKER_E_ACTION } from './types'
 import { hasClass } from '../../helpers'
 import { InlineButton } from '../InlineButtons/InlineButton'
 import { InputValidationProps } from '../../common/InputValidationProps'
+import { isDateValid } from './utils'
 import { StyledLabel } from '../TextInputE/partials/StyledLabel'
 import { StyledDatePickerEInput } from './partials/StyledDatePickerEInput'
 import { StyledDayPicker } from './partials/StyledDayPicker'
@@ -63,7 +63,7 @@ export interface DatePickerEProps
    * If set, it should be kept updated with the `endDate` value provided
    * by the `onChange` callback.
    */
-  endDate?: Date
+  endDate?: Date | null
   /**
    * Custom date format (e.g. `yyyy/MM/dd`).
    */
@@ -117,7 +117,7 @@ export interface DatePickerEProps
    * If set, it should be kept updated with the `startDate` provided
    * by the `onChange` callback.
    */
-  startDate?: Date
+  startDate?: Date | null
   /**
    * Toggles whether the picker is open on first render.
    */
@@ -139,11 +139,11 @@ export interface DatePickerEProps
   /**
    * Initial value for `startDate`. Only used when the `startDate` prop is not set.
    */
-  initialStartDate?: Date
+  initialStartDate?: Date | null
   /**
    * Initial value for `endDate`. Only used when the `endDate` prop is not set.
    */
-  initialEndDate?: Date
+  initialEndDate?: Date | null
   /**
    * Position to display the picker relative to the input.
    * NOTE: This is now calculated automatically by default based on available screen real-estate.
@@ -155,16 +155,17 @@ export interface DatePickerEProps
   value?: never
 }
 
-const replaceInvalidDate = (date: Date) => (isValid(date) ? date : undefined)
+const replaceInvalidDate = (date: Date | null | undefined): Date | undefined =>
+  isDateValid(date) ? date : undefined
 
 export const DatePickerE: React.FC<DatePickerEProps> = ({
   className,
   endDate: externalEndDate,
   format: datePickerFormat = DATE_FORMAT.SHORT,
   id: externalId,
-  isDisabled,
+  isDisabled = false,
   isInvalid,
-  isRange,
+  isRange = false,
   label = 'Date',
   onChange,
   onCalendarFocus,
@@ -172,8 +173,8 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
   initialIsOpen,
   disabledDays,
   initialMonth,
-  initialStartDate,
-  initialEndDate,
+  initialStartDate = null,
+  initialEndDate = null,
   placement = 'bottom-start',
   onBlur,
   // Formik can pass value – drop it to stop it being forwarded to the input
@@ -183,8 +184,8 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
   const id = useExternalId(externalId)
   const titleId = `datepicker-title-${useExternalId()}`
   const contentId = `datepicker-contentId-${useExternalId()}`
-  const buttonRef = useRef<HTMLButtonElement>()
-  const inputRef = useRef<HTMLInputElement>()
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const { hasFocus, onLocalBlur, onLocalFocus } = useFocus()
   const {
@@ -239,7 +240,7 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
 
   const hasContent = Boolean(startDate)
 
-  const placeholder = !isRange ? datePickerFormat.toLowerCase() : null
+  const placeholder = !isRange ? datePickerFormat.toLowerCase() : undefined
 
   return (
     <>
@@ -302,7 +303,7 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
           </StyledInputWrapper>
           <StyledInlineButtons>
             <InlineButton
-              aria-expanded={!!isOpen}
+              aria-expanded={isOpen}
               aria-label={`${isOpen ? 'Hide' : 'Show'} day picker`}
               aria-owns={contentId}
               data-testid="datepicker-input-button"

--- a/packages/react-component-library/src/components/DatePickerE/types.ts
+++ b/packages/react-component-library/src/components/DatePickerE/types.ts
@@ -1,6 +1,6 @@
 export interface DatePickerEState {
-  startDate?: Date
-  endDate?: Date
+  startDate: Date | null
+  endDate: Date | null
   inputValue: string
   datePickerFormat: string
   hasError: boolean

--- a/packages/react-component-library/src/components/DatePickerE/useDatePickerEReducer.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useDatePickerEReducer.ts
@@ -1,7 +1,6 @@
-import { isEqual, isValid } from 'date-fns'
 import React, { useEffect, useReducer } from 'react'
 
-import { formatDatesForInput } from './formatDatesForInput'
+import { areDatesEqual, isDateValid, formatDatesForInput } from './utils'
 import {
   DATEPICKER_E_ACTION,
   DatePickerEAction,
@@ -34,10 +33,10 @@ function reducer(
     case DATEPICKER_E_ACTION.REFRESH_HAS_ERROR:
       return {
         ...state,
-        hasError: state.startDate && !isValid(state.startDate),
+        hasError: Boolean(state.startDate && !isDateValid(state.startDate)),
       }
     case DATEPICKER_E_ACTION.REFRESH_INPUT_VALUE:
-      if (state.startDate && !isValid(state.startDate)) {
+      if (state.startDate && !isDateValid(state.startDate)) {
         return state
       }
 
@@ -54,19 +53,10 @@ function reducer(
   }
 }
 
-function areDatesEqual(dateLeft: Date | null, dateRight: Date | null): boolean {
-  const bothDatesInvalid =
-    dateLeft && dateRight && !isValid(dateLeft) && !isValid(dateRight)
-
-  return (
-    dateLeft === dateRight || bothDatesInvalid || isEqual(dateLeft, dateRight)
-  )
-}
-
 function shouldReset(
   state: DatePickerEState,
-  startDate: Date | undefined,
-  endDate: Date | undefined,
+  startDate: Date | null | undefined,
+  endDate: Date | null | undefined,
   datePickerFormat: string,
   isRange: boolean
 ): boolean {
@@ -82,10 +72,10 @@ function shouldReset(
 }
 
 export function useDatePickerEReducer(
-  startDate: Date | undefined,
-  endDate: Date | undefined,
-  initialStartDate: Date | undefined,
-  initialEndDate: Date | undefined,
+  startDate: Date | null | undefined,
+  endDate: Date | null | undefined,
+  initialStartDate: Date | null,
+  initialEndDate: Date | null,
   datePickerFormat: string,
   isRange: boolean
 ): [DatePickerEState, React.Dispatch<DatePickerEAction>] {
@@ -104,8 +94,8 @@ export function useDatePickerEReducer(
       dispatch({
         type: DATEPICKER_E_ACTION.RESET,
         data: {
-          startDate,
-          endDate,
+          startDate: startDate ?? null,
+          endDate: endDate ?? null,
           datePickerFormat,
         },
       })

--- a/packages/react-component-library/src/components/DatePickerE/useHandleDayClick.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useHandleDayClick.ts
@@ -15,10 +15,10 @@ import {
 
 function getNewState(
   isRange: boolean,
-  day: Date,
+  day: Date | null,
   { startDate, endDate }: DatePickerEState
 ) {
-  if (!isRange) {
+  if (!isRange || !day) {
     return { startDate: day, endDate: day }
   }
 
@@ -33,9 +33,9 @@ function getNewState(
 }
 
 function calculateDateValidity(
-  date: Date,
+  date: Date | null,
   disabledDays: DayPickerProps['disabledDays']
-): DatePickerEDateValidityType {
+): DatePickerEDateValidityType | null {
   if (!date) {
     return null
   }
@@ -57,8 +57,8 @@ export const useHandleDayClick = (
   isRange: boolean,
   disabledDays: DayPickerProps['disabledDays'],
   onChange?: (data: DatePickerEOnChangeData) => void
-): ((day: Date) => { startDate: Date; endDate: Date }) => {
-  function handleDayClick(day: Date) {
+): ((day: Date | null) => { startDate: Date | null; endDate: Date | null }) => {
+  function handleDayClick(day: Date | null) {
     const newState = getNewState(isRange, day, state)
 
     dispatch({

--- a/packages/react-component-library/src/components/DatePickerE/useInput.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useInput.ts
@@ -21,7 +21,7 @@ function parseDate(datePickerFormat: string, value: string) {
 export function useInput(
   datePickerFormat: string,
   isRange: boolean,
-  handleDayClick: (date: Date) => void,
+  handleDayClick: (date: Date | null) => void,
   dispatch: React.Dispatch<DatePickerEAction>
 ) {
   const handleKeyDown = useCallback(

--- a/packages/react-component-library/src/components/DatePickerE/useRangeHoverOrFocusDate.ts
+++ b/packages/react-component-library/src/components/DatePickerE/useRangeHoverOrFocusDate.ts
@@ -7,7 +7,7 @@ import { useCallback, useState } from 'react'
  * @todo Add handleDayBlur after upgrading to react-day-picker v8.
  */
 export function useRangeHoverOrFocusDate(isRange: boolean): {
-  rangeHoverOrFocusDate: Date
+  rangeHoverOrFocusDate: Date | null
   handleDayFocus: (date: Date) => void
   handleDayMouseEnter: (date: Date) => void
   handleDayMouseLeave: () => void

--- a/packages/react-component-library/src/components/DatePickerE/utils/areDatesEqual.test.ts
+++ b/packages/react-component-library/src/components/DatePickerE/utils/areDatesEqual.test.ts
@@ -1,0 +1,24 @@
+import { areDatesEqual } from './areDatesEqual'
+
+describe('areDatesEqual', () => {
+  it.each([
+    [undefined, undefined],
+    [undefined, null],
+    [null, undefined],
+    [null, null],
+    [new Date(NaN), new Date(NaN)],
+    [new Date('2022-01-01'), new Date('2022-01-01')],
+  ])('returns true for values `%s` and `%s`', (dateLeft, dateRight) => {
+    expect(areDatesEqual(dateLeft, dateRight)).toBeTruthy()
+  })
+
+  it.each([
+    [new Date(NaN), null],
+    [new Date('2022-01-01'), null],
+    [new Date('2022-01-01'), new Date(NaN)],
+    [new Date('2022-01-01'), new Date('2022-01-02')],
+  ])('returns false for values `%s` and `%s`', (dateLeft, dateRight) => {
+    expect(areDatesEqual(dateLeft, dateRight)).toBeFalsy()
+    expect(areDatesEqual(dateRight, dateLeft)).toBeFalsy()
+  })
+})

--- a/packages/react-component-library/src/components/DatePickerE/utils/areDatesEqual.ts
+++ b/packages/react-component-library/src/components/DatePickerE/utils/areDatesEqual.ts
@@ -1,0 +1,19 @@
+import { isEqual } from 'date-fns'
+
+import { isDateValid } from './isDateValid'
+
+export function areDatesEqual(
+  dateLeft: Date | null = null,
+  dateRight: Date | null = null
+): boolean {
+  const isDateLeftValid = isDateValid(dateLeft)
+  const isDateRightValid = isDateValid(dateRight)
+
+  const bothNull = dateLeft == null && dateRight == null
+  const bothInvalid =
+    dateLeft && dateRight && !isDateLeftValid && !isDateRightValid
+  const bothEqual =
+    isDateLeftValid && isDateRightValid && isEqual(dateLeft, dateRight)
+
+  return bothNull || bothInvalid || bothEqual
+}

--- a/packages/react-component-library/src/components/DatePickerE/utils/formatDatesForInput.ts
+++ b/packages/react-component-library/src/components/DatePickerE/utils/formatDatesForInput.ts
@@ -1,13 +1,15 @@
-import { differenceInMinutes, format, isValid } from 'date-fns'
+import { differenceInMinutes, format } from 'date-fns'
+
+import { isDateValid } from '.'
 
 export function formatDatesForInput(
-  startDate: Date,
-  endDate: Date,
+  startDate: Date | null,
+  endDate: Date | null,
   datePickerFormat: string
 ) {
   if (
-    isValid(startDate) &&
-    isValid(endDate) &&
+    isDateValid(startDate) &&
+    isDateValid(endDate) &&
     differenceInMinutes(endDate, startDate) > 0
   ) {
     return `${format(startDate, datePickerFormat)} - ${format(
@@ -16,7 +18,7 @@ export function formatDatesForInput(
     )}`
   }
 
-  if (isValid(startDate)) {
+  if (isDateValid(startDate)) {
     return format(startDate, datePickerFormat)
   }
 

--- a/packages/react-component-library/src/components/DatePickerE/utils/index.ts
+++ b/packages/react-component-library/src/components/DatePickerE/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './areDatesEqual'
+export * from './formatDatesForInput'
+export * from './isDateValid'

--- a/packages/react-component-library/src/components/DatePickerE/utils/isDateValid.ts
+++ b/packages/react-component-library/src/components/DatePickerE/utils/isDateValid.ts
@@ -1,0 +1,10 @@
+import { isValid } from 'date-fns'
+
+type DateAny = Parameters<typeof isValid>[0]
+
+/**
+ * Version of isValid with a type predicate.
+ */
+export function isDateValid(value: DateAny): value is Date | number {
+  return isValid(value)
+}

--- a/packages/react-component-library/src/components/NumberInputE/Buttons.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/Buttons.tsx
@@ -19,8 +19,8 @@ export interface ButtonsProps {
     newValue: string
   ) => void
   size: ComponentSizeType
-  step?: number
-  value: string
+  step: number
+  value: string | null
 }
 
 const iconLookup = {

--- a/packages/react-component-library/src/components/NumberInputE/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/Input.tsx
@@ -19,7 +19,7 @@ export interface InputProps {
   onPaste: (event: React.ClipboardEvent<HTMLInputElement>) => void
   placeholder?: string
   size: ComponentSizeType
-  value?: string
+  value?: string | null
 }
 
 export const Input: React.FC<InputProps> = ({

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.test.tsx
@@ -50,8 +50,8 @@ describe('NumberInputE', () => {
     now,
     text,
   }: {
-    min?: number
-    max?: number
+    min: number | null
+    max: number | null
     now: number
     text: string
   }) {
@@ -75,7 +75,10 @@ describe('NumberInputE', () => {
     })
   }
 
-  function assertOnChangeCall(expected: number, expectedNumberOfTimes = 1) {
+  function assertOnChangeCall(
+    expected: number | null,
+    expectedNumberOfTimes = 1
+  ) {
     it(`calls the \`onChange\` callback ${expectedNumberOfTimes} times with the new value ${expected}`, () => {
       expect(onChangeSpy).toHaveBeenCalledTimes(expectedNumberOfTimes)
       expect(onChangeSpy.mock.calls[expectedNumberOfTimes - 1][1]).toEqual(

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.tsx
@@ -125,9 +125,9 @@ export type NumberInputEProps =
   | NumberInputWithSuffixProps
 
 function formatValue(
-  displayValue: string,
-  prefix: string,
-  suffix: string
+  displayValue: string | null,
+  prefix?: string,
+  suffix?: string
 ): string {
   if (isNil(displayValue)) {
     return 'Not set'

--- a/packages/react-component-library/src/components/NumberInputE/useChangeHandlers.ts
+++ b/packages/react-component-library/src/components/NumberInputE/useChangeHandlers.ts
@@ -11,9 +11,9 @@ export function useChangeHandlers(
     event:
       | React.ChangeEvent<HTMLInputElement>
       | React.MouseEvent<HTMLButtonElement>,
-    newValue: number
+    newValue: number | null
   ) => void,
-  setCommittedValue: React.Dispatch<React.SetStateAction<string>>
+  setCommittedValue: React.Dispatch<React.SetStateAction<string | null>>
 ): {
   handleButtonClick: (
     event: React.MouseEvent<HTMLButtonElement>,

--- a/packages/react-component-library/src/components/NumberInputE/useEarlyValidation.ts
+++ b/packages/react-component-library/src/components/NumberInputE/useEarlyValidation.ts
@@ -7,8 +7,11 @@ import { isValueValid } from './validation'
  * new value will be based on the cursor position ond selection.
  */
 function getNewInputValue(input: HTMLInputElement, newText: string): string {
-  const textBeforeSelection = input.value.substring(0, input.selectionStart)
-  const textAfterSelection = input.value.substring(input.selectionEnd)
+  const textBeforeSelection = input.value.substring(
+    0,
+    input.selectionStart || 0
+  )
+  const textAfterSelection = input.value.substring(input.selectionEnd || 0)
   return `${textBeforeSelection}${newText}${textAfterSelection}`
 }
 

--- a/packages/react-component-library/src/components/NumberInputE/useValue.ts
+++ b/packages/react-component-library/src/components/NumberInputE/useValue.ts
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react'
 
-export function useValue(value: string): {
-  committedValue: string
-  setCommittedValue: React.Dispatch<React.SetStateAction<string>>
+export function useValue(value: string | null): {
+  committedValue: string | null
+  setCommittedValue: React.Dispatch<React.SetStateAction<string | null>>
 } {
   const [committedValue, setCommittedValue] = useState(value)
 

--- a/packages/react-component-library/src/components/NumberInputE/validation.ts
+++ b/packages/react-component-library/src/components/NumberInputE/validation.ts
@@ -12,8 +12,8 @@ export function isValueValid(
 }
 
 export function isWithinRange(
-  max: number,
-  min: number,
+  max: number | undefined,
+  min: number | undefined,
   newValue: number
 ): boolean {
   const isNotBelowMin = isNil(min) || newValue >= min

--- a/packages/react-component-library/src/components/RadioE/RadioE.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.tsx
@@ -67,12 +67,12 @@ export const RadioE = React.forwardRef<HTMLInputElement, RadioEProps>(
 
     const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
       if (event.target !== localRef.current) {
-        localRef.current.click()
+        localRef.current?.click()
       }
     }
 
     const handleKeyUp = (_: React.KeyboardEvent) => {
-      localRef.current.focus()
+      localRef.current?.focus()
     }
 
     return (

--- a/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
+++ b/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
@@ -30,5 +30,5 @@ export interface SelectBaseProps extends ComponentWithClass {
   /**
    * Optional HTML `value` attribute to apply to the component.
    */
-  value?: string
+  value?: string | null
 }

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -44,18 +44,18 @@ export interface SelectLayoutProps extends ComponentWithClass {
   value?: string
 }
 
-const isEllipsisActive = (el: HTMLInputElement): boolean => {
-  return el.offsetWidth < el.scrollWidth
+const isEllipsisActive = (el: HTMLInputElement | null): boolean => {
+  return Boolean(el && el.offsetWidth < el.scrollWidth)
 }
 
 export const SelectLayout: React.FC<SelectLayoutProps> = ({
   children,
-  hasLabelFocus,
+  hasLabelFocus = false,
   hasSelectedItem,
   id,
   inputProps,
   inputWrapperProps,
-  isDisabled,
+  isDisabled = false,
   isInvalid,
   isOpen,
   label,

--- a/packages/react-component-library/src/components/SelectBase/helpers.ts
+++ b/packages/react-component-library/src/components/SelectBase/helpers.ts
@@ -3,10 +3,17 @@ import React from 'react'
 import { SelectChildrenType, SelectChildWithStringType } from './types'
 
 function itemToString(item: SelectChildWithStringType) {
-  return React.isValidElement(item) ? item.props.children : null
+  return React.isValidElement(item) ? item.props.children : ''
 }
 
-function initialSelectedItem(children: SelectChildrenType, value: string) {
+function initialSelectedItem(
+  children: SelectChildrenType,
+  value: string | null
+) {
+  if (value === null) {
+    return null
+  }
+
   return React.Children.toArray(children).find((child) => {
     return React.isValidElement(child) ? child.props.value === value : null
   })

--- a/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.test.tsx
@@ -15,7 +15,7 @@ import { SelectE } from '.'
 import { SelectEOption } from './SelectEOption'
 
 describe('SelectE', () => {
-  let onChangeSpy: (value: string) => void
+  let onChangeSpy: (value: string | null) => void
   let wrapper: RenderResult
 
   describe('when using the default prop values', () => {
@@ -262,7 +262,7 @@ describe('SelectE', () => {
     })
   })
 
-  describe('when `value` is set', () => {
+  describe('when `value` is set to a valid value', () => {
     beforeEach(() => {
       wrapper = render(
         <SelectE label="Label" value="two">
@@ -278,10 +278,10 @@ describe('SelectE', () => {
     })
   })
 
-  describe('when `value` is invalidly set', () => {
+  describe.each(['invalid', null])('when `value` is set to `%s`', (value) => {
     beforeEach(() => {
       wrapper = render(
-        <SelectE label="Label" value="invalid">
+        <SelectE label="Label" value={value}>
           <SelectEOption value="one">One</SelectEOption>
           <SelectEOption value="two">Two</SelectEOption>
           <SelectEOption value="three">Three</SelectEOption>

--- a/packages/react-component-library/src/components/SelectE/SelectE.tsx
+++ b/packages/react-component-library/src/components/SelectE/SelectE.tsx
@@ -14,7 +14,7 @@ export const SelectE: React.FC<SelectBaseProps> = ({
   children,
   id = getId('select'),
   onChange,
-  value,
+  value = null,
   ...rest
 }) => {
   const {
@@ -27,7 +27,7 @@ export const SelectE: React.FC<SelectBaseProps> = ({
     reset,
     selectedItem,
     toggleMenu,
-  } = useSelect({
+  } = useSelect<SelectChildWithStringType>({
     itemToString,
     initialSelectedItem: initialSelectedItem(children, value),
     items: React.Children.toArray(children),

--- a/packages/react-component-library/src/components/Tooltip/partials/StyledContent.tsx
+++ b/packages/react-component-library/src/components/Tooltip/partials/StyledContent.tsx
@@ -14,7 +14,7 @@ interface StyledContentProps {
   /**
    * Where to position the tooltip relative to the target element.
    */
-  $position?: string
+  $position: string
 }
 
 function getPositionStyles(position: string): string {

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -18,8 +18,8 @@ function getId(prefix: string): string {
   return getKey(prefix, uuidv4())
 }
 
-function hasClass(allClasses: string, className: string): boolean {
-  return allClasses && allClasses.split(' ').includes(className)
+function hasClass(allClasses: string | undefined, className: string): boolean {
+  return Boolean(allClasses) && allClasses.split(' ').includes(className)
 }
 
 function isIE11(): boolean {

--- a/packages/react-component-library/src/hooks/useFloatingElement.ts
+++ b/packages/react-component-library/src/hooks/useFloatingElement.ts
@@ -7,9 +7,9 @@ import { useStatefulRef } from './useStatefulRef'
 export const useFloatingElement = (
   placement: Placement = 'bottom',
   strategy: PositioningStrategy = 'fixed',
-  externalTargetElement?: Element
+  externalTargetElement: Element | null = null
 ): {
-  targetElementRef: Dispatch<SetStateAction<Element>>
+  targetElementRef: Dispatch<SetStateAction<Element | null>>
   floatingElementRef: Dispatch<SetStateAction<HTMLElement | null>>
   arrowElementRef: Dispatch<SetStateAction<HTMLElement | null>>
   styles: { [key: string]: React.CSSProperties }

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -30,7 +30,7 @@ export interface FloatingBoxWithExternalTargetProps
   /**
    * External element that the floating box should attach to.
    */
-  targetElement?: Element
+  targetElement?: Element | null
 }
 
 export interface FloatingBoxWithEmbeddedTargetProps

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBoxContent.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBoxContent.tsx
@@ -5,7 +5,7 @@ import { StyledContent } from './partials/StyledContent'
 
 export interface FloatingBoxContentProps {
   contentId?: string
-  scheme?: FloatingBoxSchemeType
+  scheme: FloatingBoxSchemeType
 }
 
 export const FloatingBoxContent: React.FC<FloatingBoxContentProps> = ({


### PR DESCRIPTION
## Related issue

#2755

## Overview

This fixes a subset of type errors on master that were being suppressed by `"strictNullChecks": false`. 

## Link to preview

https://5e25c277526d380020b5e418-gdusxcvbhe.chromatic.com/

## Reason

> Currently, the TypeScript configuation in `packages/react-component-library/tsconfig.json` contains:
> 
> ```
>     "strictNullChecks": false,
> ```
> 
> This means that types implicitly allow null and undefined. This is undesirable as it means:
> 
> - types are misleading
> - there may be hidden bugs (either due to values being null or undefined unintentionally, or due to null or undefined not being handled)
> - there may be missed test cases

## Work carried out

- [x] Resolve strict null errors for `SelectE`, `AutocompleteE`, `FloatingBox`, `DatePickerE`, `Tooltip`, `NumberInputE` and `RadioE`

## Developer notes

These should be safe to fix on master (as opposed to `release/3.0.0`).

There was a small bit of reorganising of some of the DatePickerE utility functions.
