### PR TITLE
fix(Storybook): Disable object props

### DIFF
--- a/packages/react-component-library/src/components/Button/Button.stories.tsx
+++ b/packages/react-component-library/src/components/Button/Button.stories.tsx
@@ -7,6 +7,11 @@ import { BUTTON_VARIANT, BUTTON_ICON_POSITION } from './constants'
 import { COMPONENT_SIZE } from '../Forms'
 
 export default {
+  argTypes: {
+    icon: {
+      control: false,
+    },
+  },
   component: Button,
   title: 'Button',
   parameters: { actions: { argTypesRegex: '^on.*' } },

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
@@ -5,6 +5,11 @@ import { Checkbox, CheckboxProps } from '.'
 import { CHECKBOX_RADIO_VARIANT } from '../CheckboxRadioBase'
 
 export default {
+  argTypes: {
+    description: {
+      control: false,
+    },
+  },
   component: Checkbox,
   title: 'Checkbox',
   parameters: {

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
@@ -6,6 +6,11 @@ import { IconLayers, IconAnchor } from '@defencedigital/icon-library'
 import { Dropdown } from './Dropdown'
 
 export default {
+  argTypes: {
+    labelIcon: {
+      control: false,
+    },
+  },
   component: Dropdown,
   title: 'Dropdown',
   parameters: {

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -6,6 +6,11 @@ import { COMPONENT_SIZE } from '../Forms'
 import { NumberInput } from './NumberInput'
 
 export default {
+  argTypes: {
+    icon: {
+      control: false,
+    },
+  },
   component: NumberInput,
   title: 'Number Input',
   parameters: {

--- a/packages/react-component-library/src/components/Radio/Radio.stories.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.stories.tsx
@@ -5,6 +5,11 @@ import { Radio, RadioProps } from '.'
 import { CHECKBOX_RADIO_VARIANT } from '../CheckboxRadioBase'
 
 export default {
+  argTypes: {
+    description: {
+      control: false,
+    },
+  },
   component: Radio,
   title: 'Radio',
   parameters: {

--- a/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
@@ -5,10 +5,20 @@ import { IconSearch } from '@defencedigital/icon-library'
 import { TextInput } from '.'
 
 export default {
+  argTypes: {
+    endAdornment: {
+      control: false,
+    },
+    startAdornment: {
+      control: false,
+    },
+  },
   component: TextInput,
   title: 'Text Input',
   parameters: {
-    argTypes: { onBlur: { action: 'onBlur' } },
+    argTypes: {
+      onBlur: { action: 'onBlur' },
+    },
   },
 } as ComponentMeta<typeof TextInput>
 


### PR DESCRIPTION
## Related issue
Closes #3149 

## Overview
Disables setting of `object` properties which cannot be set.

## Reason
The properties cannot be set and give a bad experience.

## Work carried out
- [x] Disable props