### PR TITLE
Resolve various axe v4 errors

### DIFF
--- a/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
@@ -95,6 +95,34 @@ describe('Modal', () => {
     })
   })
 
+  describe('when aria-label but no title is set', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Dialog
+          aria-label="Accessible name"
+          data-arbitrary="arbitrary"
+          description={description}
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+          isOpen={isOpen}
+        />
+      )
+    })
+
+    it('does not set the `aria-labelledby` attribute', () => {
+      expect(wrapper.getByTestId('dialog')).not.toHaveAttribute(
+        'aria-labelledby'
+      )
+    })
+
+    it('sets the `aria-label` attribute', () => {
+      expect(wrapper.getByTestId('dialog')).toHaveAttribute(
+        'aria-label',
+        'Accessible name'
+      )
+    })
+  })
+
   describe('when the Dialog description changes', () => {
     let initialTitleId: string
     let initialDescriptionId: string

--- a/packages/react-component-library/src/components/Dialog/Dialog.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.tsx
@@ -10,6 +10,10 @@ import { useExternalId } from '../../hooks/useExternalId'
 
 export interface DialogProps extends ComponentWithClass {
   /**
+   * Optional override for the accessible name of the Modal.
+   */
+  'aria-label'?: string
+  /**
    * Optional text description to display under the component title.
    */
   description?: string
@@ -31,6 +35,9 @@ export interface DialogProps extends ComponentWithClass {
   onConfirm?: (event: React.FormEvent<HTMLButtonElement>) => void
   /**
    * Optional text title to display at the top of the component.
+   *
+   * If no title is set, you should set aria-label instead to ensure
+   * the Modal is accessible.
    */
   title?: string
 }
@@ -61,7 +68,7 @@ export const Dialog: React.FC<DialogProps> = ({
   return (
     <StyledDialog
       data-testid="dialog"
-      titleId={titleId}
+      titleId={title ? titleId : undefined}
       descriptionId={descriptionId}
       primaryButton={confirmButton}
       secondaryButton={cancelButton}

--- a/packages/react-component-library/src/components/List/List.test.tsx
+++ b/packages/react-component-library/src/components/List/List.test.tsx
@@ -42,13 +42,13 @@ describe('List', () => {
       )
     })
 
-    it('should apply the group role to the root element', () => {
-      expect(wrapper.getByTestId('list')).toHaveAttribute('role', 'group')
+    it('should apply the list role to the root element', () => {
+      expect(wrapper.getByRole('list')).toHaveAttribute('data-testid', 'list')
     })
 
-    it('should apply the presentation role to the li element', () => {
-      wrapper.getAllByTestId('list-item').forEach((item) => {
-        expect(item).toHaveAttribute('role', 'presentation')
+    it('should apply the listitem role to the li element', () => {
+      wrapper.getAllByRole('listitem').forEach((item) => {
+        expect(item).toHaveAttribute('data-testid', 'list-item')
       })
     })
 

--- a/packages/react-component-library/src/components/List/List.tsx
+++ b/packages/react-component-library/src/components/List/List.tsx
@@ -34,7 +34,7 @@ export const List: React.FC<ListProps> = ({ children, ...rest }) => {
   )
 
   return (
-    <StyledList role="group" data-testid="list" {...rest}>
+    <StyledList data-testid="list" {...rest}>
       {mapped}
     </StyledList>
   )

--- a/packages/react-component-library/src/components/List/ListItem.tsx
+++ b/packages/react-component-library/src/components/List/ListItem.tsx
@@ -51,7 +51,7 @@ export const ListItem: React.FC<ListItemProps> = ({
     <StyledItem
       $isInactive={isActive === false}
       data-testid="list-item"
-      role="presentation"
+      aria-labelledby={titleId}
       {...rest}
     >
       <StyledItemContent
@@ -59,7 +59,7 @@ export const ListItem: React.FC<ListItemProps> = ({
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >
-        <div role="listitem" aria-labelledby={titleId}>
+        <div>
           <StyledItemTitle id={titleId} data-testid="list-item-heading">
             {title}
           </StyledItemTitle>

--- a/packages/react-component-library/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.stories.tsx
@@ -73,6 +73,7 @@ Default.args = {
 export const NoHeader = Template.bind({})
 NoHeader.args = {
   isOpen: true,
+  'aria-label': 'Modal with no header',
   primaryButton,
   secondaryButton,
   tertiaryButton,
@@ -111,5 +112,6 @@ NoTertiaryButton.storyName = 'No tertiary button'
 export const Blank = Template.bind({})
 Blank.args = {
   isOpen: true,
+  'aria-label': 'Blank modal',
 }
 Blank.storyName = 'Blank'

--- a/packages/react-component-library/src/components/Modal/Modal.test.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.test.tsx
@@ -34,7 +34,7 @@ describe('Modal', () => {
     describe('and it is set to be initially open', () => {
       beforeEach(() => {
         wrapper = render(
-          <Modal isOpen>
+          <Modal aria-label="Accessible name" isOpen>
             <span>Example child JSX</span>
           </Modal>
         )
@@ -43,6 +43,13 @@ describe('Modal', () => {
       it('does not set the `aria-labelledby` attribute', () => {
         expect(wrapper.getByTestId('modal-wrapper')).not.toHaveAttribute(
           'aria-labelledby'
+        )
+      })
+
+      it('sets the `aria-label` attribute', () => {
+        expect(wrapper.getByTestId('modal-wrapper')).toHaveAttribute(
+          'aria-label',
+          'Accessible name'
         )
       })
 
@@ -209,6 +216,31 @@ describe('Modal', () => {
           expect(wrapper.queryByTestId('modal-primary-confirm')).toBeNull()
         })
       })
+    })
+  })
+
+  describe('when both title and aria-label are set', () => {
+    beforeEach(() => {
+      onClose = jest.fn()
+
+      wrapper = render(
+        <Modal isOpen title="Title" aria-label="Accessible name">
+          <span>Example child JSX</span>
+        </Modal>
+      )
+    })
+
+    it('does not set the `aria-labelledby` attribute', () => {
+      expect(wrapper.getByTestId('modal-wrapper')).not.toHaveAttribute(
+        'aria-labelledby'
+      )
+    })
+
+    it('sets the `aria-label` attribute', () => {
+      expect(wrapper.getByTestId('modal-wrapper')).toHaveAttribute(
+        'aria-label',
+        'Accessible name'
+      )
     })
   })
 

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -12,6 +12,10 @@ import { useOpenClose } from '../../hooks/useOpenClose'
 
 export interface ModalProps extends ComponentWithClass {
   /**
+   * Optional override for the accessible name of the Modal.
+   */
+  'aria-label'?: string
+  /**
    * Optional arbitrary JSX content to display in the main body of the component.
    */
   children?: React.ReactNode
@@ -42,6 +46,9 @@ export interface ModalProps extends ComponentWithClass {
   tertiaryButton?: ButtonProps
   /**
    * Optional text title to display at the top of the component.
+   *
+   * If no title is set, you should set aria-label instead to ensure
+   * the Modal is accessible.
    */
   title?: string
   /**
@@ -52,6 +59,7 @@ export interface ModalProps extends ComponentWithClass {
 }
 
 export const Modal: React.FC<ModalProps> = ({
+  'aria-label': ariaLabel,
   children,
   className,
   descriptionId: externalDescriptionId,
@@ -82,7 +90,10 @@ export const Modal: React.FC<ModalProps> = ({
       className={className}
       role="dialog"
       aria-modal
-      aria-labelledby={title || externalTitleId ? titleId : undefined}
+      aria-label={ariaLabel}
+      aria-labelledby={
+        (title || externalTitleId) && !ariaLabel ? titleId : undefined
+      }
       aria-describedby={descriptionId}
       data-testid="modal-wrapper"
       {...rest}

--- a/packages/react-component-library/src/components/TabBase/partials/StyledTab.tsx
+++ b/packages/react-component-library/src/components/TabBase/partials/StyledTab.tsx
@@ -5,7 +5,7 @@ import { StyledTabSetProps } from '../../TabSet/partials/StyledTabSet'
 
 const { color, fontSize, zIndex } = selectors
 
-interface StyledTabProps extends StyledTabSetProps {
+export interface StyledTabProps extends StyledTabSetProps {
   $isActive?: boolean
 }
 

--- a/packages/react-component-library/src/components/TabBase/partials/StyledTab.tsx
+++ b/packages/react-component-library/src/components/TabBase/partials/StyledTab.tsx
@@ -52,10 +52,6 @@ export const StyledTab = styled.button<StyledTabProps>`
     margin: 0 auto;
   }
 
-  &:focus {
-    outline: none;
-  }
-
   * {
     color: ${color('neutral', '600')};
   }

--- a/packages/react-component-library/src/components/TabNav/TabNavItem.tsx
+++ b/packages/react-component-library/src/components/TabNav/TabNavItem.tsx
@@ -2,12 +2,16 @@ import React from 'react'
 
 import { NavItem } from '../../common/Nav'
 import { StyledTabItem } from '../TabBase/partials/StyledTabItem'
-import { StyledTab } from '../TabBase/partials/StyledTab'
+import { StyledTabNavTab } from './partials/StyledTabNavTab'
 
 export const TabNavItem: React.FC<NavItem> = ({ isActive, link, ...rest }) => (
   <StyledTabItem data-testid="tab-nav-tab" {...rest}>
-    <StyledTab $isActive={isActive} data-testid="tab-nav-tab-button">
-      <div>{link}</div>
-    </StyledTab>
+    <StyledTabNavTab
+      as="div"
+      $isActive={isActive}
+      data-testid="tab-nav-tab-button"
+    >
+      {link}
+    </StyledTabNavTab>
   </StyledTabItem>
 )

--- a/packages/react-component-library/src/components/TabNav/partials/StyledTabNavTab.tsx
+++ b/packages/react-component-library/src/components/TabNav/partials/StyledTabNavTab.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+import { StyledTab } from '../../TabBase/partials/StyledTab'
+
+export const StyledTabNavTab = styled(StyledTab)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`

--- a/packages/react-component-library/src/components/TabSet/TabContent.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabContent.tsx
@@ -18,9 +18,9 @@ export const TabContent: React.FC<TabContentProps> = ({
   <StyledContent
     $isActive={isActive}
     role="tabpanel"
-    aria-labelledby={tabId}
+    aria-labelledby={`tab-button-${tabId}`}
     aria-hidden={!isActive}
-    id={tabId}
+    id={`tab-content-${tabId}`}
     tabIndex={0}
     data-testid="tab-set-content"
     {...rest}

--- a/packages/react-component-library/src/components/TabSet/TabItem.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabItem.tsx
@@ -9,7 +9,7 @@ interface TabItemProps {
   children: React.ReactElement | string
   isActive: boolean
   onClick: (e: MouseEvent<HTMLButtonElement>) => void
-  onKeyDown: (event: KeyboardEvent<HTMLLIElement>) => void
+  onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void
   isFullWidth?: boolean
   isScrollable?: boolean
 }
@@ -37,22 +37,23 @@ export const TabItem = forwardRef<HTMLLIElement, TabItemProps>(
         $isFullWidth={isFullWidth}
         $isScrollable={isScrollable}
         ref={ref}
-        role="tab"
-        aria-controls={tabId}
-        aria-selected={!!isActive}
-        tabIndex={!isActive ? -1 : 0}
+        role="presentation"
         data-testid="tab-set-tab"
-        aria-label={children.toString()}
-        onKeyDown={onKeyDown}
       >
         <StyledTab
           $isActive={isActive}
           $isScrollable={isScrollable}
+          id={`tab-button-${tabId}`}
+          role="tab"
+          aria-controls={`tab-content-${tabId}`}
+          aria-selected={!!isActive}
+          onKeyDown={onKeyDown}
+          tabIndex={!isActive ? -1 : 0}
           data-testid="tab-set-tab-button"
           onClick={handleClick}
         >
-          <div>{children}</div>
-          <StyledHiddenBoldTextWidthFix>
+          <div role="presentation">{children}</div>
+          <StyledHiddenBoldTextWidthFix aria-hidden>
             {children}
           </StyledHiddenBoldTextWidthFix>
         </StyledTab>

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -48,11 +48,10 @@ describe('TabSet', () => {
         )
       })
 
-      it('should apply the `aria-label` attribute to the tab', () => {
-        expect(wrapper.getAllByTestId('tab-set-tab')[0]).toHaveAttribute(
-          'aria-label',
-          'Title 1'
-        )
+      it('should give tabs an appropriate accessible name', () => {
+        expect(
+          wrapper.getByRole('tab', { name: 'Title 1' })
+        ).toBeInTheDocument()
       })
 
       it('should apply the correct roles', () => {
@@ -62,6 +61,11 @@ describe('TabSet', () => {
         )
 
         expect(wrapper.getAllByTestId('tab-set-tab')[0]).toHaveAttribute(
+          'role',
+          'presentation'
+        )
+
+        expect(wrapper.getAllByTestId('tab-set-tab-button')[0]).toHaveAttribute(
           'role',
           'tab'
         )
@@ -73,32 +77,32 @@ describe('TabSet', () => {
       })
 
       it('should set the `aria-labelledby` and `id` attributes to the ID of the tab', () => {
-        const tabId0 = wrapper
-          .getAllByTestId('tab-set-tab')[0]
-          .getAttribute('aria-controls')
+        const tabButton0 = wrapper.getAllByTestId('tab-set-tab-button')[0]
+        const tabButtonId0 = tabButton0.getAttribute('id')
+        const tabContentId0 = tabButton0.getAttribute('aria-controls')
 
         expect(wrapper.getAllByTestId('tab-set-content')[0]).toHaveAttribute(
           'aria-labelledby',
-          tabId0
+          tabButtonId0
         )
 
         expect(wrapper.getAllByTestId('tab-set-content')[0]).toHaveAttribute(
           'id',
-          tabId0
+          tabContentId0
         )
 
-        const tabId1 = wrapper
-          .getAllByTestId('tab-set-tab')[1]
-          .getAttribute('aria-controls')
+        const tabButton1 = wrapper.getAllByTestId('tab-set-tab-button')[1]
+        const tabButtonId1 = tabButton1.getAttribute('id')
+        const tabContentId1 = tabButton1.getAttribute('aria-controls')
 
         expect(wrapper.getAllByTestId('tab-set-content')[1]).toHaveAttribute(
           'aria-labelledby',
-          tabId1
+          tabButtonId1
         )
 
         expect(wrapper.getAllByTestId('tab-set-content')[1]).toHaveAttribute(
           'id',
-          tabId1
+          tabContentId1
         )
       })
 
@@ -117,12 +121,12 @@ describe('TabSet', () => {
       })
 
       it('should set the `tabIndex` values correctly', () => {
-        expect(wrapper.getAllByTestId('tab-set-tab')[0]).toHaveAttribute(
+        expect(wrapper.getAllByTestId('tab-set-tab-button')[0]).toHaveAttribute(
           'tabIndex',
           '0'
         )
 
-        expect(wrapper.getAllByTestId('tab-set-tab')[1]).toHaveAttribute(
+        expect(wrapper.getAllByTestId('tab-set-tab-button')[1]).toHaveAttribute(
           'tabIndex',
           '-1'
         )
@@ -162,15 +166,13 @@ describe('TabSet', () => {
         })
 
         it('should set the first tab `tabIndex` to -1', () => {
-          expect(wrapper.getAllByTestId('tab-set-tab')[0]).toHaveAttribute(
-            'tabIndex',
-            '-1'
-          )
+          expect(
+            wrapper.getAllByTestId('tab-set-tab-button')[0]
+          ).toHaveAttribute('tabIndex', '-1')
 
-          expect(wrapper.getAllByTestId('tab-set-tab')[1]).toHaveAttribute(
-            'tabIndex',
-            '0'
-          )
+          expect(
+            wrapper.getAllByTestId('tab-set-tab-button')[1]
+          ).toHaveAttribute('tabIndex', '0')
         })
 
         it('should set the `aria-hidden` attributes correctly', () => {
@@ -187,7 +189,7 @@ describe('TabSet', () => {
 
         describe('and the user presses the left arrow key', () => {
           beforeEach(() => {
-            fireEvent.keyDown(wrapper.getAllByTestId('tab-set-tab')[0], {
+            fireEvent.keyDown(wrapper.getAllByTestId('tab-set-tab-button')[0], {
               key: 'ArrowLeft',
               keyCode: 37,
             })
@@ -203,10 +205,13 @@ describe('TabSet', () => {
 
           describe('and the user presses the right arrow key', () => {
             beforeEach(() => {
-              fireEvent.keyDown(wrapper.getAllByTestId('tab-set-tab')[1], {
-                key: 'ArrowRight',
-                keyCode: 39,
-              })
+              fireEvent.keyDown(
+                wrapper.getAllByTestId('tab-set-tab-button')[1],
+                {
+                  key: 'ArrowRight',
+                  keyCode: 39,
+                }
+              )
             })
 
             it('sets the next tab to active', () => {

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -81,7 +81,7 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
   }
 
   const [tabIds] = useState(() =>
-    [...Array(children.length)].map(() => `tab-content-${uuidv4()}`)
+    [...Array(children.length)].map(() => `${uuidv4()}`)
   )
   const [activeTab, setActiveTab] = useState(getActiveIndex(children))
   const { scrollToNextTab, tabsRef, itemsRef } = useScrollableTabSet(children)
@@ -94,7 +94,7 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
     }
   }
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLLIElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
     const { which } = event
 
     const getNextIndex = (keyCode: number): number => {

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.stories.tsx
@@ -13,7 +13,7 @@ export default {
   },
 } as Meta<FloatingBoxWithEmbeddedTargetProps>
 
-export const Default: Story<FloatingBoxWithEmbeddedTargetProps> = (props) => (
+const Template: Story<FloatingBoxWithEmbeddedTargetProps> = (props) => (
   <FloatingBox isVisible renderTarget={<div />} {...props}>
     <div style={{ padding: '0 1rem' }}>
       <pre>Arbitrary JSX content</pre>
@@ -21,21 +21,16 @@ export const Default: Story<FloatingBoxWithEmbeddedTargetProps> = (props) => (
   </FloatingBox>
 )
 
+export const Default = Template.bind({})
 Default.args = {
   scheme: FLOATING_BOX_SCHEME.LIGHT,
+  'aria-label': 'A floating box',
 }
 
-export const Dark: Story<FloatingBoxWithEmbeddedTargetProps> = (props) => (
-  <FloatingBox
-    isVisible
-    renderTarget={<div />}
-    {...props}
-    scheme={FLOATING_BOX_SCHEME.DARK}
-  >
-    <div style={{ padding: '0 1rem' }}>
-      <pre>Arbitrary JSX content</pre>
-    </div>
-  </FloatingBox>
-)
+export const Dark = Template.bind({})
 
 Dark.storyName = 'Dark'
+Dark.args = {
+  scheme: FLOATING_BOX_SCHEME.DARK,
+  'aria-label': 'A floating box',
+}

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -13,7 +13,10 @@ import { useFloatingElement } from '../../hooks/useFloatingElement'
 import { FLOATING_BOX_SCHEME } from './constants'
 import { useExternalId } from '../../hooks/useExternalId'
 
-export interface FloatingBoxBaseProps extends PositionType, ComponentWithClass {
+export interface FloatingBoxBaseProps
+  extends PositionType,
+    ComponentWithClass,
+    Pick<React.AriaAttributes, 'aria-label' | 'aria-labelledby'> {
   role?: string
   contentId?: string
   scheme?: FloatingBoxSchemeType
@@ -64,6 +67,7 @@ export const FloatingBox: React.FC<FloatingBoxProps> = ({
   targetElement,
   isVisible,
   placement = 'auto',
+  role = 'dialog',
   ...rest
 }) => {
   const contentId = useExternalId('floating-box', externalContentId)
@@ -92,7 +96,7 @@ export const FloatingBox: React.FC<FloatingBoxProps> = ({
             ref={floatingElementRef}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
-            role="dialog"
+            role={role}
             data-testid="floating-box"
             {...attributes.popper}
             {...rest}


### PR DESCRIPTION
## Related issue

#2575

## Overview

This resolves a subset of the errors that are flagged by axe v4.

## Link to preview

https://5e25c277526d380020b5e418-pbhoxmouny.chromatic.com/

## Reason

To ensure components are accessible.

## Work carried out

- [x] Resolve errors for `FloatingBox`
- [x] Resolve errors for `List`
- [x] Resolve errors for `TabSet`
- [x] Resolve errors for `TabNav`
- [x] Resolve errors for `Modal`

Not done:

- [ ] Resolve errors for `Checkbox` and `Radio`
- [ ] Update `axe-core`, `@axe-core/puppeteer` and `puppeteer`

## Screenshot

### List accessibility tree

#### Before

![image](https://user-images.githubusercontent.com/66470099/160436853-8ad80d38-81f9-48b2-b99b-874c065555e0.png)

#### After

![image](https://user-images.githubusercontent.com/66470099/160437009-7e4eda03-146e-4b1e-9fc9-87abf68e68aa.png)

### TabSet accessibility tree

#### Before

![image](https://user-images.githubusercontent.com/66470099/160400632-074f6c0e-3e07-4dfb-95bc-729b64d34409.png)

#### After

![image](https://user-images.githubusercontent.com/66470099/160433565-935cf6f1-a5b3-4c3b-9111-c1929e977aae.png)

### TabNav accessibility tree

#### Before

![image](https://user-images.githubusercontent.com/66470099/160433946-29eb748a-2010-4186-a828-87cdb16d7061.png)

#### After

![image](https://user-images.githubusercontent.com/66470099/160434049-e36906eb-fbb9-4544-9fdc-372ba0bc0585.png)

## Developer notes

Checkbox and Radio fixes will be made in a separate PR as those are more complex. The actual upgrade to axe is also blocked by https://github.com/dequelabs/axe-core-npm/issues/484.

Comments about specific changes have been left inline.

Useful references:

- https://www.w3.org/TR/wai-aria-1.2/
- https://www.w3.org/TR/html-aria/
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles
