### PR TITLE
Fix various strict null errors (part 5)

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { isAfter } from 'date-fns'
+import { isAfter, setHours, startOfToday } from 'date-fns'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TimelineProvider } from './context'
@@ -40,7 +40,7 @@ export interface TimelineProps extends ComponentWithClass {
   /**
    * A month will display either side of this start date.
    */
-  startDate?: Date
+  startDate: Date
   /**
    * Bound the timeline by the specified start and end dates.
    */
@@ -74,7 +74,7 @@ function getHoursBlockSize(
   )
 }
 
-function getEndDate(startDate: Date, endDate: Date) {
+function getEndDate(startDate: Date, endDate: Date | null) {
   if (startDate && endDate && isAfter(startDate, endDate)) {
     logger.error('`startDate` is after `endDate`')
     return null
@@ -92,9 +92,9 @@ export const Timeline: React.FC<TimelineProps> = ({
   hideToolbar = false,
   isFullWidth = false,
   startDate,
-  endDate,
-  today,
-  range,
+  endDate = null,
+  today = setHours(startOfToday(), 12),
+  range = 1,
   unitWidth,
   ...rest
 }) => {

--- a/packages/react-component-library/src/components/Timeline/TimelineDay.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDay.tsx
@@ -9,7 +9,7 @@ interface TimelineDayProps {
   date: Date
   dayWidth: number
   index: number
-  render: (props: {
+  render?: (props: {
     index: number
     dayWidth: number
     date: Date

--- a/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineDays.tsx
@@ -32,6 +32,11 @@ export const TimelineDays: React.FC<TimelineDaysProps> = memo(
     const {
       state: { currentScaleOption, days },
     } = useContext(TimelineContext)
+
+    if (!currentScaleOption) {
+      return null
+    }
+
     const isBelowThreshold =
       currentScaleOption.widths.day < DISPLAY_THRESHOLDS.DAY
 

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -79,7 +79,7 @@ function renderDefault({
   startsBeforeStart,
   endsAfterEnd,
 }: {
-  barColor: string
+  barColor?: string
   children: React.ReactNode
   offsetPx: string
   startDate: Date

--- a/packages/react-component-library/src/components/Timeline/TimelineHour.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineHour.tsx
@@ -6,7 +6,7 @@ import { StyledHourTitle } from './partials/StyledHourTitle'
 
 interface TimelineHourProps {
   date: Date
-  render: (props: { width: number; time: string }) => React.ReactElement
+  render?: (props: { width: number; time: string }) => React.ReactElement
   time: string
   timelineEndDate: Date
   width: number

--- a/packages/react-component-library/src/components/Timeline/TimelineHours.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineHours.tsx
@@ -36,6 +36,11 @@ export type TimelineHoursProps =
 export const TimelineHours: React.FC<TimelineHoursProps> = ({ render }) => {
   const { state } = useContext(TimelineContext)
   const { currentScaleOption, days, hours } = state
+
+  if (!currentScaleOption) {
+    return null
+  }
+
   const isBelowThreshold =
     currentScaleOption.widths.hour < DISPLAY_THRESHOLDS.HOUR
 

--- a/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
@@ -28,7 +28,7 @@ interface TimelineMonthProps {
   daysTotal: number
   dayWidth: number
   index: number
-  render: (props: {
+  render?: (props: {
     index: number
     dayWidth: number
     daysTotal: number

--- a/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonths.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, memo } from 'react'
 import { differenceInDays, endOfMonth, min as minDate, max } from 'date-fns'
-import { min as minNumber } from 'lodash'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { getKey } from '../../helpers'
@@ -34,7 +33,7 @@ const MONTH_SMALL_THRESHOLD = 30
 const MONTH_MEDIUM_THRESHOLD = 160
 
 function getSize(monthWidths: { daysTotal: number; monthWidth: number }[]) {
-  const smallest = minNumber(monthWidths.map(({ monthWidth }) => monthWidth))
+  const smallest = Math.min(...monthWidths.map(({ monthWidth }) => monthWidth))
 
   if (smallest < MONTH_SMALL_THRESHOLD) {
     return MONTH_SIZE.SMALL
@@ -52,6 +51,10 @@ export const TimelineMonths = memo<TimelineMonthsProps>(
     const {
       state: { currentScaleOption, days, months },
     } = useContext(TimelineContext)
+
+    if (!currentScaleOption) {
+      return null
+    }
 
     const monthWidths = months.map(({ startDate }) => {
       const firstDateDisplayed = max([startDate, days[0].date])

--- a/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRow.tsx
@@ -41,7 +41,7 @@ export interface TimelineRowProps extends ComponentWithClass {
   /**
    * Supply a custom presentation layer for the row header.
    */
-  render?: (props: { name: string }) => React.ReactElement
+  render?: (props: { name?: string }) => React.ReactElement
   /**
    * @private
    */
@@ -56,7 +56,7 @@ export const TimelineRow: React.FC<TimelineRowProps> = ({
   name,
   ariaLabel,
   render,
-  isHeader,
+  isHeader = false,
   className,
   ...rest
 }) => {

--- a/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineRows.tsx
@@ -38,6 +38,10 @@ export const TimelineRows: React.FC<TimelineRowsProps> = ({
     state: { currentScaleOption, days },
   } = useContext(TimelineContext)
 
+  if (!currentScaleOption) {
+    return null
+  }
+
   return (
     <StyledRows
       $hasDefaultStyles={!render}

--- a/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineTodayMarker.tsx
@@ -37,10 +37,8 @@ export const TimelineTodayMarker: React.FC<TimelineTodayMarkerProps> = ({
     state: { today },
   } = useContext(TimelineContext)
 
-  const { offset, startsBeforeStart, startsAfterEnd } = useTimelinePosition(
-    today,
-    null
-  )
+  const { offset, startsBeforeStart, startsAfterEnd } =
+    useTimelinePosition(today)
 
   if (startsBeforeStart || startsAfterEnd) {
     return null

--- a/packages/react-component-library/src/components/Timeline/TimelineWeek.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeek.tsx
@@ -15,7 +15,7 @@ interface TimelineWeekProps {
   days: TimelineDay[]
   dayWidth: number
   index: number
-  render: (props: {
+  render?: (props: {
     index: number
     isOddNumber: boolean
     offsetPx: string

--- a/packages/react-component-library/src/components/Timeline/TimelineWeekColumns.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeekColumns.tsx
@@ -42,38 +42,40 @@ export const TimelineWeekColumns: React.FC<TimelineWeekColumnProps> = ({
   render,
 }) => (
   <TimelineContext.Consumer>
-    {({ state: { currentScaleOption, days, weeks } }) => (
-      <StyledWeekColumnsWrapper>
-        <StyledWeekColumns role="presentation" data-testid="timeline-columns">
-          {weeks.map(({ startDate }, index) => {
-            const lastDateDisplayed = min([
-              endOfWeek(startDate, { weekStartsOn: WEEK_START }),
-              days[days.length - 1].date,
-            ])
-            const offsetInDays = differenceInDays(
-              startDate,
-              max([startDate, days[0].date])
-            )
-            const offsetPx = formatPx(
-              currentScaleOption.widths.day,
-              offsetInDays
-            )
-            const widthPx = formatPx(
-              currentScaleOption.widths.day,
-              differenceInDays(lastDateDisplayed, startDate) + 1
-            )
+    {({ state: { currentScaleOption, days, weeks } }) =>
+      currentScaleOption && (
+        <StyledWeekColumnsWrapper>
+          <StyledWeekColumns role="presentation" data-testid="timeline-columns">
+            {weeks.map(({ startDate }, index) => {
+              const lastDateDisplayed = min([
+                endOfWeek(startDate, { weekStartsOn: WEEK_START }),
+                days[days.length - 1].date,
+              ])
+              const offsetInDays = differenceInDays(
+                startDate,
+                max([startDate, days[0].date])
+              )
+              const offsetPx = formatPx(
+                currentScaleOption.widths.day,
+                offsetInDays
+              )
+              const widthPx = formatPx(
+                currentScaleOption.widths.day,
+                differenceInDays(lastDateDisplayed, startDate) + 1
+              )
 
-            const isOddNumber = isOdd(index)
+              const isOddNumber = isOdd(index)
 
-            const column = render
-              ? render({ index, isOddNumber, offsetPx, widthPx })
-              : renderDefault({ index, isOddNumber, offsetPx, widthPx })
+              const column = render
+                ? render({ index, isOddNumber, offsetPx, widthPx })
+                : renderDefault({ index, isOddNumber, offsetPx, widthPx })
 
-            return withKey(column, 'timeline-column', startDate.toString())
-          })}
-        </StyledWeekColumns>
-      </StyledWeekColumnsWrapper>
-    )}
+              return withKey(column, 'timeline-column', startDate.toString())
+            })}
+          </StyledWeekColumns>
+        </StyledWeekColumnsWrapper>
+      )
+    }
   </TimelineContext.Consumer>
 )
 

--- a/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineWeeks.tsx
@@ -37,6 +37,10 @@ export const TimelineWeeks: React.FC<TimelineWeeksProps> = memo(
       state: { currentScaleOption, days, weeks },
     } = useContext(TimelineContext)
 
+    if (!currentScaleOption) {
+      return null
+    }
+
     const isBelowThreshold =
       currentScaleOption.widths.day * 7 < DISPLAY_THRESHOLDS.WEEK
 

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -50,7 +50,13 @@ const TimelineDates: React.FC<TimelineDaysProps> = () => {
 describe('Timeline', () => {
   let wrapper: RenderResult
 
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2020, 1, 15))
+  })
+
   afterEach(() => {
+    jest.useRealTimers()
     jest.clearAllMocks()
   })
 
@@ -86,7 +92,7 @@ describe('Timeline', () => {
         </Timeline>
       )
 
-      wrapper.getByTestId('timeline-toolbar-zoom-in').click()
+      userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
     })
 
     it('should set the `role` attribute to `grid` on the timeline', () => {
@@ -944,7 +950,7 @@ describe('Timeline', () => {
         </Timeline>
       )
 
-      wrapper.getByTestId('timeline-toolbar-zoom-in').click()
+      userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
     })
 
     it('should render the day dates as specified', () => {
@@ -981,7 +987,7 @@ describe('Timeline', () => {
         </Timeline>
       )
 
-      wrapper.getByTestId('timeline-toolbar-zoom-in').click()
+      userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
     })
 
     it('renders the correct number of hours', () => {
@@ -1214,6 +1220,23 @@ describe('Timeline', () => {
         'title',
         'Begins on 16th April 2020 and ends on 20th April 2020'
       )
+    })
+  })
+
+  describe('when the today marker is displayed and today is omitted', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Timeline startDate={new Date(2020, 1, 1, 0, 0, 0)}>
+          <TimelineTodayMarker />
+          <TimelineRows>{}</TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('positions the today marker at the current date', () => {
+      expect(wrapper.getByTestId('timeline-today-marker')).toHaveStyle({
+        left: '435px',
+      })
     })
   })
 
@@ -1736,7 +1759,7 @@ describe('Timeline', () => {
 
     describe('and then zooming out once (year view)', () => {
       beforeEach(() => {
-        wrapper.getByTestId('timeline-toolbar-zoom-out').click()
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-out'))
       })
 
       it('should render months', () => {
@@ -1779,8 +1802,8 @@ describe('Timeline', () => {
 
     describe('and then zooming out twice (5 year view)', () => {
       beforeEach(() => {
-        wrapper.getByTestId('timeline-toolbar-zoom-out').click()
-        wrapper.getByTestId('timeline-toolbar-zoom-out').click()
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-out'))
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-out'))
       })
 
       it('should render months', () => {
@@ -1823,7 +1846,7 @@ describe('Timeline', () => {
 
     describe('and then zooming in once (week view)', () => {
       beforeEach(() => {
-        wrapper.getByTestId('timeline-toolbar-zoom-in').click()
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
       })
 
       it('should render months', () => {
@@ -1845,8 +1868,8 @@ describe('Timeline', () => {
 
     describe('and then zooming in twice (day view)', () => {
       beforeEach(() => {
-        wrapper.getByTestId('timeline-toolbar-zoom-in').click()
-        wrapper.getByTestId('timeline-toolbar-zoom-in').click()
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
       })
 
       it('should render months', () => {
@@ -1868,9 +1891,9 @@ describe('Timeline', () => {
 
     describe('and then zooming in thrice (1/4 day view)', () => {
       beforeEach(() => {
-        wrapper.getByTestId('timeline-toolbar-zoom-in').click()
-        wrapper.getByTestId('timeline-toolbar-zoom-in').click()
-        wrapper.getByTestId('timeline-toolbar-zoom-in').click()
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
       })
 
       it('should render months', () => {
@@ -1892,10 +1915,10 @@ describe('Timeline', () => {
 
     describe('and then zooming in four times (1 hour view)', () => {
       beforeEach(() => {
-        wrapper.getByTestId('timeline-toolbar-zoom-in').click()
-        wrapper.getByTestId('timeline-toolbar-zoom-in').click()
-        wrapper.getByTestId('timeline-toolbar-zoom-in').click()
-        wrapper.getByTestId('timeline-toolbar-zoom-in').click()
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
+        userEvent.click(wrapper.getByTestId('timeline-toolbar-zoom-in'))
       })
 
       it('should render months', () => {
@@ -2340,7 +2363,7 @@ describe('Timeline', () => {
 
       wrapper = render(<TimelineWithUpdate />)
 
-      wrapper.getByText('Update').click()
+      userEvent.click(wrapper.getByText('Update'))
     })
 
     it('should not show the event', async () => {
@@ -2409,7 +2432,7 @@ describe('Timeline', () => {
       expect(eventSpy).toBeCalledTimes(1)
       eventSpy.mockClear()
 
-      wrapper.getByText('Force update').click()
+      userEvent.click(wrapper.getByText('Force update'))
       expect(await wrapper.findByText('Render: 2')).toBeInTheDocument()
       expect(eventSpy).not.toBeCalled()
     })

--- a/packages/react-component-library/src/components/Timeline/context/index.tsx
+++ b/packages/react-component-library/src/components/Timeline/context/index.tsx
@@ -13,7 +13,9 @@ import { buildScaleOptions } from './timeline_scales'
 const timelineContextDefaults: TimelineContextDefault = {
   hasSide: false,
   state: initialState,
-  dispatch: null,
+  dispatch: () => {
+    throw Error('TimelineContext not initialised')
+  },
 }
 
 export const TimelineContext = createContext(timelineContextDefaults)

--- a/packages/react-component-library/src/components/Timeline/context/state.ts
+++ b/packages/react-component-library/src/components/Timeline/context/state.ts
@@ -1,3 +1,4 @@
+import { DEFAULTS } from '../constants'
 import { TimelineState } from './types'
 
 const initialState: TimelineState = {
@@ -5,7 +6,7 @@ const initialState: TimelineState = {
   currentScaleOption: null,
   days: [],
   getNewEndDate(intervalMultiplier = 1) {
-    if (this.options.endDate && this.currentScaleOption.isDefault) {
+    if (this.options.endDate && this.currentScaleOption?.isDefault) {
       return this.currentScaleOption.calculateDate(
         this.currentScaleOption.to,
         this.currentScaleOption.intervalSize * intervalMultiplier
@@ -16,7 +17,13 @@ const initialState: TimelineState = {
   },
   hours: [],
   months: [],
-  options: null,
+  options: {
+    endDate: null,
+    hoursBlockSize: null,
+    startDate: new Date(NaN),
+    range: 1,
+    unitWidth: DEFAULTS.UNIT_WIDTH,
+  },
   scaleOptions: [],
   today: new Date(),
   weeks: [],

--- a/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
+++ b/packages/react-component-library/src/components/Timeline/context/timeline_scales.ts
@@ -25,7 +25,7 @@ type ScaleConfigType = { [key: string]: ScaleConfigOptionType }
 
 function getDefaultScaleConfigOption(
   startDate: Date,
-  endDate: Date,
+  endDate: Date | null,
   monthIntervalSize: number
 ) {
   if (endDate) {
@@ -45,7 +45,7 @@ function getDefaultScaleConfigOption(
 
 function getScaleConfig(
   startDate: Date,
-  endDate: Date,
+  endDate: Date | null,
   monthIntervalSize: number
 ): ScaleConfigType {
   return {
@@ -81,7 +81,7 @@ function getScaleConfig(
 function mapScaleOption(
   startDate: Date,
   maxWidth: number,
-  hoursBlockSize: BlockSizeType
+  hoursBlockSize: BlockSizeType | null
 ) {
   return ({
     calculateDate,
@@ -112,7 +112,7 @@ function mapScaleOption(
 }
 
 function getMaxWidth(
-  timelineWidth: number,
+  timelineWidth: number | null,
   unitWidth: number,
   numberOfDays: number
 ) {
@@ -127,10 +127,15 @@ function getMaxWidth(
 
 function buildScaleOptions(
   { endDate, hoursBlockSize, range, startDate, unitWidth }: TimelineOptions,
-  timelineWidth?: number
+  timelineWidth: number | null
 ): TimelineScaleOption[] {
   const scaleConfig = getScaleConfig(startDate, endDate, range)
-  const defaultConfig = find(scaleConfig, ({ isDefault }) => isDefault)
+  const defaultConfig = find(scaleConfig, { isDefault: true })
+
+  if (!defaultConfig) {
+    throw new Error('Failed to find default Timeline scale configuration')
+  }
+
   const numberOfDays = endDate
     ? defaultConfig.intervalSize
     : differenceInDays(

--- a/packages/react-component-library/src/components/Timeline/context/types.ts
+++ b/packages/react-component-library/src/components/Timeline/context/types.ts
@@ -5,7 +5,7 @@ import { BlockSizeType } from '../TimelineHours'
 export type TimelineScaleOption = {
   calculateDate: (d: Date, n: number) => Date
   from: Date
-  hoursBlockSize?: BlockSizeType
+  hoursBlockSize: BlockSizeType | null
   intervalSize: number
   isDefault?: boolean
   to: Date
@@ -16,8 +16,8 @@ export type TimelineScaleOption = {
 }
 
 export type TimelineOptions = {
-  endDate: Date
-  hoursBlockSize: BlockSizeType
+  endDate: Date | null
+  hoursBlockSize: BlockSizeType | null
   range: number
   startDate: Date
   unitWidth: number
@@ -44,17 +44,17 @@ export type TimelineMonth = {
 }
 
 export type TimelineState = {
-  currentScaleIndex: number
-  currentScaleOption: TimelineScaleOption
+  currentScaleIndex: number | null
+  currentScaleOption: TimelineScaleOption | null
   days: TimelineDay[]
-  getNewEndDate: (intervalMultiplier?: number) => Date
+  getNewEndDate: (intervalMultiplier?: number) => Date | null
   hours: TimelineHour[]
   months: TimelineMonth[]
   options: TimelineOptions
   scaleOptions: TimelineScaleOption[]
   today: Date
   weeks: TimelineWeek[]
-  width: number
+  width: number | null
 }
 
 export const TIMELINE_ACTIONS = {
@@ -73,7 +73,7 @@ export type TimelineAction =
     }
   | {
       type: typeof TIMELINE_ACTIONS.CHANGE_WIDTH
-      width: number
+      width: number | null
     }
   | {
       type: typeof TIMELINE_ACTIONS.GET_NEXT
@@ -85,9 +85,12 @@ export type TimelineAction =
     }
   | {
       type: typeof TIMELINE_ACTIONS.INITIALISE
-      width: number
+      width: number | null
     }
-  | { type: typeof TIMELINE_ACTIONS.SCALE; scaleIndex: number }
+  | {
+      type: typeof TIMELINE_ACTIONS.SCALE
+      getScaleIndex: (currentScaleIndex: number) => number
+    }
 
 export interface TimelineContextDefault {
   hasSide: boolean
@@ -97,7 +100,7 @@ export interface TimelineContextDefault {
 
 export interface TimelineProviderProps {
   children?: React.ReactNode
-  hasSide?: boolean
-  today?: Date
-  options?: TimelineOptions
+  hasSide: boolean
+  today: Date
+  options: TimelineOptions
 }

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineFrame.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineFrame.ts
@@ -15,6 +15,10 @@ export function useTimelineFrame(): {
     type: typeof TIMELINE_ACTIONS.GET_NEXT | typeof TIMELINE_ACTIONS.GET_PREV,
     intervalMultiplier = 1
   ) {
+    if (!currentScaleOption) {
+      return
+    }
+
     const newStartDate = currentScaleOption.calculateDate(
       currentScaleOption.from,
       currentScaleOption.intervalSize * intervalMultiplier

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelinePosition.ts
@@ -24,7 +24,7 @@ function getOffset(startDate: Date, timelineStart: Date): number {
 
 export function useTimelinePosition(
   startDate: Date,
-  endDate: Date
+  endDate: Date = startDate
 ): {
   endsAfterEnd: boolean
   endsBeforeStart: boolean
@@ -37,6 +37,10 @@ export function useTimelinePosition(
   const {
     state: { currentScaleOption },
   } = useContext(TimelineContext)
+
+  if (!currentScaleOption) {
+    throw new Error('Timeline has no current scale option')
+  }
 
   const { from: firstDateDisplayed, to: lastDateDisplayed } = currentScaleOption
 

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineRowContent.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineRowContent.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, MutableRefObject } from 'react'
+import React, { useEffect, useRef, useState, RefObject } from 'react'
 
 import { TimelineEventsProps } from '../TimelineEvents'
 
@@ -9,14 +9,18 @@ export function useTimelineRowContent(
     | React.ReactElement<TimelineEventsProps>[]
 ): {
   noCells: boolean
-  rowContentRef: MutableRefObject<HTMLDivElement>
+  rowContentRef: RefObject<HTMLDivElement>
 } {
-  const rowContentRef = useRef(null)
+  const rowContentRef = useRef<HTMLDivElement>(null)
   const [noCells, setNoCells] = useState<boolean>(false)
 
   useEffect(() => {
     if (isHeader) {
       setNoCells(false)
+      return
+    }
+
+    if (!rowContentRef.current) {
       return
     }
 

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineWidth.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineWidth.ts
@@ -15,12 +15,16 @@ export function useTimelineWidth(
   hasSide: boolean,
   isFullWidth: boolean
 ): {
-  timelineRef: MutableRefObject<HTMLDivElement>
+  timelineRef: MutableRefObject<HTMLDivElement | null>
 } {
-  const timelineRef = useRef<HTMLDivElement>()
+  const timelineRef = useRef<HTMLDivElement>(null)
   const { dispatch } = useContext(TimelineContext)
 
   const getWidth = useCallback(() => {
+    if (!timelineRef.current) {
+      return null
+    }
+
     const timelineWidth = timelineRef.current.getBoundingClientRect().width
     const sideWidth = hasSide ? TIMELINE_ROW_HEADER_WIDTH : 0
     return timelineWidth - 1 - sideWidth

--- a/packages/react-component-library/src/components/Timeline/hooks/useTimelineZoom.ts
+++ b/packages/react-component-library/src/components/Timeline/hooks/useTimelineZoom.ts
@@ -14,19 +14,20 @@ export function useTimelineZoom(): {
     dispatch,
     state: { currentScaleIndex, scaleOptions },
   } = useContext(TimelineContext)
-  const canZoomIn = isNil(currentScaleIndex) || currentScaleIndex > 0
-  const canZoomOut = currentScaleIndex < scaleOptions.length - 1
+  const canZoomIn = !isNil(currentScaleIndex) && currentScaleIndex > 0
+  const canZoomOut =
+    !isNil(currentScaleIndex) && currentScaleIndex < scaleOptions.length - 1
 
   function zoomIn() {
     dispatch({
-      scaleIndex: currentScaleIndex - 1,
+      getScaleIndex: (scaleIndex: number) => scaleIndex - 1,
       type: TIMELINE_ACTIONS.SCALE,
     })
   }
 
   function zoomOut() {
     dispatch({
-      scaleIndex: currentScaleIndex + 1,
+      getScaleIndex: (scaleIndex: number) => scaleIndex + 1,
       type: TIMELINE_ACTIONS.SCALE,
     })
   }

--- a/packages/react-component-library/src/components/Timeline/partials/StyledEventBar.tsx
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledEventBar.tsx
@@ -8,7 +8,7 @@ const { color } = selectors
 interface StyledEventBarProps {
   $width: string
   $maxWidth?: string
-  $barColor: string
+  $barColor?: string
   $startsBeforeStart?: boolean
   $endsAfterEnd?: boolean
 }

--- a/packages/react-component-library/src/components/Timeline/partials/StyledSubComponent.ts
+++ b/packages/react-component-library/src/components/Timeline/partials/StyledSubComponent.ts
@@ -1,5 +1,5 @@
 import { CSSProp } from 'styled-components'
 
 export interface StyledSubComponentProps {
-  $css: CSSProp
+  $css?: CSSProp
 }


### PR DESCRIPTION
## Related issue

#2755

## Overview

This resolves all strict null errors in the Timeline component.

`startDate` was made required as the component breaks without it. Also, `today` now defaults to the current date to match the docs.

## Link to preview

https://5e25c277526d380020b5e418-lkcmkjloqn.chromatic.com/?path=/story/compound-timeline--default

## Reason

> Currently, the TypeScript configuation in `packages/react-component-library/tsconfig.json` contains:
> 
> ```
>     "strictNullChecks": false,
> ```
> 
> This means that types implicitly allow null and undefined. This is undesirable as it means:
> 
> - types are misleading
> - there may be hidden bugs (either due to values being null or undefined unintentionally, or due to null or undefined not being handled)
> - there may be missed test cases

## Work carried out

- [x] Resolve strict null errors for `Timeline`
- [x] Default `today` to current date

## Developer notes

The docs for `today` say:

> Today's current date - default is the system date time.

However, if today wasn't specified, it was previously showing the marker at the start of every month:

![image](https://user-images.githubusercontent.com/66470099/154056532-4068ee95-6a67-4112-a423-b6584a6f345a.png)

I've fixed this so the behaviour matches the docs.

Open to any ideas for any other additional tests that could be written.