### PR TITLE
feat(Button): Update styles to reflect updated design

### DIFF
--- a/packages/react-component-library/src/components/Button/partials/StyledButton.tsx
+++ b/packages/react-component-library/src/components/Button/partials/StyledButton.tsx
@@ -12,7 +12,12 @@ interface StyledButtonProps {
   $iconPosition: ButtonIconPositionType
 }
 
-const { color, spacing, fontSize } = selectors
+const { color, spacing, fontSize, shadow } = selectors
+
+const DROP_SHADOW = `0 2px 6px ${rgba(0, 0, 0, 0.3)}`
+const TRANSPARENT_SHADOW = shadow('0')
+const DEFAULT_HOVER_BORDER_SHADOW = `0 0 0 3px ${color('action', '100')}`
+const DANGER_HOVER_BORDER_SHADOW = `0 0 0 3px ${color('danger', '100')}`
 
 export const StyledButton = styled.button<StyledButtonProps>`
   position: relative;
@@ -23,6 +28,7 @@ export const StyledButton = styled.button<StyledButtonProps>`
   align-items: center;
   justify-content: center;
   border-radius: 15px;
+  box-shadow: ${TRANSPARENT_SHADOW}, ${DROP_SHADOW};
   outline: 0;
   padding: 0 ${spacing('6')};
   font-size: ${fontSize('m')};
@@ -48,70 +54,54 @@ export const StyledButton = styled.button<StyledButtonProps>`
   ${({ $variant }) =>
     $variant === BUTTON_VARIANT.PRIMARY &&
     css`
-      border: 1px solid ${color('action', '600')};
       color: ${color('neutral', 'white')};
       background-color: ${color('action', '600')};
-      box-shadow: 0 1px 3px ${rgba(0, 0, 0, 0.1)};
+      border: 2px solid ${color('action', '800')};
 
       &:focus,
       &:hover {
-        background-color: ${color('action', '700')};
+        background-color: ${color('action', '800')};
       }
 
       &:active {
-        background-color: ${color('action', '800')};
+        background-color: ${color('action', '900')};
       }
     `}
 
   ${({ $variant }) =>
     $variant === BUTTON_VARIANT.SECONDARY &&
     css`
-      color: ${color('neutral', '500')};
-      background-color: ${color('neutral', 'white')};
-      border: 1px solid ${color('neutral', '200')};
-      box-shadow: 0 1px 3px ${rgba(0, 0, 0, 0.1)};
+      color: ${color('action', '900')};
+      background-color: ${color('action', '100')};
+      border: 2px solid ${color('action', '600')};
+
+      &:focus,
+      &:hover {
+        background-color: ${color('action', '200')};
+      }
+
+      &:active {
+        background-color: ${color('action', '300')};
+      }
     `}
 
   ${({ $variant }) =>
     $variant === BUTTON_VARIANT.TERTIARY &&
     css`
-      background-color: transparent;
-      background-image: none;
-      border: 1px solid transparent;
-      color: ${color('neutral', '500')};
-      text-decoration: underline;
+      color: ${color('action', '600')};
+      background-color: ${color('neutral', 'white')};
+      border: 1px solid ${color('action', '600')};
 
-      &:disabled {
-        text-decoration: none;
-        text-decoration-line: underline;
-        text-decoration-color: transparent;
-      }
-
-      &:active,
       &:focus,
       &:hover {
-        color: ${color('neutral', '500')};
-        border: 1px solid ${color('neutral', '200')};
-        text-decoration: none;
-        text-decoration-line: underline;
-        text-decoration-color: transparent;
-      }
-    `}
-
-
-  ${({ $variant }) =>
-    ($variant === BUTTON_VARIANT.TERTIARY ||
-      $variant === BUTTON_VARIANT.SECONDARY) &&
-    css`
-      &:focus,
-      &:hover {
-        background-color: ${color('neutral', 'white')};
+        background-color: ${color('neutral', '000')};
       }
 
       &:active {
         background-color: ${color('neutral', '100')};
       }
     `}
+
 
   ${({ $variant }) =>
     ($variant === BUTTON_VARIANT.PRIMARY ||
@@ -120,12 +110,11 @@ export const StyledButton = styled.button<StyledButtonProps>`
     css`
       &:focus,
       &:hover {
-        box-shadow: 0 1px 3px ${rgba(0, 0, 0, 0.1)},
-          0 0 0 3px ${color('action', '100')};
+        box-shadow: ${DEFAULT_HOVER_BORDER_SHADOW}, ${DROP_SHADOW};
       }
 
       &:active {
-        box-shadow: 0 1px 3px transparent, 0 0 0 3px ${color('action', '100')};
+        box-shadow: ${TRANSPARENT_SHADOW}, ${TRANSPARENT_SHADOW};
       }
 
       &:disabled {
@@ -134,9 +123,10 @@ export const StyledButton = styled.button<StyledButtonProps>`
         &:active,
         &:focus {
           background: ${color('neutral', '000')};
-          border: 1px solid ${color('neutral', '200')};
+          border: ${$variant === BUTTON_VARIANT.TERTIARY ? '1px' : '2px'} solid
+            ${color('neutral', '200')};
           box-shadow: none;
-          color: ${color('neutral', '300')};
+          color: ${color('neutral', '400')};
           cursor: not-allowed;
         }
       }
@@ -145,20 +135,19 @@ export const StyledButton = styled.button<StyledButtonProps>`
   ${({ $variant }) =>
     $variant === BUTTON_VARIANT.DANGER &&
     css`
-      background-color: ${color('danger', '700')};
-      border: 1px solid ${color('danger', '700')};
       color: ${color('neutral', 'white')};
+      background-color: ${color('danger', '700')};
+      border: 2px solid ${color('danger', '900')};
 
       &:focus,
       &:hover {
         background-color: ${color('danger', '800')};
-        box-shadow: 0 1px 3px ${rgba(0, 0, 0, 0.1)},
-          0 0 0 3px ${color('danger', '100')};
+        box-shadow: ${DANGER_HOVER_BORDER_SHADOW}, ${DROP_SHADOW};
       }
 
       &:active {
         background-color: ${color('danger', '900')};
-        box-shadow: 0 1px 3px transparent, 0 0 0 3px ${color('danger', '100')};
+        box-shadow: ${TRANSPARENT_SHADOW}, ${TRANSPARENT_SHADOW};
       }
 
       &:disabled {
@@ -166,10 +155,10 @@ export const StyledButton = styled.button<StyledButtonProps>`
         &:hover,
         &:active,
         &:focus {
-          background: ${color('danger', '000')};
-          border: 1px solid ${color('neutral', '200')};
+          background: ${color('neutral', '000')};
+          border: 2px solid ${color('neutral', '200')};
           box-shadow: none;
-          color: ${color('neutral', '300')};
+          color: ${color('neutral', '400')};
           cursor: not-allowed;
         }
       }

--- a/packages/react-component-library/src/components/Button/partials/StyledButton.tsx
+++ b/packages/react-component-library/src/components/Button/partials/StyledButton.tsx
@@ -6,12 +6,6 @@ import { BUTTON_ICON_POSITION, BUTTON_VARIANT } from '../constants'
 import { ButtonIconPositionType, ButtonVariantType } from '../Button'
 import { ComponentSizeType, COMPONENT_SIZE } from '../../Forms'
 
-interface StyledButtonProps {
-  $variant: ButtonVariantType
-  $size: ComponentSizeType
-  $iconPosition: ButtonIconPositionType
-}
-
 const { color, spacing, fontSize, shadow } = selectors
 
 const DROP_SHADOW = `0 2px 6px ${rgba(0, 0, 0, 0.3)}`
@@ -58,44 +52,59 @@ const COLOR_MAP = {
   },
 }
 
-export const StyledButton = styled.button<StyledButtonProps>`
-  position: relative;
-  height: 46px;
-  display: inline-flex;
-  flex-direction: ${({ $iconPosition }) =>
-    $iconPosition === BUTTON_ICON_POSITION.LEFT ? 'row-reverse' : 'row'};
-  align-items: center;
-  justify-content: center;
-  border-radius: 15px;
-  box-shadow: ${TRANSPARENT_SHADOW}, ${DROP_SHADOW};
-  outline: 0;
-  padding: 0 ${spacing('6')};
-  font-size: ${fontSize('m')};
-  font-weight: 400;
-  text-decoration: none;
-  cursor: pointer;
-  user-select: none;
-  transition: all 75ms cubic-bezier(0, 1.19, 0.82, 0.9);
-  white-space: nowrap;
+const SIZE_MAP = {
+  [COMPONENT_SIZE.FORMS]: {
+    height: '46px',
+    fontSize: fontSize('m'),
+    borderRadius: '15px',
+  },
+  [COMPONENT_SIZE.SMALL]: {
+    height: '33px',
+    fontSize: fontSize('base'),
+    borderRadius: '10px',
+  },
+}
 
-  &:hover {
+interface StyledButtonProps {
+  $variant: ButtonVariantType
+  $size: ComponentSizeType
+  $iconPosition?: ButtonIconPositionType
+}
+
+export function getButtonStyles({
+  $size,
+  $variant,
+  $iconPosition = BUTTON_ICON_POSITION.RIGHT,
+}: StyledButtonProps) {
+  return css`
+    height: ${SIZE_MAP[$size].height};
+    display: inline-flex;
+    flex-direction: ${$iconPosition === BUTTON_ICON_POSITION.LEFT
+      ? 'row-reverse'
+      : 'row'};
+    align-items: center;
+    justify-content: center;
+    border-radius: ${SIZE_MAP[$size].borderRadius};
+    box-shadow: ${TRANSPARENT_SHADOW}, ${DROP_SHADOW};
+    outline: 0;
+    padding: 0 ${spacing('6')};
+    font-size: ${SIZE_MAP[$size].fontSize};
+    font-weight: 400;
     text-decoration: none;
-  }
+    cursor: pointer;
+    user-select: none;
+    transition: all 75ms cubic-bezier(0, 1.19, 0.82, 0.9);
+    white-space: nowrap;
 
-  &:active {
-    box-shadow: ${TRANSPARENT_SHADOW}, ${TRANSPARENT_SHADOW};
-  }
+    &:hover {
+      text-decoration: none;
+    }
 
-  ${({ $size }) =>
-    $size === COMPONENT_SIZE.SMALL &&
-    css`
-      border-radius: 10px;
-      height: 33px;
-      font-size: ${fontSize('base')};
-    `}
+    &:active {
+      box-shadow: ${TRANSPARENT_SHADOW}, ${TRANSPARENT_SHADOW};
+    }
 
-  ${({ $variant }) =>
-    css`
+    ${css`
       color: ${COLOR_MAP[$variant].color};
       background-color: ${COLOR_MAP[$variant].backgroundColor};
       border: ${COLOR_MAP[$variant].borderWidth} solid
@@ -113,17 +122,23 @@ export const StyledButton = styled.button<StyledButtonProps>`
       }
     `}
 
-  &:disabled {
-    &,
-    &:hover,
-    &:active,
-    &:focus {
-      color: ${color('neutral', '400')};
-      background-color: ${color('neutral', '000')};
-      border: ${({ $variant }) => COLOR_MAP[$variant].borderWidth} solid
-        ${color('neutral', '200')};
-      box-shadow: none;
-      cursor: not-allowed;
+    &:disabled {
+      &,
+      &:hover,
+      &:active,
+      &:focus {
+        color: ${color('neutral', '400')};
+        background-color: ${color('neutral', '000')};
+        border: ${COLOR_MAP[$variant].borderWidth} solid
+          ${color('neutral', '200')};
+        box-shadow: none;
+        cursor: not-allowed;
+      }
     }
-  }
+  `
+}
+
+export const StyledButton = styled.button<StyledButtonProps>`
+  position: relative;
+  ${getButtonStyles};
 `

--- a/packages/react-component-library/src/components/Button/partials/StyledButton.tsx
+++ b/packages/react-component-library/src/components/Button/partials/StyledButton.tsx
@@ -19,6 +19,45 @@ const TRANSPARENT_SHADOW = shadow('0')
 const DEFAULT_HOVER_BORDER_SHADOW = `0 0 0 3px ${color('action', '100')}`
 const DANGER_HOVER_BORDER_SHADOW = `0 0 0 3px ${color('danger', '100')}`
 
+const COLOR_MAP = {
+  [BUTTON_VARIANT.PRIMARY]: {
+    color: color('neutral', 'white'),
+    backgroundColor: color('action', '600'),
+    borderColor: color('action', '800'),
+    borderWidth: '2px',
+    hoverBackgroundColor: color('action', '800'),
+    hoverBoxShadow: DEFAULT_HOVER_BORDER_SHADOW,
+    activeBackgroundColor: color('action', '900'),
+  },
+  [BUTTON_VARIANT.SECONDARY]: {
+    color: color('action', '900'),
+    backgroundColor: color('action', '100'),
+    borderColor: color('action', '600'),
+    borderWidth: '2px',
+    hoverBackgroundColor: color('action', '200'),
+    hoverBoxShadow: DEFAULT_HOVER_BORDER_SHADOW,
+    activeBackgroundColor: color('action', '300'),
+  },
+  [BUTTON_VARIANT.TERTIARY]: {
+    color: color('action', '600'),
+    backgroundColor: color('neutral', 'white'),
+    borderColor: color('action', '600'),
+    borderWidth: '1px',
+    hoverBackgroundColor: color('neutral', '000'),
+    hoverBoxShadow: DEFAULT_HOVER_BORDER_SHADOW,
+    activeBackgroundColor: color('neutral', '100'),
+  },
+  [BUTTON_VARIANT.DANGER]: {
+    color: color('neutral', 'white'),
+    backgroundColor: color('danger', '700'),
+    borderColor: color('danger', '900'),
+    borderWidth: '2px',
+    hoverBackgroundColor: color('danger', '800'),
+    hoverBoxShadow: DANGER_HOVER_BORDER_SHADOW,
+    activeBackgroundColor: color('danger', '900'),
+  },
+}
+
 export const StyledButton = styled.button<StyledButtonProps>`
   position: relative;
   height: 46px;
@@ -43,6 +82,10 @@ export const StyledButton = styled.button<StyledButtonProps>`
     text-decoration: none;
   }
 
+  &:active {
+    box-shadow: ${TRANSPARENT_SHADOW}, ${TRANSPARENT_SHADOW};
+  }
+
   ${({ $size }) =>
     $size === COMPONENT_SIZE.SMALL &&
     css`
@@ -52,115 +95,35 @@ export const StyledButton = styled.button<StyledButtonProps>`
     `}
 
   ${({ $variant }) =>
-    $variant === BUTTON_VARIANT.PRIMARY &&
     css`
-      color: ${color('neutral', 'white')};
-      background-color: ${color('action', '600')};
-      border: 2px solid ${color('action', '800')};
+      color: ${COLOR_MAP[$variant].color};
+      background-color: ${COLOR_MAP[$variant].backgroundColor};
+      border: ${COLOR_MAP[$variant].borderWidth} solid
+        ${COLOR_MAP[$variant].borderColor};
 
       &:focus,
       &:hover {
-        background-color: ${color('action', '800')};
+        background-color: ${COLOR_MAP[$variant].hoverBackgroundColor};
+        box-shadow: ${COLOR_MAP[$variant].hoverBoxShadow}, ${DROP_SHADOW};
       }
 
       &:active {
-        background-color: ${color('action', '900')};
-      }
-    `}
-
-  ${({ $variant }) =>
-    $variant === BUTTON_VARIANT.SECONDARY &&
-    css`
-      color: ${color('action', '900')};
-      background-color: ${color('action', '100')};
-      border: 2px solid ${color('action', '600')};
-
-      &:focus,
-      &:hover {
-        background-color: ${color('action', '200')};
-      }
-
-      &:active {
-        background-color: ${color('action', '300')};
-      }
-    `}
-
-  ${({ $variant }) =>
-    $variant === BUTTON_VARIANT.TERTIARY &&
-    css`
-      color: ${color('action', '600')};
-      background-color: ${color('neutral', 'white')};
-      border: 1px solid ${color('action', '600')};
-
-      &:focus,
-      &:hover {
-        background-color: ${color('neutral', '000')};
-      }
-
-      &:active {
-        background-color: ${color('neutral', '100')};
-      }
-    `}
-
-
-  ${({ $variant }) =>
-    ($variant === BUTTON_VARIANT.PRIMARY ||
-      $variant === BUTTON_VARIANT.SECONDARY ||
-      $variant === BUTTON_VARIANT.TERTIARY) &&
-    css`
-      &:focus,
-      &:hover {
-        box-shadow: ${DEFAULT_HOVER_BORDER_SHADOW}, ${DROP_SHADOW};
-      }
-
-      &:active {
+        background-color: ${COLOR_MAP[$variant].activeBackgroundColor};
         box-shadow: ${TRANSPARENT_SHADOW}, ${TRANSPARENT_SHADOW};
       }
-
-      &:disabled {
-        &,
-        &:hover,
-        &:active,
-        &:focus {
-          background: ${color('neutral', '000')};
-          border: ${$variant === BUTTON_VARIANT.TERTIARY ? '1px' : '2px'} solid
-            ${color('neutral', '200')};
-          box-shadow: none;
-          color: ${color('neutral', '400')};
-          cursor: not-allowed;
-        }
-      }
     `}
 
-  ${({ $variant }) =>
-    $variant === BUTTON_VARIANT.DANGER &&
-    css`
-      color: ${color('neutral', 'white')};
-      background-color: ${color('danger', '700')};
-      border: 2px solid ${color('danger', '900')};
-
-      &:focus,
-      &:hover {
-        background-color: ${color('danger', '800')};
-        box-shadow: ${DANGER_HOVER_BORDER_SHADOW}, ${DROP_SHADOW};
-      }
-
-      &:active {
-        background-color: ${color('danger', '900')};
-        box-shadow: ${TRANSPARENT_SHADOW}, ${TRANSPARENT_SHADOW};
-      }
-
-      &:disabled {
-        &,
-        &:hover,
-        &:active,
-        &:focus {
-          background: ${color('neutral', '000')};
-          border: 2px solid ${color('neutral', '200')};
-          box-shadow: none;
-          color: ${color('neutral', '400')};
-          cursor: not-allowed;
-        }
-      }
-    `}
+  &:disabled {
+    &,
+    &:hover,
+    &:active,
+    &:focus {
+      color: ${color('neutral', '400')};
+      background-color: ${color('neutral', '000')};
+      border: ${({ $variant }) => COLOR_MAP[$variant].borderWidth} solid
+        ${color('neutral', '200')};
+      box-shadow: none;
+      cursor: not-allowed;
+    }
+  }
 `

--- a/packages/react-component-library/src/components/ButtonGroup/partials/StyledButtonGroup.tsx
+++ b/packages/react-component-library/src/components/ButtonGroup/partials/StyledButtonGroup.tsx
@@ -13,10 +13,13 @@ export const StyledButtonGroup = styled.div<StyledButtonGroupProps>`
   position: relative;
   z-index: 0;
   display: inline-block;
+  border-radius: 4px;
 
   ${StyledButton} {
+    background-color: ${color('neutral', 'white')};
     border-radius: 0;
     border: 1px solid ${color('neutral', '200')};
+    box-shadow: ${shadow('2')};
     margin-right: -1px;
     position: relative;
     z-index: 1;
@@ -34,12 +37,16 @@ export const StyledButtonGroup = styled.div<StyledButtonGroupProps>`
     &:focus {
       background-color: ${color('neutral', '100')};
       color: ${color('neutral', '600')};
-      box-shadow: ${shadow('1')};
+      box-shadow: ${shadow('2')};
       z-index: 2;
     }
 
     &[disabled] {
       z-index: 0;
+      color: ${color('neutral', '300')};
+      background-color: ${color('neutral', '000')};
+      border: 1px solid ${color('neutral', '200')};
+      box-shadow: none;
     }
   }
 `

--- a/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
@@ -1,6 +1,10 @@
 import DayPicker from 'react-day-picker'
 import { selectors } from '@defencedigital/design-tokens'
 import styled, { css } from 'styled-components'
+
+import { BUTTON_VARIANT } from '../../Button'
+import { COMPONENT_SIZE } from '../../Forms'
+import { getButtonStyles } from '../../Button/partials/StyledButton'
 import { isIE11 } from '../../../helpers'
 
 const { color, spacing, fontSize } = selectors
@@ -50,36 +54,16 @@ export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
   }
 
   .DayPicker-NavButton {
+    ${getButtonStyles({
+      $size: COMPONENT_SIZE.SMALL,
+      $variant: BUTTON_VARIANT.SECONDARY,
+    })};
     position: absolute;
     top: ${spacing('6')};
-    cursor: pointer;
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
     width: 38px;
-    height: 33px;
-    padding: 0;
-    border: 1px solid ${color('neutral', '200')};
-    border-radius: 10px;
-    outline: none;
-    color: ${color('neutral', '300')};
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    background-color: ${color('neutral', 'white')};
     background-position: center;
     background-size: 18px;
     background-repeat: no-repeat;
-
-    &:focus,
-    &:hover {
-      background-color: ${color('neutral', 'white')};
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1),
-        0 0 0 3px ${color('action', '100')};
-    }
-
-    &:active {
-      background-color: ${color('neutral', '100')};
-      box-shadow: 0 1px 3px transparent, 0 0 0 3px ${color('action', '100')};
-    }
   }
 
   .DayPicker-NavButton--prev {


### PR DESCRIPTION
## Related issue

Resolves #3063

## Overview

This updates the `Button` styles to reflect the updated design (including the secondary buttons in the DatePicker).

## Link to preview

- [Storybook](https://button-updates.netlify.app/?path=/docs/button--default)
- [Non-Storybook](https://red-playground.netlify.app/)

## Reason

The design was improved – this updates the component to match.

## Work carried out

- [x] Update styles
- [x] Refactor styles
- [x] Share button styles with DatePicker

## Notes

Note this this also affects:

- DatePicker
- Dialog
- Dismissible banner
- Modal
- Timeline

It also had some impact on ButtonGroup as it's based on Button, but I've preserved the existing appearance there.

## Questions

- ~~What should the border width of a disabled tertiary button be?~~
- ~~What should the background colour of a disabled danger button be?~~

## Demo

![Screencast_02-03-22_14:18:42](https://user-images.githubusercontent.com/66470099/156379464-6f1c1212-b614-4328-827e-0dc3b27eee13.gif)
