### PR TITLE
docs(Storybook): Add <iframe> resizer library

### DIFF
--- a/packages/react-component-library/.storybook/preview.js
+++ b/packages/react-component-library/.storybook/preview.js
@@ -1,4 +1,5 @@
 import '@defencedigital/fonts'
+import 'iframe-resizer/js/iframeResizer.contentWindow'
 import { ResizeObserver } from '@juggle/resize-observer'
 
 import { GlobalStyleProvider } from '../src/styled-components/GlobalStyle'

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -121,6 +121,7 @@
     "hex-rgb": "^5.0.0",
     "html-webpack-plugin": "^5.2.0",
     "identity-obj-proxy": "^3.0.0",
+    "iframe-resizer": "^4.3.2",
     "image-webpack-loader": "^8.0.1",
     "jest": "^27.3.1",
     "jest-canvas-mock": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9953,6 +9953,11 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
+iframe-resizer@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/iframe-resizer/-/iframe-resizer-4.3.2.tgz#42dd88345d18b9e377b6044dddb98c664ab0ce6b"
+  integrity sha512-gOWo2hmdPjMQsQ+zTKbses08mDfDEMh4NneGQNP4qwePYujY1lguqP6gnbeJkf154gojWlBhIltlgnMfYjGHWA==
+
 ignore-walk@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.4.tgz#c9a09f69b7c7b479a5d74ac1a3c0d4236d2a6335"


### PR DESCRIPTION
## Related issue

Resolves #3152

## Overview

This loads a library required by `iframe-resizer-react` in the Storybook preview iframe to allow a hosting window to automatically size the iframe according to its contents.

## Link to preview

https://5e25c277526d380020b5e418-dawdbiirrh.chromatic.com/

## Reason

To allow stories to automatically sized when embedded in the docs site.

## Work carried out

- [x] Add and import library

## Developer notes

The library should have no effect when `iframe-resizer-react` isn't used in the parent window.

More information is available here:

https://github.com/davidjbradshaw/iframe-resizer
https://github.com/davidjbradshaw/iframe-resizer-react
