### PR TITLE
feat(Select): Add ability to hide clear button

### DIFF
--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -31,7 +31,7 @@ const Template: ComponentStory<typeof Autocomplete> = (args) => (
   </div>
 )
 
-const TemplateWIthIconsAndBadges: ComponentStory<typeof Autocomplete> = (
+const TemplateWithIconsAndBadges: ComponentStory<typeof Autocomplete> = (
   args
 ) => (
   <div style={{ height: args.isDisabled ? 'initial' : '18rem' }}>
@@ -63,6 +63,12 @@ Disabled.args = {
   isDisabled: true,
 }
 
+export const NoClearButton = Template.bind({})
+NoClearButton.args = {
+  hideClearButton: true,
+  value: 'two',
+}
+
 export const WithError = Template.bind({})
 WithError.args = {
   isInvalid: true,
@@ -73,4 +79,4 @@ WithValue.args = {
   value: 'two',
 }
 
-export const WithIconsAndBadges = TemplateWIthIconsAndBadges.bind({})
+export const WithIconsAndBadges = TemplateWithIconsAndBadges.bind({})

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
@@ -197,6 +197,28 @@ describe('Autocomplete', () => {
     it('sets the value', () => {
       expect(wrapper.getByTestId('select-input')).toHaveValue('Two')
     })
+
+    it('shows a clear button', () => {
+      expect(wrapper.getByTestId('select-clear-button')).toBeInTheDocument()
+    })
+  })
+
+  describe('when `value` and hideClearButton are set', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Autocomplete label="Label" value="two" hideClearButton>
+          <AutocompleteOption value="one">One</AutocompleteOption>
+          <AutocompleteOption value="two">Two</AutocompleteOption>
+          <AutocompleteOption value="three">Three</AutocompleteOption>
+        </Autocomplete>
+      )
+    })
+
+    it('does not show a clear button', () => {
+      expect(
+        wrapper.queryByTestId('select-clear-button')
+      ).not.toBeInTheDocument()
+    })
   })
 
   describe.each(['invalid', null])('when `value` is set to `%s`', (value) => {

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -14,8 +14,13 @@ import { useAutocomplete } from './hooks/useAutocomplete'
 import { useMenuVisibility } from './hooks/useMenuVisibility'
 import { useExternalId } from '../../hooks/useExternalId'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface AutocompleteProps extends SelectBaseProps {}
+export interface AutocompleteProps extends SelectBaseProps {
+  /**
+   * Whether to hide the clear button. (Note that the component can still
+   * be cleared by manually deleting the text in the input.)
+   */
+  hideClearButton?: boolean
+}
 
 export const Autocomplete: React.FC<AutocompleteProps> = ({
   children,

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -46,7 +46,7 @@ const Template: ComponentStory<typeof Select> = (args) => (
   </div>
 )
 
-const TemplateWIthIconsAndBadges: ComponentStory<typeof Select> = (args) => (
+const TemplateWithIconsAndBadges: ComponentStory<typeof Select> = (args) => (
   <div
     style={{ height: args.isDisabled ? 'initial' : '18rem', maxWidth: '20rem' }}
   >
@@ -74,6 +74,12 @@ Disabled.args = {
   isDisabled: true,
 }
 
+export const NoClearButton = Template.bind({})
+NoClearButton.args = {
+  hideClearButton: true,
+  value: 'two',
+}
+
 export const WithError = Template.bind({})
 WithError.args = {
   isInvalid: true,
@@ -84,4 +90,4 @@ WithValue.args = {
   value: 'two',
 }
 
-export const WithIconsAndBadges = TemplateWIthIconsAndBadges.bind({})
+export const WithIconsAndBadges = TemplateWithIconsAndBadges.bind({})

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -297,6 +297,28 @@ describe('Select', () => {
     it('sets the value', () => {
       expect(wrapper.getByTestId('select-input')).toHaveValue('Two')
     })
+
+    it('shows a clear button', () => {
+      expect(wrapper.getByTestId('select-clear-button')).toBeInTheDocument()
+    })
+  })
+
+  describe('when `value` and hideClearButton are set', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Select label="Label" value="two" hideClearButton>
+          <SelectOption value="one">One</SelectOption>
+          <SelectOption value="two">Two</SelectOption>
+          <SelectOption value="three">Three</SelectOption>
+        </Select>
+      )
+    })
+
+    it('does not show a clear button', () => {
+      expect(
+        wrapper.queryByTestId('select-clear-button')
+      ).not.toBeInTheDocument()
+    })
   })
 
   describe.each(['invalid', null])('when `value` is set to `%s`', (value) => {

--- a/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
+++ b/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
@@ -20,6 +20,10 @@ export interface SelectBaseProps extends ComponentWithClass {
    */
   isInvalid?: boolean
   /**
+   * Whether to hide the clear button.
+   */
+  hideClearButton?: boolean
+  /**
    * Text label to display within the component.
    */
   label: string

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -32,6 +32,7 @@ export interface SelectLayoutProps extends ComponentWithClass {
   isDisabled?: boolean
   isInvalid?: boolean
   isOpen: boolean
+  hideClearButton?: boolean
   label: string
   menuProps:
     | ReturnType<ComboboxReturnValueType['getMenuProps']>
@@ -58,6 +59,7 @@ export const SelectLayout: React.FC<SelectLayoutProps> = ({
   isDisabled = false,
   isInvalid,
   isOpen,
+  hideClearButton,
   label,
   menuProps,
   onClearButtonClick,
@@ -113,7 +115,7 @@ export const SelectLayout: React.FC<SelectLayoutProps> = ({
               />
             </StyledInputWrapper>
             <StyledInlineButtons>
-              {hasSelectedItem && (
+              {hasSelectedItem && !hideClearButton && (
                 <ClearButton
                   isDisabled={isDisabled}
                   onClick={onClearButtonClick}


### PR DESCRIPTION
## Related issue

Resolves #3151

## Overview

This adds a new prop `hideClearButton` to `Select` and `Autocomplete`. If set, this the clear button is hidden.

## Link to preview

https://red-playground.netlify.app/?path=/docs/autocomplete--no-clear-button

## Reason

Required by a downstream app to replicate functionality that was in v2.

## Work carried out

- [x] Add `hideClearButton` prop to `Select` and `Autocomplete`

## Screenshot

![image](https://user-images.githubusercontent.com/66470099/158218425-3ff16568-7a41-4da4-a265-180d85449430.png)

## Developer notes

~~The existing default of being clearable is kept, and hence the prop is named `isUnclearable` (to avoid having to do `isClearable={false}`).~~

~~Open to any other suggestions for what to name the prop etc.~~
