### PR TITLE
Fix various incorrect CSS rules

### DIFF
--- a/packages/react-component-library/src/components/Badge/partials/StyledBadge.tsx
+++ b/packages/react-component-library/src/components/Badge/partials/StyledBadge.tsx
@@ -218,7 +218,7 @@ export const StyledBadge = styled.span<StyledBadgeProps>`
 
   ${({ $color, $colorVariant, $size, $variant }) => css`
     ${StyledBadgeSizeMap[$size]}
-    ${StyledBadgeColorVariantMap[$color][$colorVariant]}}
+    ${StyledBadgeColorVariantMap[$color][$colorVariant]}
     ${$variant === BADGE_VARIANT.PILL && StyledBadgePillMap[$size]}
   `}
 `

--- a/packages/react-component-library/src/components/Button/partials/StyledIconWrapper.tsx
+++ b/packages/react-component-library/src/components/Button/partials/StyledIconWrapper.tsx
@@ -35,5 +35,5 @@ export const StyledIconWrapper = styled.span<StyledIconWrapperProps>`
       margin-right: ${$iconPosition === BUTTON_ICON_POSITION.LEFT
         ? spacing('5')
         : '0'};
-    `};
+    `}
 `

--- a/packages/react-component-library/src/components/Checkbox/partials/StyledCheckbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/partials/StyledCheckbox.tsx
@@ -61,7 +61,7 @@ export const StyledCheckbox = styled.div<CheckboxRootProps>`
       ${$hasContainer &&
       css`
         background-color: ${color('neutral', '000')};
-      `};
+      `}
 
       &:focus,
       &:active {

--- a/packages/react-component-library/src/components/Drawer/partials/StyledDrawer.tsx
+++ b/packages/react-component-library/src/components/Drawer/partials/StyledDrawer.tsx
@@ -13,7 +13,7 @@ export const StyledDrawer = styled.div<StyledDrawerProps>`
   right: 0;
   width: 280px;
   height: 100%;
-  @include ${zIndex('overlay', 1)};
+  z-index: ${zIndex('overlay', 1)};
   overflow: hidden;
   background-color: ${color('neutral', 'white')};
   box-shadow: inset 1px 0px 0px 0px rgb(226, 233, 238),

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.tsx
@@ -9,7 +9,7 @@ import { DropdownLabel } from './DropdownLabel'
 import { DropdownOption } from './DropdownOption'
 import { DropdownPlaceholder } from './DropdownPlaceholder'
 
-const { color, spacing } = selectors
+const { color, shadow, spacing } = selectors
 
 export interface DropdownProps {
   /**
@@ -71,7 +71,7 @@ const StyledSelect = styled(Select)`
   }
 
   .rn-dropdown__menu {
-    @include m.shadow('1');
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.1);
     top: 102%;
     margin: ${spacing('6')} 0 0 5%;
     width: 95%;

--- a/packages/react-component-library/src/components/Radio/partials/StyledRadio.tsx
+++ b/packages/react-component-library/src/components/Radio/partials/StyledRadio.tsx
@@ -24,7 +24,7 @@ const BackgroundColor = css<CheckboxRootProps>`
     }
 
     return color('neutral', 'white')
-  }}}
+  }}
 `
 
 const CheckmarkBackgroundColor = css<CheckboxRootProps>`

--- a/packages/react-component-library/src/components/RangeSlider/partials/StyledMarker.tsx
+++ b/packages/react-component-library/src/components/RangeSlider/partials/StyledMarker.tsx
@@ -27,7 +27,7 @@ export const StyledMarker = styled.div<StyledMarkerProps>`
     $isActive &&
     css`
       background-color: ${RANGE_SLIDER_TRACK_BELOW_FIRST_THRESHOLD};
-    `};
+    `}
 
   ${({ $thresholdColor }) =>
     $thresholdColor &&
@@ -40,5 +40,5 @@ export const StyledMarker = styled.div<StyledMarkerProps>`
     $thresholdColor &&
     css`
       background-color: ${$thresholdColor};
-    `};
+    `}
 `

