### PR TITLE
feat(DescriptionList): Add ability to programmatically set `isOpen`

### DIFF
--- a/packages/react-component-library/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/packages/react-component-library/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -62,3 +62,18 @@ export const Collapsible: ComponentStory<typeof DescriptionList> = () => (
 Collapsible.parameters = disableDefinitionList
 
 Collapsible.storyName = 'Collapsible'
+
+export const CollapsibleOpen: ComponentStory<typeof DescriptionList> = () => (
+  <DescriptionList description="Example description" isCollapsible isOpen>
+    <DescriptionListItem title="Name">Horatio Nelson</DescriptionListItem>
+    <DescriptionListItem title="Age">44</DescriptionListItem>
+    <DescriptionListItem title="Location">Portsmouth</DescriptionListItem>
+    <DescriptionListItem title="Departure">2230</DescriptionListItem>
+    <DescriptionListItem title="Water Temperature">25C</DescriptionListItem>
+    <DescriptionListItem title="Wind Speed">8Kts</DescriptionListItem>
+  </DescriptionList>
+)
+
+CollapsibleOpen.parameters = disableDefinitionList
+
+CollapsibleOpen.storyName = 'Collapsible (Open)'

--- a/packages/react-component-library/src/components/DescriptionList/DescriptionList.test.tsx
+++ b/packages/react-component-library/src/components/DescriptionList/DescriptionList.test.tsx
@@ -150,4 +150,40 @@ describe('DescriptionList', () => {
       })
     })
   })
+
+  describe('when collapsible and `isOpen` prop is set', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <DescriptionList description="title" isCollapsible isOpen>
+          <DescriptionListItem title="One">1</DescriptionListItem>
+          <DescriptionListItem title="Two">2</DescriptionListItem>
+          <DescriptionListItem title="Three">3</DescriptionListItem>
+        </DescriptionList>
+      )
+    })
+
+    it('should set `aria-expanded` on the button to `true`', () => {
+      expect(wrapper.getByTestId('description-list-header')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      )
+    })
+
+    it('should set `aria-label` on the button to `Hide data`', () => {
+      expect(wrapper.getByTestId('description-list-header')).toHaveAttribute(
+        'aria-label',
+        'Hide data'
+      )
+    })
+
+    it('should show the items', () => {
+      expect(wrapper.getAllByTestId('description-list-item')[0]).toBeVisible()
+    })
+
+    describe('when the header is clicked', () => {
+      it('should hide the items', () => {
+        expect(wrapper.getAllByTestId('description-list-item')[0]).toBeVisible()
+      })
+    })
+  })
 })

--- a/packages/react-component-library/src/components/DescriptionList/DescriptionList.tsx
+++ b/packages/react-component-library/src/components/DescriptionList/DescriptionList.tsx
@@ -25,6 +25,10 @@ export interface DescriptionListProps extends ComponentWithClass {
    */
   isCollapsible?: boolean
   /**
+   * Denotes whether the collapsible variant is open.
+   */
+  isOpen?: boolean
+  /**
    * Text description to display at the top of the component.
    */
   description: string
@@ -46,11 +50,12 @@ function useAriaAttributes(isCollapsible: boolean, expanded: boolean) {
 
 export const DescriptionList: React.FC<DescriptionListProps> = ({
   isCollapsible = false,
+  isOpen = false,
   description,
   children,
   ...rest
 }) => {
-  const { open, toggle } = useOpenClose(false)
+  const { open, toggle } = useOpenClose(isOpen)
   const ariaAttributes = useAriaAttributes(isCollapsible, open)
   const sheetId = ariaAttributes ? ariaAttributes['aria-owns'] : undefined
 


### PR DESCRIPTION
## Related issue

Closes #2655 

## Overview

Add ability to programmatically set `isOpen`

## Link to preview

https://623db0f74fd10362c445d468--graceful-sawine-067881.netlify.app

## Reason

>Allow the developer to define if the collapsible data item should start collapsed or not via props. This would provide more flexibility for use.

## Work carried out

- [x] Add `isOpen` prop

## Screenshot

![Screenshot 2022-03-25 at 12 07 25](https://user-images.githubusercontent.com/48086589/160118133-48f3daff-1ae4-46d6-82b6-dc13fd988112.png)
