### PR TITLE
Improve no-container Radio and Checkbox disabled styling

### DIFF
--- a/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
@@ -25,6 +25,7 @@ const MultipleItemsTemplate: ComponentStory<typeof Checkbox> = (props) => {
   function getProps(i: number): CheckboxProps {
     return {
       ...props,
+      variant: CHECKBOX_RADIO_VARIANT.NO_CONTAINER,
       label: `${props.label} ${i}`,
       name: `${props.name}-${i}`,
     }
@@ -34,7 +35,7 @@ const MultipleItemsTemplate: ComponentStory<typeof Checkbox> = (props) => {
     <>
       <Checkbox {...getProps(1)} />
       <Checkbox {...getProps(2)} />
-      <Checkbox {...getProps(3)} />
+      <Checkbox defaultChecked {...getProps(3)} />
     </>
   )
 }
@@ -82,14 +83,24 @@ Invalid.args = {
 }
 
 export const NoContainer = MultipleItemsTemplate.bind({})
+NoContainer.storyName = 'No container'
 NoContainer.args = {
   id: undefined,
   label: 'Item without container',
   name: 'no-container',
-  variant: CHECKBOX_RADIO_VARIANT.NO_CONTAINER,
+}
+
+export const NoContainerDisabled = MultipleItemsTemplate.bind({})
+NoContainerDisabled.storyName = 'No container, disabled'
+NoContainerDisabled.args = {
+  id: undefined,
+  label: 'Item without container',
+  name: 'no-container',
+  isDisabled: true,
 }
 
 export const WithDescription = Template.bind({})
+WithDescription.storyName = 'With description'
 WithDescription.args = {
   id: undefined,
   description:

--- a/packages/react-component-library/src/components/Checkbox/partials/StyledCheckbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/partials/StyledCheckbox.tsx
@@ -52,7 +52,7 @@ export const StyledCheckbox = styled.div<StyledCheckboxProps>`
       }
     `}
 
-  ${({ $isDisabled }) =>
+  ${({ $isDisabled, $hasContainer }) =>
     $isDisabled &&
     css`
       cursor: not-allowed;
@@ -61,8 +61,12 @@ export const StyledCheckbox = styled.div<StyledCheckboxProps>`
         cursor: not-allowed;
       }
 
-      background-color: ${color('neutral', '000')};
       border-color: transparent;
+
+      ${$hasContainer &&
+      css`
+        background-color: ${color('neutral', '000')};
+      `};
 
       &:focus,
       &:active {

--- a/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmark.tsx
@@ -64,16 +64,18 @@ export const StyledCheckmark = styled.div<CheckmarkProps>`
     }
   }
 
-  ${StyledCheckbox} input:disabled ~ & {
+  ${StyledCheckbox} input:disabled ~ && {
     background-color: ${color('neutral', '000')};
-    border-color: ${color('neutral', '200')};
+    border-color: ${({ $hasContainer }) =>
+      color('neutral', $hasContainer ? '200' : '100')};
 
     &::before {
       box-shadow: none;
     }
   }
 
-  ${StyledCheckbox} input:disabled:checked ~ & {
-    background-color: ${color('neutral', '200')};
+  ${StyledCheckbox} input:disabled:checked ~ && {
+    background-color: ${({ $hasContainer }) =>
+      color('neutral', $hasContainer ? '200' : '100')};
   }
 `

--- a/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
@@ -136,7 +136,10 @@ export const CheckboxRadioBase = React.forwardRef<
                 checked={isControlled ? isChecked : undefined}
                 {...rest}
               />
-              <Checkmark $hasContainer={hasContainer} />
+              <Checkmark
+                $hasContainer={hasContainer}
+                $isDisabled={isDisabled}
+              />
               {label}
               {description && (
                 <StyledDescription data-testid={`${type}-description`}>

--- a/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
@@ -118,6 +118,7 @@ export const CheckboxRadioBase = React.forwardRef<
             <StyledLabel
               $hasContainer={hasContainer}
               $hasDescription={!!description}
+              $isDisabled={isDisabled}
               htmlFor={id}
               data-testid={`${type}-label`}
             >

--- a/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBaseProps.ts
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBaseProps.ts
@@ -12,6 +12,7 @@ export interface CheckboxRootProps extends React.HTMLAttributes<HTMLElement> {
 
 export interface CheckmarkProps {
   $hasContainer?: boolean
+  $isDisabled?: boolean
 }
 
 export interface CheckboxRadioBaseProps

--- a/packages/react-component-library/src/components/CheckboxRadioBase/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/partials/StyledLabel.tsx
@@ -6,10 +6,12 @@ const { color, fontSize } = selectors
 interface StyledLabelProps {
   $hasContainer?: boolean
   $hasDescription?: boolean
+  $isDisabled: boolean
 }
 
 export const StyledLabel = styled.label<StyledLabelProps>`
-  color: ${color('neutral', '400')};
+  color: ${({ $hasContainer, $isDisabled }) =>
+    color('neutral', $isDisabled && !$hasContainer ? '300' : '400')};
   font-size: ${fontSize('m')};
   pointer-events: none;
   padding: 4px;
@@ -17,7 +19,7 @@ export const StyledLabel = styled.label<StyledLabelProps>`
   ${({ $hasContainer }) =>
     $hasContainer &&
     css`
-      padding: 0px 12px 0 0;
+      padding: 0 12px 0 0;
     `}
 
   ${({ $hasDescription }) =>

--- a/packages/react-component-library/src/components/Radio/Radio.stories.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.stories.tsx
@@ -23,6 +23,7 @@ const MultipleItemsTemplate: ComponentStory<typeof Radio> = (props) => {
   function getProps(i: number): RadioProps {
     return {
       ...props,
+      variant: CHECKBOX_RADIO_VARIANT.NO_CONTAINER,
       label: `${props.label} ${i}`,
     }
   }
@@ -31,7 +32,7 @@ const MultipleItemsTemplate: ComponentStory<typeof Radio> = (props) => {
     <>
       <Radio {...getProps(1)} />
       <Radio {...getProps(2)} />
-      <Radio {...getProps(3)} />
+      <Radio defaultChecked {...getProps(3)} />
     </>
   )
 }
@@ -78,14 +79,24 @@ Invalid.args = {
 }
 
 export const NoContainer = MultipleItemsTemplate.bind({})
+NoContainer.storyName = 'No container'
 NoContainer.args = {
   id: undefined,
   label: 'Item without container',
   name: 'no-container',
-  variant: CHECKBOX_RADIO_VARIANT.NO_CONTAINER,
+}
+
+export const NoContainerDisabled = MultipleItemsTemplate.bind({})
+NoContainerDisabled.storyName = 'No container, disabled'
+NoContainerDisabled.args = {
+  id: undefined,
+  label: 'Disabled item without container',
+  name: 'no-container-disabled',
+  isDisabled: true,
 }
 
 export const WithDescription = Template.bind({})
+WithDescription.storyName = 'With description'
 WithDescription.args = {
   id: undefined,
   description:

--- a/packages/react-component-library/src/components/Radio/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/Radio/partials/StyledCheckmark.tsx
@@ -1,20 +1,20 @@
 import styled from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
+import { CheckmarkProps } from '../../CheckboxRadioBase'
+
 const { color } = selectors
 
-interface StyledCheckmarkProps {
-  $hasContainer?: boolean
-}
-
-export const StyledCheckmark = styled.div<StyledCheckmarkProps>`
+export const StyledCheckmark = styled.div<CheckmarkProps>`
   position: absolute;
   top: ${({ $hasContainer }) => ($hasContainer ? '13px' : '4px')};
   left: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
   height: 16px;
   width: 16px;
   border-radius: 999px;
-  border: 1px solid ${color('neutral', '200')};
+  border: 1px solid
+    ${({ $hasContainer, $isDisabled }) =>
+      color('neutral', $hasContainer || !$isDisabled ? '200' : '100')};
   outline: none;
 
   &::after,

--- a/packages/react-component-library/src/components/Radio/partials/StyledRadio.tsx
+++ b/packages/react-component-library/src/components/Radio/partials/StyledRadio.tsx
@@ -17,26 +17,37 @@ const { spacing, fontSize, color } = selectors
 
 const BackgroundColor = css<StyledRadioProps>`
   ${({ $isDisabled, $hasContainer, $isChecked }) => {
+    if (!$hasContainer) {
+      return 'transparent'
+    }
+
     if ($isDisabled) {
       return color('neutral', '000')
     }
 
-    if ($hasContainer && $isChecked) {
+    if ($isChecked) {
       return color('action', '000')
     }
 
     return color('neutral', 'white')
+  }}}
+`
+
+const CheckmarkBackgroundColor = css<StyledRadioProps>`
+  ${({ $isDisabled, $hasContainer }) => {
+    if ($hasContainer) {
+      return BackgroundColor
+    }
+
+    return color('neutral', $isDisabled ? '000' : 'white')
   }}
 `
 
-const CheckmarkActiveBorderColor = css<StyledRadioProps>`
-  ${({ $isDisabled }) =>
-    $isDisabled ? color('neutral', '200') : color('action', '500')}
-`
-
 const CheckmarkCheckedFillColor = css<StyledRadioProps>`
-  ${({ $isDisabled }) =>
-    $isDisabled ? color('neutral', '200') : color('action', '500')}
+  ${({ $isDisabled, $hasContainer }) =>
+    $isDisabled
+      ? color('neutral', $hasContainer ? '200' : '100')
+      : color('action', '500')}
 `
 
 function getCheckmarkCheckedSelector($hasContainer: boolean | undefined) {
@@ -66,10 +77,9 @@ export const StyledRadio = styled.div<StyledRadioProps>`
   }
 
   ${StyledCheckmark} {
-    background: ${BackgroundColor};
-
     &::before {
       display: block;
+      background: ${CheckmarkBackgroundColor};
       box-shadow: 0 0 0 0 transparent;
     }
   }
@@ -108,13 +118,13 @@ export const StyledRadio = styled.div<StyledRadioProps>`
     /* Blue border (grey if disabled) */
     &::before {
       box-shadow: 0 0 0 ${RADIO_ACTIVE_BORDER_WIDTH}
-        ${CheckmarkActiveBorderColor};
+        ${CheckmarkCheckedFillColor};
     }
 
     &::after {
       display: block;
       background: ${CheckmarkCheckedFillColor};
-      border: 2px solid ${BackgroundColor};
+      border: 2px solid ${CheckmarkBackgroundColor};
     }
   }
 


### PR DESCRIPTION
## Related issue

Resolves #3218

## Overview

This fixes and improves the disabled styling for no-container `Radio` and `Checkbox`es

## Link to preview

https://5e25c277526d380020b5e418-nuxcasdqor.chromatic.com/

## Reason

To make sure no-container Checkboxes and Radios have appropriate styling when disabled.

## Work carried out

- [x] Update styles
- [x] Add additional stories

## Screenshot

### Checkbox

#### Before

![Screenshot 2022-04-01 at 13-36-42 Checkbox - No Container ⋅ Storybook](https://user-images.githubusercontent.com/66470099/161571690-a157d149-cea8-4769-b75e-e45ca0bf2476.png)

#### After

![Screenshot from 2022-04-04 11-17-25](https://user-images.githubusercontent.com/66470099/161571746-dd5cf902-f8a1-4cd3-9274-20086fc4f238.png)

### Radio

#### Before

![Screenshot 2022-04-01 at 13-37-33 Radio - Default ⋅ Storybook](https://user-images.githubusercontent.com/66470099/161571761-aad336dd-f504-4b4e-88cb-083afb4d2921.png)

#### After

![image](https://user-images.githubusercontent.com/66470099/162412977-71281ce0-70ae-4467-9bb3-f476be28c5c3.png)


## Developer notes

n/a
