### PR TITLE
refactor(Types): Simplify union types

### DIFF
--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -16,6 +16,7 @@ import { StyledDescription } from './partials/StyledDescription'
 import { StyledFooter } from './partials/StyledFooter'
 import { StyledCloseButton } from './partials/StyledCloseButton'
 import { useExternalId } from '../../hooks/useExternalId'
+import { ValueOf } from '../../helpers'
 
 const VARIANT_ICON_MAP = {
   [ALERT_VARIANT.DANGER]: (
@@ -30,11 +31,7 @@ const VARIANT_ICON_MAP = {
   ),
 }
 
-export type AlertVariantType =
-  | typeof ALERT_VARIANT.DANGER
-  | typeof ALERT_VARIANT.INFO
-  | typeof ALERT_VARIANT.SUCCESS
-  | typeof ALERT_VARIANT.WARNING
+export type AlertVariantType = ValueOf<typeof ALERT_VARIANT>
 
 export interface AlertProps {
   /**

--- a/packages/react-component-library/src/components/Avatar/Avatar.tsx
+++ b/packages/react-component-library/src/components/Avatar/Avatar.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { AVATAR_VARIANT } from '.'
 import { StyledAvatar } from './partials/StyledAvatar'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { ValueOf } from '../../helpers'
 
 export interface AvatarProps extends ComponentWithClass {
   /**
@@ -12,7 +13,7 @@ export interface AvatarProps extends ComponentWithClass {
   /**
    * Type of component to display (style varies accordingly).
    */
-  variant?: typeof AVATAR_VARIANT.DARK | typeof AVATAR_VARIANT.LIGHT
+  variant?: ValueOf<typeof AVATAR_VARIANT>
 }
 
 export const Avatar: React.FC<AvatarProps> = ({ variant, ...rest }) => (

--- a/packages/react-component-library/src/components/Badge/types.ts
+++ b/packages/react-component-library/src/components/Badge/types.ts
@@ -4,31 +4,12 @@ import {
   BADGE_SIZE,
   BADGE_VARIANT,
 } from './constants'
+import { ValueOf } from '../../helpers'
 
-export type BadgeColorType =
-  | typeof BADGE_COLOR.ACTION
-  | typeof BADGE_COLOR.DANGER
-  | typeof BADGE_COLOR.NEUTRAL
-  | typeof BADGE_COLOR.SUCCESS
-  | typeof BADGE_COLOR.WARNING
-  | typeof BADGE_COLOR.SUPA
-  | typeof BADGE_COLOR.SUPB
-  | typeof BADGE_COLOR.SUPC
-  | typeof BADGE_COLOR.SUPD
-  | typeof BADGE_COLOR.SUPE
-  | typeof BADGE_COLOR.SUPF
+export type BadgeColorType = ValueOf<typeof BADGE_COLOR>
 
-export type BadgeSizeType =
-  | typeof BADGE_SIZE.XSMALL
-  | typeof BADGE_SIZE.SMALL
-  | typeof BADGE_SIZE.REGULAR
-  | typeof BADGE_SIZE.LARGE
-  | typeof BADGE_SIZE.XLARGE
+export type BadgeSizeType = ValueOf<typeof BADGE_SIZE>
 
-export type BadgeColorVariantType =
-  | typeof BADGE_COLOR_VARIANT.FADED
-  | typeof BADGE_COLOR_VARIANT.SOLID
+export type BadgeColorVariantType = ValueOf<typeof BADGE_COLOR_VARIANT>
 
-export type BadgeVariantType =
-  | typeof BADGE_VARIANT.PILL
-  | typeof BADGE_VARIANT.REGULAR
+export type BadgeVariantType = ValueOf<typeof BADGE_VARIANT>

--- a/packages/react-component-library/src/components/Button/Button.tsx
+++ b/packages/react-component-library/src/components/Button/Button.tsx
@@ -8,16 +8,11 @@ import { StyledIconWrapper } from './partials/StyledIconWrapper'
 import { StyledText } from './partials/StyledText'
 import { StyledIconLoaderWrapper } from './partials/StyledIconLoader'
 import { ComponentSizeType, COMPONENT_SIZE } from '../Forms'
+import { ValueOf } from '../../helpers'
 
-export type ButtonVariantType =
-  | typeof BUTTON_VARIANT.PRIMARY
-  | typeof BUTTON_VARIANT.SECONDARY
-  | typeof BUTTON_VARIANT.TERTIARY
-  | typeof BUTTON_VARIANT.DANGER
+export type ButtonVariantType = ValueOf<typeof BUTTON_VARIANT>
 
-export type ButtonIconPositionType =
-  | typeof BUTTON_ICON_POSITION.LEFT
-  | typeof BUTTON_ICON_POSITION.RIGHT
+export type ButtonIconPositionType = ValueOf<typeof BUTTON_ICON_POSITION>
 
 interface ButtonBaseProps extends Omit<ComponentWithClass, 'children'> {
   /**

--- a/packages/react-component-library/src/components/CheckboxRadioBase/types.ts
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/types.ts
@@ -1,7 +1,8 @@
+import { ValueOf } from '../../helpers'
+
 export const CHECKBOX_RADIO_VARIANT = {
   DEFAULT: 'default',
   NO_CONTAINER: 'no-container',
 } as const
 
-export type CheckboxRadioVariantType =
-  typeof CHECKBOX_RADIO_VARIANT[keyof typeof CHECKBOX_RADIO_VARIANT]
+export type CheckboxRadioVariantType = ValueOf<typeof CHECKBOX_RADIO_VARIANT>

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -9,7 +9,7 @@ import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { DATE_FORMAT } from '../../constants'
 import { DATE_VALIDITY, WEEKDAY_TITLES } from './constants'
 import { DATEPICKER_E_ACTION } from './types'
-import { hasClass } from '../../helpers'
+import { hasClass, ValueOf } from '../../helpers'
 import { InlineButton } from '../InlineButtons/InlineButton'
 import { InputValidationProps } from '../../common/InputValidationProps'
 import { isDateValid } from './utils'
@@ -42,10 +42,7 @@ declare module 'react-day-picker' {
   }
 }
 
-export type DatePickerDateValidityType =
-  | typeof DATE_VALIDITY.VALID
-  | typeof DATE_VALIDITY.INVALID
-  | typeof DATE_VALIDITY.DISABLED
+export type DatePickerDateValidityType = ValueOf<typeof DATE_VALIDITY>
 
 export interface DatePickerOnChangeData {
   startDate: Date | null

--- a/packages/react-component-library/src/components/Forms/constants.ts
+++ b/packages/react-component-library/src/components/Forms/constants.ts
@@ -1,8 +1,8 @@
+import { ValueOf } from '../../helpers'
+
 export const COMPONENT_SIZE = {
   FORMS: 'forms',
   SMALL: 'small',
 } as const
 
-export type ComponentSizeType =
-  | typeof COMPONENT_SIZE.SMALL
-  | typeof COMPONENT_SIZE.FORMS
+export type ComponentSizeType = ValueOf<typeof COMPONENT_SIZE>

--- a/packages/react-component-library/src/components/Pagination/PaginationButton.tsx
+++ b/packages/react-component-library/src/components/Pagination/PaginationButton.tsx
@@ -7,6 +7,7 @@ import {
 } from '@defencedigital/icon-library'
 
 import { StyledButton } from './partials/StyledButton'
+import { ValueOf } from '../../helpers'
 
 export const PAGINATION_BUTTON_VARIANT = {
   FIRST: 'First',
@@ -15,11 +16,7 @@ export const PAGINATION_BUTTON_VARIANT = {
   NEXT: 'Next',
 } as const
 
-type PaginationButtonChildrenType =
-  | typeof PAGINATION_BUTTON_VARIANT.FIRST
-  | typeof PAGINATION_BUTTON_VARIANT.LAST
-  | typeof PAGINATION_BUTTON_VARIANT.PREV
-  | typeof PAGINATION_BUTTON_VARIANT.NEXT
+type PaginationButtonChildrenType = ValueOf<typeof PAGINATION_BUTTON_VARIANT>
 
 interface PaginationButtonProps {
   children: PaginationButtonChildrenType

--- a/packages/react-component-library/src/components/Table/TableColumn.tsx
+++ b/packages/react-component-library/src/components/Table/TableColumn.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import get from 'lodash/get'
 import {
   IconSortAscending,
   IconSortDescending,
@@ -8,10 +7,9 @@ import {
 
 import { TABLE_SORT_ORDER } from './constants'
 import { StyledTableColumn } from './partials/StyledTableColumn'
+import { ValueOf } from '../../helpers'
 
-type SortOrderType =
-  | typeof TABLE_SORT_ORDER.ASCENDING
-  | typeof TABLE_SORT_ORDER.DESCENDING
+export type SortOrderType = ValueOf<typeof TABLE_SORT_ORDER>
 
 type AriaSortType = 'ascending' | 'descending' | 'none'
 

--- a/packages/react-component-library/src/components/Table/useTableData.ts
+++ b/packages/react-component-library/src/components/Table/useTableData.ts
@@ -1,14 +1,10 @@
 import { useEffect, useState } from 'react'
 import orderBy from 'lodash/orderBy'
 
-import { RowProps, TABLE_SORT_ORDER } from '.'
-
-type sortType =
-  | typeof TABLE_SORT_ORDER.ASCENDING
-  | typeof TABLE_SORT_ORDER.DESCENDING
+import { RowProps, SortOrderType, TABLE_SORT_ORDER } from '.'
 
 function getNextSortOrder(
-  currentSortOrder: sortType | null,
+  currentSortOrder: SortOrderType | null,
   hasSortFieldChanged: boolean
 ) {
   if (!currentSortOrder || hasSortFieldChanged) {
@@ -24,7 +20,7 @@ function getNextSortOrder(
 
 export function useTableData(data: RowProps[]) {
   const [tableData, setTableData] = useState(data)
-  const [sortOrder, setSortOrder] = useState<sortType | null>(null)
+  const [sortOrder, setSortOrder] = useState<SortOrderType | null>(null)
   const [sortField, setSortField] = useState<string | null>(null)
 
   function sortTableData(field: string) {

--- a/packages/react-component-library/src/components/Timeline/TimelineHours.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineHours.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 
-import { getKey } from '../../helpers'
+import { getKey, ValueOf } from '../../helpers'
 import { StyledHours } from './partials/StyledHours'
 import { DISPLAY_THRESHOLDS, TIMELINE_BLOCK_SIZE } from './constants'
 import { TimelineContext } from './context'
@@ -8,10 +8,7 @@ import { TimelineColumnHeader } from './TimelineColumnHeader'
 import { TimelineHour } from './TimelineHour'
 import { TimelineHeaderRow } from './TimelineHeaderRow'
 
-export type BlockSizeType =
-  | typeof TIMELINE_BLOCK_SIZE.SINGLE_HOUR
-  | typeof TIMELINE_BLOCK_SIZE.QUARTER_DAY
-  | typeof TIMELINE_BLOCK_SIZE.HALF_DAY
+export type BlockSizeType = ValueOf<typeof TIMELINE_BLOCK_SIZE>
 
 export interface TimelineHoursWithRenderContentProps {
   /**

--- a/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineMonth.tsx
@@ -9,6 +9,7 @@ import { StyledMonthTitle } from './partials/StyledMonthTitle'
 import { StyledMonthTitleMedium } from './partials/StyledMonthTitleMedium'
 import { StyledMonthTitleSmall } from './partials/StyledMonthTitleSmall'
 import { TimelineDay } from './context/types'
+import { ValueOf } from '../../helpers'
 
 const DECEMBER_INDEX = 11
 
@@ -18,10 +19,7 @@ export const MONTH_SIZE = {
   LARGE: 'large',
 } as const
 
-export type TimelineMonthSizeType =
-  | typeof MONTH_SIZE.SMALL
-  | typeof MONTH_SIZE.MEDIUM
-  | typeof MONTH_SIZE.LARGE
+export type TimelineMonthSizeType = ValueOf<typeof MONTH_SIZE>
 
 interface TimelineMonthProps {
   days: TimelineDay[]

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.tsx
@@ -7,12 +7,9 @@ import { StyledContent } from './partials/StyledContent'
 import { StyledTitle } from './partials/StyledTitle'
 import { StyledMessage } from './partials/StyledMessage'
 import { useExternalId } from '../../hooks/useExternalId'
+import { ValueOf } from '../../helpers'
 
-type TooltipPositionType =
-  | typeof TOOLTIP_POSITION.ABOVE
-  | typeof TOOLTIP_POSITION.BELOW
-  | typeof TOOLTIP_POSITION.LEFT
-  | typeof TOOLTIP_POSITION.RIGHT
+type TooltipPositionType = ValueOf<typeof TOOLTIP_POSITION>
 
 export interface TooltipProps extends PositionType {
   /**

--- a/packages/react-component-library/src/helpers.ts
+++ b/packages/react-component-library/src/helpers.ts
@@ -60,6 +60,8 @@ function sleep(ms: number): Promise<undefined> {
   })
 }
 
+export type ValueOf<T> = T[keyof T]
+
 export {
   getInitials,
   getKey,


### PR DESCRIPTION
## Related issue
Closes #3099 

## Overview
Adds a helper to simplify union types.

## Reason
Reduces code repetition.

## Work carried out
- [x] Utilise helper