### PR TITLE
Fix various strict null errors (part 4)

### DIFF
--- a/packages/design-tokens/src/__tests__/selectors.test.tsx
+++ b/packages/design-tokens/src/__tests__/selectors.test.tsx
@@ -4,7 +4,17 @@ import { render, RenderResult } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import 'jest-styled-components'
 
-import { selectors } from '..'
+import {
+  AnimationTiming,
+  BreakpointSize,
+  ColorGroup,
+  ColorShade,
+  selectors,
+  ShadowWeight,
+  Spacing,
+  TypographySize,
+  ZIndexGroup,
+} from '..'
 
 const {
   mediaQuery,
@@ -121,125 +131,203 @@ describe('mediaQuery / mq', () => {
 })
 
 describe('breakpoint', () => {
-  const StyledComponent = styled.div`
-    @media only screen and (min-width: ${breakpoint('xs').breakpoint}) {
-      font-size: 14px;
-    }
-  `
-
-  beforeEach(() => {
-    wrapper = render(<StyledComponent data-testid="test-element" />)
+  describe('when the breakpoint is invalid', () => {
+    it('throws a friendly error', () => {
+      expect(() => breakpoint('invalid' as BreakpointSize)).toThrowError(
+        'Invalid breakpoint token'
+      )
+    })
   })
 
-  it('should set styles correctly', () => {
-    expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
-      'font-size',
-      '14px',
-      {
-        media: 'only screen and (min-width:576px)',
+  describe('when the breakpoint is valid', () => {
+    const StyledComponent = styled.div`
+      @media only screen and (min-width: ${breakpoint('xs').breakpoint}) {
+        font-size: 14px;
       }
-    )
+    `
+
+    beforeEach(() => {
+      wrapper = render(<StyledComponent data-testid="test-element" />)
+    })
+
+    it('should set styles correctly', () => {
+      expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
+        'font-size',
+        '14px',
+        {
+          media: 'only screen and (min-width:576px)',
+        }
+      )
+    })
   })
 })
 
 describe('animation', () => {
-  const StyledComponent = styled.div`
-    transition: opacity ${animation('default')} linear;
-  `
-
-  beforeEach(() => {
-    wrapper = render(<StyledComponent data-testid="test-element" />)
+  describe('when the index is invalid', () => {
+    it('throws a friendly error', () => {
+      expect(() => animation('invalid' as AnimationTiming)).toThrowError(
+        'Invalid animation token'
+      )
+    })
   })
 
-  it('should set styles correctly', () => {
-    expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
-      'transition',
-      'opacity 0.2s linear'
-    )
+  describe('when the index is valid', () => {
+    const StyledComponent = styled.div`
+      transition: opacity ${animation('default')} linear;
+    `
+
+    beforeEach(() => {
+      wrapper = render(<StyledComponent data-testid="test-element" />)
+    })
+
+    it('should set styles correctly', () => {
+      expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
+        'transition',
+        'opacity 0.2s linear'
+      )
+    })
   })
 })
 
 describe('color', () => {
-  const StyledComponent = styled.div`
-    color: ${color('neutral', '100')};
-  `
-
-  beforeEach(() => {
-    wrapper = render(<StyledComponent data-testid="test-element" />)
+  describe('when the group is invalid', () => {
+    it('throws a friendly error', () => {
+      expect(() => color('invalid' as ColorGroup, '400')).toThrowError(
+        'Invalid color token'
+      )
+    })
   })
 
-  it('should set styles correctly', () => {
-    expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
-      'color',
-      '#e2e9ee'
-    )
+  describe('when the shade is invalid', () => {
+    it('throws a friendly error', () => {
+      expect(() => color('action', 'invalid' as ColorShade)).toThrowError(
+        'Invalid color token'
+      )
+    })
+  })
+
+  describe('when the group and shade are valid', () => {
+    const StyledComponent = styled.div`
+      color: ${color('neutral', '100')};
+    `
+
+    beforeEach(() => {
+      wrapper = render(<StyledComponent data-testid="test-element" />)
+    })
+
+    it('should set styles correctly', () => {
+      expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
+        'color',
+        '#e2e9ee'
+      )
+    })
   })
 })
 
 describe('fontSize', () => {
-  const StyledComponent = styled.div`
-    font-size: ${fontSize('xs')};
-  `
-
-  beforeEach(() => {
-    wrapper = render(<StyledComponent data-testid="test-element" />)
+  describe('when the size is invalid', () => {
+    it('throws a friendly error', () => {
+      expect(() => fontSize('invalid' as TypographySize)).toThrowError(
+        'Invalid typography token'
+      )
+    })
   })
 
-  it('should set styles correctly', () => {
-    expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
-      'font-size',
-      '0.625rem'
-    )
+  describe('when the size is valid', () => {
+    const StyledComponent = styled.div`
+      font-size: ${fontSize('xs')};
+    `
+
+    beforeEach(() => {
+      wrapper = render(<StyledComponent data-testid="test-element" />)
+    })
+
+    it('should set styles correctly', () => {
+      expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
+        'font-size',
+        '0.625rem'
+      )
+    })
   })
 })
 
 describe('shadow', () => {
-  const StyledComponent = styled.div`
-    box-shadow: ${shadow('0')};
-  `
-
-  beforeEach(() => {
-    wrapper = render(<StyledComponent data-testid="test-element" />)
+  describe('when the weight is invalid', () => {
+    it('throws a friendly error', () => {
+      expect(() => shadow('invalid' as ShadowWeight)).toThrowError(
+        'Invalid shadow token'
+      )
+    })
   })
 
-  it('should set styles correctly', () => {
-    expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
-      'box-shadow',
-      '0 0 0 transparent'
-    )
+  describe('when the weight is valid', () => {
+    const StyledComponent = styled.div`
+      box-shadow: ${shadow('0')};
+    `
+
+    beforeEach(() => {
+      wrapper = render(<StyledComponent data-testid="test-element" />)
+    })
+
+    it('should set styles correctly', () => {
+      expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
+        'box-shadow',
+        '0 0 0 transparent'
+      )
+    })
   })
 })
 
 describe('spacing', () => {
-  const StyledComponent = styled.div`
-    padding: ${spacing('4')};
-  `
-
-  beforeEach(() => {
-    wrapper = render(<StyledComponent data-testid="test-element" />)
+  describe('when the spacing value is invalid', () => {
+    it('throws a friendly error', () => {
+      expect(() => spacing('invalid' as Spacing)).toThrowError(
+        'Invalid spacing token'
+      )
+    })
   })
 
-  it('should set styles correctly', () => {
-    expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
-      'padding',
-      '0.5rem'
-    )
+  describe('when the value is valid', () => {
+    const StyledComponent = styled.div`
+      padding: ${spacing('4')};
+    `
+
+    beforeEach(() => {
+      wrapper = render(<StyledComponent data-testid="test-element" />)
+    })
+
+    it('should set styles correctly', () => {
+      expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
+        'padding',
+        '0.5rem'
+      )
+    })
   })
 })
 
 describe('zIndex', () => {
-  const StyledComponent = styled.div`
-    z-index: ${zIndex('overlay', 1)};
-  `
-
-  beforeEach(() => {
-    wrapper = render(<StyledComponent data-testid="test-element" />)
+  describe('when the group is invalid', () => {
+    it('throws a friendly error', () => {
+      expect(() => zIndex('invalid' as ZIndexGroup, 1)).toThrowError(
+        'Invalid z-index token'
+      )
+    })
   })
 
-  it('should set styles correctly', () => {
-    expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
-      'z-index',
-      '6001'
-    )
+  describe('when the group and offset are valid', () => {
+    const StyledComponent = styled.div`
+      z-index: ${zIndex('overlay', 1)};
+    `
+
+    beforeEach(() => {
+      wrapper = render(<StyledComponent data-testid="test-element" />)
+    })
+
+    it('should set styles correctly', () => {
+      expect(wrapper.getByTestId('test-element')).toHaveStyleRule(
+        'z-index',
+        '6001'
+      )
+    })
   })
 })

--- a/packages/design-tokens/src/getters.ts
+++ b/packages/design-tokens/src/getters.ts
@@ -1,4 +1,4 @@
-import get from 'lodash/get'
+import { get, isNil } from 'lodash'
 import { css } from 'styled-components'
 
 import defaultTheme from './themes/light'
@@ -20,10 +20,11 @@ function getTheme(theme?: Theme): Theme {
   return theme?.colorsTokens ? theme : defaultTheme
 }
 
-export function getBreakpoint(
-  size: BreakpointSize,
-  theme?: Theme
-): Breakpoint | undefined {
+function isTokenValid(token: unknown): boolean {
+  return !isNil(token) && token !== ''
+}
+
+export function getBreakpoint(size: BreakpointSize, theme?: Theme): Breakpoint {
   const { breakpointsTokens } = getTheme(theme)
 
   const breakpoint = get(
@@ -31,9 +32,13 @@ export function getBreakpoint(
     `breakpoint[${size}].breakpoint.value`
   )
 
-  return {
-    breakpoint,
+  if (isTokenValid(breakpoint)) {
+    return {
+      breakpoint,
+    }
   }
+
+  throw new Error(`Invalid breakpoint token for size: '${size}'`)
 }
 
 export function getMediaQuery(
@@ -88,48 +93,79 @@ export function getMediaQuery(
   }
 }
 
-export function getAnimation(
-  index: AnimationTiming,
-  theme?: Theme
-): string | undefined {
-  return get(getTheme(theme).animationTokens, `timing[${index}].value`)
+export function getAnimation(index: AnimationTiming, theme?: Theme): string {
+  const value = get(getTheme(theme).animationTokens, `timing[${index}].value`)
+
+  if (isTokenValid(value)) {
+    return value
+  }
+
+  throw new Error(`Invalid animation token for index: '${index}'`)
 }
 
 export function getColor(
   group: ColorGroup,
   weight: ColorShade,
   theme?: Theme
-): string | undefined {
-  return get(getTheme(theme).colorsTokens, `color[${group}][${weight}].value`)
+): string {
+  const value = get(
+    getTheme(theme).colorsTokens,
+    `color[${group}][${weight}].value`
+  )
+
+  if (isTokenValid(value)) {
+    return value
+  }
+
+  throw new Error(
+    `Invalid color token for group: '${group}' weight: '${weight}'`
+  )
 }
 
-export function getTypography(
-  size: TypographySize,
-  theme?: Theme
-): string | undefined {
-  return get(getTheme(theme).typographyTokens, `typography[${size}].value`)
+export function getTypography(size: TypographySize, theme?: Theme): string {
+  const value = get(
+    getTheme(theme).typographyTokens,
+    `typography[${size}].value`
+  )
+
+  if (isTokenValid(value)) {
+    return value
+  }
+
+  throw new Error(`Invalid typography token for size: '${size}'`)
 }
 
-export function getShadow(
-  weight: ShadowWeight,
-  theme?: Theme
-): string | undefined {
-  return get(getTheme(theme).shadowsTokens, `shadow[${weight}].value`)
+export function getShadow(weight: ShadowWeight, theme?: Theme): string {
+  const value = get(getTheme(theme).shadowsTokens, `shadow[${weight}].value`)
+
+  if (isTokenValid(value)) {
+    return value
+  }
+
+  throw new Error(`Invalid shadow token for weight: '${weight}'`)
 }
 
-export function getSpacing(
-  spacing: Spacing,
-  theme?: Theme
-): string | undefined {
-  return get(getTheme(theme).spacingTokens, `spacing[${spacing}].value`)
+export function getSpacing(spacing: Spacing, theme?: Theme): string {
+  const value = get(getTheme(theme).spacingTokens, `spacing[${spacing}].value`)
+
+  if (isTokenValid(value)) {
+    return value
+  }
+
+  throw new Error(`Invalid spacing token for value: '${spacing}'`)
 }
 
 export function getZIndex(
   group: ZIndexGroup,
   offset: number,
   theme?: Theme
-): number | undefined {
-  return (
-    Number(get(getTheme(theme).zindexTokens, `zindex[${group}].value`)) + offset
+): number {
+  const value = get(getTheme(theme).zindexTokens, `zindex[${group}].value`)
+  if (isTokenValid(value)) {
+    return Number(value) + offset
+  }
+
+  throw new Error(
+    `Invalid z-index token for: group '${group}' offset: ${offset}`
   )
 }

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -14,7 +14,6 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "preserve",
-    "strictNullChecks": false,
     "suppressImplicitAnyIndexErrors": true
   },
   "include": ["src"]

--- a/packages/icon-library/tsconfig.json
+++ b/packages/icon-library/tsconfig.json
@@ -14,7 +14,6 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "preserve",
-    "strictNullChecks": false,
     "suppressImplicitAnyIndexErrors": true
   },
   "include": ["src"]

--- a/packages/react-component-library/src/components/DescriptionList/DescriptionList.tsx
+++ b/packages/react-component-library/src/components/DescriptionList/DescriptionList.tsx
@@ -44,14 +44,14 @@ function getAriaAttributes(isCollapsible: boolean, expanded: boolean) {
 }
 
 export const DescriptionList: React.FC<DescriptionListProps> = ({
-  isCollapsible,
+  isCollapsible = false,
   description,
   children,
   ...rest
 }) => {
   const { open, toggle } = useOpenClose(false)
   const ariaAttributes = getAriaAttributes(isCollapsible, open)
-  const sheetId = ariaAttributes && ariaAttributes['aria-owns']
+  const sheetId = ariaAttributes ? ariaAttributes['aria-owns'] : undefined
 
   return (
     <StyledDescriptionList

--- a/packages/react-component-library/src/components/DescriptionList/DescriptionListItem.tsx
+++ b/packages/react-component-library/src/components/DescriptionList/DescriptionListItem.tsx
@@ -23,7 +23,7 @@ export interface DescriptionListItemProps {
 export const DescriptionListItem: React.FC<DescriptionListItemProps> = ({
   children,
   title,
-  isCollapsible,
+  isCollapsible = false,
   ...rest
 }) => (
   <StyledItem

--- a/packages/react-component-library/src/components/DismissibleBanner/DismissibleBanner.test.tsx
+++ b/packages/react-component-library/src/components/DismissibleBanner/DismissibleBanner.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { DismissibleBanner } from '.'
 
@@ -116,6 +117,18 @@ describe('DismissibleBanner', () => {
         'data-arbitrary',
         'arbitrary'
       )
+    })
+  })
+
+  describe('when onDismiss is not set', () => {
+    beforeEach(() => {
+      wrapper = render(<DismissibleBanner>Content</DismissibleBanner>)
+    })
+
+    it('does not throw an error when the dismiss button is clicked', () => {
+      expect(() => {
+        userEvent.click(wrapper.getByTestId('dimissiblebanner-dismiss'))
+      }).not.toThrowError()
     })
   })
 })

--- a/packages/react-component-library/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/react-component-library/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -40,7 +40,7 @@ export interface DismissibleBannerWithArbitraryContentProps
   /**
    * Arbitrary JSX content to display in the main body of the component.
    */
-  children: React.ReactElement
+  children: React.ReactChild
   /**
    * Optional handler function to be invoked when the Dismiss button is clicked.
    */
@@ -68,7 +68,7 @@ export const DismissibleBanner: React.FC<DismissibleBannerProps> = ({
   const [canShowAgain, setCanShowAgain] = useState(true)
 
   const onButtonClick = (event: React.FormEvent<HTMLButtonElement>) => {
-    onDismiss(event, canShowAgain)
+    onDismiss?.(event, canShowAgain)
   }
 
   return (


### PR DESCRIPTION
## Related issue

#2755

## Overview

This fixes a subset of type errors on `release/3.0.0` that were being suppressed by `"strictNullChecks": false`, and enables strict null checks for the icon library and design tokens packages.

## Link to preview

https://5e25c277526d380020b5e418-xtetyxjycj.chromatic.com/

## Reason

> Currently, the TypeScript configuation in `packages/react-component-library/tsconfig.json` contains:
> 
> ```
>     "strictNullChecks": false,
> ```
> 
> This means that types implicitly allow null and undefined. This is undesirable as it means:
> 
> - types are misleading
> - there may be hidden bugs (either due to values being null or undefined unintentionally, or due to null or undefined not being handled)
> - there may be missed test cases

## Work carried out

- [x] Resolve strict null errors for `DescriptionList`, `DismissibleBanner` icon library and design tokens
- [x] Turn on strict null checks for the icon library and design tokens packages
- [x] Improve error handling in the design tokens package

## Developer notes

n/a