### PR TITLE
Update `CheckboxE` to include `description` and variant `no-container`

### DIFF
--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
@@ -56,3 +56,12 @@ Invalid.args = {
   name: 'invalid',
   isInvalid: true,
 }
+
+export const WithDescription = Template.bind({})
+WithDescription.args = {
+  id: undefined,
+  description:
+    'She must have hidden the plans in the escape pod. Send a detachment down to retrieve them.',
+  label: 'With description',
+  name: 'with-description',
+}

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { CheckboxE } from '.'
+import { CheckboxE, CheckboxEProps } from '.'
+import { CHECKBOX_VARIANT } from './constants'
 
 export default {
   component: CheckboxE,
@@ -14,6 +15,24 @@ export default {
 const Template: ComponentStory<typeof CheckboxE> = (props) => (
   <CheckboxE {...props} />
 )
+
+const MultipleItemsTemplate: ComponentStory<typeof CheckboxE> = (props) => {
+  function getProps(i: number): CheckboxEProps {
+    return {
+      ...props,
+      label: `${props.label} ${i}`,
+      name: `${props.name}-${i}`,
+    }
+  }
+
+  return (
+    <>
+      <CheckboxE {...getProps(1)} />
+      <CheckboxE {...getProps(2)} />
+      <CheckboxE {...getProps(3)} />
+    </>
+  )
+}
 
 export const Default = Template.bind({})
 Default.args = {
@@ -55,6 +74,14 @@ Invalid.args = {
   label: 'Invalid checkbox',
   name: 'invalid',
   isInvalid: true,
+}
+
+export const NoContainer = MultipleItemsTemplate.bind({})
+NoContainer.args = {
+  id: undefined,
+  label: 'Item without container',
+  name: 'no-container',
+  variant: CHECKBOX_VARIANT.NO_CONTAINER,
 }
 
 export const WithDescription = Template.bind({})

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.test.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.test.tsx
@@ -244,6 +244,22 @@ describe('Checkbox', () => {
     })
   })
 
+  describe('when a field has a description that is arbitrary JSX', () => {
+    beforeEach(() => {
+      checkbox = render(
+        <CheckboxE
+          description={<div>Arbitrary content</div>}
+          label="Label"
+          name={field.name}
+        />
+      )
+    })
+
+    it('should render a arbitrary description', () => {
+      expect(checkbox.getByText('Arbitrary content')).toBeInTheDocument()
+    })
+  })
+
   describe('when a field does not have a container', () => {
     beforeEach(() => {
       checkbox = render(

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.test.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.test.tsx
@@ -56,6 +56,10 @@ describe('Checkbox', () => {
       )
     })
 
+    it('should not render a description', () => {
+      expect(checkbox.queryAllByTestId('checkbox-description')).toHaveLength(0)
+    })
+
     it('should populate the field value', () => {
       expect(input).toHaveAttribute('value', 'false')
     })
@@ -209,6 +213,20 @@ describe('Checkbox', () => {
       expect(checkbox.queryByTestId('checkbox-input')).toHaveAttribute(
         'data-arbitrary',
         'arbitrary'
+      )
+    })
+  })
+
+  describe('when a field has a description', () => {
+    beforeEach(() => {
+      checkbox = render(
+        <CheckboxE description="Description" label="Label" name={field.name} />
+      )
+    })
+
+    it('should render a description', () => {
+      expect(checkbox.getByTestId('checkbox-description')).toHaveTextContent(
+        'Description'
       )
     })
   })

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.test.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
+import 'jest-styled-components'
+import { ColorNeutral200 } from '@defencedigital/design-tokens'
 import { render, RenderResult } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { CheckboxE } from '.'
+import { CheckboxE, CHECKBOX_VARIANT } from '.'
 import { FieldProps } from '../../common/FieldProps'
 import { FormProps } from '../../common/FormProps'
 
@@ -105,6 +107,17 @@ describe('Checkbox', () => {
           })
         })
       })
+    })
+
+    it('should render a container', () => {
+      expect(checkbox.getByTestId('checkbox')).toHaveStyleRule(
+        'border',
+        `1px solid ${ColorNeutral200}`
+      )
+      expect(checkbox.getByTestId('checkbox')).toHaveStyleRule(
+        'border-radius',
+        '15px'
+      )
     })
   })
 
