### PR TITLE
fix(Forms): Stop long input labels from wrapping

### DIFF
--- a/packages/react-component-library/babel.config.js
+++ b/packages/react-component-library/babel.config.js
@@ -45,7 +45,13 @@ module.exports = {
       ],
     },
     test: {
-      plugins: ['@babel/plugin-transform-modules-commonjs'],
+      plugins: [
+        'babel-plugin-styled-components',
+        '@babel/plugin-transform-modules-commonjs',
+      ],
+    },
+    'storybook-test': {
+      plugins: ['babel-plugin-styled-components'],
     },
   },
 }

--- a/packages/react-component-library/cypress/specs/Autocomplete/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/Autocomplete/index.spec.ts
@@ -4,7 +4,9 @@ import {
   ColorDanger800,
   ColorNeutral100,
   ColorNeutral200,
+  TypographyS,
 } from '@defencedigital/design-tokens'
+import { remToPx } from 'polished'
 
 import { hexToRgb } from '../../helpers'
 import selectors from '../../selectors'
@@ -179,8 +181,8 @@ describe('Autocomplete', () => {
         it('keeps the small label', () => {
           cy.get(selectors.select.label).should(
             'have.css',
-            'transform',
-            'matrix(0.75, 0, 0, 0.75, 11, 6)'
+            'font-size',
+            remToPx(TypographyS)
           )
         })
       })

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -38,7 +38,7 @@
     "prepare": "yarn build",
     "storybook": "BABEL_ENV=es RNDS_LOG_LEVEL=debug start-storybook -p 6006",
     "storybook:static": "BABEL_ENV=es build-storybook -c .storybook -o .static_storybook",
