### PR TITLE
fix(Modal): Stop regenerating IDs on every render

### DIFF
--- a/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
+++ b/packages/react-component-library/src/components/DatePickerE/DatePickerE.tsx
@@ -182,8 +182,8 @@ export const DatePickerE: React.FC<DatePickerEProps> = ({
   ...rest
 }) => {
   const id = useExternalId(externalId)
-  const titleId = `datepicker-title-${useExternalId()}`
-  const contentId = `datepicker-contentId-${useExternalId()}`
+  const titleId = useExternalId('datepicker-title')
+  const contentId = useExternalId('datepicker-contentId')
   const buttonRef = useRef<HTMLButtonElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 

--- a/packages/react-component-library/src/components/Modal/Modal.test.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.test.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useState } from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import {
@@ -296,6 +295,40 @@ describe('Modal', () => {
         'data-arbitrary',
         'arbitrary'
       )
+    })
+  })
+
+  describe('when the Modal content changes', () => {
+    let initialIds: Record<string, string>
+
+    const ExampleModal = ({ content }: { content: string }) => (
+      <Modal title="Example title" isOpen>
+        <span>{content}</span>
+      </Modal>
+    )
+
+    function getIds() {
+      return {
+        titleId: wrapper.getByTestId('modal-header-text').id,
+        descriptionId: wrapper.getByTestId('modal-body').id,
+        labelledBy: wrapper
+          .getByTestId('modal-wrapper')
+          .getAttribute('aria-labelledby'),
+        describedBy: wrapper
+          .getByTestId('modal-wrapper')
+          .getAttribute('aria-describedby'),
+      }
+    }
+
+    beforeEach(() => {
+      wrapper = render(<ExampleModal content="initial content" />)
+      initialIds = getIds()
+
+      wrapper.rerender(<ExampleModal content="new content" />)
+    })
+
+    it('does not generate new IDs', () => {
+      expect(getIds()).toEqual(initialIds)
     })
   })
 })

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -4,10 +4,10 @@ import { IconForward } from '@defencedigital/icon-library'
 import { ButtonProps } from '../Button'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { Footer } from './Footer'
-import { getId } from '../../helpers'
 import { Header } from './Header'
 import { StyledModal } from './partials/StyledModal'
 import { StyledMain } from './partials/StyledMain'