@@ -227,6 +240,29 @@ describe('Checkbox', () => {
     it('should render a description', () => {
       expect(checkbox.getByTestId('checkbox-description')).toHaveTextContent(
         'Description'
+      )
+    })
+  })
+
+  describe('when a field does not have a container', () => {
+    beforeEach(() => {
+      checkbox = render(
+        <CheckboxE
+          label="Label"
+          name={field.name}
+          variant={CHECKBOX_VARIANT.NO_CONTAINER}
+        />
+      )
+    })
+
+    it('should not render a container', () => {
+      expect(checkbox.getByTestId('checkbox')).not.toHaveStyleRule(
+        'border',
+        `1px solid ${ColorNeutral200}`
+      )
+      expect(checkbox.getByTestId('checkbox')).not.toHaveStyleRule(
+        'border-radius',
+        '15px'
       )
     })
   })

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
@@ -35,7 +35,7 @@ export interface CheckboxEProps
   /**
    * Optional description to display below the label.
    */
-  description?: string
+  description?: React.ReactNode
   /**
    * Toggles whether the component is disabled or not (preventing user interaction).
    */

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import mergeRefs from 'react-merge-refs'
 
+import { CHECKBOX_VARIANT } from './constants'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { InputValidationProps } from '../../common/InputValidationProps'
 import { StyledCheckbox } from './partials/StyledCheckbox'
@@ -11,6 +12,10 @@ import { StyledDescription } from './partials/StyledDescription'
 import { StyledInput } from './partials/StyledInput'
 import { StyledLabel } from './partials/StyledLabel'
 import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
+
+type CheckboxVariantType =
+  | typeof CHECKBOX_VARIANT.DEFAULT
+  | typeof CHECKBOX_VARIANT.NO_CONTAINER
 
 export interface CheckboxEProps
   extends ComponentWithClass,
@@ -55,23 +60,28 @@ export interface CheckboxEProps
    * Optional HTML `value` attribute associated with the component.
    */
   value?: string