-    "storybook:test": "RNDS_LOG_LEVEL=debug start-storybook -p 6006",
+    "storybook:test": "BABEL_ENV=storybook-test RNDS_LOG_LEVEL=debug start-storybook -p 6006",
     "test": "BABEL_ENV=test jest --testPathIgnorePatterns=./src/a11y/index.test.tsx",
     "test:a11y": "BABEL_ENV=test yarn storybook:static && jest ./src/a11y/index.test.tsx",
     "test:watch": "BABEL_ENV=test jest --watch",

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
@@ -1,3 +1,4 @@
+import { TypographyS } from '@defencedigital/design-tokens'
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
@@ -85,8 +86,8 @@ describe('Autocomplete', () => {
 
       it('renders the label smaller', () => {
         expect(wrapper.getByText('Label')).toHaveStyleRule(
-          'transform',
-          'translate(11px,6px) scale(0.75)'
+          'font-size',
+          TypographyS
         )
       })
 

--- a/packages/react-component-library/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
+import { css } from 'styled-components'
 
 import { TextArea } from '.'
 
@@ -31,3 +32,18 @@ export const WithError: ComponentStory<typeof TextArea> = (props) => (
 )
 
 WithError.storyName = 'With error'
+
+export const WithLongLabel: ComponentStory<typeof TextArea> = (props) => (
+  <div
+    css={css`
+      max-width: 400px;
+    `}
+  >
+    <TextArea
+      {...props}
+      label="This text input has a long label that doesn't fit in the container"
+    />
+  </div>
+)
+
+WithLongLabel.storyName = 'With long label'

--- a/packages/react-component-library/src/components/TextArea/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/TextArea/partials/StyledLabel.tsx
@@ -7,19 +7,20 @@ import {
   StyledLabelProps,
 } from '../../../styled-components/partials/StyledLabel'
 
-const { color, spacing } = selectors
+const { fontSize, spacing } = selectors
 
 export const StyledLabel = styled(StyledLabelBase)<StyledLabelProps>`
   padding-bottom: ${spacing('2')};
+  padding-left: 10px;
+  padding-right: 7px;
+  padding-top: ${isIE11() ? '9px' : '11px'};
   pointer-events: none;
-  background-color: ${color('neutral', 'white')};
   border-radius: 3px 3px 0 0;
-
-  transform: translate(10px, ${isIE11() ? '9px' : '11px'}) scale(1);
 
   ${({ $hasFocus, $hasContent }) =>
     ($hasFocus || $hasContent) &&
     css`
-      transform: translate(10px, ${isIE11() ? '6px' : '4px'}) scale(0.75);
+      padding-top: ${isIE11() ? '6px' : '4px'};
+      font-size: ${fontSize('s')};
     `}
 `

--- a/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
+import { css } from 'styled-components'
 
 import { IconSearch } from '@defencedigital/icon-library'
 import { TextInput } from '.'
@@ -74,3 +75,19 @@ export const WithError: ComponentStory<typeof TextInput> = (props) => (
 )
 
 WithError.storyName = 'With error'
+
+export const WithLongLabel: ComponentStory<typeof TextInput> = (props) => (
+  <div
+    css={css`
+      max-width: 400px;
+    `}
+  >
+    <TextInput
+      {...props}
+      label="This text input has a long label that doesn't fit in the container"
+      name="text-input-long-label"
+    />
+  </div>
+)
+
+WithLongLabel.storyName = 'With long label'

--- a/packages/react-component-library/src/components/TextInput/TextInput.test.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.test.tsx
@@ -1,3 +1,4 @@
+import { TypographyS, TypographyM } from '@defencedigital/design-tokens'
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult, waitFor } from '@testing-library/react'
@@ -39,8 +40,8 @@ describe('TextInput', () => {
 
     it('should apply the `$hasContent` style rule to label', () => {
       expect(wrapper.getByTestId('text-input-label')).toHaveStyleRule(
-        'transform',
-        'translate(11px,6px) scale(0.75)'
+        'font-size',
+        TypographyS
       )
     })
 
@@ -171,8 +172,8 @@ describe('TextInput', () => {
       it('should remove the `$hasContent` style rule from label', () => {
         return waitFor(() => {
           expect(wrapper.getByTestId('text-input-label')).toHaveStyleRule(
-            'transform',
-            'translate(11px,13px) scale(1)'
+            'font-size',
+            TypographyM
           )
         })
       })

--- a/packages/react-component-library/src/components/TextInput/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/TextInput/partials/StyledLabel.tsx
@@ -1,3 +1,4 @@
+import { selectors } from '@defencedigital/design-tokens'
 import styled, { css } from 'styled-components'
 
 import { COMPONENT_SIZE, ComponentSizeType } from '../../Forms'
@@ -6,6 +7,8 @@ import {
   StyledLabel as StyledLabelBase,
   StyledLabelProps,
 } from '../../../styled-components/partials/StyledLabel'
+
+const { fontSize } = selectors
 
 function getYPosition($size: ComponentSizeType) {
   if ($size === COMPONENT_SIZE.SMALL) {
@@ -16,8 +19,11 @@ function getYPosition($size: ComponentSizeType) {
 }
 
 export const StyledLabel = styled(StyledLabelBase)<StyledLabelProps>`
+  padding-left: 11px;
+  padding-right: 7px;
+
   ${({ $size = COMPONENT_SIZE.FORMS }) => css`
-    transform: translate(11px, ${getYPosition($size)}) scale(1);
+    padding-top: ${getYPosition($size)};
   `}
 
   ${({ $hasContent, $hasFocus, $size }) => {
@@ -32,7 +38,8 @@ export const StyledLabel = styled(StyledLabelBase)<StyledLabelProps>`
     }
 
     return css`
-      transform: translate(11px, 6px) scale(0.75);
+      padding-top: 6px;
+      font-size: ${fontSize('s')};
     `
   }}
 `

--- a/packages/react-component-library/src/styled-components/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/styled-components/partials/StyledLabel.tsx
@@ -3,7 +3,7 @@ import { selectors } from '@defencedigital/design-tokens'
 
 import { ComponentSizeType } from '../../components/Forms'
 
-const { color, fontSize } = selectors
+const { animation, color, fontSize } = selectors
 
 export interface StyledLabelProps {
   $hasContent: boolean
@@ -16,10 +16,12 @@ export const StyledLabel = styled.label<StyledLabelProps>`
   position: absolute;
   top: 0;
   left: 0;
-  transform-origin: top left;
-  transition: color 200ms cubic-bezier(0, 0, 0.2, 1) 0ms,
-    transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+  max-width: 100%;
+  overflow: hidden;
+  transition: all cubic-bezier(0, 0, 0.2, 1) ${animation('default')};
   pointer-events: none;
   color: ${color('neutral', '400')};
   font-size: ${fontSize('m')};
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `


### PR DESCRIPTION
## Related issue

Resolves #3217

## Overview

This stops long labels wrapping in `TextInput`, `TextArea` and various other components.

Instead, an ellipsis is shown when a label doesn't fit in the available space.

## Link to preview

https://5e25c277526d380020b5e418-yzdzruclmq.chromatic.com/

## Reason

To avoid visual glitches.

## Work carried out

- [x] Rework label styles
- [x] Add stories
- [x] Update Babel config

## Screenshot

### TextInput

#### Before

![Screencast_19-04-22_14:27:52](https://user-images.githubusercontent.com/66470099/164016816-f3ae5657-da2b-43e6-ba68-24167c04b11c.gif)

#### After

![Screencast_19-04-22_14:37:47](https://user-images.githubusercontent.com/66470099/164016840-faef2a91-9f1f-42cf-af95-35ed72439b59.gif)

### TextArea

#### Before

![Screencast_19-04-22_14:29:13](https://user-images.githubusercontent.com/66470099/164016831-90274a0e-b5ed-4e8f-b0fa-a7b07f4a03d2.gif)

#### After

![Screencast_19-04-22_14:38:41](https://user-images.githubusercontent.com/66470099/164016859-c6c5b8c3-550a-4adc-af43-c534dcb46a66.gif)

## Developer notes

The styles have been updated to use a transition on `font-size` and `padding` instead of `transform`, as it wasn't possible to fix this while still using a `transform`.

Full list of affected components:

- Autocomplete
- DatePicker
- Select
- NumberInput
- TextArea
- TextInput
