### PR TITLE
feat(TabSet): Improve scrolling behaviour

### DIFF
--- a/packages/cra-template-defencedigital/template.json
+++ b/packages/cra-template-defencedigital/template.json
@@ -16,6 +16,7 @@
       "@graphql-codegen/typescript": "^2.4.1",
       "@graphql-codegen/typescript-operations": "^2.2.1",
       "@graphql-codegen/typescript-react-apollo": "^3.2.2",
+      "@juggle/resize-observer": "^3.3.1",
       "@testing-library/jest-dom": "^5.5.0",
       "@testing-library/react": "^12.1.2",
       "@testing-library/user-event": "^13.5.0",

--- a/packages/cra-template-defencedigital/template/src/setupTests.ts
+++ b/packages/cra-template-defencedigital/template/src/setupTests.ts
@@ -2,5 +2,8 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom'
 import 'jest-canvas-mock'
+import { ResizeObserver } from '@juggle/resize-observer'
+
+global.ResizeObserver ??= ResizeObserver

--- a/packages/react-component-library/.storybook/preview.js
+++ b/packages/react-component-library/.storybook/preview.js
@@ -1,6 +1,9 @@
 import '@defencedigital/fonts'
+import { ResizeObserver } from '@juggle/resize-observer'
 
 import { GlobalStyleProvider } from '../src/styled-components/GlobalStyle'