+import { useExternalId } from '../../hooks/useExternalId'
 import { useOpenClose } from '../../hooks/useOpenClose'
 
 export interface ModalProps extends ComponentWithClass {
@@ -51,29 +51,17 @@ export interface ModalProps extends ComponentWithClass {
   titleId?: string
 }
 
-function getTitleId(title: string, titleId: string) {
-  if (titleId) {
-    return titleId
-  }
-
-  if (title) {
-    return getId('modal-title')
-  }
-
-  return null
-}
-
 export const Modal: React.FC<ModalProps> = ({
   children,
   className,
-  descriptionId = getId('modal-description'),
-  isOpen,
+  descriptionId: externalDescriptionId,
+  isOpen = false,
   onClose,
   primaryButton,
   secondaryButton,
   tertiaryButton,
   title,
-  titleId,
+  titleId: externalTitleId,
   ...rest
 }) => {
   const { handleOnClose, open } = useOpenClose(isOpen, onClose)
@@ -82,7 +70,11 @@ export const Modal: React.FC<ModalProps> = ({
     ...primaryButton,
   }
 
-  const modalTitleId = getTitleId(title, titleId)
+  const descriptionId = useExternalId(
+    'modal-description',
+    externalDescriptionId
+  )
+  const titleId = useExternalId('modal-title', externalTitleId)
 
   return (
     <StyledModal
@@ -90,18 +82,14 @@ export const Modal: React.FC<ModalProps> = ({
       className={className}
       role="dialog"
       aria-modal
-      aria-labelledby={modalTitleId}
+      aria-labelledby={title || externalTitleId ? titleId : undefined}
       aria-describedby={descriptionId}
       data-testid="modal-wrapper"
       {...rest}
     >
       <StyledMain data-testid="modal-main">
         {title && (
-          <Header
-            titleId={modalTitleId}
-            title={title}
-            onClose={handleOnClose}
-          />
+          <Header titleId={titleId} title={title} onClose={handleOnClose} />
         )}
         <section id={descriptionId} data-testid="modal-body">
           {children}

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -1,12 +1,11 @@
 import { UseSelectReturnValue, UseComboboxReturnValue } from 'downshift'
-import React, { useMemo, useState } from 'react'
+import React, { useState } from 'react'
 import mergeRefs from 'react-merge-refs'
 
 import { ArrowButton } from '../SelectE/ArrowButton'
 import { ClearButton } from '../SelectE/ClearButton'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { FloatingBox } from '../../primitives/FloatingBox'
-import { getId } from '../../helpers'
 import { SelectChildWithStringType } from './types'
 import { StyledInlineButtons } from './partials/StyledInlineButtons'
 import { StyledInput } from './partials/StyledInput'
@@ -18,6 +17,7 @@ import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
 import { StyledSelect } from './partials/StyledSelect'
 import { StyledTextInput } from './partials/StyledTextInput'
 import { StyledTooltip } from './partials/StyledTooltip'
+import { useExternalId } from '../../hooks/useExternalId'
 import { useStatefulRef } from '../../hooks/useStatefulRef'
 
 type ComboboxReturnValueType = UseComboboxReturnValue<SelectChildWithStringType>
@@ -66,7 +66,7 @@ export const SelectLayout: React.FC<SelectLayoutProps> = ({
   ...rest
 }) => {
   const [hasHover, setHasHover] = useState<boolean>(false)
-  const labelId = useMemo(() => getId('label'), [])
+  const labelId = useExternalId('label')
   const [floatingBoxTarget, setFloatingBoxTarget] =
     useStatefulRef<HTMLInputElement>()
   const { ref, ...inputPropsRest } = inputProps

--- a/packages/react-component-library/src/components/SwitchE/SwitchE.tsx
+++ b/packages/react-component-library/src/components/SwitchE/SwitchE.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
-import { v4 as uuidv4 } from 'uuid'
+import React, { useState, useEffect } from 'react'
 
 import { warnIfOverwriting, getKey } from '../../helpers'
 import { SwitchEOption, SwitchEOptionProps } from '.'
@@ -9,6 +8,7 @@ import { StyledSwitch } from './partials/StyledSwitch'
 import { StyledLegend } from './partials/StyledLegend'
 import { StyledContainer } from './partials/StyledContainer'
 import { ComponentSizeType, COMPONENT_SIZE } from '../Forms'
+import { useExternalId } from '../../hooks/useExternalId'
 
 export type SwitchEChildType =
   | React.ReactElement<SwitchEOptionProps>
@@ -60,7 +60,7 @@ export const SwitchE: React.FC<SwitchEProps> = ({
   ...rest
 }) => {
   const [active, setActive] = useState<string | undefined>()
-  const id = useMemo(() => uuidv4(), [])
+  const id = useExternalId()
 
   useEffect(() => {
     setActive(value)

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -14,6 +14,9 @@ function getKey(prefix: string, suffix: string | number): string {
   return `${prefix}-${suffix}`.replace(/\s/g, '')
 }
 
+/**
+ * @deprecated Use the useExternalId() hook instead as it's memoised.
+ */
 function getId(prefix: string): string {
   return getKey(prefix, uuidv4())
 }

--- a/packages/react-component-library/src/hooks/useExternalId.ts
+++ b/packages/react-component-library/src/hooks/useExternalId.ts
@@ -4,8 +4,19 @@ import { v4 as uuidv4 } from 'uuid'
 /**
  * Return a memoised unique ID as a string.
  *
- * Returns externalId if provided, otherwise generates a random ID.
+ * Returns externalId if provided, otherwise generates a random ID
+ * (with an optional prefix).
  */
-export function useExternalId(externalId?: string) {
-  return useMemo(() => externalId || uuidv4(), [externalId])
+export function useExternalId(prefix?: string, externalId?: string): string {
+  return useMemo(() => {
+    if (externalId) {
+      return externalId
+    }
+
+    if (prefix) {
+      return `${prefix}-${uuidv4()}`
+    }
+
+    return uuidv4()
+  }, [externalId, prefix])
 }


### PR DESCRIPTION
## Related issue

Resolves #3059
#2755 

## Overview

This updates `Modal` to use the `useExternalId` hook to avoid regenerating title and body IDs on every render.

## Link to preview

[Example app](https://red-playground.netlify.app)

(Note: I have used a standard `<input>` to isolate Modal from other components.)

[Storybook](https://5e25c277526d380020b5e418-tyunscyfnm.chromatic.com/?path=/docs/modal--default)

## Reason

IDs and aria keys should be stable between renders.

## Work carried out

- [x] Memoise Modal IDs
- [x] Fix Modal strict null errors

## Demo

### Before

![Screencast_10-02-22_13:16:40](https://user-images.githubusercontent.com/66470099/153416331-d9350eb4-e619-4ac1-b241-d7289ae14dbb.gif)

### After

![Screencast_10-02-22_13:18:45](https://user-images.githubusercontent.com/66470099/153416340-a47acc90-8b9f-4ccd-8065-02f4bb0b95d4.gif)

## Developer notes

A number of other components have the same problem. I've created #3081 as a follow-up for other components and have marked `getId()` as deprecated to stop the same problem being introduced in new components. (I've updated existing uses that were already memoised as those should be safe to change without further testing.)

Strict null errors in the `Modal` component were also fixed.