### PR TITLE
fix(NumberInputE): Deprecate `min` and `max`

### DIFF
--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -45,6 +45,10 @@ interface NumberInputBaseProps
   label?: string
   /**
    * Maximum value selectable by the component (upper bound).
+   *
+   * Deprecated: Use app-side validation (ideally triggered `onBlur`).
+   *
+   * @deprecated
    */
   max?: number
   /**
@@ -52,6 +56,10 @@ interface NumberInputBaseProps
    *
    * To disable the entry of negative numbers, set this to `0` or
    * greater.
+   *
+   * Deprecated: Use app-side validation (ideally triggered `onBlur`).
+   *
+   * @deprecated
    */
   min?: number
   /**


### PR DESCRIPTION
## Related issue

Closes #3031

## Overview

App-side validation should be used (ideally triggered `onBlur`) instead of this feature.

## Reason

>After some discussion we have come to the conclusion that responsibility for validating min and max input should be devolved to the consuming application (as with all other validation).

## Work carried out

- [x] Mark as deprecated

## Developer notes

A seperate ticket (https://github.com/defencedigital/mod-uk-design-system/issues/3188) has been created to look into potentially providing a validation library that allows consumers to apply common and consistent validation rules across applications.
