### PR TITLE
Update axe to version 4 and improve Checkbox and Radio accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "resolutions": {
     "**/ansi-regex": "^5.0.1",
-    "**/axe-core": "^3.5.3",
+    "**/@axe-core/puppeteer": "4.2.1",
     "**/browserslist": "^4.19.1",
     "**/glob-parent": "^5.1.2",
     "**/immer": "^9.0.6",

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { CheckboxRadioBase, CheckboxRadioBaseProps } from '../CheckboxRadioBase'
 import { StyledCheckbox } from './partials/StyledCheckbox'
 import { StyledCheckmark } from './partials/StyledCheckmark'
+import { StyledCheckmarkWrapper } from './partials/StyledCheckmarkWrapper'
 
 export type CheckboxProps = Omit<CheckboxRadioBaseProps, 'type' | 'partials'>
 
@@ -15,6 +16,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
         partials={{
           Root: StyledCheckbox,
           Checkmark: StyledCheckmark,
+          CheckmarkWrapper: StyledCheckmarkWrapper,
         }}
         {...props}
       />

--- a/packages/react-component-library/src/components/Checkbox/partials/StyledCheckbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/partials/StyledCheckbox.tsx
@@ -1,16 +1,11 @@
 import { selectors } from '@defencedigital/design-tokens'
 import styled, { css } from 'styled-components'
 
+import { CheckboxRootProps } from '../../CheckboxRadioBase'
+
 const { color, fontSize, spacing } = selectors
 
-export interface StyledCheckboxProps {
-  $hasContainer?: boolean
-  $isDisabled?: boolean
-  $isInvalid?: boolean
-  $isChecked?: boolean
-}
-
-export const StyledCheckbox = styled.div<StyledCheckboxProps>`
+export const StyledCheckbox = styled.div<CheckboxRootProps>`
   display: inline-flex;
   position: relative;
   padding: ${({ $hasContainer }) =>

--- a/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmark.tsx
@@ -15,12 +15,11 @@ function getCheckboxActiveStyle() {
   `
 }
 
-export const StyledCheckmark = styled.div<CheckmarkProps>`
-  position: absolute;
-  top: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
-  left: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
-  height: 18px;
-  width: 18px;
+export const StyledCheckmark = styled.span<CheckmarkProps>`
+  display: block;
+  position: relative;
+  height: 100%;
+  width: 100%;
   background-color: ${color('neutral', 'white')};
   border: 1px solid ${color('neutral', '200')};
   border-radius: 3px;

--- a/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmarkWrapper.tsx
+++ b/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmarkWrapper.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components'
+
+import { CheckmarkWrapperProps } from '../../CheckboxRadioBase'
+
+export const StyledCheckmarkWrapper = styled.span<CheckmarkWrapperProps>`
+  display: block;
+  position: absolute;
+  top: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
+  left: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
+  height: 18px;
+  width: 18px;
+`

--- a/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
@@ -30,7 +30,7 @@ export const CheckboxRadioBase = React.forwardRef<
       value,
       variant = CHECKBOX_RADIO_VARIANT.DEFAULT,
       type,
-      partials: { Root, Checkmark },
+      partials: { Root, Checkmark, CheckmarkWrapper },
       ...rest
     },
     ref
@@ -104,8 +104,6 @@ export const CheckboxRadioBase = React.forwardRef<
       <StyledWrapper>
         <Root
           className={className}
-          role={type}
-          aria-checked={isChecked}
           $isDisabled={isDisabled}
           $hasContainer={hasContainer}
           $isInvalid={isInvalid}
@@ -122,24 +120,26 @@ export const CheckboxRadioBase = React.forwardRef<
               htmlFor={id}
               data-testid={`${type}-label`}
             >
-              <StyledInput
-                defaultChecked={defaultChecked}
-                ref={mergeRefs([localRef, ref])}
-                id={id}
-                type={type}
-                name={name}
-                value={value}
-                onChange={handleOnChange}
-                onBlur={onBlur}
-                disabled={isDisabled}
-                data-testid={`${type}-input`}
-                checked={isControlled ? isChecked : undefined}
-                {...rest}
-              />
-              <Checkmark
-                $hasContainer={hasContainer}
-                $isDisabled={isDisabled}
-              />
+              <CheckmarkWrapper $hasContainer={hasContainer}>
+                <StyledInput
+                  defaultChecked={defaultChecked}
+                  ref={mergeRefs([localRef, ref])}
+                  id={id}
+                  type={type}
+                  name={name}
+                  value={value}
+                  onChange={handleOnChange}
+                  onBlur={onBlur}
+                  disabled={isDisabled}
+                  data-testid={`${type}-input`}
+                  checked={isControlled ? isChecked : undefined}
+                  {...rest}
+                />
+                <Checkmark
+                  $hasContainer={hasContainer}
+                  $isDisabled={isDisabled}
+                />
+              </CheckmarkWrapper>
               {label}
               {description && (
                 <StyledDescription data-testid={`${type}-description`}>

--- a/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBaseProps.ts
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBaseProps.ts
@@ -15,6 +15,10 @@ export interface CheckmarkProps {
   $isDisabled?: boolean
 }
 
+export interface CheckmarkWrapperProps {
+  $hasContainer: boolean
+}
+
 export interface CheckboxRadioBaseProps
   extends ComponentWithClass,
     InputValidationProps {
@@ -72,5 +76,6 @@ export interface CheckboxRadioBaseProps
   partials: {
     Root: React.ComponentType<CheckboxRootProps>
     Checkmark: React.ComponentType<CheckmarkProps>
+    CheckmarkWrapper: React.ComponentType<CheckmarkWrapperProps>
   }
 }

--- a/packages/react-component-library/src/components/CheckboxRadioBase/partials/StyledInput.tsx
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/partials/StyledInput.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components'
 
 export const StyledInput = styled.input`
   position: absolute;
-  height: 0;
-  width: 0;
+  height: 100%;
+  width: 100%;
   opacity: 0;
   cursor: pointer;
 `

--- a/packages/react-component-library/src/components/Radio/Radio.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { CheckboxRadioBase, CheckboxRadioBaseProps } from '../CheckboxRadioBase'
 import { StyledRadio } from './partials/StyledRadio'
 import { StyledCheckmark } from './partials/StyledCheckmark'
+import { StyledCheckmarkWrapper } from './partials/StyledCheckmarkWrapper'
 
 export type RadioProps = Omit<CheckboxRadioBaseProps, 'type' | 'partials'>
 
@@ -15,6 +16,7 @@ export const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
         partials={{
           Root: StyledRadio,
           Checkmark: StyledCheckmark,
+          CheckmarkWrapper: StyledCheckmarkWrapper,
         }}
         {...props}
       />

--- a/packages/react-component-library/src/components/Radio/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/Radio/partials/StyledCheckmark.tsx
@@ -5,12 +5,11 @@ import { CheckmarkProps } from '../../CheckboxRadioBase'
 
 const { color } = selectors
 
-export const StyledCheckmark = styled.div<CheckmarkProps>`
-  position: absolute;
-  top: ${({ $hasContainer }) => ($hasContainer ? '13px' : '4px')};
-  left: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
-  height: 16px;
-  width: 16px;
+export const StyledCheckmark = styled.span<CheckmarkProps>`
+  display: block;
+  position: relative;
+  height: 100%;
+  width: 100%;
   border-radius: 999px;
   border: 1px solid
     ${({ $hasContainer, $isDisabled }) =>

--- a/packages/react-component-library/src/components/Radio/partials/StyledCheckmarkWrapper.tsx
+++ b/packages/react-component-library/src/components/Radio/partials/StyledCheckmarkWrapper.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components'
+
+import { CheckmarkWrapperProps } from '../../CheckboxRadioBase'
+
+export const StyledCheckmarkWrapper = styled.span<CheckmarkWrapperProps>`
+  display: block;
+  position: absolute;
+  top: ${({ $hasContainer }) => ($hasContainer ? '13px' : '4px')};
+  left: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
+  height: 16px;
+  width: 16px;
+`

--- a/packages/react-component-library/src/components/Radio/partials/StyledRadio.tsx
+++ b/packages/react-component-library/src/components/Radio/partials/StyledRadio.tsx
@@ -1,21 +1,15 @@
 import styled, { css } from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
+import { CheckboxRootProps } from '../../CheckboxRadioBase'
 import { StyledCheckmark } from './StyledCheckmark'
 import { StyledInput } from '../../CheckboxRadioBase/partials/StyledInput'
-
-interface StyledRadioProps {
-  $hasContainer?: boolean
-  $isDisabled?: boolean
-  $isInvalid?: boolean
-  $isChecked?: boolean
-}
 
 const RADIO_ACTIVE_BORDER_WIDTH = '2px'
 
 const { spacing, fontSize, color } = selectors
 
-const BackgroundColor = css<StyledRadioProps>`
+const BackgroundColor = css<CheckboxRootProps>`
   ${({ $isDisabled, $hasContainer, $isChecked }) => {
     if (!$hasContainer) {
       return 'transparent'
@@ -33,7 +27,7 @@ const BackgroundColor = css<StyledRadioProps>`
   }}}
 `
 
-const CheckmarkBackgroundColor = css<StyledRadioProps>`
+const CheckmarkBackgroundColor = css<CheckboxRootProps>`
   ${({ $isDisabled, $hasContainer }) => {
     if ($hasContainer) {
       return BackgroundColor
@@ -43,26 +37,14 @@ const CheckmarkBackgroundColor = css<StyledRadioProps>`
   }}
 `
 
-const CheckmarkCheckedFillColor = css<StyledRadioProps>`
+const CheckmarkCheckedFillColor = css<CheckboxRootProps>`
   ${({ $isDisabled, $hasContainer }) =>
     $isDisabled
       ? color('neutral', $hasContainer ? '200' : '100')
       : color('action', '500')}
 `
 
