### PR TITLE
feat(ReactComponentLibrary): Turn on strict null checks

### DIFF
--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -15,11 +15,14 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
+  args: {
+    label: 'Some label',
+  },
 } as ComponentMeta<typeof Autocomplete>
 
 const Template: ComponentStory<typeof Autocomplete> = (args) => (
   <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
-    <Autocomplete label="Some label" {...args}>
+    <Autocomplete {...args}>
       <AutocompleteOption value="one">One</AutocompleteOption>
       <AutocompleteOption value="two">Two</AutocompleteOption>
       <AutocompleteOption value="three">Three</AutocompleteOption>
@@ -32,7 +35,7 @@ const TemplateWIthIconsAndBadges: ComponentStory<typeof Autocomplete> = (
   args
 ) => (
   <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
-    <Autocomplete label="Some label" {...args}>
+    <Autocomplete {...args}>
       <AutocompleteOption badge={100} icon={<IconAnchor />} value="one">
         One
       </AutocompleteOption>

--- a/packages/react-component-library/src/components/Drawer/Drawer.test.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.test.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useState } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import '@testing-library/jest-dom/extend-expect'
@@ -144,7 +143,7 @@ describe('Drawer', () => {
   describe('when a `ref` prop is specified', () => {
     beforeEach(() => {
       const DrawerWithRef: React.FC = () => {
-        const [content, setContent] = useState<string>('Not set')
+        const [content, setContent] = useState<string | null>('Not set')
 
         return (
           <Drawer

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { IconLayers, IconAnchor, IconShare } from '@defencedigital/icon-library'
 import { render, RenderResult, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { Dropdown } from './Dropdown'
 
@@ -48,8 +49,8 @@ describe('Dropdown', () => {
 
     describe('when the dropdown is clicked', () => {
       beforeEach(() => {
-        fireEvent.focus(wrapper.container.querySelector('input'))
-        fireEvent.keyDown(wrapper.container.querySelector('input'), {
+        fireEvent.focus(wrapper.getByRole('textbox'))
+        fireEvent.keyDown(wrapper.getByRole('textbox'), {
           key: 'ArrowDown',
           code: 40,
         })
@@ -135,8 +136,8 @@ describe('Dropdown', () => {
         />
       )
 
-      fireEvent.focus(wrapper.container.querySelector('input'))
-      fireEvent.keyDown(wrapper.container.querySelector('input'), {
+      fireEvent.focus(wrapper.getByRole('textbox'))
+      fireEvent.keyDown(wrapper.getByRole('textbox'), {
         key: 'ArrowDown',
         code: 40,
       })
@@ -156,6 +157,17 @@ describe('Dropdown', () => {
       expect(
         wrapper.getByTestId('dropdown-label-icon-share')
       ).toBeInTheDocument()
+    })
+  })
+
+  describe('when onChange is omitted and the dropdown is clicked', () => {
+    beforeEach(() => {
+      wrapper = render(<Dropdown options={options} label="Dropdown label" />)
+      userEvent.click(wrapper.getByRole('textbox'))
+    })
+
+    it('does not throw an error when an option is clicked', () => {
+      expect(() => wrapper.getByText('Option 1').click()).not.toThrowError()
     })
   })
 })

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.tsx
@@ -145,7 +145,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
 }) => {
   const onChange = (option: ValueType<DropdownOption, boolean>) => {
     const dropdownOption = option as DropdownOption
-    onSelect(dropdownOption.value)
+    onSelect?.(dropdownOption.value)
   }
 
   return (

--- a/packages/react-component-library/src/components/Dropdown/DropdownLabel.tsx
+++ b/packages/react-component-library/src/components/Dropdown/DropdownLabel.tsx
@@ -9,7 +9,7 @@ import { StyledEndAdornment } from './partials/StyledEndAdornment'
 
 export const DropdownLabel: React.FC<DropdownOption> = ({
   icon,
-  isDisabled,
+  isDisabled = false,
   isHidden,
   label,
   rightContent,

--- a/packages/react-component-library/src/components/Field/Field.tsx
+++ b/packages/react-component-library/src/components/Field/Field.tsx
@@ -7,7 +7,7 @@ import { StyledHintText } from './partials/StyledHintText'
 import { getId } from '../../helpers'
 
 export type ErrorType = {
-  error: boolean | string
+  error: boolean | string | null | undefined
 }
 
 export interface FieldProps extends ComponentWithClass {

--- a/packages/react-component-library/src/components/Modal/Modal.test.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.test.tsx
@@ -299,7 +299,7 @@ describe('Modal', () => {
   })
 
   describe('when the Modal content changes', () => {
-    let initialIds: Record<string, string>
+    let initialIds: Record<string, string | null>
 
     const ExampleModal = ({ content }: { content: string }) => (
       <Modal title="Example title" isOpen>

--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { renderToStaticMarkup } from 'react-dom/server'
@@ -50,7 +49,7 @@ describe('Popover', () => {
     })
 
     it('allows button covered by Popover to be clicked when Popover is hidden', () => {
-      wrapper.queryByText('Click me!').click()
+      wrapper.getByText('Click me!').click()
       expect(clickSpy).toHaveBeenCalledTimes(1)
     })
 

--- a/packages/react-component-library/src/components/Radio/partials/StyledRadio.tsx
+++ b/packages/react-component-library/src/components/Radio/partials/StyledRadio.tsx
@@ -5,7 +5,7 @@ import { StyledCheckmark } from './StyledCheckmark'
 import { StyledInput } from './StyledInput'
 
 interface StyledRadioProps {
-  $hasContainer?: boolean
+  $hasContainer: boolean
   $isDisabled?: boolean
   $isInvalid?: boolean
   $isChecked?: boolean

--- a/packages/react-component-library/src/components/RangeSlider/ThresholdRail.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/ThresholdRail.tsx
@@ -18,7 +18,7 @@ export interface RailChunkProps {
   $width: number
   $maxWidth: number
   testId: string
-  $thresholdColor?: ThresholdColor
+  $thresholdColor: ThresholdColor
 }
 
 const RailChunk: React.FC<RailChunkProps> = ({

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -25,13 +25,16 @@ export default {
       enableShortcuts: false,
     },
   },
+  args: {
+    label: 'Some label',
+  },
 } as ComponentMeta<typeof Select>
 
 const Template: ComponentStory<typeof Select> = (args) => (
   <div
     style={{ height: args.isDisabled ? 'initial' : '18rem', maxWidth: '20rem' }}
   >
-    <Select label="Some label" {...args}>
+    <Select {...args}>
       <SelectOption value="one">
         This is a really, really long select option label that overflows the
         container when selected
@@ -47,7 +50,7 @@ const TemplateWIthIconsAndBadges: ComponentStory<typeof Select> = (args) => (
   <div
     style={{ height: args.isDisabled ? 'initial' : '18rem', maxWidth: '20rem' }}
   >
-    <Select label="Some label" {...args}>
+    <Select {...args}>
       <SelectOption badge={100} icon={<IconAnchor />} value="one">
         One
       </SelectOption>

--- a/packages/react-component-library/src/components/TextInput/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/TextInput/partials/StyledLabel.tsx
@@ -16,7 +16,7 @@ function getYPosition($size: ComponentSizeType) {
 }
 
 export const StyledLabel = styled(StyledLabelBase)<StyledLabelProps>`
-  ${({ $size }) => css`
+  ${({ $size = COMPONENT_SIZE.FORMS }) => css`
     transform: translate(11px, ${getYPosition($size)}) scale(1);
   `}
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -117,7 +117,7 @@ export const CustomLogo: ComponentStory<typeof Masthead> = (props) => (
 
 CustomLogo.storyName = 'Custom logo'
 CustomLogo.args = {
-  onSearch: null as undefined,
+  onSearch: null,
 }
 
 export const WithoutLogo: ComponentStory<typeof Masthead> = (props) => (
@@ -130,7 +130,7 @@ export const WithoutLogo: ComponentStory<typeof Masthead> = (props) => (
 
 WithoutLogo.storyName = 'Without logo'
 WithoutLogo.args = {
-  onSearch: null as undefined,
+  onSearch: null,
 }
 
 export const WithSearch: ComponentStory<typeof Masthead> = (props) => (
@@ -168,7 +168,7 @@ export const WithAvatarLinks: ComponentStory<typeof Masthead> = (props) => {
 
 WithAvatarLinks.storyName = 'With avatar links'
 WithAvatarLinks.args = {
-  onSearch: null as undefined,
+  onSearch: null,
 }
 
 export const WithNavigation: ComponentStory<typeof Masthead> = (props) => {
@@ -193,7 +193,7 @@ export const WithNavigation: ComponentStory<typeof Masthead> = (props) => {
 
 WithNavigation.storyName = 'With navigation'
 WithNavigation.args = {
-  onSearch: null as undefined,
+  onSearch: null,
 }
 
 export const WithNotifications: ComponentStory<typeof Masthead> = (props) => {
@@ -237,5 +237,5 @@ export const WithNotifications: ComponentStory<typeof Masthead> = (props) => {
 
 WithNotifications.storyName = 'With notifications'
 WithNotifications.args = {
-  onSearch: null as undefined,
+  onSearch: null,
 }

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
@@ -49,7 +49,9 @@ export interface MastheadProps {
   /**
    * Optional handler invoked when the submit search button is clicked.
    */
-  onSearch?: (event: React.FormEvent<HTMLFormElement>, term: string) => void
+  onSearch?:
+    | ((event: React.FormEvent<HTMLFormElement>, term: string) => void)
+    | null
   /**
    * Text title of the application.
    */

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -22,7 +22,7 @@ function getId(prefix: string): string {
 }
 
 function hasClass(allClasses: string | undefined, className: string): boolean {
-  return Boolean(allClasses) && allClasses.split(' ').includes(className)
+  return Boolean(allClasses && allClasses.split(' ').includes(className))
 }
 
 function isIE11(): boolean {
@@ -52,7 +52,7 @@ function withKey(
   element: React.ReactElement,
   prefix: string,
   suffix: string | number
-): React.ReactElement {
+): React.ReactNode {
   if (element) {
     return React.cloneElement(element, {
       key: getKey(prefix, suffix),

--- a/packages/react-component-library/tsconfig.json
+++ b/packages/react-component-library/tsconfig.json
@@ -15,7 +15,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "strict": true,
-    "strictNullChecks": false,
     "suppressImplicitAnyIndexErrors": true,
     "target": "esnext",
     "types": ["jest", "@testing-library/jest-dom"]


### PR DESCRIPTION
## Related issue

Resolves #2755

Depends on #3098

## Overview

This change turns on strict null checks for the component library by removing `"strictNullChecks": false` from `packages/react-component-library/tsconfig.json`.

## Link to preview

https://5e25c277526d380020b5e418-xixshjtsou.chromatic.com/

## Reason

Having strict null checks off means that types implicitly allow null and undefined. This is undesirable as it means:

- types are misleading for users of the component library
- there may be hidden bugs (either due to values being null or undefined unintentionally, or due to null or undefined not being handled)
- there may be missed test cases

## Work carried out

- [x] Resolve remaining strict null errors
- [x] Ignore errors in components pending removal
- [x] Remove ``"strictNullChecks": false``

## Developer notes

There should be no more references to `strictNullChecks` in the repo.

Errors in `Button`, `CheckboxEnhanced`, `DatePicker`, `NumberInput`, `RadioEnhanced`, `RangeSlider`, `Select` and `Switch` have been ignored as these are deprecated components for which there is a separate piece of work in progress to remove them.
