### PR TITLE
fix(IconLibrary): Resolve installation errors and replace react-svg-unique-id

### DIFF
--- a/packages/icon-library/.svgrrc.js
+++ b/packages/icon-library/.svgrrc.js
@@ -1,13 +1,12 @@
 const template = ({ componentName, exports, interfaces, jsx }, { tpl }) => {
   return tpl`
 import React from 'react'
-import { SVGUniqueID } from 'react-svg-unique-id'
 import { SVGIconProps } from '../types'
 
 ${interfaces}
 
 const ${componentName} = ({ size = 16, ...props }: SVGIconProps) => (
-  <SVGUniqueID>{${jsx}}</SVGUniqueID>
+  ${jsx}
 );
 
 ${exports}
@@ -20,6 +19,11 @@ module.exports = {
   prettierConfig: {
     ...require('./prettier.config.js'),
     parser: 'typescript',
+  },
+  jsx: {
+    babelConfig: {
+      plugins: ['react-inline-svg-unique-id'],
+    },
   },
   svgProps: {
     width: '{size}',

--- a/packages/icon-library/package.json
+++ b/packages/icon-library/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.7",
-    "react-svg-unique-id": "^1.3.3"
+    "@inline-svg-unique-id/react": "^1.2.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.3",
@@ -43,6 +43,7 @@
     "@svgr/cli": "^6.1.2",
     "@types/react": "^17.0.38",
     "babel-loader": "^8.0.6",
+    "babel-plugin-react-inline-svg-unique-id": "^1.3.1",
     "clean-webpack-plugin": "^4.0.0",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,7 +32,7 @@
     "@nicolo-ribaudo/chokidar-2" "2.1.8-no-fsevents.3"
     chokidar "^3.4.0"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
   integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
@@ -359,6 +359,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.0.tgz#f0ac33eddbe214e4105363bb17c3341c5ffcc43c"
   integrity sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==
 
+"@babel/parser@^7.15.4":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.7.tgz#fc19b645a5456c8d6fdb6cecd3c66c0173902800"
+  integrity sha512-bm3AQf45vR4gKggRfvJdYJ0gFLoCbsPxiFLSH6hTVYABptNHY6l9NrhnucVjQ/X+SPtLANT9lc0fFhikj+VBRA==
+
 "@babel/parser@^7.17.3":
   version "7.17.8"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.8.tgz#2817fb9d885dd8132ea0f8eb615a6388cca1c240"
@@ -617,6 +622,13 @@
   integrity sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-jsx@7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz#000e2e25d8673cce49300517a3eda44c263e4201"
+  integrity sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-syntax-jsx@^7.16.7":
   version "7.16.7"
@@ -1147,6 +1159,15 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/template@7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
+  integrity sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
 "@babel/template@^7.12.7", "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -1188,7 +1209,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.15.6", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.17.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
+"@babel/types@^7.0.0", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.15.4", "@babel/types@^7.15.6", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.17.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
   integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
@@ -1587,6 +1608,11 @@
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
+
+"@inline-svg-unique-id/react@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@inline-svg-unique-id/react/-/react-1.2.2.tgz#c3c71671efe3d71fe924b0d327c810169eda3d94"
+  integrity sha512-LXdtYmLFhjaspgRBX8MXsBTwqPt55K92IdOJjocUZwj/ga5lzetQlcrzZ1agFvfKLi1nbtbJYkJyqa35kjWF/g==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -5631,6 +5657,14 @@ babel-plugin-react-docgen@^4.2.1:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
+babel-plugin-react-inline-svg-unique-id@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-inline-svg-unique-id/-/babel-plugin-react-inline-svg-unique-id-1.3.1.tgz#3d4d24056c9d3968e9b6ac221353e1891dbb924e"
+  integrity sha512-6amb0UwQNQCkxPftat3IAdjMQ4KCdaPFVS+QpjNm6YW7tEpk+aAsGd0biDR4h5ju6PfiP8r4pt7+X8kW9P/8Ug==
+  dependencies:
+    "@babel/plugin-syntax-jsx" "7.14.5"
+    "@babel/template" "7.15.4"
+
 babel-plugin-search-and-replace@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-search-and-replace/-/babel-plugin-search-and-replace-1.1.0.tgz#ad26f2037a80034613dae61b913902d9aa58ed2c"
@@ -7011,7 +7045,7 @@ core-js@^2.4.0, core-js@^2.5.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
-core-js@^3.0.0, core-js@^3.0.4, core-js@^3.6.5, core-js@^3.8.2:
+core-js@^3.0.4, core-js@^3.6.5, core-js@^3.8.2:
   version "3.20.2"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.20.2.tgz#46468d8601eafc8b266bd2dd6bf9dee622779581"
   integrity sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw==
@@ -14543,11 +14577,6 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-react-children-utilities@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/react-children-utilities/-/react-children-utilities-1.3.3.tgz#4d6725b51471c119e5319a309d07c51543b65cb2"
-  integrity sha512-4VnHQweSerPlsKS65dBeKuAPDhHAOllDgsjDLLdluMOZ+1yOE29pFqdGAnnOnFVfhIhvYnGyRbiJ7NtMemsu7w==
-
 react-compound-slider@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/react-compound-slider/-/react-compound-slider-3.3.1.tgz#1c1fc07873dc70f7bd93510d1f2372ac3062c15b"
@@ -14725,14 +14754,6 @@ react-string-replace@^0.4.4:
   integrity sha512-FAMkhxmDpCsGTwTZg7p/2v+/GTmxAp73so3fbSvlAcBBX36ujiGRNEaM/1u+jiYQrArhns+7eE92g2pi5E5FUA==
   dependencies:
     lodash "^4.17.4"
-
-react-svg-unique-id@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/react-svg-unique-id/-/react-svg-unique-id-1.3.3.tgz#277a0f8d752bd3cbf8565bc7ee7c487bf4586eff"
-  integrity sha512-Cbm4jz1svWHUm9eGN4nALt3vzA9nZXw//oDYOYQIK5qgUPze3wru7od6I5Omhq6lRtUlOYPE5Rhx5659sLWcrw==
-  dependencies:
-    core-js "^3.0.0"
-    react-children-utilities "^1.2.1"
 
 "react-test-renderer@^16.8.0 || ^17.0.0":
   version "17.0.2"


### PR DESCRIPTION
## Related issue

Resolve #3211

## Overview

This replaces `react-svg-unique-id` with https://github.com/laleksiunas/inline-svg-unique-id due to peer dependency problems with the former causing an infinite loop when installing the icon library with the latest npm.

## Link to preview

n/a

## Reason

- make sure our packages can be installed
- `react-svg-unique-id` hasn't been updated in two years, and still has a peer dependency on React 16

