### PR TITLE
fix(SelectBase): Resolve inconsistent popover in Chrome

### DIFF
--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -5,7 +5,6 @@ import mergeRefs from 'react-merge-refs'
 import { ArrowButton } from '../Select/ArrowButton'
 import { ClearButton } from '../Select/ClearButton'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
-import { FloatingBox } from '../../primitives/FloatingBox'
 import { SelectChildWithStringType } from './types'
 import { StyledInlineButtons } from './partials/StyledInlineButtons'
 import { StyledInput } from './partials/StyledInput'
@@ -19,6 +18,7 @@ import { StyledTextInput } from './partials/StyledTextInput'
 import { StyledTooltip } from './partials/StyledTooltip'
 import { useExternalId } from '../../hooks/useExternalId'
 import { useStatefulRef } from '../../hooks/useStatefulRef'
+import { StyledFloatingBox } from './partials/StyledFloatingBox'
 
 type ComboboxReturnValueType = UseComboboxReturnValue<SelectChildWithStringType>
 type SelectReturnValueType = UseSelectReturnValue<SelectChildWithStringType>
@@ -134,14 +134,14 @@ export const SelectLayout: React.FC<SelectLayoutProps> = ({
           <StyledOptions {...menuProps}>{children}</StyledOptions>
         </StyledOptionsWrapper>
       </StyledSelect>
-      <FloatingBox
+      <StyledFloatingBox
         placement="bottom"
         scheme="dark"
         isVisible={hasHover && isEllipsisActive(floatingBoxTarget)}
         targetElement={floatingBoxTarget}
       >
         <StyledTooltip>{value}</StyledTooltip>
-      </FloatingBox>
+      </StyledFloatingBox>
     </>
   )
 }

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledFloatingBox.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledFloatingBox.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+
+import { FloatingBox } from '../../../primitives/FloatingBox'
+
+export const StyledFloatingBox = styled(FloatingBox)`
+  pointer-events: none;
+`


### PR DESCRIPTION
## Related issue

Closes #3169

## Overview

Resolve `SelectBase` inconsistent popover behaviour.

## Reason

>In Chrome when slowly hovering over the truncated selected option the Popover does not display.

## Work carried out

- [x] Extend `FloatingBox` styles

## Screenshot

Before

![2022-03-25 10 21 16](https://user-images.githubusercontent.com/48086589/160110994-563c240d-e332-4ed4-a6b8-fa56ba325c52.gif)

After

![2022-03-25 11 15 02](https://user-images.githubusercontent.com/48086589/160111241-eba9b2dd-e537-4116-94ab-5271a481841d.gif)

