### PR TITLE
feat(CheckboxRadioBase): Convert to a controlled component

### DIFF
--- a/packages/react-component-library/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import 'jest-styled-components'
 import { ColorNeutral200 } from '@defencedigital/design-tokens'
@@ -115,7 +115,7 @@ describe('Checkbox', () => {
     })
   })
 
-  describe('when a field has defaultChecked prop set', () => {
+  describe('when a field has `defaultChecked` prop set', () => {
     beforeEach(() => {
       label = 'My Label 1'
       field.value = 'false'
@@ -133,6 +133,51 @@ describe('Checkbox', () => {
 
     it('should initially render as checked', () => {
       expect(checkbox.getByTestId('checkbox-input')).toBeChecked()
+    })
+  })
+
+  describe('when a field has `checked` prop set', () => {
+    beforeEach(() => {
+      label = 'My Label 1'
+      field.value = 'false'
+
+      const StateWrapper = () => {
+        const [isChecked, setIsChecked] = useState<boolean>(true)
+
+        return (
+          <>
+            <Checkbox
+              name={field.name}
+              value={field.value}
+              label={label}
+              onChange={field.onChange}
+              checked={isChecked}
+            />
+            <button
+              data-testid="change-checked-state"
+              onClick={(_) => setIsChecked(false)}
+            >
+              Click Me!
+            </button>
+          </>
+        )
+      }
+
+      checkbox = render(<StateWrapper />)
+    })
+
+    it('should initially render as checked', () => {
+      expect(checkbox.getByTestId('checkbox-input')).toBeChecked()
+    })
+
+    describe('and the button is clicked, changing the `isChecked` state', () => {
+      beforeEach(() => {
+        userEvent.click(checkbox.getByTestId('change-checked-state'))
+      })
+
+      it('should uncheck the checkbox', () => {
+        expect(checkbox.getByTestId('checkbox-input')).not.toBeChecked()
+      })
     })
   })
 

--- a/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
@@ -18,6 +18,7 @@ export const CheckboxRadioBase = React.forwardRef<
     {
       className = '',
       id: externalId,
+      checked = false,
       defaultChecked,
       description,
       isDisabled = false,
@@ -36,7 +37,16 @@ export const CheckboxRadioBase = React.forwardRef<
   ) => {
     const id = useExternalId(`${type}-input`, externalId)
     const localRef = useRef<HTMLInputElement>(null)
-    const [isChecked, setIsChecked] = useState(defaultChecked)
+    const isControlled = defaultChecked === undefined
+    const hasContainer = variant !== CHECKBOX_RADIO_VARIANT.NO_CONTAINER
+    const [isChecked, setIsChecked] = useState<boolean>(
+      defaultChecked ?? checked
+    )
+
+    // Respect external changes to `defaultChecked` and `checked`
+    useEffect(() => {
+      setIsChecked(defaultChecked ?? checked)
+    }, [defaultChecked, checked])
 
     // Handle implicit deselection of radio in collection
     useEffect(() => {
@@ -75,7 +85,7 @@ export const CheckboxRadioBase = React.forwardRef<
     }
 
     const handleOnChange = (e: React.FormEvent<HTMLInputElement>) => {
-      setIsChecked(!isChecked)
+      setIsChecked(e.currentTarget.checked)
 
       if (type === 'radio') {
         const event = new CustomEvent('_mod-uk-ds:radio:selected', {
@@ -89,8 +99,6 @@ export const CheckboxRadioBase = React.forwardRef<
         onChange(e)
       }
     }
-
-    const hasContainer = variant !== CHECKBOX_RADIO_VARIANT.NO_CONTAINER
 
     return (
       <StyledWrapper>
@@ -114,8 +122,8 @@ export const CheckboxRadioBase = React.forwardRef<
               data-testid={`${type}-label`}
             >
               <StyledInput
-                ref={mergeRefs([localRef, ref])}
                 defaultChecked={defaultChecked}
+                ref={mergeRefs([localRef, ref])}
                 id={id}
                 type={type}
                 name={name}
@@ -124,6 +132,7 @@ export const CheckboxRadioBase = React.forwardRef<
                 onBlur={onBlur}
                 disabled={isDisabled}
                 data-testid={`${type}-input`}
+                checked={isControlled ? isChecked : undefined}
                 {...rest}
               />
               <Checkmark $hasContainer={hasContainer} />

--- a/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBaseProps.ts
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBaseProps.ts
@@ -22,13 +22,17 @@ export interface CheckboxRadioBaseProps
    */
   id?: string
   /**
-   * Toggles whether or not the component is marked as checked by default.
-   */
-  defaultChecked?: boolean
-  /**
    * Optional description to display below the label.
    */
   description?: React.ReactNode
+  /**
+   * Toggles whether or not to the component is initially marked as checked.
+   */
+  defaultChecked?: boolean
+  /**
+   * Toggles whether or not the component is marked as checked.
+   */
+  checked?: boolean
   /**
    * Toggles whether the component is disabled or not (preventing user interaction).
    */

--- a/packages/react-component-library/src/components/Radio/Radio.stories.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.stories.tsx
@@ -46,7 +46,7 @@ Default.args = {
 export const Checked = Template.bind({})
 Checked.args = {
   id: undefined,
-  defaultChecked: true,
+  checked: true,
   label: 'Checked radio',
   name: 'checked',
 }
@@ -64,7 +64,7 @@ DisabledChecked.storyName = 'Disabled, checked'
 DisabledChecked.args = {
   id: undefined,
   isDisabled: true,
-  defaultChecked: true,
+  checked: true,
   label: 'Disabled, checked radio',
   name: 'disabled-checked',
 }

--- a/packages/react-component-library/src/components/Radio/Radio.test.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import 'jest-styled-components'
 import {
@@ -234,6 +234,72 @@ describe('Radio', () => {
 
     it('does not generate a new `id`', () => {
       expect(radio.getByTestId('radio-input')).toHaveAttribute('id', initialId)
+    })
+  })
+
+  describe('when a field has `defaultChecked` prop set', () => {
+    beforeEach(() => {
+      label = 'My Label 1'
+      field.value = 'false'
+
+      radio = render(
+        <Radio
+          name={field.name}
+          value={field.value}
+          label={label}
+          onChange={field.onChange}
+          defaultChecked
+        />
+      )
+    })
+
+    it('should initially render as checked', () => {
+      expect(radio.getByTestId('radio-input')).toBeChecked()
+    })
+  })
+
+  describe('when a field has `checked` prop set', () => {
+    beforeEach(() => {
+      label = 'My Label 1'
+      field.value = 'false'
+
+      const StateWrapper = () => {
+        const [isChecked, setIsChecked] = useState<boolean>(true)
+
+        return (
+          <>
+            <Radio
+              name={field.name}
+              value={field.value}
+              label={label}
+              onChange={field.onChange}
+              checked={isChecked}
+            />
+            <button
+              data-testid="change-checked-state"
+              onClick={(_) => setIsChecked(false)}
+            >
+              Click Me!
+            </button>
+          </>
+        )
+      }
+
+      radio = render(<StateWrapper />)
+    })
+
+    it('should initially render as checked', () => {
+      expect(radio.getByTestId('radio-input')).toBeChecked()
+    })
+
+    describe('and the button is clicked, changing the `isChecked` state', () => {
+      beforeEach(() => {
+        userEvent.click(radio.getByTestId('change-checked-state'))
+      })
+
+      it('should uncheck the radio', () => {
+        expect(radio.getByTestId('radio-input')).not.toBeChecked()
+      })
     })
   })
 })

--- a/packages/react-component-library/src/forms/native/native.stories.tsx
+++ b/packages/react-component-library/src/forms/native/native.stories.tsx
@@ -93,18 +93,30 @@ const Example: React.FC<{
             name="exampleCheckbox"
             label="Option 1"
             value="Option 1"
+            checked={
+              Array.isArray(initialValues.exampleCheckbox) &&
+              initialValues.exampleCheckbox.includes('Option 1')
+            }
           />
           <Checkbox
             onChange={handleCheckboxGroup}
             name="exampleCheckbox"
             label="Option 2"
             value="Option 2"
+            checked={
+              Array.isArray(initialValues.exampleCheckbox) &&
+              initialValues.exampleCheckbox.includes('Option 2')
+            }
           />
           <Checkbox
             onChange={handleCheckboxGroup}
             name="exampleCheckbox"
             label="Option 3"
             value="Option 3"
+            checked={
+              Array.isArray(initialValues.exampleCheckbox) &&
+              initialValues.exampleCheckbox.includes('Option 3')
+            }
           />
         </Fieldset>
         <Fieldset legend="Example radio selection">
@@ -113,12 +125,14 @@ const Example: React.FC<{
             name="exampleRadio"
             label="Option 1"
             value="Option 1"
+            checked={initialValues.exampleRadio === 'Option 1'}
           />
           <Radio
             onChange={handleRadioGroup}
             name="exampleRadio"
             label="Option 2"
             value="Option 2"
+            checked={initialValues.exampleRadio === 'Option 2'}
           />
         </Fieldset>
         <Field hintText="Example hint text.">

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -1,7 +1,11 @@
 /* eslint-disable no-console */
 import { isBefore, isValid, parseISO } from 'date-fns'
-import React, { useState, useEffect } from 'react'
-import { useForm, Controller } from 'react-hook-form/dist/index.ie11'
+import React, { useState, useEffect, useMemo } from 'react'
+import {
+  useForm,
+  Controller,
+  useController,
+} from 'react-hook-form/dist/index.ie11'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import styled from 'styled-components'
 
@@ -39,6 +43,7 @@ const Example: React.FC<{ initialValues: FormValues }> = ({
     handleSubmit,
     watch,
     formState: { errors, isSubmitting },
+    getValues,
   } = useForm({
     defaultValues: initialValues,
   })
@@ -67,6 +72,16 @@ const Example: React.FC<{ initialValues: FormValues }> = ({
       | React.MouseEvent<HTMLButtonElement>,
     newValue: number | null
   ) => setValue('exampleNumberInput', newValue)
+
+  const handleCheckboxChange = (value: string, name: string) => {
+    const values = getValues()
+
+    if (values[name]?.includes(value)) {
+      return values[name]?.filter((id: string) => id !== value)
+    }
+
+    return [...(values[name] ?? []), value]
+  }
 
   return (
     <main>
@@ -102,37 +117,83 @@ const Example: React.FC<{ initialValues: FormValues }> = ({
           />
         </Field>
         <Fieldset legend="Example checkbox selection">
-          <Checkbox
+          <Controller
+            control={control}
             name="exampleCheckbox"
-            label="Option 1"
-            ref={register}
-            value="Option 1"
+            render={({ onChange, value, name, ref }) => (
+              <Checkbox
+                name={name}
+                label="Option 1"
+                value="Option 1"
+                ref={ref}
+                onChange={() =>
+                  onChange(handleCheckboxChange('Option 1', name))
+                }
+                checked={Array.isArray(value) && value.includes('Option 1')}
+              />
+            )}
           />
-          <Checkbox
+          <Controller
+            control={control}
             name="exampleCheckbox"
-            label="Option 2"
-            ref={register}
-            value="Option 2"
+            render={({ onChange, value, name, ref }) => (
+              <Checkbox
+                name={name}
+                label="Option 2"
+                value="Option 2"
+                ref={ref}
+                onChange={() =>
+                  onChange(handleCheckboxChange('Option 2', name))
+                }
+                checked={Array.isArray(value) && value.includes('Option 2')}
+              />
+            )}
           />
-          <Checkbox
+          <Controller
+            control={control}
             name="exampleCheckbox"
-            label="Option 3"
-            ref={register}
-            value="Option 3"
+            render={({ onChange, value, name, ref }) => (
+              <Checkbox
+                name={name}
+                label="Option 3"
+                value="Option 3"
+                ref={ref}
+                onChange={() =>
+                  onChange(handleCheckboxChange('Option 3', name))
+                }
+                checked={Array.isArray(value) && value.includes('Option 3')}
+              />
+            )}
           />
         </Fieldset>
         <Fieldset legend="Example radio selection">
-          <Radio
+          <Controller
+            control={control}
             name="exampleRadio"
-            label="Option 1"
-            ref={register}
-            value="Option 1"
+            render={({ onChange, value, name, ref }) => (
+              <Radio
+                name={name}
+                label="Option 1"
+                value="Option 1"
+                ref={ref}
+                onChange={() => onChange('Option 1')}
+                checked={value === 'Option 1'}
+              />
+            )}
           />
-          <Radio
+          <Controller
+            control={control}
             name="exampleRadio"
-            label="Option 2"
-            ref={register}
-            value="Option 2"
+            render={({ onChange, value, name, ref }) => (
+              <Radio
+                name={name}
+                label="Option 2"
+                value="Option 2"
+                ref={ref}
+                onChange={() => onChange('Option 2')}
+                checked={value === 'Option 2'}
+              />
+            )}
           />
         </Fieldset>
         <Field hintText="Example hint text.">


### PR DESCRIPTION
## Related issue

Closes #3214

## Overview

Support both uncontrolled and controlled usage and fix usage examples.

## Reason

>Would this be possible if the checkbox component was passed a checked prop that updated the value when the props changed instead of a defaultProp.

## Work carried out

- [x] Supplement with additional tests
- [x] Support both uncontrolled and controlled usage
- [x] Fix broken react-hook-form example usage
- [x] Fix broken native example usage
