### PR TITLE
Fix various strict null errors (part 3)

### DIFF
--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
@@ -75,12 +75,12 @@ export const CheckboxE = React.forwardRef<HTMLInputElement, CheckboxEProps>(
 
     const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
       if (event.target !== localRef.current) {
-        localRef.current.click()
+        localRef.current?.click()
       }
     }
 
     const handleKeyUp = (_: React.KeyboardEvent) => {
-      localRef.current.focus()
+      localRef.current?.focus()
     }
 
     const handleOnChange = (e: React.FormEvent<HTMLInputElement>) => {

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
@@ -518,4 +518,35 @@ describe('ContextMenu', () => {
       )
     })
   })
+
+  describe('when attachedToRef.current is null', () => {
+    beforeEach(() => {
+      const ContextExample = () => {
+        const ref = useRef<HTMLDivElement>(null)
+
+        return (
+          <>
+            <div>Clickable area</div>
+            <ContextMenu
+              attachedToRef={ref}
+              clickType="left"
+              data-arbitrary="arbitrary"
+            >
+              <ContextMenuItem
+                link={<Link href="/hello-foo">Hello, Foo!</Link>}
+              />
+            </ContextMenu>
+          </>
+        )
+      }
+
+      wrapper = render(<ContextExample />)
+    })
+
+    it('does not throw an error when clicking', () => {
+      expect(() => {
+        userEvent.click(wrapper.getByText('Clickable area'))
+      }).not.toThrowError()
+    })
+  })
 })

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
@@ -45,9 +45,9 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   const { coordinates, isOpen, menuRef } = useClickMenu<HTMLOListElement>({
     attachedToRef,
     clickType,
+    position,
     onHide,
     onShow,
-    position,
   })
 
   const hasIcons = !!React.Children.toArray(children).filter(

--- a/packages/react-component-library/src/components/List/useListItem.ts
+++ b/packages/react-component-library/src/components/List/useListItem.ts
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 
 export function useListItem() {
-  const [activeIndex, setActiveIndex] = useState<number>(null)
+  const [activeIndex, setActiveIndex] = useState<number | null>(null)
 
-  function isActive(currentIndex: number): boolean {
+  function isActive(currentIndex: number): boolean | undefined {
     if (activeIndex === null) {
-      return null
+      return undefined
     }
 
     return currentIndex === activeIndex

--- a/packages/react-component-library/src/components/NumberInputE/NumberInputE.tsx
+++ b/packages/react-component-library/src/components/NumberInputE/NumberInputE.tsx
@@ -89,7 +89,7 @@ interface NumberInputBaseProps
   /**
    * Currently selected value displayed by the component.
    */
-  value?: number
+  value?: number | null
 }
 
 export interface NumberInputWithIconProps extends NumberInputBaseProps {
@@ -162,7 +162,7 @@ export const NumberInputE: React.FC<NumberInputEProps> = ({
   size = COMPONENT_SIZE.FORMS,
   step = 1,
   suffix,
-  value,
+  value = null,
   ...rest
 }) => {
   const isNegativeAllowed = isNil(min) || min < 0

--- a/packages/react-component-library/src/components/RangeSliderE/HandleE.tsx
+++ b/packages/react-component-library/src/components/RangeSliderE/HandleE.tsx
@@ -51,7 +51,7 @@ export const HandleE = React.forwardRef<HTMLDivElement, HandleEProps>(
         <StyledValue
           data-testid="rangeslider-value"
           onMouseDown={(_) =>
-            (ref as React.RefObject<HTMLDivElement>).current.focus()
+            (ref as React.RefObject<HTMLDivElement>).current?.focus()
           }
         >
           {formatValue(positionBag)}

--- a/packages/react-component-library/src/components/RangeSliderE/RangeSliderE.test.tsx
+++ b/packages/react-component-library/src/components/RangeSliderE/RangeSliderE.test.tsx
@@ -23,8 +23,8 @@ describe('RangeSliderE', () => {
     values: ReadonlyArray<number>,
     data: { activeHandleID: string }
   ) => void
-  let domain: number[] // lower and upper bounds
-  let values: readonly [number, number?] // initial handle values
+  let domain: readonly [number, number] // lower and upper bounds
+  let values: readonly [number] | readonly [number, number] // initial handle values
   let step: number
   let tickCount: number
 

--- a/packages/react-component-library/src/components/RangeSliderE/SliderE.tsx
+++ b/packages/react-component-library/src/components/RangeSliderE/SliderE.tsx
@@ -42,13 +42,13 @@ export interface RangeSliderEProps extends Omit<SliderProps, SliderOmitType> {
    * Two element array of numbers providing the min and max values for the slider [min, max] e.g. [0, 100].
    * It does not matter if the slider is reversed on the screen, domain is always [min, max] with min < max.
    */
-  domain?: ReadonlyArray<number>
+  domain: readonly [number, number]
   /**
    * An array of numbers. You can supply one for a value slider, two for a range slider.
    * The values should correspond to valid step values in the domain.
    * The numbers will be forced into the domain if they are two small or large.
    */
-  values: readonly [number, number?]
+  values: readonly [number] | readonly [number, number]
   /**
    * The step value for the slider.
    */
@@ -143,13 +143,13 @@ export const RangeSliderE: React.FC<RangeSliderEProps> = ({
 
       // Single handle
       if (sliderValues.length === 1) {
-        handleRefs[0].current.focus()
+        handleRefs[0].current?.focus()
       }
 
       // Multiple handles
       if (sliderValues.length === 2 && staticValues.length === 1) {
         const refId = sliderValues.indexOf(staticValues[0]) === 1 ? 0 : 1
-        handleRefs[refId].current.focus()
+        handleRefs[refId].current?.focus()
       }
     },
     [sliderValues, handleRefs]

--- a/packages/react-component-library/src/components/RangeSliderE/ThresholdRailE.tsx
+++ b/packages/react-component-library/src/components/RangeSliderE/ThresholdRailE.tsx
@@ -10,7 +10,7 @@ import {
 import { StyledRailChunk } from './partials/StyledRailChunk'
 
 export interface ThresholdRailEProps {
-  thresholds?: number[]
+  thresholds: number[]
 }
 
 export interface RailChunkEProps {

--- a/packages/react-component-library/src/components/RangeSliderE/ThresholdTrackE.tsx
+++ b/packages/react-component-library/src/components/RangeSliderE/ThresholdTrackE.tsx
@@ -11,7 +11,7 @@ import { StyledTrackChunk } from './partials/StyledTrackChunk'
 
 export interface ThresholdTrackEProps extends TrackItem {
   getTrackProps: GetTrackProps
-  thresholds?: number[]
+  thresholds: number[]
 }
 
 export interface TrackChunkEProps {

--- a/packages/react-component-library/src/components/RangeSliderE/TickE.tsx
+++ b/packages/react-component-library/src/components/RangeSliderE/TickE.tsx
@@ -44,8 +44,8 @@ export const TickE: React.FC<TickEProps> = ({
   domain,
   isReversed,
   thresholds,
-  tracksLeft,
-  tracksRight,
+  tracksLeft = false,
+  tracksRight = false,
 }) => {
   const percent: number = useMemo(
     () => (isReversed ? 100 - tick.percent : tick.percent),

--- a/packages/react-component-library/src/components/RangeSliderE/partials/StyledRailChunk.tsx
+++ b/packages/react-component-library/src/components/RangeSliderE/partials/StyledRailChunk.tsx
@@ -4,7 +4,7 @@ import { setLightness } from 'polished'
 import { ThresholdColor } from '../useThresholdColor'
 
 interface StyledRailChunkProps {
-  $thresholdColor?: ThresholdColor
+  $thresholdColor: ThresholdColor
   $left: string
   $width: string
   $maxWidth: string

--- a/packages/react-component-library/src/components/RangeSliderE/partials/StyledTrackChunk.tsx
+++ b/packages/react-component-library/src/components/RangeSliderE/partials/StyledTrackChunk.tsx
@@ -4,7 +4,7 @@ import { setLightness } from 'polished'
 import { ThresholdColor } from '../useThresholdColor'
 
 interface StyledTrackChunkProps {
-  $thresholdColor?: ThresholdColor
+  $thresholdColor: ThresholdColor
   $left: string
   $width: string
   $maxWidth: string

--- a/packages/react-component-library/src/components/RangeSliderE/useThresholdColor.ts
+++ b/packages/react-component-library/src/components/RangeSliderE/useThresholdColor.ts
@@ -11,7 +11,7 @@ export type ThresholdColor =
 
 export function useThresholdColor(
   percent: number,
-  thresholds: number[]
+  thresholds: number[] | undefined
 ): ThresholdColor | undefined {
   const singleThreshold = thresholds?.length === 1
   const doubleThreshold = thresholds?.length === 2

--- a/packages/react-component-library/src/components/SwitchE/SwitchE.test.tsx
+++ b/packages/react-component-library/src/components/SwitchE/SwitchE.test.tsx
@@ -115,7 +115,7 @@ describe('SwitchE', () => {
     })
 
     it('should not invoke the onChange handler when an option is clicked', () => {
-      wrapper.queryByText('Option 1').click()
+      wrapper.getByText('Option 1').click()
       expect(onChangeSpy).not.toHaveBeenCalled()
     })
   })

--- a/packages/react-component-library/src/components/SwitchE/SwitchEOption.tsx
+++ b/packages/react-component-library/src/components/SwitchE/SwitchEOption.tsx
@@ -55,7 +55,7 @@ export const SwitchEOption: React.FC<SwitchEOptionProps> = ({
 
     if (selectKeys.includes(e.key)) {
       e.preventDefault()
-      localRef.current.click()
+      localRef.current?.click()
     }
   }
 

--- a/packages/react-component-library/src/components/Table/Table.tsx
+++ b/packages/react-component-library/src/components/Table/Table.tsx
@@ -46,7 +46,7 @@ export const Table: React.FC<TableProps> = ({
     (child: React.ReactElement<TableColumnProps>) =>
       React.cloneElement(child, {
         ...child.props,
-        sortOrder: sortField === child.props.field ? sortOrder : null,
+        sortOrder: sortField === child.props.field ? sortOrder : undefined,
         onSortClick: sortTableData,
       })
   )

--- a/packages/react-component-library/src/components/Table/TableColumn.tsx
+++ b/packages/react-component-library/src/components/Table/TableColumn.tsx
@@ -35,7 +35,7 @@ export interface TableColumnProps {
   /**
    * Optional sort order by which to sort the column.
    */
-  sortOrder?: SortOrderType
+  sortOrder?: SortOrderType | null
 }
 
 const SORT_ORDER_ICONS_MAP = {
@@ -47,39 +47,43 @@ const SORT_ORDER_ICONS_MAP = {
   ),
 }
 
-const SORT_ORDER_ARIA_SORT_MAP = {
+const SORT_ORDER_ARIA_SORT_MAP: Record<SortOrderType, AriaSortType> = {
   [TABLE_SORT_ORDER.ASCENDING]: 'ascending',
   [TABLE_SORT_ORDER.DESCENDING]: 'descending',
 }
 
-function getIcon(sortable: boolean, sortOrder: string) {
+function getIcon(sortable: boolean, sortOrder: SortOrderType | null) {
   if (!sortable) {
     return null
   }
 
-  return (
-    get(SORT_ORDER_ICONS_MAP, sortOrder) || (
-      <IconSortUnsorted aria-hidden data-testid="unsorted" />
-    )
-  )
+  if (!sortOrder) {
+    return <IconSortUnsorted aria-hidden data-testid="unsorted" />
+  }
+
+  return SORT_ORDER_ICONS_MAP[sortOrder]
 }
 
 function getAriaSort(
   isSortable: boolean,
-  sortOrder: SortOrderType
-): AriaSortType {
-  if (isSortable) {
-    return (SORT_ORDER_ARIA_SORT_MAP[sortOrder] || 'none') as AriaSortType
+  sortOrder: SortOrderType | null
+): AriaSortType | undefined {
+  if (!isSortable) {
+    return undefined
   }
 
-  return null
+  if (!sortOrder) {
+    return 'none'
+  }
+
+  return SORT_ORDER_ARIA_SORT_MAP[sortOrder]
 }
 
 export const TableColumn: React.FC<TableColumnProps> = ({
   field,
-  isSortable,
+  isSortable = false,
   onSortClick,
-  sortOrder,
+  sortOrder = null,
   children,
   ...rest
 }) => {
@@ -87,7 +91,7 @@ export const TableColumn: React.FC<TableColumnProps> = ({
 
   const onClick = () => {
     if (isSortable) {
-      onSortClick(field)
+      onSortClick?.(field)
     }
   }
 

--- a/packages/react-component-library/src/components/Table/useTableData.ts
+++ b/packages/react-component-library/src/components/Table/useTableData.ts
@@ -8,7 +8,7 @@ type sortType =
   | typeof TABLE_SORT_ORDER.DESCENDING
 
 function getNextSortOrder(
-  currentSortOrder: sortType,
+  currentSortOrder: sortType | null,
   hasSortFieldChanged: boolean
 ) {
   if (!currentSortOrder || hasSortFieldChanged) {
@@ -24,12 +24,12 @@ function getNextSortOrder(
 
 export function useTableData(data: RowProps[]) {
   const [tableData, setTableData] = useState(data)
-  const [sortOrder, setSortOrder] = useState<sortType>()
-  const [sortField, setSortField] = useState<string>()
+  const [sortOrder, setSortOrder] = useState<sortType | null>(null)
+  const [sortField, setSortField] = useState<string | null>(null)
 
   function sortTableData(field: string) {
     const hasSortFieldChanged = field !== sortField
-    const order: sortType = getNextSortOrder(sortOrder, hasSortFieldChanged)
+    const order = getNextSortOrder(sortOrder, hasSortFieldChanged)
     const sorted = order ? orderBy(tableData, [field], [order]) : data
 
     setSortOrder(order)

--- a/packages/react-component-library/src/components/Toast/Toast.test.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.test.tsx
@@ -6,7 +6,7 @@ import { Toast } from '.'
 
 describe('Toast', () => {
   let wrapper: RenderResult
-  let onDismissSpy: (id: string) => void
+  let onDismissSpy: (id?: string) => void
   let onMouseEnterSpy: () => void
   let onMouseLeaveSpy: () => void
   const LABEL = 'Example label'

--- a/packages/react-component-library/src/components/Toast/Toast.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.tsx
@@ -85,8 +85,8 @@ export const Toast: React.FC<ToastProps> = ({
     })
   )
 
-  const titleId = label ? getId('toast-title') : null
-  const descriptionId = children ? getId('toast-description') : null
+  const titleId = label ? getId('toast-title') : undefined
+  const descriptionId = children ? getId('toast-description') : undefined
 
   return (
     <StyledToast

--- a/packages/react-component-library/src/components/Toast/partials/StyledToast.tsx
+++ b/packages/react-component-library/src/components/Toast/partials/StyledToast.tsx
@@ -5,7 +5,7 @@ import { AppearanceTypes } from 'react-toast-notifications'
 import { StyledToastLabel } from './StyledToastLabel'
 
 interface StyledToastProps {
-  $appearance?: AppearanceTypes
+  $appearance: AppearanceTypes
 }
 
 const { shadow, color, spacing } = selectors

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -107,7 +107,7 @@ export const Default: ComponentStory<typeof Masthead> = (props) => {
 }
 
 Default.args = {
-  searchPlaceholder: null,
+  searchPlaceholder: undefined,
   title: 'Defence Digital Design System',
   hasUnreadNotification: true,
 }
@@ -118,7 +118,7 @@ export const CustomLogo: ComponentStory<typeof Masthead> = (props) => (
 
 CustomLogo.storyName = 'Custom logo'
 CustomLogo.args = {
-  onSearch: null,
+  onSearch: null as undefined,
 }
 
 export const WithoutLogo: ComponentStory<typeof Masthead> = (props) => (
@@ -131,7 +131,7 @@ export const WithoutLogo: ComponentStory<typeof Masthead> = (props) => (
 
 WithoutLogo.storyName = 'Without logo'
 WithoutLogo.args = {
-  onSearch: null,
+  onSearch: null as undefined,
 }
 
 export const WithSearch: ComponentStory<typeof Masthead> = (props) => (
@@ -173,7 +173,7 @@ export const WithAvatarLinks: ComponentStory<typeof Masthead> = (props) => {
 
 WithAvatarLinks.storyName = 'With avatar links'
 WithAvatarLinks.args = {
-  onSearch: null,
+  onSearch: null as undefined,
 }
 
 export const WithNavigation: ComponentStory<typeof Masthead> = (props) => {
@@ -198,7 +198,7 @@ export const WithNavigation: ComponentStory<typeof Masthead> = (props) => {
 
 WithNavigation.storyName = 'With navigation'
 WithNavigation.args = {
-  onSearch: null,
+  onSearch: null as undefined,
 }
 
 export const WithNotifications: ComponentStory<typeof Masthead> = (props) => {
@@ -242,5 +242,5 @@ export const WithNotifications: ComponentStory<typeof Masthead> = (props) => {
 
 WithNotifications.storyName = 'With notifications'
 WithNotifications.args = {
-  onSearch: null,
+  onSearch: null as undefined,
 }

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
@@ -63,8 +63,8 @@ export interface MastheadProps {
 }
 
 function getServiceName(
-  homeLink: React.ReactElement<LinkTypes>,
-  Logo: React.ComponentType,
+  homeLink: React.ReactElement<LinkTypes> | null,
+  Logo: React.ComponentType | null,
   title: string
 ) {
   const link = homeLink || <span />
@@ -87,7 +87,7 @@ function getServiceName(
 export const Masthead: React.FC<MastheadProps> = ({
   hasDefaultLogo = true,
   hasUnreadNotification,
-  homeLink,
+  homeLink = null,
   Logo,
   nav,
   notifications,
@@ -110,7 +110,7 @@ export const Masthead: React.FC<MastheadProps> = ({
   const DisplayLogo = Logo ?? (hasDefaultLogo ? DefaultLogo : null)
 
   const submitSearch = (term: string) => {
-    onSearch(term)
+    onSearch?.(term)
     setShowSearch(false)
   }
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadNavItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadNavItem.tsx
@@ -5,7 +5,7 @@ import { getKey } from '../../../helpers'
 import { StyledScrollableNavItem } from './partials/StyledScrollableNavItem'
 
 export const MastheadNavItem: React.FC<NavItem> = ({
-  isActive,
+  isActive = false,
   link,
   ...rest
 }) => (

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/useMastheadSearch.ts
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/useMastheadSearch.ts
@@ -8,13 +8,17 @@ export function useMastheadSearch() {
   function toggleSearch(
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) {
+    if (!mastheadContainerRef.current) {
+      return
+    }
+
     event.currentTarget.blur()
     const newShowSearch = !showSearch
 
     // if opening the searchbar then get the container width and set that
     // as the width of the searchbar so that it does not spill
     // over to other parts of the page, such as the sidebar.
-    if (newShowSearch === true) {
+    if (newShowSearch) {
       setContainerWidth(mastheadContainerRef.current.offsetWidth)
     }
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.test.tsx
@@ -32,14 +32,14 @@ describe('Notification', () => {
 
     it('should render the notification as a list item', () => {
       const listItem = wrapper.container.firstElementChild
-      expect(listItem.tagName).toEqual('LI')
+      expect(listItem?.tagName).toEqual('LI')
     })
 
     it('should set the href of the entire notification item', () => {
       const listItem = wrapper.container.firstElementChild
-      const itemWrapper = listItem.firstElementChild
-      const link = itemWrapper.firstElementChild
-      expect(link.getAttribute('href')).toEqual('notifications/1')
+      const itemWrapper = listItem?.firstElementChild
+      const link = itemWrapper?.firstElementChild
+      expect(link?.getAttribute('href')).toEqual('notifications/1')
     })
 
     it('should render the initials as an avatar', () => {

--- a/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.tsx
@@ -23,7 +23,7 @@ export const SearchBar: React.FC<SearchbarProps> = ({
   setShowSearch,
   ...rest
 }) => {
-  const searchBoxRef = useRef()
+  const searchBoxRef = useRef(null)
   const [term, setTerm] = useState('')
 
   const onDocumentClick = useCallback(

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sheet/SheetButton.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sheet/SheetButton.tsx
@@ -5,7 +5,7 @@ import { selectors } from '@defencedigital/design-tokens'
 import { ComponentWithClass } from '../../../common/ComponentWithClass'
 
 export interface SheetButtonProps extends ComponentWithClass {
-  children?: React.ReactElement
+  children?: React.ReactNode
   icon: React.ReactElement
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
 }

--- a/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarNavE.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SidebarE/SidebarNavE.tsx
@@ -30,7 +30,7 @@ export interface SidebarNavEProps extends Nav<NavItem> {
 
 function mapNavItem(
   navItem: React.ReactElement<SidebarNavItemEProps>,
-  onClick: (e: React.MouseEvent<HTMLElement>) => void
+  onClick: ((e: React.MouseEvent<HTMLElement>) => void) | undefined
 ) {
   warnIfOverwriting(navItem.props, 'onClick', SidebarNavItemE.name)
 
@@ -41,7 +41,7 @@ function mapNavItem(
 }
 
 export const SidebarNavE: React.FC<SidebarNavEProps> = ({
-  children,
+  children = [],
   onBlur,
   onFocus,
   onItemClick,

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -32,7 +32,7 @@ export interface FormValues {
   exampleCheckbox: string[]
   exampleRadio: string[]
   exampleSwitch: string
-  exampleNumberInput: number
+  exampleNumberInput: number | null
   exampleDatePicker: Date | null
   exampleSelect: string | null
   exampleAutocomplete: string | null
@@ -100,7 +100,7 @@ export const Example: React.FC<unknown> = () => {
             errors.exampleDatePicker = 'Enter a valid date'
           }
 
-          if (isBefore(exampleDatePicker, MINIMUM_DATE)) {
+          if (exampleDatePicker && isBefore(exampleDatePicker, MINIMUM_DATE)) {
             errors.exampleDatePicker = 'Enter a date on or after 1 January 2022'
           }
 

--- a/packages/react-component-library/src/forms/native/native.stories.tsx
+++ b/packages/react-component-library/src/forms/native/native.stories.tsx
@@ -27,11 +27,11 @@ export interface FormValues {
   exampleCheckbox: string[]
   exampleRadio: string[]
   exampleSwitch: string
-  exampleNumberInput: number
+  exampleNumberInput: number | null
   exampleDatePicker: Date | null
   exampleSelect: string | null
   exampleAutocomplete: string | null
-  exampleRangeSlider: readonly [number, number?]
+  exampleRangeSlider: readonly [number]
 }
 
 const MINIMUM_DATE = parseISO('2022-01-01')
@@ -75,7 +75,7 @@ export const Example: React.FC<unknown> = () => {
           return 'Enter a valid date'
         }
 
-        if (isBefore(value, MINIMUM_DATE)) {
+        if (value && isBefore(value, MINIMUM_DATE)) {
           return 'Enter a date on or after 1 January 2022'
         }
 
@@ -174,7 +174,7 @@ export const Example: React.FC<unknown> = () => {
             _:
               | React.ChangeEvent<HTMLInputElement>
               | React.MouseEvent<HTMLButtonElement>,
-            newValue: number
+            newValue: number | null
           ) => {
             handleChange({
               currentTarget: {

--- a/packages/react-component-library/src/forms/native/useNativeForm.ts
+++ b/packages/react-component-library/src/forms/native/useNativeForm.ts
@@ -13,7 +13,7 @@ type FormErrors<FormValues> = Partial<{
 interface SyntheticFormEvent {
   currentTarget: {
     name: string
-    value: string | string[] | number | number[] | Date
+    value: string | string[] | number | number[] | Date | null
   }
 }
 

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -87,7 +87,7 @@ export const Example: React.FC<unknown> = () => {
     _:
       | React.ChangeEvent<HTMLInputElement>
       | React.MouseEvent<HTMLButtonElement>,
-    newValue: number
+    newValue: number | null
   ) => setValue('exampleNumberInput', newValue)
 
   return (

--- a/packages/react-component-library/src/hooks/useClickMenu.ts
+++ b/packages/react-component-library/src/hooks/useClickMenu.ts
@@ -34,9 +34,42 @@ export type ClickMenuPositionType =
 interface UseClickMenuParams {
   attachedToRef: React.RefObject<HTMLElement>
   clickType: ClickType
+  position: ClickMenuPositionType
   onHide?: () => void
   onShow?: () => void
-  position?: ClickMenuPositionType
+}
+
+function getCoordinates(
+  { clientX, clientY }: MouseEvent,
+  menuElement: HTMLElement,
+  position: ClickMenuPositionType
+) {
+  const { height: menuHeight, width: menuWidth } =
+    menuElement.getBoundingClientRect()
+
+  if (
+    position === CLICK_MENU_POSITION.BELOW ||
+    position === CLICK_MENU_POSITION.RIGHT_BELOW
+  ) {
+    return { x: clientX, y: clientY }
+  }
+
+  if (
+    position === CLICK_MENU_POSITION.ABOVE ||
+    position === CLICK_MENU_POSITION.RIGHT_ABOVE
+  ) {
+    return { x: clientX, y: clientY - menuHeight }
+  }
+
+  if (position === CLICK_MENU_POSITION.LEFT_ABOVE) {
+    return { x: clientX - menuWidth, y: clientY - menuHeight }
+  }
+
+  if (position === CLICK_MENU_POSITION.LEFT_BELOW) {
+    return { x: clientX - menuWidth, y: clientY }
+  }
+
+  throw new Error('Unknown CLICK_MENU_POSITION')
 }
 
 export const useClickMenu = <TMenuElement extends HTMLElement>({
@@ -54,43 +87,17 @@ export const useClickMenu = <TMenuElement extends HTMLElement>({
   const [coordinates, setCoordinates] = useState<Coordinates>({ x: 0, y: 0 })
   const menuRef = useRef<TMenuElement>(null)
 
-  function getCoordinates({ clientX, clientY }: MouseEvent) {
-    const {
-      height: menuHeight,
-      width: menuWidth,
-    } = menuRef.current.getBoundingClientRect()
-
-    if (
-      position === CLICK_MENU_POSITION.BELOW ||
-      position === CLICK_MENU_POSITION.RIGHT_BELOW
-    ) {
-      return { x: clientX, y: clientY }
-    }
-
-    if (
-      position === CLICK_MENU_POSITION.ABOVE ||
-      position === CLICK_MENU_POSITION.RIGHT_ABOVE
-    ) {
-      return { x: clientX, y: clientY - menuHeight }
-    }
-
-    if (position === CLICK_MENU_POSITION.LEFT_ABOVE) {
-      return { x: clientX - menuWidth, y: clientY - menuHeight }
-    }
-
-    if (position === CLICK_MENU_POSITION.LEFT_BELOW) {
-      return { x: clientX - menuWidth, y: clientY }
-    }
-
-    throw new Error('Unknown CLICK_MENU_POSITION')
-  }
-
   function displayMenu(e: MouseEvent) {
-    const mousePoint: Coordinates = getCoordinates(e)
-    setCoordinates(mousePoint)
-
-    if (attachedToRef.current.contains(e.target as Node)) {
+    if (menuRef.current && attachedToRef.current?.contains(e.target as Node)) {
       e.preventDefault()
+
+      const mousePoint: Coordinates = getCoordinates(
+        e,
+        menuRef.current,
+        position
+      )
+      setCoordinates(mousePoint)
+
       setOpen(true)
       if (onShow) {
         onShow()
@@ -129,8 +136,7 @@ export const useClickMenu = <TMenuElement extends HTMLElement>({
   })
 
   useEffect(() => {
-    const body = document.querySelector('body')
-    body.style.overflow = open ? 'hidden' : 'auto'
+    document.body.style.overflow = open ? 'hidden' : 'auto'
   }, [open])
 
   return {

--- a/packages/react-component-library/src/primitives/Container/partials/StyledContainer.tsx
+++ b/packages/react-component-library/src/primitives/Container/partials/StyledContainer.tsx
@@ -7,7 +7,7 @@ import { CONTAINER_CONTENT_WIDTH } from '../constants'
 const { spacing } = selectors
 
 interface StyledContainerProps {
-  $size?: ContainerSizeType
+  $size: ContainerSizeType
 }
 
 const sizeStyles = {

--- a/packages/react-component-library/src/styled-components/GlobalStyle.tsx
+++ b/packages/react-component-library/src/styled-components/GlobalStyle.tsx
@@ -98,7 +98,7 @@ const Fonts = createGlobalStyle`
 `
 
 const globalStyleContextDefaults: GlobalStyleContextDefaults = {
-  theme: null,
+  theme: undefined,
 }
 
 export const GlobalStyleContext = createContext(globalStyleContextDefaults)


### PR DESCRIPTION
## Related issue

#2755

## Overview

This fixes a subset of type errors on master that were being suppressed by `"strictNullChecks": false`. 

## Link to preview

https://5e25c277526d380020b5e418-lylsvjcbge.chromatic.com/

## Reason

> Currently, the TypeScript configuation in `packages/react-component-library/tsconfig.json` contains:
> 
> ```
>     "strictNullChecks": false,
> ```
> 
> This means that types implicitly allow null and undefined. This is undesirable as it means:
> 
> - types are misleading
> - there may be hidden bugs (either due to values being null or undefined unintentionally, or due to null or undefined not being handled)
> - there may be missed test cases

## Work carried out

- [x] Resolve strict null errors for various components

## Developer notes

These should be safe to fix on master (as opposed to `release/3.0.0`).