--- a/packages/react-component-library/src/components/Switch/partials/StyledSwitch.tsx
+++ b/packages/react-component-library/src/components/Switch/partials/StyledSwitch.tsx
@@ -46,7 +46,7 @@ export const StyledSwitch = styled.div<StyledSwitchProps>`
           }
         }
       }
-    `};
+    `}
 
   ${({ $isDisabled }) =>
     $isDisabled &&

--- a/packages/react-component-library/src/components/TextInput/partials/StyledInput.tsx
+++ b/packages/react-component-library/src/components/TextInput/partials/StyledInput.tsx
@@ -21,7 +21,7 @@ function removeAutoFillBackground() {
     &:-webkit-autofill:hover,
     &:-webkit-autofill:focus,
     &:-webkit-autofill:active {
-      -webkit-transition: background-color 9999s ease-out;
+      transition: background-color 9999s ease-out;
     }
 
     filter: none; // Firefox

--- a/packages/react-component-library/src/components/Toast/partials/StyledToastLabel.tsx
+++ b/packages/react-component-library/src/components/Toast/partials/StyledToastLabel.tsx
@@ -4,12 +4,10 @@ import { selectors } from '@defencedigital/design-tokens'
 const { color, fontSize, spacing } = selectors
 
 export const StyledToastLabel = styled.span`
-  display: inline-flex;
-  align-items: center;
+  display: block;
   color: ${color('neutral', '500')};
   font-size: ${fontSize('m')};
   font-weight: 600;
-  display: block;
   padding: 0;
 
   > svg {

--- a/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/partials/StyledSearchBar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/partials/StyledSearchBar.tsx
@@ -4,7 +4,7 @@ import { selectors } from '@defencedigital/design-tokens'
 const { zIndex, mq, fontSize } = selectors
 
 export const StyledSearchBar = styled.div`
-  z-index: ${zIndex('dropdown', 1)}
+  z-index: ${zIndex('dropdown', 1)};
   display: block;
   margin-top: -1px;
   position: absolute;

--- a/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/partials/StyledSearchBar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/partials/StyledSearchBar.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
-const { zIndex, mq, fontSize } = selectors
+const { zIndex } = selectors
 
 export const StyledSearchBar = styled.div`
   z-index: ${zIndex('dropdown', 1)};
@@ -9,14 +9,4 @@ export const StyledSearchBar = styled.div`
   margin-top: -1px;
   position: absolute;
   width: 100%;
-
-  .rn-textinput__input {
-    font-size: ${fontSize('l')};
-  }
-
-  ${mq({ gte: 'xs' })`
-    .rn-textinput__input {
-      font-size: ${fontSize('base')};
-    }
-  `}
 `


### PR DESCRIPTION
## Related issue

Resolves #3229

## Overview

This fixes various incorrect CSS, including a z-order problem with the Masthead search box.

## Link to preview

https://5e25c277526d380020b5e418-vdhbcknonq.chromatic.com/

## Reason

To make sure all CSS is correct.

## Work carried out

- [x] Fix CSS errors identified with linting tool

## Screenshot

### Masthead search

#### Before

![image](https://user-images.githubusercontent.com/66470099/167446527-7a26d783-4b1b-46de-86f0-7667a5e2c88d.png)

#### After

![image](https://user-images.githubusercontent.com/66470099/167446597-46937583-b506-4683-a331-5f9b3ffca079.png)

## Developer notes

I got the CSS-in-JS linting working here: https://github.com/defencedigital/mod-uk-design-system/commit/f9c863133bacad90892d2cf84e637a41a22ce202

However, [it depends on a package that is being deprecated](https://github.com/stylelint/postcss-css-in-js/issues/225), and it isn't the smoothest of experiences either. So I've left it out; things should be better further down the line when a new PostCSS syntax for Styled Components has been written.