### PR TITLE
test(Forms): Add e2e tests for pre-populated forms 

### DIFF
--- a/packages/react-component-library/cypress/specs/forms/empty.ts
+++ b/packages/react-component-library/cypress/specs/forms/empty.ts
@@ -1,0 +1,121 @@
+import { describe, cy, expect, it, before } from 'local-cypress'
+
+import selectors from '../../selectors'
+
+const expectedResult = {
+  email: 'hello@world.com',
+  password: 'password',
+  description: 'Hello, World!',
+  exampleCheckbox: ['Option 2'],
+  exampleRadio: 'Option 1',
+  exampleSwitch: '1',
+  exampleNumberInput: 1,
+  exampleDatePicker: '2022-01-31T12:00:00.000Z',
+  exampleSelect: 'three',
+  exampleAutocomplete: 'four',
+  exampleRangeSlider: [28],
+}
+
+const getSelect = () =>
+  cy.contains(selectors.form.input.select, 'Example select')
+
+const getAutocomplete = () =>
+  cy.contains(selectors.form.input.select, 'Example autocomplete')
+
+describe('Form Examples (empty)', () => {
+  describe(
+    'when browsing on desktop',
+    {
+      viewportHeight: 800,
+      viewportWidth: 1200,
+    },
+    () => {
+      const examples = [
+        {
+          name: 'Formik',
+          uri: '/iframe.html?id=forms-usage-formik--default&viewMode=story',
+        },
+        {
+          name: 'react-hook-form',
+          uri: '/iframe.html?id=forms-usage-react-hook-form--default&viewMode=story',
+        },
+        {
+          name: 'Native',
+          uri: '/iframe.html?id=forms-usage-native--default&viewMode=story',
+        },
+      ]
+
+      examples.forEach(({ name, uri }) => {
+        describe(name, () => {
+          before(() => {
+            cy.visit(uri)
+          })
+
+          it('should render the relevant fields', () => {
+            cy.get(selectors.form.input.email).should('be.visible')
+            cy.get(selectors.form.input.password).should('be.visible')
+            cy.get(selectors.form.input.description).should('be.visible')
+            cy.get(selectors.form.input.radio).should('be.visible')
+            cy.get(selectors.form.input.checkbox).should('be.visible')
+            cy.get(selectors.form.input.switch).should('be.visible')
+            cy.get(selectors.form.input.numberInput).should('be.visible')
+            cy.get(selectors.form.input.datePicker).should('be.visible')
+            getSelect().should('be.visible')
+            getAutocomplete().should('be.visible')
+            cy.get(selectors.form.input.rangeSlider).should('be.visible')
+          })
+
+          describe('when an empty form is submitted', () => {
+            before(() => {
+              cy.get(selectors.form.submit).click()
+            })
+
+            it('should show the appropriate validation errors', () => {
+              cy.contains('Required').should('be.visible')
+            })
+          })
+
+          describe('when the user fills in the form successfully', () => {
+            before(() => {
+              cy.get(selectors.form.input.email).type('hello@world.com')
+              cy.get(selectors.form.input.password).type('password')
+              cy.get(selectors.form.input.description).type('Hello, World!')
+              cy.get(selectors.form.input.radio).eq(0).click()
+              cy.get(selectors.form.input.checkbox).eq(1).click()
+              cy.get(selectors.form.input.switchOption).eq(0).click()
+              cy.get(selectors.form.input.numberInputIncrease).click()
+              cy.get(selectors.form.input.datePickerInput).type('31/01/2022')
+              getSelect().type('th{enter}')
+              getAutocomplete().type('fo{downArrow}{enter}')
+              cy.get(selectors.form.input.rangeSliderRail).click(800, 0)
+            })
+
+            it('should not show any validation errors', () => {
+              cy.contains('Required').should('not.exist')
+            })
+
+            describe('when the user submits the form', () => {
+              before(() => {
+                cy.get(selectors.form.submit).click()
+              })
+
+              it('should set the submit Button state to disabled', () => {
+                cy.get(selectors.form.submit).should('have.attr', 'disabled')
+              })
+
+              it('should supply form the field values', () => {
+                cy.get(selectors.form.values)
+                  .invoke('text')
+                  .should((submittedData) => {
+                    expect(JSON.parse(submittedData)).to.deep.equal(
+                      expectedResult
+                    )
+                  })
+              })
+            })
+          })
+        })
+      })
+    }
+  )
+})

