### PR TITLE
Update to axe v4 and resolve new errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,9 @@
   },
   "resolutions": {
     "**/ansi-regex": "^5.0.1",
-    "**/axe-core": "^3.5.3",
     "**/browserslist": "^4.19.1",
     "**/glob-parent": "^5.1.2",
     "**/immer": "^9.0.6",
-    "**/node-fetch": "^2.6.7",
     "**/semver-regex": "^3.1.3",
     "**/trim": "^0.0.3",
     "**/trim-newlines": "^3.0.1",

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -126,7 +126,7 @@
     "local-cypress": "^1.2.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
-    "puppeteer": "^12.0.0",
+    "puppeteer": "^13.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "6.15.8",

--- a/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
@@ -96,8 +96,6 @@ export const CheckboxRadioBase = React.forwardRef<
       <StyledWrapper>
         <Root
           className={className}
-          role={type}
-          aria-checked={isChecked}
           $isDisabled={isDisabled}
           $hasContainer={hasContainer}
           $isInvalid={isInvalid}

--- a/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
@@ -95,6 +95,34 @@ describe('Modal', () => {
     })
   })
 
+  describe('when aria-label but no title is set', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Dialog
+          aria-label="Accessible name"
+          data-arbitrary="arbitrary"
+          description={description}
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+          isOpen={isOpen}
+        />
+      )
+    })
+
+    it('does not set the `aria-labelledby` attribute', () => {
+      expect(wrapper.getByTestId('dialog')).not.toHaveAttribute(
+        'aria-labelledby'
+      )
+    })
+
+    it('sets the `aria-label` attribute', () => {
+      expect(wrapper.getByTestId('dialog')).toHaveAttribute(
+        'aria-label',
+        'Accessible name'
+      )
+    })
+  })
+
   describe('when the Dialog description changes', () => {
     let initialTitleId: string
     let initialDescriptionId: string

--- a/packages/react-component-library/src/components/Dialog/Dialog.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.tsx
@@ -10,6 +10,10 @@ import { useExternalId } from '../../hooks/useExternalId'
 
 export interface DialogProps extends ComponentWithClass {
   /**
+   * Optional override for the accessible name of the Modal.
+   */
+  'aria-label'?: string
+  /**
    * Optional text description to display under the component title.
    */
   description?: string
@@ -31,6 +35,9 @@ export interface DialogProps extends ComponentWithClass {
   onConfirm?: (event: React.FormEvent<HTMLButtonElement>) => void
   /**
    * Optional text title to display at the top of the component.
+   *
+   * If no title is set, you should set aria-label instead to ensure
+   * the Modal is accessible.
    */
   title?: string
 }
@@ -61,7 +68,7 @@ export const Dialog: React.FC<DialogProps> = ({
   return (
     <StyledDialog
       data-testid="dialog"
-      titleId={titleId}
+      titleId={title ? titleId : undefined}
       descriptionId={descriptionId}
       primaryButton={confirmButton}
       secondaryButton={cancelButton}

--- a/packages/react-component-library/src/components/List/List.test.tsx
+++ b/packages/react-component-library/src/components/List/List.test.tsx
@@ -42,13 +42,13 @@ describe('List', () => {
       )
     })
 
-    it('should apply the group role to the root element', () => {
-      expect(wrapper.getByTestId('list')).toHaveAttribute('role', 'group')
+    it('should apply the list role to the root element', () => {
+      expect(wrapper.getByRole('list')).toHaveAttribute('data-testid', 'list')
     })
 
-    it('should apply the presentation role to the li element', () => {
-      wrapper.getAllByTestId('list-item').forEach((item) => {
-        expect(item).toHaveAttribute('role', 'presentation')
+    it('should apply the listitem role to the li element', () => {
+      wrapper.getAllByRole('listitem').forEach((item) => {
+        expect(item).toHaveAttribute('data-testid', 'list-item')
       })
     })
 

--- a/packages/react-component-library/src/components/List/List.tsx
+++ b/packages/react-component-library/src/components/List/List.tsx
@@ -34,7 +34,7 @@ export const List: React.FC<ListProps> = ({ children, ...rest }) => {
   )
 
   return (
-    <StyledList role="group" data-testid="list" {...rest}>
+    <StyledList data-testid="list" {...rest}>
       {mapped}
     </StyledList>
   )

--- a/packages/react-component-library/src/components/List/ListItem.tsx
+++ b/packages/react-component-library/src/components/List/ListItem.tsx
@@ -51,7 +51,7 @@ export const ListItem: React.FC<ListItemProps> = ({
     <StyledItem
       $isInactive={isActive === false}
       data-testid="list-item"
-      role="presentation"
+      aria-labelledby={titleId}
       {...rest}
     >
       <StyledItemContent
@@ -59,7 +59,7 @@ export const ListItem: React.FC<ListItemProps> = ({
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >
-        <div role="listitem" aria-labelledby={titleId}>
+        <div>
           <StyledItemTitle id={titleId} data-testid="list-item-heading">
             {title}
           </StyledItemTitle>

--- a/packages/react-component-library/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.stories.tsx
@@ -73,6 +73,7 @@ Default.args = {
 export const NoHeader = Template.bind({})
 NoHeader.args = {
   isOpen: true,
+  'aria-label': 'Modal with no header',
   primaryButton,
   secondaryButton,
   tertiaryButton,
@@ -111,5 +112,6 @@ NoTertiaryButton.storyName = 'No tertiary button'
 export const Blank = Template.bind({})
 Blank.args = {
   isOpen: true,
+  'aria-label': 'Blank modal',
 }
 Blank.storyName = 'Blank'

--- a/packages/react-component-library/src/components/Modal/Modal.test.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.test.tsx
@@ -34,7 +34,7 @@ describe('Modal', () => {
     describe('and it is set to be initially open', () => {
       beforeEach(() => {
         wrapper = render(
-          <Modal isOpen>
+          <Modal aria-label="Accessible name" isOpen>
             <span>Example child JSX</span>
           </Modal>
         )
@@ -43,6 +43,13 @@ describe('Modal', () => {
       it('does not set the `aria-labelledby` attribute', () => {
         expect(wrapper.getByTestId('modal-wrapper')).not.toHaveAttribute(
           'aria-labelledby'
+        )
+      })
+
+      it('sets the `aria-label` attribute', () => {
+        expect(wrapper.getByTestId('modal-wrapper')).toHaveAttribute(
+          'aria-label',
+          'Accessible name'
         )
       })
 
@@ -209,6 +216,31 @@ describe('Modal', () => {
           expect(wrapper.queryByTestId('modal-primary-confirm')).toBeNull()
         })
       })
+    })
+  })
+
+  describe('when both title and aria-label are set', () => {
+    beforeEach(() => {
+      onClose = jest.fn()
+
+      wrapper = render(
+        <Modal isOpen title="Title" aria-label="Accessible name">
+          <span>Example child JSX</span>
+        </Modal>
+      )
+    })
+
+    it('does not set the `aria-labelledby` attribute', () => {
+      expect(wrapper.getByTestId('modal-wrapper')).not.toHaveAttribute(
+        'aria-labelledby'
+      )
+    })
+
+    it('sets the `aria-label` attribute', () => {
+      expect(wrapper.getByTestId('modal-wrapper')).toHaveAttribute(
+        'aria-label',
+        'Accessible name'
+      )
     })
   })
 

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -12,6 +12,10 @@ import { useOpenClose } from '../../hooks/useOpenClose'
 
 export interface ModalProps extends ComponentWithClass {
   /**
+   * Optional override for the accessible name of the Modal.
+   */
+  'aria-label'?: string
+  /**
    * Optional arbitrary JSX content to display in the main body of the component.
    */
   children?: React.ReactNode
@@ -42,6 +46,9 @@ export interface ModalProps extends ComponentWithClass {
   tertiaryButton?: ButtonProps
   /**
    * Optional text title to display at the top of the component.
+   *
+   * If no title is set, you should set aria-label instead to ensure
+   * the Modal is accessible.
    */
   title?: string
   /**
@@ -52,6 +59,7 @@ export interface ModalProps extends ComponentWithClass {
 }
 
 export const Modal: React.FC<ModalProps> = ({
+  'aria-label': ariaLabel,
   children,
   className,
   descriptionId: externalDescriptionId,
@@ -82,7 +90,10 @@ export const Modal: React.FC<ModalProps> = ({
       className={className}
       role="dialog"
       aria-modal
-      aria-labelledby={title || externalTitleId ? titleId : undefined}
+      aria-label={ariaLabel}
+      aria-labelledby={
+        (title || externalTitleId) && !ariaLabel ? titleId : undefined
+      }
       aria-describedby={descriptionId}
       data-testid="modal-wrapper"
       {...rest}

--- a/packages/react-component-library/src/components/TabBase/partials/StyledTab.tsx
+++ b/packages/react-component-library/src/components/TabBase/partials/StyledTab.tsx
@@ -5,7 +5,7 @@ import { StyledTabSetProps } from '../../TabSet/partials/StyledTabSet'
 
 const { color, fontSize, zIndex } = selectors
 
-interface StyledTabProps extends StyledTabSetProps {
+export interface StyledTabProps extends StyledTabSetProps {
   $isActive?: boolean
 }
 

--- a/packages/react-component-library/src/components/TabBase/partials/StyledTab.tsx
+++ b/packages/react-component-library/src/components/TabBase/partials/StyledTab.tsx
@@ -52,10 +52,6 @@ export const StyledTab = styled.button<StyledTabProps>`
     margin: 0 auto;
   }
 
-  &:focus {
-    outline: none;
-  }
-
   * {
     color: ${color('neutral', '600')};
   }

--- a/packages/react-component-library/src/components/TabNav/TabNavItem.tsx
+++ b/packages/react-component-library/src/components/TabNav/TabNavItem.tsx
@@ -2,12 +2,16 @@ import React from 'react'
 
 import { NavItem } from '../../common/Nav'
 import { StyledTabItem } from '../TabBase/partials/StyledTabItem'
-import { StyledTab } from '../TabBase/partials/StyledTab'
+import { StyledTabNavTab } from './partials/StyledTabNavTab'
 
 export const TabNavItem: React.FC<NavItem> = ({ isActive, link }) => (
   <StyledTabItem data-testid="tab-nav-tab">
-    <StyledTab $isActive={isActive} data-testid="tab-nav-tab-button">
-      <div>{link}</div>
-    </StyledTab>
+    <StyledTabNavTab
+      as="div"
+      $isActive={isActive}
+      data-testid="tab-nav-tab-button"
+    >
+      {link}
+    </StyledTabNavTab>
   </StyledTabItem>
 )

--- a/packages/react-component-library/src/components/TabNav/partials/StyledTabNavTab.tsx
+++ b/packages/react-component-library/src/components/TabNav/partials/StyledTabNavTab.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+import { StyledTab } from '../../TabBase/partials/StyledTab'
+
+export const StyledTabNavTab = styled(StyledTab)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`

--- a/packages/react-component-library/src/components/TabSet/TabContent.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabContent.tsx
@@ -18,9 +18,9 @@ export const TabContent: React.FC<TabContentProps> = ({
   <StyledContent
     $isActive={isActive}
     role="tabpanel"
-    aria-labelledby={tabId}
+    aria-labelledby={`tab-button-${tabId}`}
     aria-hidden={!isActive}
-    id={tabId}
+    id={`tab-content-${tabId}`}
     tabIndex={0}
     data-testid="tab-set-content"
     {...rest}

--- a/packages/react-component-library/src/components/TabSet/TabItem.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabItem.tsx
@@ -9,7 +9,7 @@ interface TabItemProps {
   children: React.ReactElement | string
   isActive: boolean
   onClick: (e: MouseEvent<HTMLButtonElement>) => void
-  onKeyDown: (event: KeyboardEvent<HTMLLIElement>) => void
+  onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void
   isFullWidth?: boolean
   isScrollable?: boolean
 }
@@ -37,22 +37,23 @@ export const TabItem = forwardRef<HTMLLIElement, TabItemProps>(
         $isFullWidth={isFullWidth}
         $isScrollable={isScrollable}
         ref={ref}
-        role="tab"
-        aria-controls={tabId}
-        aria-selected={!!isActive}
-        tabIndex={!isActive ? -1 : 0}
+        role="presentation"
         data-testid="tab-set-tab"
-        aria-label={children.toString()}
-        onKeyDown={onKeyDown}
       >
         <StyledTab
           $isActive={isActive}
           $isScrollable={isScrollable}
+          id={`tab-button-${tabId}`}
+          role="tab"
+          aria-controls={`tab-content-${tabId}`}
+          aria-selected={!!isActive}
+          onKeyDown={onKeyDown}
+          tabIndex={!isActive ? -1 : 0}
           data-testid="tab-set-tab-button"
           onClick={handleClick}
         >
-          <div>{children}</div>
-          <StyledHiddenBoldTextWidthFix>
+          <div role="presentation">{children}</div>
+          <StyledHiddenBoldTextWidthFix aria-hidden="true">
             {children}
           </StyledHiddenBoldTextWidthFix>
         </StyledTab>

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -48,11 +48,10 @@ describe('TabSet', () => {
         )
       })
 
-      it('should apply the `aria-label` attribute to the tab', () => {
-        expect(wrapper.getAllByTestId('tab-set-tab')[0]).toHaveAttribute(
-          'aria-label',
-          'Title 1'
-        )
+      it('should give tabs an appropriate accessible name', () => {
+        expect(
+          wrapper.getByRole('tab', { name: 'Title 1' })
+        ).toBeInTheDocument()
       })
 
       it('should apply the correct roles', () => {
@@ -62,6 +61,11 @@ describe('TabSet', () => {
         )
 
         expect(wrapper.getAllByTestId('tab-set-tab')[0]).toHaveAttribute(
+          'role',
+          'presentation'
+        )
+
+        expect(wrapper.getAllByTestId('tab-set-tab-button')[0]).toHaveAttribute(
           'role',
           'tab'
         )
@@ -73,32 +77,32 @@ describe('TabSet', () => {
       })
 
       it('should set the `aria-labelledby` and `id` attributes to the ID of the tab', () => {
-        const tabId0 = wrapper
-          .getAllByTestId('tab-set-tab')[0]
-          .getAttribute('aria-controls')
+        const tabButton0 = wrapper.getAllByTestId('tab-set-tab-button')[0]
+        const tabButtonId0 = tabButton0.getAttribute('id')
+        const tabContentId0 = tabButton0.getAttribute('aria-controls')
 
         expect(wrapper.getAllByTestId('tab-set-content')[0]).toHaveAttribute(
           'aria-labelledby',
-          tabId0
+          tabButtonId0
         )
 
         expect(wrapper.getAllByTestId('tab-set-content')[0]).toHaveAttribute(
           'id',
-          tabId0
+          tabContentId0
         )
 
-        const tabId1 = wrapper
-          .getAllByTestId('tab-set-tab')[1]
-          .getAttribute('aria-controls')
+        const tabButton1 = wrapper.getAllByTestId('tab-set-tab-button')[1]
+        const tabButtonId1 = tabButton1.getAttribute('id')
+        const tabContentId1 = tabButton1.getAttribute('aria-controls')
 
         expect(wrapper.getAllByTestId('tab-set-content')[1]).toHaveAttribute(
           'aria-labelledby',
-          tabId1
+          tabButtonId1
         )
 
         expect(wrapper.getAllByTestId('tab-set-content')[1]).toHaveAttribute(
           'id',
-          tabId1
+          tabContentId1
         )
       })
 
@@ -117,12 +121,12 @@ describe('TabSet', () => {
       })
 
       it('should set the `tabIndex` values correctly', () => {
-        expect(wrapper.getAllByTestId('tab-set-tab')[0]).toHaveAttribute(
+        expect(wrapper.getAllByTestId('tab-set-tab-button')[0]).toHaveAttribute(
           'tabIndex',
           '0'
         )
 
-        expect(wrapper.getAllByTestId('tab-set-tab')[1]).toHaveAttribute(
+        expect(wrapper.getAllByTestId('tab-set-tab-button')[1]).toHaveAttribute(
           'tabIndex',
           '-1'
         )
@@ -162,15 +166,13 @@ describe('TabSet', () => {
         })
 
         it('should set the first tab `tabIndex` to -1', () => {
-          expect(wrapper.getAllByTestId('tab-set-tab')[0]).toHaveAttribute(
-            'tabIndex',
-            '-1'
-          )
+          expect(
+            wrapper.getAllByTestId('tab-set-tab-button')[0]
+          ).toHaveAttribute('tabIndex', '-1')
 
-          expect(wrapper.getAllByTestId('tab-set-tab')[1]).toHaveAttribute(
-            'tabIndex',
-            '0'
-          )
+          expect(
+            wrapper.getAllByTestId('tab-set-tab-button')[1]
+          ).toHaveAttribute('tabIndex', '0')
         })
 
         it('should set the `aria-hidden` attributes correctly', () => {
@@ -187,7 +189,7 @@ describe('TabSet', () => {
 
         describe('and the user presses the left arrow key', () => {
           beforeEach(() => {
-            fireEvent.keyDown(wrapper.getAllByTestId('tab-set-tab')[0], {
+            fireEvent.keyDown(wrapper.getAllByTestId('tab-set-tab-button')[0], {
               key: 'ArrowLeft',
               keyCode: 37,
             })
@@ -203,10 +205,13 @@ describe('TabSet', () => {
 
           describe('and the user presses the right arrow key', () => {
             beforeEach(() => {
-              fireEvent.keyDown(wrapper.getAllByTestId('tab-set-tab')[1], {
-                key: 'ArrowRight',
-                keyCode: 39,
-              })
+              fireEvent.keyDown(
+                wrapper.getAllByTestId('tab-set-tab-button')[1],
+                {
+                  key: 'ArrowRight',
+                  keyCode: 39,
+                }
+              )
             })
 
             it('sets the next tab to active', () => {

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -81,7 +81,7 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
   }
 
   const [tabIds] = useState(() =>
-    [...Array(children.length)].map(() => `tab-content-${uuidv4()}`)
+    [...Array(children.length)].map(() => `${uuidv4()}`)
   )
   const [activeTab, setActiveTab] = useState(getActiveIndex(children))
   const { scrollToNextTab, tabsRef, itemsRef } = useScrollableTabSet(children)
@@ -94,7 +94,7 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
     }
   }
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLLIElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
     const { which } = event
 
     const getNextIndex = (keyCode: number): number => {

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
@@ -13,7 +13,7 @@ export default {
   },
 } as Meta<FloatingBoxWithEmbeddedTargetProps>
 
-export const Default: Story<FloatingBoxWithEmbeddedTargetProps> = (props) => (
+const Template: Story<FloatingBoxWithEmbeddedTargetProps> = (props) => (
   <FloatingBox isVisible renderTarget={<div />} {...props}>
     <div style={{ padding: '0 1rem' }}>
       <pre>Arbitrary JSX content</pre>
@@ -21,21 +21,16 @@ export const Default: Story<FloatingBoxWithEmbeddedTargetProps> = (props) => (
   </FloatingBox>
 )
 
+export const Default = Template.bind({})
 Default.args = {
   scheme: FLOATING_BOX_SCHEME.LIGHT,
+  'aria-label': 'A floating box',
 }
 
-export const Dark: Story<FloatingBoxWithEmbeddedTargetProps> = (props) => (
-  <FloatingBox
-    isVisible
-    renderTarget={<div />}
-    {...props}
-    scheme={FLOATING_BOX_SCHEME.DARK}
-  >
-    <div style={{ padding: '0 1rem' }}>
-      <pre>Arbitrary JSX content</pre>
-    </div>
-  </FloatingBox>
-)
+export const Dark = Template.bind({})
 
 Dark.storyName = 'Dark'
+Dark.args = {
+  scheme: FLOATING_BOX_SCHEME.DARK,
+  'aria-label': 'A floating box',
+}

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -13,7 +13,10 @@ import { useFloatingElement } from '../../hooks/useFloatingElement'
 import { FLOATING_BOX_SCHEME } from './constants'
 import { useExternalId } from '../../hooks/useExternalId'
 
-export interface FloatingBoxBaseProps extends PositionType, ComponentWithClass {
+export interface FloatingBoxBaseProps
+  extends PositionType,
+    ComponentWithClass,
+    Pick<React.AriaAttributes, 'aria-label' | 'aria-labelledby'> {
   role?: string
   contentId?: string
   scheme?: FloatingBoxSchemeType
@@ -64,6 +67,7 @@ export const FloatingBox: React.FC<FloatingBoxProps> = ({
   targetElement,
   isVisible,
   placement = 'auto',
+  role = 'dialog',
   ...rest
 }) => {
   const contentId = useExternalId('floating-box', externalContentId)
@@ -92,7 +96,7 @@ export const FloatingBox: React.FC<FloatingBoxProps> = ({
             ref={floatingElementRef}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
-            role="dialog"
+            role={role}
             data-testid="floating-box"
             {...attributes.popper}
             {...rest}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,11 +10,11 @@
     "@jridgewell/trace-mapping" "^0.3.0"
 
 "@axe-core/puppeteer@^4.2.0":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@axe-core/puppeteer/-/puppeteer-4.3.2.tgz#196748648ce1c5bcf537395441f4ae3b8d9190e9"
-  integrity sha512-/0Od30pNxUr00cO20pndz2n/b5DyYrkAKBBXlpTAbAMPuLtz6JnavR9A1oQMDyBeoQDNbKr7B97FRYSNPPgI9Q==
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@axe-core/puppeteer/-/puppeteer-4.4.2.tgz#63ada57d407d8bea45bac5b05974e16282f41820"
+  integrity sha512-HsiXUALjQ5fcWZZgGUvYGr/b7qvWbQXeDuW2z+2YYOJsavlPV9z0IGdm4rmX0lmsdJ9usA5vq5LNLiz23ZyXmw==
   dependencies:
-    axe-core "^4.3.3"
+    axe-core "^4.4.1"
 
 "@babel/cli@^7.11.6", "@babel/cli@^7.8.3":
   version "7.17.0"
@@ -5190,10 +5190,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axe-core@^3.5.3, axe-core@^4.2.0, axe-core@^4.3.3, axe-core@^4.3.5:
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.6.tgz#e762a90d7f6dbd244ceacb4e72760ff8aad521b5"
-  integrity sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==
+axe-core@^4.2.0, axe-core@^4.3.5, axe-core@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
+  integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -6851,6 +6851,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-fetch@3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -7170,10 +7177,10 @@ debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, de
   dependencies:
     ms "2.1.2"
 
-debug@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+debug@4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
 
@@ -7418,10 +7425,10 @@ detect-port@^1.3.0:
     address "^1.0.1"
     debug "^2.6.0"
 
-devtools-protocol@0.0.937139:
-  version "0.0.937139"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.937139.tgz#bdee3751fdfdb81cb701fd3afa94b1065dafafcf"
-  integrity sha512-daj+rzR3QSxsPRy5vjjthn58axO8c11j58uY0lG5vvlJk/EiOdCWOptGdkXDjtuRHr78emKq0udHCXM4trhoDQ==
+devtools-protocol@0.0.969999:
+  version "0.0.969999"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.969999.tgz#3d6be0a126b3607bb399ae2719b471dda71f3478"
+  integrity sha512-6GfzuDWU0OFAuOvBokXpXPLxjOJ5DZ157Ue3sGQQM3LgAamb8m0R0ruSfN0DDu+XG5XJgT50i6zZ/0o8RglreQ==
 
 dezalgo@^1.0.0:
   version "1.0.3"
@@ -12631,7 +12638,7 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@2.6.5, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -14150,23 +14157,23 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^12.0.0:
-  version "12.0.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-12.0.1.tgz#ae79d0e174a07563e0bf2e05c94ccafce3e70033"
-  integrity sha512-YQ3GRiyZW0ddxTW+iiQcv2/8TT5c3+FcRUCg7F8q2gHqxd5akZN400VRXr9cHQKLWGukmJLDiE72MrcLK9tFHQ==
+puppeteer@^13.5.1:
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-13.5.1.tgz#d0f751bf36120efc2ebf74c7562a204a84e500e9"
+  integrity sha512-wWxO//vMiqxlvuzHMAJ0pRJeDHvDtM7DQpW1GKdStz2nZo2G42kOXBDgkmQ+zqjwMCFofKGesBeeKxIkX9BO+w==
   dependencies:
-    debug "4.3.2"
-    devtools-protocol "0.0.937139"
+    cross-fetch "3.1.5"
+    debug "4.3.3"
+    devtools-protocol "0.0.969999"
     extract-zip "2.0.1"
     https-proxy-agent "5.0.0"
-    node-fetch "2.6.5"
     pkg-dir "4.2.0"
     progress "2.0.3"
     proxy-from-env "1.1.0"
     rimraf "3.0.2"
     tar-fs "2.1.1"
     unbzip2-stream "1.4.3"
-    ws "8.2.3"
+    ws "8.5.0"
 
 q@^1.5.1:
   version "1.5.1"
@@ -17514,7 +17521,7 @@ write-pkg@^4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
-ws@8.2.3, ws@^7.3.1, ws@^7.4.6, ws@^8.2.3, ws@^8.4.2:
+ws@8.5.0, ws@^7.3.1, ws@^7.4.6, ws@^8.2.3, ws@^8.4.2:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
   integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==


### PR DESCRIPTION
## Related issue

Resolve #2575

## Overview

This unpins axe and updates it to the latest version, and resolves errors that have been highlighted by the new version.

**Note: Currently blocked by https://github.com/dequelabs/axe-core-npm/issues/484**

## Link to preview

https://5e25c277526d380020b5e418-agrbksufqr.chromatic.com/

## Reason

Ensure the current version of axe is being used and accessibility errors are resolved.

## Work carried out

- [ ] Resolve errors for `Checkbox` and `Radio`
- [x] Resolve errors for `FloatingBox`
- [x] Resolve errors for `List`
- [x] Resolve errors for `TabSet`
- [x] Resolve errors for `TabNav`
- [x] Resolve errors for `Modal`
- [x] Update `axe-core`, `@axe-core/puppeteer` and `puppeteer`

## Developer notes

Comments about specific changes have been left inline.

Useful references:

- https://www.w3.org/TR/wai-aria-1.2/
- https://www.w3.org/TR/html-aria/
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles
