### PR TITLE
docs(Sidebar): Remove experimental notice from Storybook

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
@@ -48,12 +48,6 @@ export default {
   title: 'Sidebar',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
-    docs: {
-      description: {
-        component:
-          'This API is experimental and may change outside of the typical semver release cycle.',
-      },
-    },
     layout: 'fullscreen',
   },
 } as ComponentMeta<typeof Sidebar>


### PR DESCRIPTION
## Overview

Remove missed experimental notice from Storybook component description.