-function getCheckmarkCheckedSelector($hasContainer: boolean | undefined) {
-  if ($hasContainer) {
-    return css`
-      ${StyledInput}:checked ~ ${StyledCheckmark}
-    `
-  }
-
-  return css`
-    ${StyledInput}:checked ~ ${StyledCheckmark}, ${StyledInput}:focus-within ~ ${StyledCheckmark}
-  `
-}
-
-export const StyledRadio = styled.div<StyledRadioProps>`
+export const StyledRadio = styled.div<CheckboxRootProps>`
   display: inline-flex;
   position: relative;
   padding: ${({ $hasContainer }) =>
@@ -112,9 +94,18 @@ export const StyledRadio = styled.div<StyledRadioProps>`
       }
     `}
 
+  ${({ $hasContainer }) =>
+    !$hasContainer &&
+    css`
+      ${StyledInput}:focus ~ ${StyledCheckmark}::before {
+        box-shadow: 0 0 0 ${RADIO_ACTIVE_BORDER_WIDTH}
+          ${CheckmarkCheckedFillColor};
+      }
+    `}
+
   /* Checkmark checked state */
 
-  ${({ $hasContainer }) => getCheckmarkCheckedSelector($hasContainer)} {
+  ${StyledInput}:checked ~ ${StyledCheckmark} {
     /* Blue border (grey if disabled) */
     &::before {
       box-shadow: 0 0 0 ${RADIO_ACTIVE_BORDER_WIDTH}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,12 +9,12 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@axe-core/puppeteer@^4.2.0":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@axe-core/puppeteer/-/puppeteer-4.3.2.tgz#196748648ce1c5bcf537395441f4ae3b8d9190e9"
-  integrity sha512-/0Od30pNxUr00cO20pndz2n/b5DyYrkAKBBXlpTAbAMPuLtz6JnavR9A1oQMDyBeoQDNbKr7B97FRYSNPPgI9Q==
+"@axe-core/puppeteer@4.2.1", "@axe-core/puppeteer@^4.2.0":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@axe-core/puppeteer/-/puppeteer-4.2.1.tgz#5b7a191e4f4f3d56f975fdf5c2682eed3ad306a7"
+  integrity sha512-2JDELbLCKK2KqBvLOpsROtJU0i+zqyseMCd8S86S1H8loxy30/v7xJQo32WWbAa+x8xABQcejO1U4Kk1VEVssw==
   dependencies:
-    axe-core "^4.3.3"
+    axe-core "^4.2.1"
 
 "@babel/cli@^7.11.6", "@babel/cli@^7.8.3":
   version "7.17.6"
@@ -6041,10 +6041,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axe-core@^3.5.3, axe-core@^4.2.0, axe-core@^4.3.3, axe-core@^4.3.5:
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.6.tgz#e762a90d7f6dbd244ceacb4e72760ff8aad521b5"
-  integrity sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==
+axe-core@^4.2.0, axe-core@^4.2.1, axe-core@^4.3.5:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
+  integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
 axobject-query@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Related issue

Resolves #2575 

## Overview

This:

- resolves accessibility problems with Checkbox and Radio
- fixes a problem where a no-container radio appeared checked after tabbing to it
- fixes a problem where a checked no-container radio didn't appear checked in IE11
- unpins axe-core and updates it to the latest version

## Link to preview

https://5e25c277526d380020b5e418-flizpnqrju.chromatic.com/

## Reason

To ensure components are accessible, and function correctly.

## Work carried out

- [x] Resolve accessibility problems
- [x] Fix no-container radio styling bugs
- [x] Update axe-core and pin @axe-core/puppeteer

## Screenshot

### No-container tabbing bug

(Note: can only be reproduced if no radios are checked.)

#### Before

![Screencast_11-04-22_15:01:18](https://user-images.githubusercontent.com/66470099/162756438-42134bcc-d89f-4758-b93c-54386179142b.gif)

#### After

![Screencast_11-04-22_15:00:26](https://user-images.githubusercontent.com/66470099/162756431-0c722ef5-102b-4847-b2ea-c892da2291d9.gif)

### IE11 checked no-container radio

#### Before

![image](https://user-images.githubusercontent.com/66470099/162761109-50d53924-3b24-479b-9113-ce3dbffd9340.png)

#### After

![image](https://user-images.githubusercontent.com/66470099/162761636-aacf2287-091a-44b6-8cd3-f40be8f7bb40.png)

## Developer notes

The axe error resolved was:

https://dequeuniversity.com/rules/axe/4.4/nested-interactive

This was occurring as we effectively had a checkbox within a checkbox, as we had a visually-hidden `<input>` contained within an element with `role="checkbox"`.

The removes the roles from the parent elements.

A further problem was that the 0px \<input\> (or even a 1px one) caused a screen reader used with Firefox to behave oddly. This fixes that by reorganising things slightly so that the \<input\> has the same dimensions as `StyledCheckmark`.

A bug was also fixed where, when no radio is checked in a group, tabbing to a no-container radio caused it to incorrectly appear checked. A related bug where a checked no-container radio didn't appear checked in IE11 was also fixed.

@axe-core/puppeteer was pinned to an older version due to https://github.com/dequelabs/axe-core-npm/issues/484 (which has been fixed, but the fix hasn't been released yet).