--- a/packages/react-component-library/cypress/specs/forms/index.ts
+++ b/packages/react-component-library/cypress/specs/forms/index.ts
@@ -1,47 +1,19 @@
-import { describe, cy, it, before } from 'local-cypress'
+import { describe, cy, expect, it, before } from 'local-cypress'
 
 import selectors from '../../selectors'
 
 const expectedResult = {
-  'react-hook-form': {
-    email: 'hello@world.com',
-    password: 'password',
-    description: 'Hello, World!',
-    exampleCheckbox: [],
-    exampleRadio: 'Option 1',
-    exampleDatePicker: '2022-01-31T12:00:00.000Z',
-    exampleSelect: 'three',
-    exampleAutocomplete: 'four',
-    exampleRangeSlider: [28],
-    exampleSwitch: '1',
-    exampleNumberInput: 1,
-  },
-  Formik: {
-    email: 'hello@world.com',
-    password: 'password',
-    description: 'Hello, World!',
-    exampleCheckbox: [],
-    exampleRadio: 'Option 1',
-    exampleSwitch: '1',
-    exampleNumberInput: 1,
-    exampleDatePicker: '2022-01-31T12:00:00.000Z',
-    exampleSelect: 'three',
-    exampleAutocomplete: 'four',
-    exampleRangeSlider: [28],
-  },
-  Native: {
-    email: 'hello@world.com',
-    password: 'password',
-    description: 'Hello, World!',
-    exampleCheckbox: [],
-    exampleRadio: ['Option 1'],
-    exampleSwitch: '1',
-    exampleNumberInput: 1,
-    exampleDatePicker: '2022-01-31T12:00:00.000Z',
-    exampleSelect: 'three',
-    exampleAutocomplete: 'four',
-    exampleRangeSlider: [28],
-  },
+  email: 'hello@world.com',
+  password: 'password',
+  description: 'Hello, World!',
+  exampleCheckbox: ['Option 2'],
+  exampleRadio: 'Option 1',
+  exampleDatePicker: '2022-01-31T12:00:00.000Z',
+  exampleSelect: 'three',
+  exampleAutocomplete: 'four',
+  exampleRangeSlider: [28],
+  exampleSwitch: '1',
+  exampleNumberInput: 1,
 }
 
 const getSelect = () =>
@@ -83,6 +55,8 @@ describe('Form Examples', () => {
             cy.get(selectors.form.input.email).should('be.visible')
             cy.get(selectors.form.input.password).should('be.visible')
             cy.get(selectors.form.input.description).should('be.visible')
+            cy.get(selectors.form.input.radio).should('be.visible')
+            cy.get(selectors.form.input.checkbox).should('be.visible')
             cy.get(selectors.form.input.switch).should('be.visible')
             cy.get(selectors.form.input.numberInput).should('be.visible')
             cy.get(selectors.form.input.datePicker).should('be.visible')
@@ -107,6 +81,7 @@ describe('Form Examples', () => {
               cy.get(selectors.form.input.password).type('password')
               cy.get(selectors.form.input.description).type('Hello, World!')
               cy.get(selectors.form.input.radio).eq(0).click()
+              cy.get(selectors.form.input.checkbox).eq(1).click()
               cy.get(selectors.form.input.switchOption).eq(0).click()
               cy.get(selectors.form.input.numberInputIncrease).click()
               cy.get(selectors.form.input.datePickerInput).type('31/01/2022')
@@ -129,9 +104,13 @@ describe('Form Examples', () => {
               })
 
               it('should supply form the field values', () => {
-                cy.get(selectors.form.values).contains(
-                  JSON.stringify(expectedResult[name], null, 2)
-                )
+                cy.get(selectors.form.values)
+                  .invoke('text')
+                  .should((submittedData) => {
+                    expect(JSON.parse(submittedData)).to.deep.equal(
+                      expectedResult
+                    )
+                  })
               })
             })
           })

--- a/packages/react-component-library/cypress/specs/forms/prepopulated.ts
+++ b/packages/react-component-library/cypress/specs/forms/prepopulated.ts
@@ -2,18 +2,32 @@ import { describe, cy, expect, it, before } from 'local-cypress'
 
 import selectors from '../../selectors'
 
