### PR TITLE
Ensure element and ARIA IDs are stable between renders

### DIFF
--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -155,4 +155,35 @@ describe('Alert', () => {
       })
     })
   })
+
+  describe('when the Alert content changes', () => {
+    let initialContentId: string
+    let initialTitleId: string | null
+
+    const ExampleAlert = ({ content }: { content: string }) => (
+      <Alert title="Example title">{content}</Alert>
+    )
+
+    beforeEach(() => {
+      wrapper = render(<ExampleAlert content="initial content" />)
+      initialContentId = wrapper.getByTestId('content-description').id
+      initialTitleId = wrapper.getByTestId('content-title').id
+
+      wrapper.rerender(<ExampleAlert content="new content" />)
+    })
+
+    it('does not generate a new content `id`', () => {
+      expect(wrapper.getByTestId('content-description')).toHaveAttribute(
+        'id',
+        initialContentId
+      )
+    })
+
+    it('does not generate a new title `id`', () => {
+      expect(wrapper.getByTestId('content-title')).toHaveAttribute(
+        'id',
+        initialTitleId
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -7,7 +7,6 @@ import {
 } from '@defencedigital/icon-library'
 
 import { ALERT_VARIANT } from './constants'
-import { getId } from '../../helpers'
 import { useOpenClose } from '../../hooks'
 import { StyledAlert } from './partials/StyledAlert'
 import { StyledIcon } from './partials/StyledIcon'
@@ -16,6 +15,7 @@ import { StyledTitle } from './partials/StyledTitle'
 import { StyledDescription } from './partials/StyledDescription'
 import { StyledFooter } from './partials/StyledFooter'
 import { StyledCloseButton } from './partials/StyledCloseButton'
+import { useExternalId } from '../../hooks/useExternalId'
 
 const VARIANT_ICON_MAP = {
   [ALERT_VARIANT.DANGER]: (
@@ -63,9 +63,8 @@ export const Alert: React.FC<AlertProps> = ({
   ...rest
 }) => {
   const { open, handleOnClose } = useOpenClose(true, onClose)
-
-  const titleId = title ? getId('alert-title') : undefined
-  const descriptionId = getId('alert-description')
+  const titleId = useExternalId('alert-title')
+  const descriptionId = useExternalId('alert-description')
 
   if (!open) {
     return null
@@ -75,7 +74,7 @@ export const Alert: React.FC<AlertProps> = ({
     <StyledAlert
       $variant={variant}
       aria-describedby={descriptionId}
-      aria-labelledby={titleId}
+      aria-labelledby={title ? titleId : undefined}
       data-testid="alert"
       role="alert"
       {...rest}

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
@@ -162,6 +162,27 @@ describe('Autocomplete', () => {
     })
   })
 
+  describe('when the default `id` is used and the arrow button is clicked', () => {
+    let initialId: string
+
+    beforeEach(() => {
+      wrapper = render(
+        <Autocomplete label="Label" value="two">
+          <AutocompleteOption value="one">One</AutocompleteOption>
+        </Autocomplete>
+      )
+      initialId = wrapper.getByTestId('select-input').id
+      userEvent.click(wrapper.getByTestId('select-arrow-button'))
+    })
+
+    it('does not generate a new `id`', () => {
+      expect(wrapper.getByTestId('select-input')).toHaveAttribute(
+        'id',
+        initialId
+      )
+    })
+  })
+
   describe('when `value` is set to a valid value', () => {
     beforeEach(() => {
       wrapper = render(

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useCombobox } from 'downshift'
 
-import { getId } from '../../helpers'
 import {
   initialSelectedItem,
   itemToString,
@@ -13,13 +12,14 @@ import { NoResults } from './NoResults'
 import { useHighlightedIndex } from './hooks/useHighlightedIndex'
 import { useAutocomplete } from './hooks/useAutocomplete'
 import { useMenuVisibility } from './hooks/useMenuVisibility'
+import { useExternalId } from '../../hooks/useExternalId'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AutocompleteProps extends SelectBaseProps {}
 
 export const Autocomplete: React.FC<AutocompleteProps> = ({
   children,
-  id = getId('autocomplete'),
+  id: externalId,
   isInvalid = false,
   onChange,
   value = null,
@@ -27,6 +27,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
 }) => {
   const { hasError, inputRef, items, onInputValueChange, onIsOpenChange } =
     useAutocomplete(React.Children.toArray(children), isInvalid)
+  const id = useExternalId('autocomplete', externalId)
 
   const {
     getComboboxProps,

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.test.tsx
@@ -255,4 +255,22 @@ describe('Checkbox', () => {
       )
     })
   })
+
+  describe('when the default `id` is used and input is toggled', () => {
+    let initialId: string
+
+    beforeEach(() => {
+      checkbox = render(<Checkbox label="label" name="name" />)
+      const input = checkbox.getByTestId('checkbox-input')
+      initialId = input.id
+      userEvent.click(checkbox.getByTestId('checkbox'))
+    })
+
+    it('does not generate a new `id`', () => {
+      expect(checkbox.getByTestId('checkbox-input')).toHaveAttribute(
+        'id',
+        initialId
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useState, useEffect } from 'react'
-import { v4 as uuidv4 } from 'uuid'
 import mergeRefs from 'react-merge-refs'
 
 import { CHECKBOX_RADIO_VARIANT } from './types'
@@ -9,6 +8,7 @@ import { StyledInnerWrapper } from './partials/StyledInnerWrapper'
 import { StyledDescription } from './partials/StyledDescription'
 import { StyledLabel } from './partials/StyledLabel'
 import { StyledInput } from './partials/StyledInput'
+import { useExternalId } from '../../hooks/useExternalId'
 
 export const CheckboxRadioBase = React.forwardRef<
   HTMLInputElement,
@@ -17,7 +17,7 @@ export const CheckboxRadioBase = React.forwardRef<
   (
     {
       className = '',
-      id = uuidv4(),
+      id: externalId,
       defaultChecked,
       description,
       isDisabled = false,
@@ -34,6 +34,7 @@ export const CheckboxRadioBase = React.forwardRef<
     },
     ref
   ) => {
+    const id = useExternalId(`${type}-input`, externalId)
     const localRef = useRef<HTMLInputElement>(null)
     const [isChecked, setIsChecked] = useState(defaultChecked)
 

--- a/packages/react-component-library/src/components/DescriptionList/DescriptionList.test.tsx
+++ b/packages/react-component-library/src/components/DescriptionList/DescriptionList.test.tsx
@@ -117,8 +117,18 @@ describe('DescriptionList', () => {
     })
 
     describe('when the header is clicked', () => {
+      let initialSheetId: string
+
       beforeEach(() => {
+        initialSheetId = wrapper.getByTestId('description-list-sheet').id
         wrapper.getByTestId('description-list-header').click()
+      })
+
+      it('does not generate a new sheet `id`', () => {
+        expect(wrapper.getByTestId('description-list-sheet')).toHaveAttribute(
+          'id',
+          initialSheetId
+        )
       })
 
       it('should set `aria-expanded` on the button to `true`', () => {

--- a/packages/react-component-library/src/components/DescriptionList/DescriptionList.tsx
+++ b/packages/react-component-library/src/components/DescriptionList/DescriptionList.tsx
@@ -3,7 +3,7 @@ import { IconKeyboardArrowDown } from '@defencedigital/icon-library'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { DescriptionListItem, DescriptionListItemProps } from '.'
-import { getId, warnIfOverwriting } from '../../helpers'
+import { warnIfOverwriting } from '../../helpers'
 import { useOpenClose } from '../../hooks'
 import { StyledAction } from './partials/StyledAction'
 import { StyledBadge } from './partials/StyledBadge'
@@ -11,6 +11,7 @@ import { StyledDescriptionList } from './partials/StyledDescriptionList'
 import { StyledHeader } from './partials/StyledHeader'
 import { StyledSheet } from './partials/StyledSheet'
 import { StyledDescription } from './partials/StyledDescription'
+import { useExternalId } from '../../hooks/useExternalId'
 
 export interface DescriptionListProps extends ComponentWithClass {
   /**
@@ -29,8 +30,8 @@ export interface DescriptionListProps extends ComponentWithClass {
   description: string
 }
 
-function getAriaAttributes(isCollapsible: boolean, expanded: boolean) {
-  const sheetId = getId('sheet')
+function useAriaAttributes(isCollapsible: boolean, expanded: boolean) {
+  const sheetId = useExternalId('sheet')
 
   if (isCollapsible) {
     return {
@@ -50,7 +51,7 @@ export const DescriptionList: React.FC<DescriptionListProps> = ({
   ...rest
 }) => {
   const { open, toggle } = useOpenClose(false)
-  const ariaAttributes = getAriaAttributes(isCollapsible, open)
+  const ariaAttributes = useAriaAttributes(isCollapsible, open)
   const sheetId = ariaAttributes ? ariaAttributes['aria-owns'] : undefined
 
   return (

--- a/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
@@ -94,4 +94,39 @@ describe('Modal', () => {
       })
     })
   })
+
+  describe('when the Dialog description changes', () => {
+    let initialTitleId: string
+    let initialDescriptionId: string
+
+    const ExampleDialog = ({
+      exampleDescription,
+    }: {
+      exampleDescription: string
+    }) => (
+      <Dialog title="Example title" description={exampleDescription} isOpen />
+    )
+
+    beforeEach(() => {
+      wrapper = render(<ExampleDialog exampleDescription="initial content" />)
+      initialTitleId = wrapper.getByTestId('dialog-title').id
+      initialDescriptionId = wrapper.getByTestId('modal-body').id
+
+      wrapper.rerender(<ExampleDialog exampleDescription="new content" />)
+    })
+
+    it('does not generate new a new title `id`', () => {
+      expect(wrapper.getByTestId('dialog-title')).toHaveAttribute(
+        'id',
+        initialTitleId
+      )
+    })
+
+    it('does not generate new a new description `id`', () => {
+      expect(wrapper.getByTestId('modal-body')).toHaveAttribute(
+        'id',
+        initialDescriptionId
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Dialog/Dialog.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { ButtonProps } from '../Button'
-import { getId } from '../../helpers'
 import { StyledBody } from './partials/StyledBody'
 import { StyledDialog } from './partials/StyledDialog'
 import { StyledDescription } from './partials/StyledDescription'
 import { StyledTitle } from './partials/StyledTitle'
+import { useExternalId } from '../../hooks/useExternalId'
 
 export interface DialogProps extends ComponentWithClass {
   /**
@@ -55,8 +55,8 @@ export const Dialog: React.FC<DialogProps> = ({
     variant: 'secondary',
   }
 
-  const titleId = getId('dialog-title')
-  const descriptionId = getId('dialog-description')
+  const titleId = useExternalId('dialog-title')
+  const descriptionId = useExternalId('dialog-description')
 
   return (
     <StyledDialog

--- a/packages/react-component-library/src/components/Field/Field.tsx
+++ b/packages/react-component-library/src/components/Field/Field.tsx
@@ -4,7 +4,7 @@ import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { StyledField } from './partials/StyledField'
 import { StyledError } from './partials/StyledError'
 import { StyledHintText } from './partials/StyledHintText'
-import { getId } from '../../helpers'
+import { useExternalId } from '../../hooks/useExternalId'
 
 export type ErrorType = {
   error: boolean | string | null | undefined
@@ -38,7 +38,7 @@ export const Field: React.FC<FieldProps> = ({
     return errors.some(({ error }) => error)
   }, [errors])
 
-  const fieldId: string = useMemo(() => getId('field'), [])
+  const fieldId: string = useExternalId('field')
 
   return (
     <StyledField className={className}>

--- a/packages/react-component-library/src/components/List/List.test.tsx
+++ b/packages/react-component-library/src/components/List/List.test.tsx
@@ -121,8 +121,18 @@ describe('List', () => {
     })
 
     describe('when the mouse pointer enters the first item', () => {
+      let initialItemHeadingId: string
+
       beforeEach(() => {
+        initialItemHeadingId = wrapper.getAllByTestId('list-item-heading')[0].id
         fireEvent.mouseEnter(wrapper.getAllByText('This is the description')[0])
+      })
+
+      it('does not generate a new `id` for the list item heading', () => {
+        expect(wrapper.getAllByTestId('list-item-heading')[0]).toHaveAttribute(
+          'id',
+          initialItemHeadingId
+        )
       })
 
       it('should not give the first item the `is-inactive` class', () => {

--- a/packages/react-component-library/src/components/List/ListItem.tsx
+++ b/packages/react-component-library/src/components/List/ListItem.tsx
@@ -2,12 +2,12 @@ import React from 'react'
 import { IconChevronRight } from '@defencedigital/icon-library'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
-import { getId } from '../../helpers'
 import { StyledItem } from './partials/StyledItem'
 import { StyledItemContent } from './partials/StyledItemContent'
 import { StyledItemTitle } from './partials/StyledItemTitle'
 import { StyledItemDescription } from './partials/StyledItemDescription'
 import { StyledItemAction } from './partials/StyledItemAction'
+import { useExternalId } from '../../hooks/useExternalId'
 
 export interface ListItemProps extends ComponentWithClass {
   /**
@@ -45,7 +45,7 @@ export const ListItem: React.FC<ListItemProps> = ({
   title,
   ...rest
 }) => {
-  const titleId = getId('list-title')
+  const titleId = useExternalId('list-title')
 
   return (
     <StyledItem

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
@@ -907,4 +907,32 @@ describe('NumberInput', () => {
       })
     })
   })
+
+  describe('when the default `id` is used and a number is typed in the input', () => {
+    let initialInputId: string
+    let initialWrapperId: string
+
+    beforeEach(() => {
+      wrapper = render(<NumberInput onChange={jest.fn()} name="example" />)
+      initialWrapperId = wrapper.getByTestId('number-input').id
+
+      const input = wrapper.getByTestId('number-input-input')
+      initialInputId = input.id
+      userEvent.type(input, '123')
+    })
+
+    it('does not generate a new `id` for the wrapper', () => {
+      expect(wrapper.getByTestId('number-input')).toHaveAttribute(
+        'id',
+        initialWrapperId
+      )
+    })
+
+    it('does not generate a new `id` for the input', () => {
+      expect(wrapper.getByTestId('number-input-input')).toHaveAttribute(
+        'id',
+        initialInputId
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import { isNil } from 'lodash'
-import { v4 as uuidv4 } from 'uuid'
 
 import { Buttons } from './Buttons'
 import { COMPONENT_SIZE, ComponentSizeType } from '../Forms'
-import { getId, hasClass } from '../../helpers'
+import { hasClass } from '../../helpers'
 import { Input } from './Input'
 import { InputValidationProps } from '../../common/InputValidationProps'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
@@ -19,6 +18,7 @@ import { StyledNumberInput } from './partials/StyledNumberInput'
 import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
 import { StyledPrefix } from './partials/StyledPrefix'
 import { StyledSuffix } from './partials/StyledSuffix'
+import { useExternalId } from '../../hooks/useExternalId'
 
 interface NumberInputBaseProps
   extends ComponentWithClass,
@@ -148,7 +148,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   className,
   footnote,
   icon,
-  id = uuidv4(),
+  id: externalId,
   isDisabled = false,
   isInvalid,
   label,
@@ -165,6 +165,8 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   value = null,
   ...rest
 }) => {
+  const wrapperId = useExternalId('number-input')
+  const inputId = useExternalId('number-input-input', externalId)
   const isNegativeAllowed = isNil(min) || min < 0
   const { committedValue, setCommittedValue } = useValue(
     value ? String(value) : null
@@ -180,7 +182,6 @@ export const NumberInput: React.FC<NumberInputProps> = ({
     setCommittedValue
   )
 
-  const numberInputId = getId('number-input')
   const isCommittedValueInvalid =
     committedValue && !Number.isFinite(parseFloat(committedValue))
 
@@ -189,7 +190,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
       aria-label={label || 'Number input'}
       className={className}
       data-testid="number-input"
-      id={numberInputId}
+      id={wrapperId}
       role="spinbutton"
       aria-valuemin={min}
       aria-valuemax={max}
@@ -221,9 +222,9 @@ export const NumberInput: React.FC<NumberInputProps> = ({
         )}
 
         <Input
-          aria-labelledby={numberInputId}
+          aria-labelledby={wrapperId}
           hasFocus={hasFocus}
-          id={id}
+          id={inputId}
           isDisabled={isDisabled}
           label={label}
           name={name}

--- a/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.test.tsx
@@ -99,8 +99,18 @@ describe('Pagination', () => {
     })
 
     describe('and the `Next` button is clicked', () => {
+      let inputName: string | null
+
       beforeEach(() => {
+        inputName = wrapper.getByTestId('text-input-input').getAttribute('name')
         userEvent.click(wrapper.getByTestId('page-next'))
+      })
+
+      it('does not generate new a new input `name`', () => {
+        expect(wrapper.getByTestId('text-input-input')).toHaveAttribute(
+          'name',
+          inputName
+        )
       })
 
       it('should call the onChange callback', () => {

--- a/packages/react-component-library/src/components/Pagination/Pagination.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { getId, getKey } from '../../helpers'
+import { getKey } from '../../helpers'
 import { usePageChange } from './usePageChange'
 import { PAGINATION_BUTTON_VARIANT, PaginationButton } from './PaginationButton'
 import { PaginationErrorMessage } from './PaginationErrorMessage'
@@ -9,6 +9,7 @@ import { StyledListItem } from './partials/StyledListItem'
 import { StyledTextInput } from './partials/StyledTextInput'
 import { StyledTotalPages } from './partials/StyledTotalPages'
 import { OnChangeEventType } from './types'
+import { useExternalId } from '../../hooks/useExternalId'
 
 const KEY_PREFIX = 'pagination-item'
 
@@ -41,7 +42,7 @@ export interface PaginationProps {
 
 export const Pagination: React.FC<PaginationProps> = ({
   initialPage = 1,
-  name = getId('pagination'),
+  name: externalName,
   onChange,
   pageSize,
   total,
@@ -50,6 +51,7 @@ export const Pagination: React.FC<PaginationProps> = ({
   const totalPages = Math.ceil(total / pageSize)
   const { currentPage, hasError, onKeyDown, onPaginationButtonClickHandler } =
     usePageChange(initialPage, totalPages, onChange)
+  const name = useExternalId('pagination', externalName)
 
   const isOnFirstPage = currentPage === 1
   const isOnLastPage = currentPage === totalPages

--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -217,4 +217,32 @@ describe('Popover', () => {
       })
     })
   })
+
+  describe('when the popover content changes after being hovered', () => {
+    let initialContentId: string
+
+    beforeEach(() => {
+      wrapper = render(
+        <Popover content={<>initial content</>}>
+          <div>{HOVER_ON_ME}</div>
+        </Popover>
+      )
+
+      fireEvent.mouseEnter(wrapper.getByText(HOVER_ON_ME))
+      initialContentId = wrapper.getByTestId('floating-box-content').id
+
+      wrapper.rerender(
+        <Popover content={<>new content</>}>
+          <div>{HOVER_ON_ME}</div>
+        </Popover>
+      )
+    })
+
+    it('does not generate a new content `id`', () => {
+      expect(wrapper.getByTestId('floating-box-content')).toHaveAttribute(
+        'id',
+        initialContentId
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Popover/Popover.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.tsx
@@ -8,9 +8,9 @@ import {
   FloatingBoxProps,
   FloatingBoxSchemeType,
 } from '../../primitives/FloatingBox'
-import { getId } from '../../helpers'
 import { POPOVER_CLOSE_DELAY } from './constants'
 import { useHideShow } from '../../hooks/useHideShow'
+import { useExternalId } from '../../hooks/useExternalId'
 
 export interface PopoverProps
   extends Omit<
@@ -57,7 +57,7 @@ export const Popover: React.FC<PopoverProps> = ({
     closeDelay
   )
 
-  const contentId = getId('popover-content')
+  const contentId = useExternalId('popover-content')
 
   const PopoverTarget = () => {
     return React.Children.map(children, (item: React.ReactElement) =>

--- a/packages/react-component-library/src/components/Radio/Radio.test.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.test.tsx
@@ -221,4 +221,19 @@ describe('Radio', () => {
       )
     })
   })
+
+  describe('when the default `id` is used and input is toggled', () => {
+    let initialId: string
+
+    beforeEach(() => {
+      radio = render(<Radio label="label" name="name" />)
+      const input = radio.getByTestId('radio-input')
+      initialId = input.id
+      userEvent.click(radio.getByTestId('radio'))
+    })
+
+    it('does not generate a new `id`', () => {
+      expect(radio.getByTestId('radio-input')).toHaveAttribute('id', initialId)
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -186,6 +186,27 @@ describe('Select', () => {
     })
   })
 
+  describe('when the default `id` is used and the arrow button is clicked', () => {
+    let initialId: string
+
+    beforeEach(() => {
+      wrapper = render(
+        <Select label="Label" value="two">
+          <SelectOption value="one">One</SelectOption>
+        </Select>
+      )
+      initialId = wrapper.getByTestId('select-input').id
+      userEvent.click(wrapper.getByTestId('select-arrow-button'))
+    })
+
+    it('does not generate a new `id`', () => {
+      expect(wrapper.getByTestId('select-input')).toHaveAttribute(
+        'id',
+        initialId
+      )
+    })
+  })
+
   describe('when disabled', () => {
     beforeEach(() => {
       wrapper = render(

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useSelect } from 'downshift'
 
-import { getId } from '../../helpers'
 import {
   initialSelectedItem,
   itemToString,
@@ -9,14 +8,16 @@ import {
   SelectChildWithStringType,
   SelectLayout,
 } from '../SelectBase'
+import { useExternalId } from '../../hooks/useExternalId'
 
 export const Select: React.FC<SelectBaseProps> = ({
   children,
-  id = getId('select'),
+  id: externalId,
   onChange,
   value = null,
   ...rest
 }) => {
+  const id = useExternalId('select', externalId)
   const {
     getItemProps,
     getMenuProps,

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -3,10 +3,10 @@ import {
   IconKeyboardArrowLeft,
   IconKeyboardArrowRight,
 } from '@defencedigital/icon-library'
+import { v4 as uuidv4 } from 'uuid'
 
 import { ARROW_LEFT, ARROW_RIGHT } from '../../utils/keyCodes'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
-import { getId } from '../../helpers'
 import { SCROLL_DIRECTION } from './constants'
 import { StyledBody } from './partials/StyledBody'
 import { StyledHeader } from './partials/StyledHeader'
@@ -83,8 +83,8 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
     return activeIndex === -1 ? 0 : activeIndex
   }
 
-  const [tabIds] = useState(
-    Array.from({ length: children.length }).map(() => getId('tab-content'))
+  const [tabIds] = useState(() =>
+    [...Array(children.length)].map(() => `tab-content-${uuidv4()}`)
   )
   const [activeTab, setActiveTab] = useState(getActiveIndex(children))
   const { scrollToNextTab, tabsRef, itemsRef } = useScrollableTabSet(children)

--- a/packages/react-component-library/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.test.tsx
@@ -108,4 +108,22 @@ describe('TextArea', () => {
       })
     })
   })
+
+  describe('when the default `id` is used and text is typed in the input', () => {
+    let initialId: string
+
+    beforeEach(() => {
+      wrapper = render(<TextArea label="label" name="name" />)
+      const input = wrapper.getByTestId('textarea-input')
+      initialId = input.id
+      userEvent.type(input, 'some text')
+    })
+
+    it('does not generate a new `id`', () => {
+      expect(wrapper.getByTestId('textarea-input')).toHaveAttribute(
+        'id',
+        initialId
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/TextArea/TextArea.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.tsx
@@ -5,8 +5,8 @@ import { StyledTextArea } from './partials/StyledTextArea'
 import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
 import { StyledLabel } from './partials/StyledLabel'
 import { StyledInput } from './partials/StyledInput'
-import { getId } from '../../helpers'
 import { InputValidationProps } from '../../common/InputValidationProps'
+import { useExternalId } from '../../hooks/useExternalId'
 import { useFocus } from '../../hooks/useFocus'
 import { useInputValue } from '../../hooks/useInputValue'
 
@@ -38,7 +38,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
       className,
       isDisabled,
       isInvalid,
-      id = getId('text-area'),
+      id: externalId,
       label,
       onBlur,
       onChange,
@@ -47,6 +47,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     },
     ref
   ) => {
+    const id = useExternalId('text-area', externalId)
     const { hasFocus, onLocalBlur, onLocalFocus } = useFocus(onBlur)
     const { committedValue, hasValue, onValueChange } = useInputValue(value)
 

--- a/packages/react-component-library/src/components/TextInput/Input.tsx
+++ b/packages/react-component-library/src/components/TextInput/Input.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
-import { getId } from '../../helpers'
 import { StyledInput } from './partials/StyledInput'
 import { StyledLabel } from './partials/StyledLabel'
+import { useExternalId } from '../../hooks/useExternalId'
 import { useInputValue } from '../../hooks/useInputValue'
 
 export interface InputProps extends ComponentWithClass {
@@ -22,17 +22,10 @@ export interface InputProps extends ComponentWithClass {
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (
-    {
-      hasFocus,
-      id = getId('text-input'),
-      isDisabled,
-      label,
-      onChange,
-      value,
-      ...rest
-    },
+    { hasFocus, id: externalId, isDisabled, label, onChange, value, ...rest },
     ref
   ) => {
+    const id = useExternalId('text-input', externalId)
     const { committedValue, hasValue, onValueChange } = useInputValue(value)
 
     return (

--- a/packages/react-component-library/src/components/TextInput/TextInput.test.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.test.tsx
@@ -204,4 +204,22 @@ describe('TextInput', () => {
       )
     })
   })
+
+  describe('when the default `id` is used and text is typed in the input', () => {
+    let initialId: string
+
+    beforeEach(() => {
+      wrapper = render(<TextInput label="label" name="name" />)
+      const input = wrapper.getByTestId('text-input-input')
+      initialId = input.id
+      userEvent.type(input, 'some text')
+    })
+
+    it('does not generate a new `id`', () => {
+      expect(wrapper.getByTestId('text-input-input')).toHaveAttribute(
+        'id',
+        initialId
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Toast/Toast.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.tsx
@@ -13,7 +13,6 @@ import {
 } from '@defencedigital/icon-library'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
-import { getId } from '../../helpers'
 import { StyledToast } from './partials/StyledToast'
 import { StyledToastHeader } from './partials/StyledToastHeader'
 import { StyledToastTitle } from './partials/StyledToastTitle'
@@ -22,6 +21,7 @@ import { StyledToastTime } from './partials/StyledToastTime'
 import { StyledToastButton } from './partials/StyledToastButton'
 import { StyledToastContent } from './partials/StyledToastContent'
 import { StyledToastDescription } from './partials/StyledToastDescription'
+import { useExternalId } from '../../hooks/useExternalId'
 
 export interface ToastProps
   extends BaseToastProps,
@@ -85,8 +85,8 @@ export const Toast: React.FC<ToastProps> = ({
     })
   )
 
-  const titleId = label ? getId('toast-title') : undefined
-  const descriptionId = children ? getId('toast-description') : undefined
+  const titleId = useExternalId('toast-title')
+  const descriptionId = useExternalId('toast-description')
 
   return (
     <StyledToast
@@ -99,8 +99,8 @@ export const Toast: React.FC<ToastProps> = ({
         ...transitionStates(placement)[transitionState],
       }}
       role="alert"
-      aria-labelledby={titleId}
-      aria-describedby={descriptionId}
+      aria-labelledby={label ? titleId : undefined}
+      aria-describedby={children ? descriptionId : undefined}
       data-testid="toast-wrapper"
       {...rest}
     >

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.test.tsx
@@ -116,4 +116,30 @@ describe('Tooltip', () => {
       expect(wrapper.getByText('Content')).toBeInTheDocument()
     })
   })
+
+  describe('when the default `id` is used and the content changes', () => {
+    let initialTitleId: string
+    let initialContentId: string
+
+    beforeEach(() => {
+      wrapper = render(<Tooltip title="Title">Initial content</Tooltip>)
+      initialTitleId = wrapper.getByTestId('tooltip-title').id
+      initialContentId = wrapper.getByTestId('tooltip-content').id
+      wrapper.rerender(<Tooltip title="Title">New content</Tooltip>)
+    })
+
+    it('does not generate new title `id`', () => {
+      expect(wrapper.getByTestId('tooltip-title')).toHaveAttribute(
+        'id',
+        initialTitleId
+      )
+    })
+
+    it('does not generate new content `id`', () => {
+      expect(wrapper.getByTestId('tooltip-content')).toHaveAttribute(
+        'id',
+        initialContentId
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import { getId } from '../../helpers'
 import { PositionType } from '../../common/Position'
 import { TOOLTIP_POSITION } from '.'
 import { StyledTooltip } from './partials/StyledTooltip'
 import { StyledContent } from './partials/StyledContent'
 import { StyledTitle } from './partials/StyledTitle'
 import { StyledMessage } from './partials/StyledMessage'
+import { useExternalId } from '../../hooks/useExternalId'
 
 type TooltipPositionType =
   | typeof TOOLTIP_POSITION.ABOVE
@@ -48,8 +48,8 @@ export const Tooltip: React.FC<TooltipProps> = ({
   width,
   ...rest
 }) => {
-  const contentId = getId('tooltip-content')
-  const titleId = title ? getId('tooltip-title') : undefined
+  const contentId = useExternalId('tooltip-content')
+  const titleId = useExternalId('tooltip-title')
 
   return (
     <StyledTooltip
@@ -59,13 +59,17 @@ export const Tooltip: React.FC<TooltipProps> = ({
       $top={top}
       $width={width}
       aria-describedby={contentId}
-      aria-labelledby={titleId}
+      aria-labelledby={title ? titleId : undefined}
       data-testid="tooltip"
       role="tooltip"
       {...rest}
     >
       <StyledContent $position={position}>
-        {title && <StyledTitle id={titleId}>{title}</StyledTitle>}
+        {title && (
+          <StyledTitle data-testid="tooltip-title" id={titleId}>
+            {title}
+          </StyledTitle>
+        )}
         {children && (
           <StyledMessage data-testid="tooltip-content" id={contentId}>
             {children}

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
 
 import { Link } from '../../Link'
@@ -151,6 +152,34 @@ describe('Notification', () => {
 
     it('should not render the not-read indicator', () => {
       expect(wrapper.queryAllByTestId('not-read')).toHaveLength(0)
+    })
+  })
+
+  describe('when isRead changes', () => {
+    const ExampleNotification = ({ isRead }: { isRead?: boolean }) => (
+      <Notification
+        link={<Link href="notifications/1" />}
+        name="Thomas Stephens"
+        action="added a new comment to your"
+        on="review"
+        when={new Date('2019-11-05T10:57:00.000Z')}
+        description="description"
+        isRead={isRead}
+      />
+    )
+    let initialId: string
+
+    beforeEach(() => {
+      wrapper = render(<ExampleNotification />)
+      initialId = wrapper.getByTestId('notification-content').id
+      wrapper.rerender(<ExampleNotification isRead />)
+    })
+
+    it('does not generate a new content `id`', () => {
+      expect(wrapper.getByTestId('notification-content')).toHaveAttribute(
+        'id',
+        initialId
+      )
     })
   })
 })

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.tsx
@@ -4,7 +4,7 @@ import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 import format from 'date-fns/format'
 
 import { Avatar, AVATAR_VARIANT } from '../../Avatar'
-import { getInitials, getId } from '../../../helpers'
+import { getInitials } from '../../../helpers'
 import { LinkTypes } from '../../../common/Link'
 import { StyledNotification } from './partials/StyledNotification'
 import { StyledWrapper } from './partials/StyledWrapper'
@@ -14,6 +14,7 @@ import { StyledItemNotRead } from './partials/StyledItemNotRead'
 import { StyledContent } from './partials/StyledContent'
 import { StyledCircle } from './partials/StyledCircle'
 import { StyledDescription } from './partials/StyledDescription'
+import { useExternalId } from '../../../hooks/useExternalId'
 
 export interface NotificationProps {
   /**
@@ -71,7 +72,7 @@ export const Notification: React.FC<NotificationProps> = ({
   description,
   ...rest
 }) => {
-  const contentId = getId('content')
+  const contentId = useExternalId('content')
 
   return (
     <StyledNotification data-testid="notification" {...rest}>

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
@@ -6,8 +6,8 @@ import {
   FloatingBox,
 } from '../../../primitives/FloatingBox'
 import { ComponentWithClass } from '../../../common/ComponentWithClass'
-import { getId } from '../../../helpers'
 import { SheetButtonProps } from './SheetButton'
+import { useExternalId } from '../../../hooks/useExternalId'
 import { useHideShow } from '../../../hooks/useHideShow'
 
 export interface SheetProps extends ComponentWithClass {
@@ -23,8 +23,9 @@ export const Sheet: React.FC<SheetProps> = ({
   children,
   placement = FLOATING_BOX_PLACEMENT.RIGHT,
   closeDelay = 250,
-  id = getId('sheet'),
+  id: externalId,
 }) => {
+  const id = useExternalId('sheet', externalId)
   const { floatingBoxChildrenRef, isVisible, mouseEvents } = useHideShow(
     true,
     closeDelay

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -1,5 +1,4 @@
 import React from 'react'
-import { v4 as uuidv4 } from 'uuid'
 
 import logger from './utils/logger'
 
@@ -12,13 +11,6 @@ function getInitials(name: string): string {
 
 function getKey(prefix: string, suffix: string | number): string {
   return `${prefix}-${suffix}`.replace(/\s/g, '')
-}
-
-/**
- * @deprecated Use the useExternalId() hook instead as it's memoised.
- */
-function getId(prefix: string): string {
-  return getKey(prefix, uuidv4())
 }
 
 function hasClass(allClasses: string | undefined, className: string): boolean {
@@ -70,7 +62,6 @@ function sleep(ms: number): Promise<undefined> {
 
 export {
   getInitials,
-  getId,
   getKey,
   hasClass,
   isIE11,

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.test.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.test.tsx
@@ -107,4 +107,35 @@ describe('FloatingBox', () => {
       )
     })
   })
+
+  describe('when the content changes', () => {
+    const ExampleFloatingBox = ({
+      children: content,
+    }: {
+      children: string
+    }) => (
+      <FloatingBox
+        isVisible
+        renderTarget={<div>Hello, World!</div>}
+        role="dialog"
+        aria-modal
+      >
+        <>{content}</>
+      </FloatingBox>
+    )
+    let initialId: string
+
+    beforeEach(() => {
+      wrapper = render(<ExampleFloatingBox>Initial content</ExampleFloatingBox>)
+      initialId = wrapper.getByTestId('floating-box-content').id
+      wrapper.rerender(<ExampleFloatingBox>Updated content</ExampleFloatingBox>)
+    })
+
+    it('does not generate a new content `id`', () => {
+      expect(wrapper.getByTestId('floating-box-content')).toHaveAttribute(
+        'id',
+        initialId
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -5,13 +5,13 @@ import { Transition } from 'react-transition-group'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { FloatingBoxContent } from './FloatingBoxContent'
 import { FloatingBoxSchemeType } from './types'
-import { getId } from '../../helpers'
 import { PositionType } from '../../common/Position'
 import { StyledFloatingBox } from './partials/StyledFloatingBox'
 import { StyledTarget } from './partials/StyledTarget'
 import { StyledArrow } from './partials/StyledArrow'
 import { useFloatingElement } from '../../hooks/useFloatingElement'
 import { FLOATING_BOX_SCHEME } from './constants'
+import { useExternalId } from '../../hooks/useExternalId'
 
 export interface FloatingBoxBaseProps extends PositionType, ComponentWithClass {
   role?: string
@@ -55,7 +55,7 @@ const TRANSITION_STYLES = {
 }
 
 export const FloatingBox: React.FC<FloatingBoxProps> = ({
-  contentId = getId('floating-box'),
+  contentId: externalContentId,
   scheme = FLOATING_BOX_SCHEME.LIGHT,
   onMouseEnter,
   onMouseLeave,
@@ -66,6 +66,7 @@ export const FloatingBox: React.FC<FloatingBoxProps> = ({
   placement = 'auto',
   ...rest
 }) => {
+  const contentId = useExternalId('floating-box', externalContentId)
   const {
     targetElementRef,
     floatingElementRef,


### PR DESCRIPTION
## Related issue

Resolves #3081

## Overview

This ensures all `id` attributes (and hence related ARIA attributes) are stable between renders of a component

## Link to preview

https://5e25c277526d380020b5e418-kaqafeyiho.chromatic.com/

## Reason

It's undesirable to have the element ID and ARIA IDs changing unnecessarily.

## Work carried out

- [x] Replace uses of `getId()` and `uuid.v4()` for `id` attributes with `useExternalId()`
- [x] Add additional tests
- [x] Remove `getId()`

## Developer notes

n/a