+  /**
+   * Optional variant to set container visibility.
+   */
+  variant?: CheckboxVariantType
 }
 
 export const CheckboxE = React.forwardRef<HTMLInputElement, CheckboxEProps>(
   (
     {
       className = '',
-      id = uuidv4(),
       checked,
       defaultChecked,
       description,
+      id = uuidv4(),
       isDisabled,
+      isInvalid,
       label,
       name,
       onBlur,
       onChange,
       value,
-      isInvalid,
+      variant = CHECKBOX_VARIANT.DEFAULT,
       ...rest
     },
     ref
@@ -97,9 +107,12 @@ export const CheckboxE = React.forwardRef<HTMLInputElement, CheckboxEProps>(
       }
     }
 
+    const hasContainer = variant !== CHECKBOX_VARIANT.NO_CONTAINER
+
     return (
       <StyledCheckboxWrapper>
         <StyledCheckbox
+          $hasContainer={hasContainer}
           $isDisabled={isDisabled}
           $isInvalid={isInvalid}
           $isChecked={isChecked}
@@ -108,8 +121,12 @@ export const CheckboxE = React.forwardRef<HTMLInputElement, CheckboxEProps>(
           onKeyUp={handleKeyUp}
           data-testid="checkbox"
         >
-          <StyledOuterWrapper>
-            <StyledLabel htmlFor={id} data-testid="checkbox-label">
+          <StyledOuterWrapper $hasContainer={hasContainer}>
+            <StyledLabel
+              $hasContainer={hasContainer}
+              htmlFor={id}
+              data-testid="checkbox-label"
+            >
               <StyledInput
                 ref={mergeRefs([localRef, ref])}
                 id={id}
@@ -124,7 +141,7 @@ export const CheckboxE = React.forwardRef<HTMLInputElement, CheckboxEProps>(
                 {...rest}
                 data-testid="checkbox-input"
               />
-              <StyledCheckmark />
+              <StyledCheckmark $hasContainer={hasContainer} />
               {label}
               {description && (
                 <StyledDescription data-testid="checkbox-description">

--- a/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/CheckboxE.tsx
@@ -5,11 +5,12 @@ import mergeRefs from 'react-merge-refs'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { InputValidationProps } from '../../common/InputValidationProps'
 import { StyledCheckbox } from './partials/StyledCheckbox'
-import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
-import { StyledLabel } from './partials/StyledLabel'
-import { StyledInput } from './partials/StyledInput'
 import { StyledCheckmark } from './partials/StyledCheckmark'
 import { StyledCheckboxWrapper } from './partials/StyledCheckboxWrapper'
+import { StyledDescription } from './partials/StyledDescription'
+import { StyledInput } from './partials/StyledInput'
+import { StyledLabel } from './partials/StyledLabel'
+import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
 
 export interface CheckboxEProps
   extends ComponentWithClass,
@@ -26,6 +27,10 @@ export interface CheckboxEProps
    * Toggles whether the component should be checked on initial render.
    */
   defaultChecked?: boolean
+  /**
+   * Optional description to display below the label.
+   */
+  description?: string
   /**
    * Toggles whether the component is disabled or not (preventing user interaction).
    */
@@ -59,6 +64,7 @@ export const CheckboxE = React.forwardRef<HTMLInputElement, CheckboxEProps>(
       id = uuidv4(),
       checked,
       defaultChecked,
+      description,
       isDisabled,
       label,
       name,
@@ -120,6 +126,11 @@ export const CheckboxE = React.forwardRef<HTMLInputElement, CheckboxEProps>(
               />
               <StyledCheckmark />
               {label}
+              {description && (
+                <StyledDescription data-testid="checkbox-description">
+                  {description}
+                </StyledDescription>
+              )}
             </StyledLabel>
           </StyledOuterWrapper>
         </StyledCheckbox>

--- a/packages/react-component-library/src/components/CheckboxE/constants.ts
+++ b/packages/react-component-library/src/components/CheckboxE/constants.ts
@@ -1,0 +1,6 @@
+const CHECKBOX_VARIANT = {
+  DEFAULT: 'default',
+  NO_CONTAINER: 'no-container',
+} as const
+
+export { CHECKBOX_VARIANT }

--- a/packages/react-component-library/src/components/CheckboxE/index.ts
+++ b/packages/react-component-library/src/components/CheckboxE/index.ts
@@ -1,1 +1,2 @@
 export * from './CheckboxE'
+export * from './constants'

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckbox.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckbox.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components'
 const { color, fontSize } = selectors
 
 export interface StyledCheckboxProps {
+  $hasContainer?: boolean
   $isDisabled?: boolean
   $isInvalid?: boolean
   $isChecked?: boolean
@@ -14,20 +15,10 @@ export const StyledCheckbox = styled.div<StyledCheckboxProps>`
   position: relative;
   font-size: ${fontSize('base')};
   user-select: none;
-  border: 1px solid ${color('neutral', '200')};
-  border-radius: 15px;
   cursor: pointer;
 
   * {
     cursor: pointer;
-  }
-
-  &:focus-within,
-  &:active {
-    outline: none;
-    border-color: ${color('action', '500')};
-    box-shadow: 0 0 0 2px ${color('action', '500')},
-      0 0 0 5px ${color('action', '100')};
   }
 
   ${({ $isInvalid }) =>
@@ -37,10 +28,26 @@ export const StyledCheckbox = styled.div<StyledCheckboxProps>`
       box-shadow: 0 0 0 2px ${color('danger', '800')};
     `}
 
-  ${({ $isChecked }) =>
+  ${({ $hasContainer, $isChecked }) =>
+    $hasContainer &&
     $isChecked &&
     css`
       background-color: ${color('action', '000')};
+    `}
+
+  ${({ $hasContainer }) =>
+    $hasContainer &&
+    css`
+      border: 1px solid ${color('neutral', '200')};
+      border-radius: 15px;
+
+      &:focus-within,
+      &:active {
+        outline: none;
+        border-color: ${color('action', '500')};
+        box-shadow: 0 0 0 2px ${color('action', '500')},
+          0 0 0 5px ${color('action', '100')};
+      }
     `}
 
   ${({ $isDisabled }) =>

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckmark.tsx
@@ -8,9 +8,8 @@ const { animation, color } = selectors
 
 export const StyledCheckmark = styled.div`
   position: absolute;
-  top: 50%;
+  top: 12px;
   left: 12px;
-  transform: translateY(-50%);
   height: 18px;
   width: 18px;
   background-color: ${color('neutral', 'white')};

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledCheckmark.tsx
@@ -1,15 +1,28 @@
 import { position } from 'polished'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
 import { StyledCheckbox } from './StyledCheckbox'
 
 const { animation, color } = selectors
 
-export const StyledCheckmark = styled.div`
+interface StyledCheckmarkProps {
+  $hasContainer?: boolean
+}
+
+function getCheckboxActiveStyle() {
+  return css`
+    &::before {
+      box-shadow: 0 0 0 2px ${color('action', '500')};
+      transition: all ${animation('default')};
+    }
+  `
+}
+
+export const StyledCheckmark = styled.div<StyledCheckmarkProps>`
   position: absolute;
-  top: 12px;
-  left: 12px;
+  top: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
+  left: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
   height: 18px;
   width: 18px;
   background-color: ${color('neutral', 'white')};
@@ -29,12 +42,21 @@ export const StyledCheckmark = styled.div`
     color: ${color('neutral', 'white')};
   }
 
-  ${StyledCheckbox}:hover &, ${StyledCheckbox}:active & {
-    &::before {
-      box-shadow: 0 0 0 2px ${color('action', '500')};
-      transition: all ${animation('default')};
+  ${({ $hasContainer }) => {
+    if ($hasContainer) {
+      return css`
+        ${StyledCheckbox}:hover &, ${StyledCheckbox}:active & {
+          ${getCheckboxActiveStyle()}
+        }
+      `
     }
-  }
+
+    return css`
+      ${StyledCheckbox}:hover &, ${StyledCheckbox}:active &, ${StyledCheckbox}:focus-within & {
+        ${getCheckboxActiveStyle()}
+      }
+    `
+  }}
 
   ${StyledCheckbox} input:checked ~ & {
     background-color: ${color('action', '500')};

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledDescription.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledDescription.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+import { selectors } from '@defencedigital/design-tokens'
+
+const { fontSize } = selectors
+
+export const StyledDescription = styled.div`
+  font-size: ${fontSize('base')};
+  margin-top: 4px;
+`

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledLabel.tsx
@@ -3,10 +3,15 @@ import styled from 'styled-components'
 
 const { color, fontSize } = selectors
 
-export const StyledLabel = styled.label`
+interface StyledLabelProps {
+  $hasContainer?: boolean
+}
+
+export const StyledLabel = styled.label<StyledLabelProps>`
   color: ${color('neutral', '400')};
   font-size: ${fontSize('m')};
-  padding: 12px 12px 12px 17px;
+  padding: ${({ $hasContainer }) =>
+    $hasContainer ? '12px 12px 12px 17px' : '4px'};
   margin-left: 24px;
   pointer-events: none;
 `

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledOuterWrapper.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledOuterWrapper.tsx
@@ -1,13 +1,22 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
-export const StyledOuterWrapper = styled.div`
+interface StyledOuterWrapperProps {
+  $hasContainer?: boolean
+}
+
+export const StyledOuterWrapper = styled.div<StyledOuterWrapperProps>`
   display: inline-flex;
   align-items: center;
   flex-direction: row;
-  min-height: 44px;
   border-radius: 15px;
 
   &:active {
     pointer-events: none;
   }
+
+  ${({ $hasContainer }) =>
+    $hasContainer &&
+    css`
+      min-height: 44px;
+    `}
 `

--- a/packages/react-component-library/src/components/CheckboxE/partials/StyledOuterWrapper.tsx
+++ b/packages/react-component-library/src/components/CheckboxE/partials/StyledOuterWrapper.tsx
@@ -4,7 +4,7 @@ export const StyledOuterWrapper = styled.div`
   display: inline-flex;
   align-items: center;
   flex-direction: row;
-  height: 44px;
+  min-height: 44px;
   border-radius: 15px;
 
   &:active {


### PR DESCRIPTION
## Related issue
Closes #3082 

## Overview
Updates `CheckboxE` to include the `description` and variant `no-container`.

## Link to preview
https://checkboxe-updates.netlify.app/?path=/story/checkbox-experimental--no-container
https://checkboxe-updates.netlify.app/?path=/story/checkbox-experimental--with-description

## Reason
Required for feature parity.

## Work carried out
- [x] Add `description`
- [x] Add `no-container` variant

## Screenshot

### Description
<img width="649" alt="Screenshot 2022-02-14 at 17 35 38" src="https://user-images.githubusercontent.com/56078793/153916538-e81b3495-c6a9-4e46-97a3-38f098c501c8.png">

### No container
<img width="244" alt="Screenshot 2022-02-14 at 17 35 30" src="https://user-images.githubusercontent.com/56078793/153916611-cd220a05-0f47-4c89-ad97-bf918909805e.png">