-const expectedResult = {
+const expectedInitialResult = {
+  email: 'example@email.test',
+  password: 'example-password',
+  description: 'Example description',
+  exampleCheckbox: ['Option 2'],
+  exampleRadio: 'Option 2',
+  exampleSwitch: '2',
+  exampleNumberInput: 156,
+  exampleDatePicker: '2022-02-10T00:00:00.000Z',
+  exampleSelect: 'three',
+  exampleAutocomplete: 'two',
+  exampleRangeSlider: [4],
+}
+
+const expectedEditedResult = {
   email: 'hello@world.com',
   password: 'password',
   description: 'Hello, World!',
-  exampleCheckbox: ['Option 2'],
+  exampleCheckbox: ['Option 1', 'Option 2'],
   exampleRadio: 'Option 1',
+  exampleSwitch: '1',
+  exampleNumberInput: 157,
   exampleDatePicker: '2022-01-31T12:00:00.000Z',
   exampleSelect: 'three',
   exampleAutocomplete: 'four',
   exampleRangeSlider: [28],
-  exampleSwitch: '1',
-  exampleNumberInput: 1,
 }
 
 const getSelect = () =>
@@ -22,7 +36,7 @@ const getSelect = () =>
 const getAutocomplete = () =>
   cy.contains(selectors.form.input.select, 'Example autocomplete')
 
-describe('Form Examples', () => {
+describe('Form Examples (pre-populated)', () => {
   describe(
     'when browsing on desktop',
     {
@@ -33,15 +47,15 @@ describe('Form Examples', () => {
       const examples = [
         {
           name: 'Formik',
-          uri: '/iframe.html?id=forms-usage-formik--example&viewMode=story',
+          uri: '/iframe.html?id=forms-usage-formik--prepopulated&viewMode=story',
         },
         {
           name: 'react-hook-form',
-          uri: '/iframe.html?id=forms-usage-react-hook-form--example&viewMode=story',
+          uri: '/iframe.html?id=forms-usage-react-hook-form--prepopulated&viewMode=story',
         },
         {
           name: 'Native',
-          uri: '/iframe.html?id=forms-usage-native--example&viewMode=story',
+          uri: '/iframe.html?id=forms-usage-native--prepopulated&viewMode=story',
         },
       ]
 
@@ -51,7 +65,7 @@ describe('Form Examples', () => {
             cy.visit(uri)
           })
 
-          it('should render the relevant fields', () => {
+          it('renders the form fields', () => {
             cy.get(selectors.form.input.email).should('be.visible')
             cy.get(selectors.form.input.password).should('be.visible')
             cy.get(selectors.form.input.description).should('be.visible')
@@ -65,32 +79,48 @@ describe('Form Examples', () => {
             cy.get(selectors.form.input.rangeSlider).should('be.visible')
           })
 
-          describe('when an empty form is submitted', () => {
+          describe('when the form is submitted unchanged', () => {
             before(() => {
               cy.get(selectors.form.submit).click()
             })
 
-            it('should show the appropriate validation errors', () => {
-              cy.contains('Required').should('be.visible')
+            it('does not show any validation errors', () => {
+              cy.contains('Required').should('not.exist')
+            })
+
+            it('submits the existing data', () => {
+              cy.get(selectors.form.values)
+                .invoke('text')
+                .should((submittedData) => {
+                  expect(JSON.parse(submittedData)).to.deep.equal(
+                    expectedInitialResult
+                  )
+                })
             })
           })
 
-          describe('when the user fills in the form successfully', () => {
+          describe('when the user edits the form data', () => {
             before(() => {
-              cy.get(selectors.form.input.email).type('hello@world.com')
-              cy.get(selectors.form.input.password).type('password')
-              cy.get(selectors.form.input.description).type('Hello, World!')
+              cy.get(selectors.form.input.email).type(
+                '{selectall}hello@world.com'
+              )
+              cy.get(selectors.form.input.password).type('{selectall}password')
+              cy.get(selectors.form.input.description).type(
+                '{selectall}Hello, World!'
+              )
               cy.get(selectors.form.input.radio).eq(0).click()
-              cy.get(selectors.form.input.checkbox).eq(1).click()
+              cy.get(selectors.form.input.checkbox).eq(0).click()
               cy.get(selectors.form.input.switchOption).eq(0).click()
               cy.get(selectors.form.input.numberInputIncrease).click()
-              cy.get(selectors.form.input.datePickerInput).type('31/01/2022')
+              cy.get(selectors.form.input.datePickerInput).type(
+                '{selectall}31/01/2022'
+              )
               getSelect().type('th{enter}')
-              getAutocomplete().type('fo{downArrow}{enter}')
+              getAutocomplete().type('{selectall}fo{downArrow}{enter}')
               cy.get(selectors.form.input.rangeSliderRail).click(800, 0)
             })
 
-            it('should not show any validation errors', () => {
+            it('does not show any validation errors', () => {
               cy.contains('Required').should('not.exist')
             })
 
@@ -99,17 +129,13 @@ describe('Form Examples', () => {
                 cy.get(selectors.form.submit).click()
               })
 
-              it('should set the submit Button state to disabled', () => {
-                cy.get(selectors.form.submit).should('have.attr', 'disabled')
-              })
-
-              it('should supply form the field values', () => {
+              it('submits the updated field values', () => {
                 cy.get(selectors.form.values)
                   .invoke('text')
                   .should((submittedData) => {
-                    expect(JSON.parse(submittedData)).to.deep.equal(
-                      expectedResult
-                    )
+                    const parsedData = JSON.parse(submittedData)
+                    parsedData.exampleCheckbox.sort()
+                    expect(parsedData).to.deep.equal(expectedEditedResult)
                   })
               })
             })

--- a/packages/react-component-library/src/forms/constants.ts
+++ b/packages/react-component-library/src/forms/constants.ts
@@ -1,0 +1,29 @@
+import { FormValues } from './types'
+
+export const EMPTY_FORM_VALUES: FormValues = {
+  email: '',
+  password: '',
+  description: '',
+  exampleCheckbox: [],
+  exampleRadio: '',
+  exampleSwitch: '',
+  exampleNumberInput: null,
+  exampleDatePicker: null,
+  exampleSelect: null,
+  exampleAutocomplete: null,
+  exampleRangeSlider: [20],
+}
+
+export const PREPOPULATED_FORM_VALUES: FormValues = {
+  email: 'example@email.test',
+  password: 'example-password',
+  description: 'Example description',
+  exampleCheckbox: ['Option 2'],
+  exampleRadio: 'Option 2',
+  exampleSwitch: '2',
+  exampleNumberInput: 156,
+  exampleDatePicker: new Date(2022, 1, 10),
+  exampleSelect: 'three',
+  exampleAutocomplete: 'two',
+  exampleRangeSlider: [4],
+}

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -1,6 +1,6 @@
 import { isBefore, isValid, parseISO } from 'date-fns'
 import React, { useState } from 'react'
-import { ComponentMeta } from '@storybook/react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { Formik, Field as FormikField, FieldProps } from 'formik'
 
 import { TextInput } from '../../components/TextInput'
@@ -18,42 +18,20 @@ import { sleep } from '../../helpers'
 import { Field } from '../../components/Field'
 import { Fieldset } from '../../components/Fieldset'
 import { SectionDivider } from '../../components/SectionDivider'
-
-export interface FormValues {
-  email: string
-  password: string
-  description: string
-  exampleCheckbox: string[]
-  exampleRadio: string[]
-  exampleSwitch: string
-  exampleNumberInput: number | null
-  exampleDatePicker: Date | null
-  exampleSelect: string | null
-  exampleAutocomplete: string | null
-  exampleRangeSlider: number[]
-}
+import { EMPTY_FORM_VALUES, PREPOPULATED_FORM_VALUES } from '../constants'
+import { FormValues } from '../types'
 
 const MINIMUM_DATE = parseISO('2022-01-01')
 
-export const Example: React.FC<unknown> = () => {
+const Example: React.FC<{ initialValues: FormValues }> = ({
+  initialValues,
+}) => {
   const [formValues, setFormValues] = useState<FormValues>()
 
   return (
     <main>
       <Formik<FormValues>
-        initialValues={{
-          email: '',
-          password: '',
-          description: '',
-          exampleCheckbox: [],
-          exampleRadio: [],
-          exampleSwitch: '',
-          exampleNumberInput: null,
-          exampleDatePicker: null,
-          exampleSelect: null,
-          exampleAutocomplete: null,
-          exampleRangeSlider: [20],
-        }}
+        initialValues={initialValues}
         validate={({ email, exampleDatePicker }) => {
           const errors: Record<string, unknown> = {}
 
@@ -309,7 +287,7 @@ export const Example: React.FC<unknown> = () => {
                     <RangeSlider
                       domain={[0, 40]}
                       mode={1}
-                      values={[20]}
+                      values={values.exampleRangeSlider}
                       tracksLeft
                       step={2}
                       onChange={(newValues: ReadonlyArray<number>) => {
@@ -342,3 +320,15 @@ export default {
   title: 'Forms/Usage/Formik',
   component: Example,
 } as ComponentMeta<typeof Example>
+
+const Template: ComponentStory<typeof Example> = (args) => <Example {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  initialValues: EMPTY_FORM_VALUES,
+}
+
+export const Prepopulated = Template.bind({})
+Prepopulated.args = {
+  initialValues: PREPOPULATED_FORM_VALUES,
+}

--- a/packages/react-component-library/src/forms/native/native.stories.tsx
+++ b/packages/react-component-library/src/forms/native/native.stories.tsx
@@ -1,6 +1,6 @@
 import { isBefore, isValid, parseISO } from 'date-fns'
 import React from 'react'
-import { ComponentMeta } from '@storybook/react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
 
 import { TextInput } from '../../components/TextInput'
 import { TextArea } from '../../components/TextArea'
@@ -14,27 +14,18 @@ import { Switch, SwitchOption } from '../../components/Switch'
 import { RangeSlider } from '../../components/RangeSlider'
 import { Button } from '../../components/Button'
 import { Fieldset } from '../../components/Fieldset'
-import { useNativeForm } from './useNativeForm'
+import { FormErrors, useNativeForm } from './useNativeForm'
 import { Field } from '../../components/Field'
 import { SectionDivider } from '../../components/SectionDivider'
-
-export interface FormValues {
-  email: string
-  password: string
-  description: string
-  exampleCheckbox: string[]
-  exampleRadio: string[]
-  exampleSwitch: string
-  exampleNumberInput: number | null
-  exampleDatePicker: Date | null
-  exampleSelect: string | null
-  exampleAutocomplete: string | null
-  exampleRangeSlider: readonly [number]
-}
+import { EMPTY_FORM_VALUES, PREPOPULATED_FORM_VALUES } from '../constants'
+import { FormValues } from '../types'
 
 const MINIMUM_DATE = parseISO('2022-01-01')
 
-export const Example: React.FC<unknown> = () => {
+const Example: React.FC<{
+  initialValues: FormValues
+  initialErrors?: FormErrors<FormValues>
+}> = ({ initialValues, initialErrors = {} }) => {
   const {
     formErrors,
     formPayload,
@@ -44,40 +35,21 @@ export const Example: React.FC<unknown> = () => {
     handleRadioGroup,
     isSubmitting,
     onSubmit,
-  } = useNativeForm<FormValues>(
-    {
-      email: '',
-      password: '',
-      description: '',
-      exampleCheckbox: [],
-      exampleRadio: [],
-      exampleSwitch: '',
-      exampleNumberInput: null,
-      exampleDatePicker: null,
-      exampleSelect: null,
-      exampleAutocomplete: null,
-      exampleRangeSlider: [20],
-    },
-    {
-      email: true,
-      // ...
-    },
-    {
-      email: (value: string): boolean => !value,
-      exampleDatePicker: (value) => {
-        if (value && !isValid(value)) {
-          return 'Enter a valid date'
-        }
+  } = useNativeForm<FormValues>(initialValues, initialErrors, {
+    email: (value: string): boolean => !value,
+    exampleDatePicker: (value) => {
+      if (value && !isValid(value)) {
+        return 'Enter a valid date'
+      }
 
-        if (value && isBefore(value, MINIMUM_DATE)) {
-          return 'Enter a date on or after 1 January 2022'
-        }
+      if (value && isBefore(value, MINIMUM_DATE)) {
+        return 'Enter a date on or after 1 January 2022'
+      }
 
-        return false
-      },
-      // ...
-    }
-  )
+      return false
+    },
+    // ...
+  })
 
   return (
     <main>
@@ -282,3 +254,18 @@ export default {
   title: 'Forms/Usage/Native',
   component: Example,
 } as ComponentMeta<typeof Example>
+
+const Template: ComponentStory<typeof Example> = (args) => <Example {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  initialValues: EMPTY_FORM_VALUES,
+  initialErrors: {
+    email: true,
+  },
+}
+
+export const Prepopulated = Template.bind({})
+Prepopulated.args = {
+  initialValues: PREPOPULATED_FORM_VALUES,
+}

--- a/packages/react-component-library/src/forms/native/useNativeForm.ts
+++ b/packages/react-component-library/src/forms/native/useNativeForm.ts
@@ -73,7 +73,7 @@ export const useNativeForm = <FormValues>(
     handleChange({
       currentTarget: {
         name,
-        value: [value],
+        value,
       },
     })
   }

--- a/packages/react-component-library/src/forms/native/useNativeForm.ts
+++ b/packages/react-component-library/src/forms/native/useNativeForm.ts
@@ -6,7 +6,7 @@ type Validators<FormValues> = Partial<{
   [key in keyof FormValues]: (value: FormValues[key]) => boolean | string
 }>
 
-type FormErrors<FormValues> = Partial<{
+export type FormErrors<FormValues> = Partial<{
   [key in keyof FormValues]: boolean | string
 }>
 

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -2,7 +2,7 @@
 import { isBefore, isValid, parseISO } from 'date-fns'
 import React, { useState, useEffect } from 'react'
 import { useForm, Controller } from 'react-hook-form/dist/index.ie11'
-import { ComponentMeta } from '@storybook/react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
 import styled from 'styled-components'
 
 import { TextInput } from '../../components/TextInput'
@@ -20,20 +20,8 @@ import { Fieldset } from '../../components/Fieldset'
 import { sleep } from '../../helpers'
 import { Field } from '../../components/Field'
 import { SectionDivider } from '../../components/SectionDivider'
-
-export interface FormValues {
-  email: string
-  password: string
-  description: string
-  exampleCheckbox: string[]
-  exampleDatePicker: Date | null
-  exampleRadio: string[]
-  exampleSwitch: string
-  exampleNumberInput: number
-  exampleSelect: string | null
-  exampleAutocomplete: null
-  exampleRangeSlider: number[]
-}
+import { EMPTY_FORM_VALUES, PREPOPULATED_FORM_VALUES } from '../constants'
+import { FormValues } from '../types'
 
 const MINIMUM_DATE = parseISO('2022-01-01')
 
@@ -41,7 +29,9 @@ const StyledRangeSlider = styled(RangeSlider)`
   margin-top: 3rem;
 `
 
-export const Example: React.FC<unknown> = () => {
+const Example: React.FC<{ initialValues: FormValues }> = ({
+  initialValues,
+}) => {
   const {
     control,
     setValue,
@@ -50,18 +40,7 @@ export const Example: React.FC<unknown> = () => {
     watch,
     formState: { errors, isSubmitting },
   } = useForm({
-    defaultValues: {
-      email: '',
-      password: '',
-      description: '',
-      exampleCheckbox: [],
-      exampleDatePicker: null,
-      exampleRadio: [],
-      exampleSelect: null,
-      exampleSwitch: '',
-      exampleNumberInput: null,
-      exampleRangeSlider: [20],
-    },
+    defaultValues: initialValues,
   })
 
   const exampleSwitchValue = watch('exampleSwitch')
@@ -286,3 +265,15 @@ export default {
   title: 'Forms/Usage/react-hook-form',
   component: Example,
 } as ComponentMeta<typeof Example>
+
+const Template: ComponentStory<typeof Example> = (args) => <Example {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  initialValues: EMPTY_FORM_VALUES,
+}
+
+export const Prepopulated = Template.bind({})
+Prepopulated.args = {
+  initialValues: PREPOPULATED_FORM_VALUES,
+}

--- a/packages/react-component-library/src/forms/types.ts
+++ b/packages/react-component-library/src/forms/types.ts
@@ -1,0 +1,13 @@
+export interface FormValues {
+  email: string
+  password: string
+  description: string
+  exampleCheckbox: string[]
+  exampleRadio: string
+  exampleSwitch: string
+  exampleNumberInput: number | null
+  exampleDatePicker: Date | null
+  exampleSelect: string | null
+  exampleAutocomplete: string | null
+  exampleRangeSlider: [number]
+}


### PR DESCRIPTION
## Related issue

Resolves #3100

## Overview

This adds end-to-end tests for pre-populated forms with various form libraries.

## Link to preview

https://5e25c277526d380020b5e418-hprztncsyz.chromatic.com/?path=/docs/forms-usage-formik--default

## Reason

To cover edit scenarios in our form tests (in addition to the existing tests covering a create/add scenario).

## Work carried out

- [x] Simplify existing e2e form tests
- [x] Add additional stories and tests

## Developer notes

I've harmonised the stories and tests a bit to cut down on repetition.
