### PR TITLE
Remove outdated Formik references

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ To install and save to your project's package.json dependencies, run:
 
 ```
 # with npm
-npm install @defencedigital/fonts @defencedigital/react-component-library styled-components formik
+npm install @defencedigital/fonts @defencedigital/react-component-library styled-components
 
 # ...or with yarn
-yarn add @defencedigital/fonts @defencedigital/react-component-library styled-components formik
+yarn add @defencedigital/fonts @defencedigital/react-component-library styled-components
 ```
 
-Note: [`styled-components`](https://styled-components.com/) and [`formik`](https://formik.org/) are required [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/) and are installed with the above commands.
+Note: [`styled-components`](https://styled-components.com/) is a required [peer dependency](https://nodejs.org/en/blog/npm/peer-dependencies/) and is installed with the above command.
 
 ### Quick start
 

--- a/packages/cra-template-defencedigital/template.json
+++ b/packages/cra-template-defencedigital/template.json
@@ -26,7 +26,6 @@
       "@types/react-dom": "^17.0.11",
       "@types/react-router-dom": "^5.3.2",
       "@types/styled-components": "^5.1.18",
-      "formik": "^2.2.9",
       "graphql": "^16.1.0",
       "jest-canvas-mock": "^2.3.0",
       "react-router-dom": "^5.1.2",

--- a/packages/react-component-library/README.md
+++ b/packages/react-component-library/README.md
@@ -10,13 +10,13 @@ To install it, run the relevant command for your package manager:
 
 ```shell
 // npm
-npm install @defencedigital/fonts @defencedigital/react-component-library styled-components formik
+npm install @defencedigital/fonts @defencedigital/react-component-library styled-components
 
 // yarn
-yarn add @defencedigital/fonts @defencedigital/react-component-library styled-components formik
+yarn add @defencedigital/fonts @defencedigital/react-component-library styled-components
 ```
 
-Note: [`styled-components`](https://styled-components.com/) and [`formik`](https://formik.org/) are required [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/) and are installed with the above commands.
+Note: [`styled-components`](https://styled-components.com/) is a required [peer dependency](https://nodejs.org/en/blog/npm/peer-dependencies/) and is installed with the above command.
 
 ## Usage
 


### PR DESCRIPTION
## Related issue

n/a

## Overview

This:
- removes Formik references from the main README and the component library README
- removes Formik as a dependency in the CRA template

## Reason

The dependency on Formik was removed in #3085 (and hence it's no longer required).

## Work carried out

- [x] Update READMEs
- [x] Update CRA template

