### PR TITLE
fix(ComponentSizeType): Correct type definition

### DIFF
--- a/packages/react-component-library/src/components/Forms/constants.ts
+++ b/packages/react-component-library/src/components/Forms/constants.ts
@@ -1,7 +1,7 @@
 export const COMPONENT_SIZE = {
   FORMS: 'forms',
   SMALL: 'small',
-}
+} as const
 
 export type ComponentSizeType =
   | typeof COMPONENT_SIZE.SMALL


### PR DESCRIPTION
## Related issue

Resolves #3146
Resolves #3147

## Overview

This corrects the definition of ComponentSizeType (previously it was inadvertently a string).

This also fixes the size control for the relevant stories in Storybook.

## Link to preview

https://5e25c277526d380020b5e418-lojxgzxzgu.chromatic.com/

## Reason

Make sure the types are correct, and the story controls work.

## Work carried out

- [x] Correct types

## Screenshot

### Before

![image](https://user-images.githubusercontent.com/66470099/157283989-b5d6db49-5d50-470d-9a4e-222112fbf21b.png)

### After

![image](https://user-images.githubusercontent.com/66470099/157283936-1f9a4ba9-085c-4abf-9c05-19c095d7cff6.png)

