### PR TITLE
fix(FloatingBox): Resolve StrictMode warning

### DIFF
--- a/packages/react-component-library/.storybook/main.js
+++ b/packages/react-component-library/.storybook/main.js
@@ -20,4 +20,7 @@ module.exports = {
     ${process.env.NETLIFY ? newRelic.script : ''}
   `,
   stories: ['../src/**/*.stories.tsx'],
+  reactOptions: {
+    strictMode: process.env.REACT_STRICT_MODE === '1',
+  },
 }

--- a/packages/react-component-library/.storybook/preview.js
+++ b/packages/react-component-library/.storybook/preview.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import '@defencedigital/fonts'
 import 'iframe-resizer/js/iframeResizer.contentWindow'
 import { ResizeObserver } from '@juggle/resize-observer'
@@ -58,8 +59,10 @@ export const parameters = {
 
 export const decorators = [
   (Story) => (
-    <GlobalStyleProvider>
-      <Story />
-    </GlobalStyleProvider>
+    <React.StrictMode>
+      <GlobalStyleProvider>
+        <Story />
+      </GlobalStyleProvider>
+    </React.StrictMode>
   ),
 ]

--- a/packages/react-component-library/.storybook/preview.js
+++ b/packages/react-component-library/.storybook/preview.js
@@ -58,11 +58,6 @@ export const parameters = {
 }
 
 export const decorators = [
-  (Story) => (
-    <React.StrictMode>
-      <GlobalStyleProvider>
-        <Story />
-      </GlobalStyleProvider>
-    </React.StrictMode>
-  ),
+  // https://github.com/storybookjs/storybook/issues/15223#issuecomment-1092837912
+  (Story) => <GlobalStyleProvider>{Story()}</GlobalStyleProvider>,
 ]

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { Placement } from '@popperjs/core'
 import { Transition } from 'react-transition-group'
+import mergeRefs from 'react-merge-refs'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { FloatingBoxContent } from './FloatingBoxContent'
@@ -70,6 +71,7 @@ export const FloatingBox: React.FC<FloatingBoxProps> = ({
   role = 'dialog',
   ...rest
 }) => {
+  const nodeRef = useRef(null)
   const contentId = useExternalId('floating-box', externalContentId)
   const {
     targetElementRef,
@@ -89,11 +91,11 @@ export const FloatingBox: React.FC<FloatingBoxProps> = ({
           {renderTarget}
         </StyledTarget>
       )}
-      <Transition in={isVisible} timeout={0} unmountOnExit>
+      <Transition nodeRef={nodeRef} in={isVisible} timeout={0} unmountOnExit>
         {(state) => (
           <StyledFloatingBox
             style={{ ...styles.popper, ...TRANSITION_STYLES[state] }}
-            ref={floatingElementRef}
+            ref={mergeRefs([nodeRef, floatingElementRef])}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
             role={role}


### PR DESCRIPTION
## Related issue

Closes #3250 

## Overview

Resolve `React.StrictMode` warning about deprecated `findDOMNode` usage.

## Reason

>Transition from 'react-transition-group' using findDomNode could we use a nodeRef to stop this warning.

## Work carried out

- [x] Enable `React.StrictMode` for Storybook development builds
- [x] Use a ref to avoid the `findDOMNode` usage by `Transition`

## Developer notes

Note that `React.StrictMode` is disabled in the deployed production build of Storybook.
