### PR TITLE
Remove `dayWidth` from `Timeline`

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.tsx
@@ -18,10 +18,6 @@ export interface TimelineProps extends ComponentWithClass {
    */
   children: timelineChildrenType | timelineChildrenType[]
   /**
-   * Width of a single day unit (pixels).
-   */
-  dayWidth?: number
-  /**
    * Specify whether or not to output sidebar headings.
    */
   hasSide?: boolean
@@ -86,7 +82,6 @@ function getEndDate(startDate: Date, endDate: Date | null) {
 export const Timeline: React.FC<TimelineProps> = ({
   children,
   className,
-  dayWidth,
   hasSide = false,
   hideScaling = false,
   hideToolbar = false,
@@ -103,7 +98,7 @@ export const Timeline: React.FC<TimelineProps> = ({
     startDate,
     endDate: getEndDate(startDate, endDate),
     hoursBlockSize: getHoursBlockSize(children),
-    unitWidth: dayWidth || unitWidth || DEFAULTS.UNIT_WIDTH,
+    unitWidth: unitWidth || DEFAULTS.UNIT_WIDTH,
   }
 
   return (


### PR DESCRIPTION
## Related issue
Closes #3121

## Overview
Removes the redundant `dayWidth` prop.

## Reason
`unitWidth` is used instead.

## Work carried out
- [x] Remove prop
