### PR TITLE
Update `RadioE` for feature parity

### DIFF
--- a/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import { RadioE } from '.'
+import { RADIO_VARIANT, RadioE, RadioEProps } from '.'
 
 export default {
   component: RadioE,
@@ -12,6 +12,23 @@ export default {
 } as ComponentMeta<typeof RadioE>
 
 const Template: ComponentStory<typeof RadioE> = (props) => <RadioE {...props} />
+
+const MultipleItemsTemplate: ComponentStory<typeof RadioE> = (props) => {
+  function getProps(i: number): RadioEProps {
+    return {
+      ...props,
+      label: `${props.label} ${i}`,
+    }
+  }
+
+  return (
+    <>
+      <RadioE {...getProps(1)} />
+      <RadioE {...getProps(2)} />
+      <RadioE {...getProps(3)} />
+    </>
+  )
+}
 
 export const Default = Template.bind({})
 Default.args = {
@@ -52,6 +69,14 @@ Invalid.args = {
   label: 'Invalid radio',
   name: 'invalid',
   isInvalid: true,
+}
+
+export const NoContainer = MultipleItemsTemplate.bind({})
+NoContainer.args = {
+  id: undefined,
+  label: 'Item without container',
+  name: 'no-container',
+  variant: RADIO_VARIANT.NO_CONTAINER,
 }
 
 export const WithDescription = Template.bind({})

--- a/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.stories.tsx
@@ -53,3 +53,12 @@ Invalid.args = {
   name: 'invalid',
   isInvalid: true,
 }
+
+export const WithDescription = Template.bind({})
+WithDescription.args = {
+  id: undefined,
+  description:
+    'She must have hidden the plans in the escape pod. Send a detachment down to retrieve them.',
+  label: 'With description',
+  name: 'with-description',
+}

--- a/packages/react-component-library/src/components/RadioE/RadioE.test.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
+import 'jest-styled-components'
+import { ColorNeutral200 } from '@defencedigital/design-tokens'
 import { render, RenderResult } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { RADIO_VARIANT, RadioE } from '.'
 import { FieldProps } from '../../common/FieldProps'
 import { FormProps } from '../../common/FormProps'
-import { RadioE } from '.'
 
 describe('RadioE', () => {
   let field: FieldProps
@@ -46,6 +48,17 @@ describe('RadioE', () => {
       )
 
       input = radio.getByTestId('radio-input')
+    })
+
+    it('should render a container', () => {
+      expect(radio.getByTestId('radio')).toHaveStyleRule(
+        'border',
+        `1px solid ${ColorNeutral200}`
+      )
+      expect(radio.getByTestId('radio')).toHaveStyleRule(
+        'border-radius',
+        '15px'
+      )
     })
 
     it('should render a field with a label', () => {
@@ -156,6 +169,29 @@ describe('RadioE', () => {
     it('should render a description', () => {
       expect(radio.getByTestId('checkbox-description')).toHaveTextContent(
         'Description'
+      )
+    })
+  })
+
+  describe('when a field does not have a container', () => {
+    beforeEach(() => {
+      radio = render(
+        <RadioE
+          label="Label"
+          name={field.name}
+          variant={RADIO_VARIANT.NO_CONTAINER}
+        />
+      )
+    })
+
+    it('should not render a container', () => {
+      expect(radio.getByTestId('radio')).not.toHaveStyleRule(
+        'border',
+        `1px solid ${ColorNeutral200}`
+      )
+      expect(radio.getByTestId('radio')).not.toHaveStyleRule(
+        'border-radius',
+        '15px'
       )
     })
   })

--- a/packages/react-component-library/src/components/RadioE/RadioE.test.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.test.tsx
@@ -52,6 +52,10 @@ describe('RadioE', () => {
       expect(radio.getByTestId('radio-label')).toHaveTextContent('My Label 1')
     })
 
+    it('should not render a description', () => {
+      expect(radio.queryAllByTestId('checkbox-description')).toHaveLength(0)
+    })
+
     it('should populate the field value', () => {
       expect(input).toHaveAttribute('value', 'option1')
     })
@@ -138,6 +142,20 @@ describe('RadioE', () => {
       expect(radio.getByTestId('radio-input')).toHaveAttribute(
         'data-arbitrary',
         'arbitrary'
+      )
+    })
+  })
+
+  describe('when a field has a description', () => {
+    beforeEach(() => {
+      radio = render(
+        <RadioE description="Description" label="Label" name={field.name} />
+      )
+    })
+
+    it('should render a description', () => {
+      expect(radio.getByTestId('checkbox-description')).toHaveTextContent(
+        'Description'
       )
     })
   })

--- a/packages/react-component-library/src/components/RadioE/RadioE.test.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.test.tsx
@@ -173,6 +173,22 @@ describe('RadioE', () => {
     })
   })
 
+  describe('when a field has a description that is arbitrary JSX', () => {
+    beforeEach(() => {
+      radio = render(
+        <RadioE
+          description={<div>Arbitrary content</div>}
+          label="Label"
+          name={field.name}
+        />
+      )
+    })
+
+    it('should render a arbitrary description', () => {
+      expect(radio.getByText('Arbitrary content')).toBeInTheDocument()
+    })
+  })
+
   describe('when a field does not have a container', () => {
     beforeEach(() => {
       radio = render(

--- a/packages/react-component-library/src/components/RadioE/RadioE.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import mergeRefs from 'react-merge-refs'
 
+import { RADIO_VARIANT } from './constants'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { InputValidationProps } from '../../common/InputValidationProps'
 import { StyledCheckmark } from './partials/StyledCheckmark'
@@ -11,6 +12,8 @@ import { StyledLabel } from './partials/StyledLabel'
 import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
 import { StyledRadio } from './partials/StyledRadio'
 import { StyledRadioWrapper } from './partials/StyledRadioWrapper'
+
+type RadioVariantType = typeof RADIO_VARIANT[keyof typeof RADIO_VARIANT]
 
 export interface RadioEProps extends ComponentWithClass, InputValidationProps {
   /**
@@ -49,6 +52,10 @@ export interface RadioEProps extends ComponentWithClass, InputValidationProps {
    * Optional HTML `value` attribute associated with the component.
    */
   value?: string
+  /**
+   * Optional variant to set container visibility.
+   */
+  variant?: RadioVariantType
 }
 
 export const RadioE = React.forwardRef<HTMLInputElement, RadioEProps>(
@@ -59,12 +66,13 @@ export const RadioE = React.forwardRef<HTMLInputElement, RadioEProps>(
       defaultChecked,
       description,
       isDisabled = false,
+      isInvalid,
       label,
       name,
       onChange,
       onBlur,
       value,
-      isInvalid,
+      variant = RADIO_VARIANT.DEFAULT,
       ...rest
     },
     ref
@@ -81,6 +89,8 @@ export const RadioE = React.forwardRef<HTMLInputElement, RadioEProps>(
       localRef.current?.focus()
     }
 
+    const hasContainer = variant !== RADIO_VARIANT.NO_CONTAINER
+
     return (
       <StyledRadioWrapper>
         <StyledRadio
@@ -88,14 +98,19 @@ export const RadioE = React.forwardRef<HTMLInputElement, RadioEProps>(
           role="radio"
           aria-checked={defaultChecked}
           $isDisabled={isDisabled}
+          $hasContainer={hasContainer}
           $isInvalid={isInvalid}
           $isChecked={defaultChecked}
           onClick={handleClick}
           onKeyUp={handleKeyUp}
           data-testid="radio"
         >
-          <StyledOuterWrapper>
-            <StyledLabel htmlFor={id} data-testid="radio-label">
+          <StyledOuterWrapper $hasContainer={hasContainer}>
+            <StyledLabel
+              $hasContainer={hasContainer}
+              htmlFor={id}
+              data-testid="radio-label"
+            >
               <StyledInput
                 ref={mergeRefs([localRef, ref])}
                 defaultChecked={defaultChecked}
@@ -109,7 +124,7 @@ export const RadioE = React.forwardRef<HTMLInputElement, RadioEProps>(
                 data-testid="radio-input"
                 {...rest}
               />
-              <StyledCheckmark />
+              <StyledCheckmark $hasContainer={hasContainer} />
               {label}
               {description && (
                 <StyledDescription data-testid="checkbox-description">

--- a/packages/react-component-library/src/components/RadioE/RadioE.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.tsx
@@ -4,11 +4,12 @@ import mergeRefs from 'react-merge-refs'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { InputValidationProps } from '../../common/InputValidationProps'
-import { StyledRadio } from './partials/StyledRadio'
-import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
-import { StyledLabel } from './partials/StyledLabel'
-import { StyledInput } from './partials/StyledInput'
 import { StyledCheckmark } from './partials/StyledCheckmark'
+import { StyledDescription } from './partials/StyledDescription'
+import { StyledInput } from './partials/StyledInput'
+import { StyledLabel } from './partials/StyledLabel'
+import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
+import { StyledRadio } from './partials/StyledRadio'
 import { StyledRadioWrapper } from './partials/StyledRadioWrapper'
 
 export interface RadioEProps extends ComponentWithClass, InputValidationProps {
@@ -20,6 +21,10 @@ export interface RadioEProps extends ComponentWithClass, InputValidationProps {
    * Toggles whether or not the component is marked as checked by default.
    */
   defaultChecked?: boolean
+  /**
+   * Optional description to display below the label.
+   */
+  description?: string
   /**
    * Toggles whether the component is disabled or not (preventing user interaction).
    */
@@ -52,6 +57,7 @@ export const RadioE = React.forwardRef<HTMLInputElement, RadioEProps>(
       className = '',
       id = uuidv4(),
       defaultChecked,
+      description,
       isDisabled = false,
       label,
       name,
@@ -105,6 +111,11 @@ export const RadioE = React.forwardRef<HTMLInputElement, RadioEProps>(
               />
               <StyledCheckmark />
               {label}
+              {description && (
+                <StyledDescription data-testid="checkbox-description">
+                  {description}
+                </StyledDescription>
+              )}
             </StyledLabel>
           </StyledOuterWrapper>
         </StyledRadio>

--- a/packages/react-component-library/src/components/RadioE/RadioE.tsx
+++ b/packages/react-component-library/src/components/RadioE/RadioE.tsx
@@ -27,7 +27,7 @@ export interface RadioEProps extends ComponentWithClass, InputValidationProps {
   /**
    * Optional description to display below the label.
    */
-  description?: string
+  description?: React.ReactNode
   /**
    * Toggles whether the component is disabled or not (preventing user interaction).
    */

--- a/packages/react-component-library/src/components/RadioE/constants.ts
+++ b/packages/react-component-library/src/components/RadioE/constants.ts
@@ -1,0 +1,6 @@
+const RADIO_VARIANT = {
+  DEFAULT: 'default',
+  NO_CONTAINER: 'no-container',
+} as const
+
+export { RADIO_VARIANT }

--- a/packages/react-component-library/src/components/RadioE/index.ts
+++ b/packages/react-component-library/src/components/RadioE/index.ts
@@ -1,1 +1,2 @@
+export * from './constants'
 export * from './RadioE'

--- a/packages/react-component-library/src/components/RadioE/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledCheckmark.tsx
@@ -3,10 +3,14 @@ import { selectors } from '@defencedigital/design-tokens'
 
 const { color } = selectors
 
-export const StyledCheckmark = styled.span`
+interface StyledCheckmarkProps {
+  $hasContainer?: boolean
+}
+
+export const StyledCheckmark = styled.div<StyledCheckmarkProps>`
   position: absolute;
-  top: 12px;
-  left: 12px;
+  top: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
+  left: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
   height: 16px;
   width: 16px;
   border-radius: 999px;

--- a/packages/react-component-library/src/components/RadioE/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledCheckmark.tsx
@@ -5,9 +5,8 @@ const { color } = selectors
 
 export const StyledCheckmark = styled.span`
   position: absolute;
-  top: 50%;
+  top: 12px;
   left: 12px;
-  transform: translateY(-50%);
   height: 16px;
   width: 16px;
   border-radius: 999px;

--- a/packages/react-component-library/src/components/RadioE/partials/StyledDescription.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledDescription.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+import { selectors } from '@defencedigital/design-tokens'
+
+const { fontSize } = selectors
+
+export const StyledDescription = styled.div`
+  font-size: ${fontSize('base')};
+  margin-top: 4px;
+`

--- a/packages/react-component-library/src/components/RadioE/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledLabel.tsx
@@ -3,9 +3,14 @@ import { selectors } from '@defencedigital/design-tokens'
 
 const { color, fontSize } = selectors
 
-export const StyledLabel = styled.label`
+interface StyledLabelProps {
+  $hasContainer?: boolean
+}
+
+export const StyledLabel = styled.label<StyledLabelProps>`
   color: ${color('neutral', '400')};
   font-size: ${fontSize('m')};
-  padding: 12px 12px 12px 17px;
+  padding: ${({ $hasContainer }) =>
+    $hasContainer ? '12px 12px 12px 17px' : '3px'};
   pointer-events: none;
 `

--- a/packages/react-component-library/src/components/RadioE/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledLabel.tsx
@@ -6,6 +6,6 @@ const { color, fontSize } = selectors
 export const StyledLabel = styled.label`
   color: ${color('neutral', '400')};
   font-size: ${fontSize('m')};
-  padding: 0 16px;
+  padding: 12px 12px 12px 17px;
   pointer-events: none;
 `

--- a/packages/react-component-library/src/components/RadioE/partials/StyledOuterWrapper.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledOuterWrapper.tsx
@@ -1,13 +1,22 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
-export const StyledOuterWrapper = styled.div`
+interface StyledOuterWrapperProps {
+  $hasContainer?: boolean
+}
+
+export const StyledOuterWrapper = styled.div<StyledOuterWrapperProps>`
   display: inline-flex;
   align-items: center;
   flex-direction: row;
-  min-height: 44px;
   border-radius: 15px;
 
   &:active {
     pointer-events: none;
   }
+
+  ${({ $hasContainer }) =>
+    $hasContainer &&
+    css`
+      min-height: 44px;
+    `}
 `

--- a/packages/react-component-library/src/components/RadioE/partials/StyledOuterWrapper.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledOuterWrapper.tsx
@@ -4,7 +4,7 @@ export const StyledOuterWrapper = styled.div`
   display: inline-flex;
   align-items: center;
   flex-direction: row;
-  height: 44px;
+  min-height: 44px;
   border-radius: 15px;
 
   &:active {

--- a/packages/react-component-library/src/components/RadioE/partials/StyledRadio.tsx
+++ b/packages/react-component-library/src/components/RadioE/partials/StyledRadio.tsx
@@ -5,6 +5,7 @@ import { StyledCheckmark } from './StyledCheckmark'
 import { StyledInput } from './StyledInput'
 
 interface StyledRadioProps {
+  $hasContainer?: boolean
   $isDisabled?: boolean
   $isInvalid?: boolean
   $isChecked?: boolean
@@ -29,6 +30,18 @@ const CheckmarkCheckedFillColor = css<StyledRadioProps>`
     $isDisabled ? color('neutral', '200') : color('action', '500')}
 `
 
+function getCheckmarkCheckedSelector($hasContainer: boolean) {
+  if ($hasContainer) {
+    return css`
+      ${StyledInput}:checked ~ ${StyledCheckmark}
+    `
+  }
+
+  return css`
+    ${StyledInput}:checked ~ ${StyledCheckmark}, ${StyledInput}:focus-within ~ ${StyledCheckmark}
+  `
+}
+
 export const StyledRadio = styled.div<StyledRadioProps>`
   display: inline-flex;
   position: relative;
@@ -42,17 +55,6 @@ export const StyledRadio = styled.div<StyledRadioProps>`
     cursor: pointer;
   }
 
-  border: 1px solid ${color('neutral', '200')};
-  border-radius: 15px;
-
-  &:focus-within,
-  &:active {
-    outline: none;
-    border-color: ${color('action', '500')};
-    box-shadow: 0 0 0 2px ${color('action', '500')},
-      0 0 0 5px ${color('action', '100')};
-  }
-
   ${StyledCheckmark} {
     background: ${BackgroundColor};
 
@@ -62,6 +64,21 @@ export const StyledRadio = styled.div<StyledRadioProps>`
       transition: all ${animation('default')};
     }
   }
+
+  ${({ $hasContainer }) =>
+    $hasContainer &&
+    css`
+      border: 1px solid ${color('neutral', '200')};
+      border-radius: 15px;
+
+      &:focus-within,
+      &:active {
+        outline: none;
+        border-color: ${color('action', '500')};
+        box-shadow: 0 0 0 2px ${color('action', '500')},
+          0 0 0 5px ${color('action', '100')};
+      }
+    `}
 
   /* Checkmark hover and active states, blue border */
 
@@ -78,7 +95,7 @@ export const StyledRadio = styled.div<StyledRadioProps>`
 
   /* Checkmark checked state */
 
-  ${StyledInput}:checked ~ ${StyledCheckmark} {
+  ${({ $hasContainer }) => getCheckmarkCheckedSelector($hasContainer)} {
     background-color: ${color('neutral', 'white')};
 
     /* Blue border (grey if disabled) */


### PR DESCRIPTION
## Related issue
Closes #3083 

## Overview
Adds `description` and `no-container` variant.

## Link to preview
https://radioe-updates.netlify.app/?path=/story/radio-experimental--no-container
https://radioe-updates.netlify.app/?path=/story/radio-experimental--with-description

## Reason
Required for feature parity.

## Work carried out
- [x] Add description
- [x] Add `no-container` variant

## Screenshot
### No container
![Screenshot 2022-02-16 at 11 09 42](https://user-images.githubusercontent.com/56078793/154252671-68db25a5-ac65-42bb-87d3-f82c7fb48728.png)

### Description
![Screenshot 2022-02-16 at 11 09 59](https://user-images.githubusercontent.com/56078793/154252724-d968d9fe-bb16-48ac-bcd2-d45a922e0234.png)
