### PR TITLE
fix(Forms): Resolve broken react-hook-form prepopulated usage

### DIFF
--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -91,29 +91,54 @@ const Example: React.FC<{ initialValues: FormValues }> = ({
           hintText="Example hint text."
           errors={[{ error: !!errors.email && 'Required' }]}
         >
-          <TextInput
-            type="email"
+          <Controller
+            control={control}
             name="email"
-            ref={register({ required: true })}
-            label="Email"
-            data-testid="form-example-TextInput-email"
+            rules={{ required: true }}
+            render={({ onChange, value, name, ref }) => (
+              <TextInput
+                type="email"
+                name={name}
+                ref={ref}
+                onChange={onChange}
+                value={value}
+                label="Email"
+                data-testid="form-example-TextInput-email"
+              />
+            )}
           />
         </Field>
         <Field hintText="Example hint text.">
-          <TextInput
-            type="password"
+          <Controller
+            control={control}
             name="password"
-            ref={register}
-            label="Password"
-            data-testid="form-example-TextInput-password"
+            render={({ onChange, value, name, ref }) => (
+              <TextInput
+                type="password"
+                name={name}
+                ref={ref}
+                onChange={onChange}
+                value={value}
+                label="Password"
+                data-testid="form-example-TextInput-password"
+              />
+            )}
           />
         </Field>
         <Field hintText="Example hint text.">
-          <TextArea
+          <Controller
+            control={control}
             name="description"
-            ref={register}
-            label="Description"
-            data-testid="form-example-TextArea-description"
+            render={({ onChange, value, name, ref }) => (
+              <TextInput
+                name={name}
+                ref={ref}
+                onChange={onChange}
+                value={value}
+                label="Description"
+                data-testid="form-example-TextArea-description"
+              />
+            )}
           />
         </Field>
         <Fieldset legend="Example checkbox selection">


### PR DESCRIPTION
## Related issue

Closes #3219

## Overview

Use `Controller` to consume `TextInput` and `TextArea` components with react-hook-form.

## Reason

>The register function does not correctly inject prepopulated values.

## Work carried out

- [x] Use `Controller` to consume components

## Screenshot

Before:

![Screenshot 2022-04-04 at 15 48 48](https://user-images.githubusercontent.com/48086589/161570526-541c6ddf-3b65-4785-880e-df87b18fbc87.png)

After:

![Screenshot 2022-04-04 at 15 50 54](https://user-images.githubusercontent.com/48086589/161570613-06ddb9f4-b1c6-434f-bd96-2fdcc8bf27e3.png)
