### PR TITLE
fix(Popover): Apply missing `aria-label` attribute

### DIFF
--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -30,7 +30,7 @@ describe('Popover', () => {
 
       wrapper = render(
         <>
-          <Popover content={content}>
+          <Popover content={content} aria-label="Hello, World!">
             <div
               style={{
                 display: 'inline-block',
@@ -60,6 +60,13 @@ describe('Popover', () => {
 
       afterEach(() => {
         jest.clearAllTimers()
+      })
+
+      it('should set the `aria-label` attribute to the supplied value', () => {
+        expect(wrapper.getByTestId('popover')).toHaveAttribute(
+          'aria-label',
+          'Hello, World!'
+        )
       })
 
       it('should set the `aria-describedby` attribute to the ID of the content', () => {
@@ -127,6 +134,13 @@ describe('Popover', () => {
         return waitFor(() => {
           expect(wrapper.getByTestId('floating-box-content')).toBeVisible()
         })
+      })
+
+      it('should set the `aria-label` attribute to the defualt value', () => {
+        expect(wrapper.getByTestId('popover')).toHaveAttribute(
+          'aria-label',
+          'Popover'
+        )
       })
 
       describe('and the user clicks on the target again', () => {

--- a/packages/react-component-library/src/components/Popover/Popover.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.tsx
@@ -50,6 +50,7 @@ export const Popover: React.FC<PopoverProps> = ({
   isClick = false,
   scheme = FLOATING_BOX_SCHEME.LIGHT,
   placement = FLOATING_BOX_PLACEMENT.RIGHT,
+  'aria-label': ariaLabel,
   ...rest
 }) => {
   const { floatingBoxChildrenRef, isVisible, mouseEvents } = useHideShow(
@@ -73,6 +74,7 @@ export const Popover: React.FC<PopoverProps> = ({
       renderTarget={<PopoverTarget />}
       scheme={scheme}
       aria-describedby={contentId}
+      aria-label={ariaLabel || 'Popover'}
       contentId={contentId}
       data-testid="popover"
       placement={placement}


### PR DESCRIPTION
## Related issue

Closes #3260

## Overview

Apply missing `aria-label` attribute to `Popover`.

## Reason

>Accessibility fails when the Popover is active.

## Work carried out

- [x] Supplement with automated tests
- [x] Add missing attribute and sensible default