+
+window.ResizeObserver ??= ResizeObserver
 
 /**
  * Hacky way of clicking on Docs button on first load of page.

--- a/packages/react-component-library/cypress/selectors/TabSet.ts
+++ b/packages/react-component-library/cypress/selectors/TabSet.ts
@@ -1,0 +1,6 @@
+export default {
+  scrollLeft: '[data-testid="scroll-left"]',
+  scrollRight: '[data-testid="scroll-right"]',
+  tabItem: '[data-testid="tab-set-tab"]',
+  tabs: '[data-testid="tabs"]',
+}

--- a/packages/react-component-library/cypress/selectors/index.ts
+++ b/packages/react-component-library/cypress/selectors/index.ts
@@ -8,6 +8,7 @@ import form from './form'
 import numberInput from './NumberInput'
 import rangeSlider from './RangeSlider'
 import select from './Select'
+import tabSet from './TabSet'
 import timeline from './timeline'
 
 export default {
@@ -21,5 +22,6 @@ export default {
   numberInput,
   rangeSlider,
   select,
+  tabSet,
   timeline,
 }

--- a/packages/react-component-library/cypress/specs/TabSet/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/TabSet/index.spec.ts
@@ -1,0 +1,173 @@
+import { cy, describe, it } from 'local-cypress'
+
+import selectors from '../../selectors'
+
+const INITIAL_VIEWPORT_WIDTH = 1400
+const VIEWPORT_HEIGHT = 200
+
+function clickNTimes(selector: string, numClicks: number) {
+  ;[...Array(numClicks)].forEach(() => {
+    cy.get(selector).click()
+  })
+}
+
+describe('TabSet (scrollable)', () => {
+  beforeEach(() => {
+    cy.viewport(INITIAL_VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+    cy.visit('/iframe.html?args=&id=tab-set--scrollable&viewMode=story')
+    cy.get(selectors.tabSet.tabItem).eq(0).as('tabItem')
+  })
+
+  describe('when the scroll left button is clicked', () => {
+    beforeEach(() => {
+      clickNTimes(selectors.tabSet.scrollRight, 1)
+    })
+
+    it('scrolls right one tab', () => {
+      cy.get('@tabItem').then(($tabItem) => {
+        cy.get(selectors.tabSet.tabs)
+          .invoke('scrollLeft')
+          .should('be.closeTo', $tabItem.outerWidth(), 1)
+      })
+    })
+  })
+
+  describe('when the scroll right button is clicked twice in quick succession', () => {
+    beforeEach(() => {
+      clickNTimes(selectors.tabSet.scrollRight, 2)
+    })
+
+    it('scrolls right two tabs', () => {
+      cy.get('@tabItem').then(($tabItem) => {
+        cy.get(selectors.tabSet.tabs)
+          .invoke('scrollLeft')
+          .should('be.closeTo', $tabItem.outerWidth() * 2, 1)
+      })
+    })
+
+    describe('and scroll left is clicked', () => {
+      beforeEach(() => {
+        clickNTimes(selectors.tabSet.scrollLeft, 1)
+      })
+
+      it('scrolls left one tab', () => {
+        cy.get('@tabItem').then(($tabItem) => {
+          cy.get(selectors.tabSet.tabs)
+            .invoke('scrollLeft')
+            .should('be.closeTo', $tabItem.outerWidth(), 1)
+        })
+      })
+    })
+  })
+
+  describe('when the scroll right button is clicked ten times', () => {
+    beforeEach(() => {
+      clickNTimes(selectors.tabSet.scrollRight, 10)
+    })
+
+    it('scrolls right as far as possible', () => {
+      cy.get(selectors.tabSet.tabs).then(($tabs) => {
+        cy.get(selectors.tabSet.tabs)
+          .invoke('scrollLeft')
+          .should('be.closeTo', $tabs[0].scrollWidth - $tabs[0].clientWidth, 1)
+      })
+    })
+
+    describe('and scroll left is clicked twice', () => {
+      beforeEach(() => {
+        clickNTimes(selectors.tabSet.scrollLeft, 2)
+      })
+
+      it('scrolls left two and half tabs', () => {
+        cy.get('@tabItem').then(($tabItem) => {
+          cy.get(selectors.tabSet.tabs)
+            .invoke('scrollLeft')
+            .should('be.closeTo', $tabItem.outerWidth() * 2, 1)
+        })
+      })
+    })
+
+    describe('and scroll left is clicked eight times', () => {
+      beforeEach(() => {
+        clickNTimes(selectors.tabSet.scrollLeft, 8)
+      })
+
+      it('scrolls left all the way', () => {
+        cy.get(selectors.tabSet.tabs).invoke('scrollLeft').should('eq', 0)
+      })
+    })
+  })
+
+  describe('when the tab set is scrolled right fully', () => {
+    beforeEach(() => {
+      cy.get(selectors.tabSet.tabs).invoke('scrollLeft', 9999)
+    })
+
+    describe('and the viewport is made narrower by three tab widths', () => {
+      beforeEach(() => {
+        cy.get('@tabItem').then(($tabItem) => {
+          cy.viewport(
+            INITIAL_VIEWPORT_WIDTH - $tabItem.outerWidth() * 3,
+            VIEWPORT_HEIGHT
+          )
+        })
+      })
+
+      describe('and the scroll right button is clicked once', () => {
+        beforeEach(() => {
+          clickNTimes(selectors.tabSet.scrollRight, 1)
+        })
+
+        it('scrolls right once', () => {
+          cy.get('@tabItem').then(($tabItem) => {
+            cy.get(selectors.tabSet.tabs)
+              .invoke('scrollLeft')
+              .should('be.closeTo', $tabItem.outerWidth() * 5, 1)
+          })
+        })
+      })
+
+      describe('and the scroll right button is clicked four times', () => {
+        beforeEach(() => {
+          clickNTimes(selectors.tabSet.scrollRight, 4)
+        })
+
+        it('scrolls right as far as possible', () => {
+          cy.get(selectors.tabSet.tabs).then(($tabs) => {
+            cy.get(selectors.tabSet.tabs)
+              .invoke('scrollLeft')
+              .should(
+                'be.closeTo',
+                $tabs[0].scrollWidth - $tabs[0].clientWidth,
+                1
+              )
+          })
+        })
+      })
+
+      describe('and the scroll left button is clicked once', () => {
+        beforeEach(() => {
+          clickNTimes(selectors.tabSet.scrollLeft, 1)
+        })
+
+        it('scrolls left once', () => {
+          cy.get('@tabItem').then(($tabItem) => {
+            cy.get(selectors.tabSet.tabs)
+              .invoke('scrollLeft')
+              .should('be.closeTo', $tabItem.outerWidth() * 3, 1)
+          })
+        })
+      })
+
+      describe('and the scroll left button is clicked four times', () => {
+        beforeEach(() => {
+          clickNTimes(selectors.tabSet.scrollLeft, 4)
+        })
+
+        it('scrolls left all the way', () => {
+          cy.get(selectors.tabSet.tabs).invoke('scrollLeft').should('eq', 0)
+        })
+      })
+    })
+  })
+})

--- a/packages/react-component-library/jest/setupTests.js
+++ b/packages/react-component-library/jest/setupTests.js
@@ -2,8 +2,11 @@ import 'babel-polyfill'
 import 'jest-canvas-mock'
 import 'jest-styled-components'
 import { format } from 'util'
+import { ResizeObserver } from '@juggle/resize-observer'
 
 const originalConsoleError = global.console.error
+
+global.ResizeObserver ??= ResizeObserver
 
 global.console.error = (...args) => {
   const blocked = [/Failed prop type/, /Warning: /, /StrictMode/]

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -66,6 +66,7 @@
     "@babel/preset-react": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",
     "@defencedigital/eslint-config-react": "^2.80.2",
+    "@juggle/resize-observer": "^3.3.1",
     "@storybook/addon-a11y": "^6.5.0-alpha.34",
     "@storybook/addon-actions": "^6.5.0-alpha.34",
     "@storybook/addon-docs": "^6.5.0-alpha.34",
@@ -180,6 +181,7 @@
     "react-transition-group": "^4.4.1",
     "styled-normalize": "^8.0.7",
     "styled-theming": "^2.2.0",
+    "use-resize-observer": "^8.0.0",
     "usehooks-ts": "^2.2.1"
   },
   "peerDependencies": {

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -9,6 +9,12 @@ export default {
   title: 'Tab Set',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
+    docs: {
+      description: {
+        component:
+          'This component requires a [ResizeObserver polyfill](https://github.com/ZeeCoder/use-resize-observer#transpilation--polyfilling) in older browsers.',
+      },
+    },
     layout: 'fullscreen',
   },
 } as ComponentMeta<typeof TabSet>

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -1,24 +1,11 @@
-// @ts-nocheck
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import {
-  fireEvent,
-  render,
-  RenderResult,
-  waitFor,
-} from '@testing-library/react'
+import { fireEvent, render, RenderResult } from '@testing-library/react'
 import { selectors } from '@defencedigital/design-tokens'
 
-import { TabSetItem, TabSet } from '.'
-import { SCROLL_DIRECTION } from './constants'
+import { TabSet, TabSetItem } from '.'
 
 const { color } = selectors
-
-function flushPromises() {
-  return new Promise((resolve) => {
-    setImmediate(resolve)
-  })
-}
 
 describe('TabSet', () => {
   let wrapper: RenderResult
@@ -303,7 +290,10 @@ describe('TabSet', () => {
 
           Object.assign(clickEventSpy, { preventDefault: jest.fn() })
 
-          fireEvent(wrapper.getByText('Title 2').parentElement, clickEventSpy)
+          fireEvent(
+            wrapper.getByText('Title 2').parentElement as HTMLElement,
+            clickEventSpy
+          )
         })
 
         it('should invoke preventDefault', () => {
@@ -336,16 +326,6 @@ describe('TabSet', () => {
   })
 
   describe('when the tab set is scrollable', () => {
-    let scrollToSpy: jest.SpyInstance
-
-    async function scroll(
-      direction: typeof SCROLL_DIRECTION.LEFT | typeof SCROLL_DIRECTION.RIGHT
-    ) {
-      wrapper.getByTestId(`scroll-${direction}`).click()
-
-      await waitFor(flushPromises)
-    }
-
     beforeEach(() => {
       wrapper = render(
         <TabSet isScrollable>
@@ -354,129 +334,14 @@ describe('TabSet', () => {
           <TabSetItem title="Title 3">Content 3</TabSetItem>
         </TabSet>
       )
-
-      const tabs = wrapper.getByTestId('tabs')
-      tabs.scrollTo = () => {
-        return true
-      }
-
-      scrollToSpy = jest
-        .spyOn(tabs, 'scrollTo')
-        // @ts-ignore
-        .mockImplementation(({ left }) => {
-          Object.defineProperty(tabs, 'scrollLeft', {
-            configurable: true,
-            value: left,
-          })
-          fireEvent.scroll(tabs)
-        })
-
-      Object.defineProperty(tabs, 'offsetLeft', { value: 50 })
-
-      Object.defineProperty(
-        wrapper.getByText('Title 1').parentElement.parentElement,
-        'offsetLeft',
-        { value: 150 }
-      )
-      Object.defineProperty(
-        wrapper.getByText('Title 2').parentElement.parentElement,
-        'offsetLeft',
-        { value: 250 }
-      )
-      Object.defineProperty(
-        wrapper.getByText('Title 3').parentElement.parentElement,
-        'offsetLeft',
-        { value: 350 }
-      )
     })
 
-    it('should add the `aria-label` attributes to the scroll buttons', () => {
-      expect(wrapper.getByTestId('scroll-left')).toHaveAttribute(
-        'aria-label',
-        'Scroll left'
-      )
-      expect(wrapper.getByTestId('scroll-right')).toHaveAttribute(
-        'aria-label',
-        'Scroll right'
-      )
+    it('displays a left scroll button', () => {
+      expect(wrapper.getByTestId('scroll-left')).toBeInTheDocument()
     })
 
-    describe('when scrolling right', () => {
-      describe('when the scroll right button is clicked twice', () => {
-        beforeEach(async () => {
-          await scroll(SCROLL_DIRECTION.RIGHT)
-          await scroll(SCROLL_DIRECTION.RIGHT)
-        })
-
-        it('should scroll the tabs twice', () => {
-          expect(scrollToSpy).toHaveBeenCalledWith({
-            left: 200,
-            behavior: 'smooth',
-          })
-          expect(scrollToSpy).toHaveBeenCalledWith({
-            left: 300,
-            behavior: 'smooth',
-          })
-        })
-      })
-
-      describe('when the scroll right button is clicked three times (once more than available tabs)', () => {
-        beforeEach(async () => {
-          await scroll(SCROLL_DIRECTION.RIGHT)
-          await scroll(SCROLL_DIRECTION.RIGHT)
-          await scroll(SCROLL_DIRECTION.RIGHT)
-        })
-
-        it('should scroll the tabs only twice', () => {
-          expect(scrollToSpy).toHaveBeenCalledTimes(2)
-        })
-      })
-    })
-
-    describe('when scrolling left', () => {
-      describe('when scroll right is clicked twice and scroll left is clicked once', () => {
-        beforeEach(async () => {
-          await scroll(SCROLL_DIRECTION.RIGHT)
-          await scroll(SCROLL_DIRECTION.RIGHT)
-          await scroll(SCROLL_DIRECTION.LEFT)
-        })
-
-        it('should scroll the tabs twice', () => {
-          expect(scrollToSpy).toHaveBeenCalledTimes(3)
-          expect(scrollToSpy.mock.calls[0][0]).toEqual({
-            left: 200,
-            behavior: 'smooth',
-          })
-          expect(scrollToSpy.mock.calls[1][0]).toEqual({
-            left: 300,
-            behavior: 'smooth',
-          })
-          expect(scrollToSpy.mock.calls[2][0]).toEqual({
-            left: 200,
-            behavior: 'smooth',
-          })
-        })
-      })
-
-      describe('when scroll right button is clicked once and scroll left is clicked twice', () => {
-        beforeEach(async () => {
-          await scroll(SCROLL_DIRECTION.RIGHT)
-          await scroll(SCROLL_DIRECTION.LEFT)
-          await scroll(SCROLL_DIRECTION.LEFT)
-        })
-
-        it('should scroll the tabs twice', () => {
-          expect(scrollToSpy).toHaveBeenCalledTimes(2)
-          expect(scrollToSpy).toHaveBeenCalledWith({
-            left: 200,
-            behavior: 'smooth',
-          })
-          expect(scrollToSpy).toHaveBeenCalledWith({
-            left: 100,
-            behavior: 'smooth',
-          })
-        })
-      })
+    it('displays a right scroll button', () => {
+      expect(wrapper.getByTestId('scroll-right')).toBeInTheDocument()
     })
   })
 })

--- a/packages/react-component-library/src/components/TabSet/useScrollableTabSet.ts
+++ b/packages/react-component-library/src/components/TabSet/useScrollableTabSet.ts
@@ -1,55 +1,65 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import useResizeObserver from 'use-resize-observer'
 
 import { TabSetItemProps } from './TabSetItem'
-
-function hasTab(tabIndex: number, itemsRef: Array<HTMLLIElement>) {
-  return tabIndex > -1 && tabIndex < itemsRef.length
-}
-
-function scrollTo(element: HTMLDivElement, left: number): Promise<void> {
-  return new Promise((resolve) => {
-    function onScroll() {
-      if (Math.ceil(element.scrollLeft) >= left) {
-        element.removeEventListener('scroll', onScroll)
-        resolve()
-      }
-    }
-    element.addEventListener('scroll', onScroll)
-    element.scrollTo({
-      left,
-      behavior: 'smooth',
-    })
-  })
-}
 
 export function useScrollableTabSet(
   items: React.ReactElement<TabSetItemProps>[]
 ) {
   const [currentScrollToTab, setCurrentScrollToTab] = useState(0)
-  const itemsRef = useRef<Array<HTMLLIElement>>([])
-  const tabsRef = useRef<HTMLDivElement>()
+  const itemsRef = useRef<Array<HTMLLIElement | null>>([])
+  const tabsRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     itemsRef.current = itemsRef.current.slice(0, items.length)
   }, [items])
 
+  const handleResize = useCallback(() => {
+    const tabs = tabsRef.current
+    const firstTabItem = itemsRef.current[0]
+
+    if (!tabs || !firstTabItem) {
+      return
+    }
+
+    const newScrollTabIndex = itemsRef.current.findIndex(
+      (tab) =>
+        tab &&
+        tab.offsetLeft + tab.offsetWidth / 2 - firstTabItem.offsetLeft >=
+          tabs.scrollLeft
+    )
+
+    setCurrentScrollToTab(Math.max(0, newScrollTabIndex))
+  }, [])
+
+  useResizeObserver<HTMLDivElement>({
+    ref: tabsRef,
+    onResize: handleResize,
+  })
+
   function scrollToNextTab(change: (currentTab: number) => number) {
-    return async () => {
-      const nextTab = change(currentScrollToTab)
+    return () => {
+      const tabs = tabsRef.current
+      const nextTabIndex = change(currentScrollToTab)
+      const nextTabItem = itemsRef.current[nextTabIndex]
+      const firstTabItem = itemsRef.current[0]
 
-      if (hasTab(nextTab, itemsRef.current)) {
-        const currentPosition = tabsRef.current.scrollLeft
-        const newPosition =
-          itemsRef.current[nextTab].offsetLeft - tabsRef.current.offsetLeft
+      if (!(tabs && firstTabItem && nextTabItem)) {
+        return
+      }
 
-        await scrollTo(tabsRef.current, newPosition).then(() => {
-          const isPositionTheSame =
-            currentPosition === tabsRef.current.scrollLeft
+      const maxScrollLeft = tabs.scrollWidth - tabs.clientWidth
+      const newScrollLeft = nextTabItem.offsetLeft - firstTabItem.offsetLeft
 
-          if (!isPositionTheSame) {
-            setCurrentScrollToTab(nextTab)
-          }
-        })
+      tabs.scrollTo({
+        left: newScrollLeft,
+        behavior: 'smooth',
+      })
+
+      // If this was a scroll to the very right, only update the tab index if
+      // we've scrolled more than half a tab
+      if (newScrollLeft - nextTabItem.offsetWidth / 2 < maxScrollLeft) {
+        setCurrentScrollToTab(nextTabIndex)
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,6 +1806,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@juggle/resize-observer@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
+  integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
+
 "@lerna/add@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-4.0.0.tgz#c36f57d132502a57b9e7058d1548b7a565ef183f"
@@ -18458,6 +18463,13 @@ use-latest@^1.0.0:
   integrity sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
+
+use-resize-observer@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/use-resize-observer/-/use-resize-observer-8.0.0.tgz#69bd80c1ddd94f3758563fe107efb25fed85067a"
+  integrity sha512-n0iKSeiQpJCyaFh5JA0qsVLBIovsF4EIIR1G6XiBwKJN66ZrD4Oj62bjcuTAATPKiSp6an/2UZZxCf/67fk3sQ==
+  dependencies:
+    "@juggle/resize-observer" "^3.3.1"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Related issue

Resolves #3096
#2755 

## Overview

This:
- improves TabSet scrolling behaviour so that repeated clicks are quick for both scrolling left and right
- resolves problems with scrolling getting stuck after resizing the viewport, or sometimes in Firefox when scrolling left
- fixes strict null errors in the TabSet component

The scrolling tests were rewritten in Cypress as layout isn't supported by jsdom.

## Link to preview

https://tab-set-scrollable.netlify.app/?path=/docs/tab-set--scrollable

## Reason

Fix strict null errors while improving the scrolling behaviour at the same time.

## Work carried out

- [x] Rewrite scrolling logic
- [x] Fix strict null errors
- [x] Add new scrolling tests in Cypress

## Demos

### Before

#### Slow right scrolling

![slow-right](https://user-images.githubusercontent.com/66470099/154313079-e9757fc3-7f62-4af6-ba54-fdd5f838d774.gif)

#### Left scrolling stuck in Firefox

![left-stuck](https://user-images.githubusercontent.com/66470099/154313132-806285b4-b904-4f78-9ace-4f6794baddce.gif)

#### Stuck after resizing

![resize-stuck](https://user-images.githubusercontent.com/66470099/154313298-9314b446-0d9c-423f-ab9b-58dab03de094.gif)

### After

![after-2](https://user-images.githubusercontent.com/66470099/154313565-0872884a-a3de-481b-bfd8-bfdd74c0b081.gif)

## Developer notes

My main aim was to fix the strict null errors, but trying to do this in the old logic exacerbated the problems mentioned above, so I wrote new logic to avoid making things worse (while otherwise behaving similarly).

The scrolling tests were rewritten in Cypress as layout isn't supported by jsdom (the old tests were mocking various scrolling and layout DOM stuff, which broke after changing the scrolling logic).

`use-resize-observer` was used to fix the resize behaviour – a `window.ResizeObserver` polyfill is needed for old browsers and Jest.
