### PR TITLE
chore(Deps): Remove usehooks-ts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 5
-  reviewers:
-  - m7kvqbe1
-  - thyhjwb6
-  labels:
-  - "Type: Dependencies"
-  commit-message:
-    prefix: chore(Security)
-  rebase-strategy: auto
-  ignore:
-    # Newer versions break older browsers, see e.g. https://github.com/juliencrn/usehooks-ts/issues/97
-    - dependency-name: "usehooks-ts"
-      versions: [">2.2.1"]
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    reviewers:
+      - m7kvqbe1
+      - thyhjwb6
+    labels:
+      - 'Type: Dependencies'
+    commit-message:
+      prefix: chore(Security)
+    rebase-strategy: auto

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -165,7 +165,6 @@
     "react-transition-group": "^4.4.1",
     "styled-normalize": "^8.0.7",
     "styled-theming": "^2.2.0",
-    "usehooks-ts": "2.2.1",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -1,9 +1,8 @@
 import { IconEvent } from '@defencedigital/icon-library'
 import FocusTrap from 'focus-trap-react'
-import React, { useRef } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { Placement } from '@popperjs/core'
 import { DayModifiers, DayPickerProps } from 'react-day-picker'
-import { useBoolean } from 'usehooks-ts'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { DATE_FORMAT } from '../../constants'
@@ -167,7 +166,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   onChange,
   onCalendarFocus,
   startDate: externalStartDate,
-  initialIsOpen,
+  initialIsOpen = false,
   disabledDays,
   initialMonth,
   initialStartDate = null,
@@ -185,11 +184,12 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   const inputRef = useRef<HTMLInputElement>(null)
 
   const { hasFocus, onLocalBlur, onLocalFocus } = useFocus()
-  const {
-    setFalse: close,
-    value: isOpen,
-    toggle: toggleIsOpen,
-  } = useBoolean(initialIsOpen)
+  const [isOpen, setIsOpen] = useState(initialIsOpen)
+  const close = useCallback(() => setIsOpen(false), [])
+  const toggleIsOpen = useCallback(
+    () => setIsOpen((previousIsOpen) => !previousIsOpen),
+    []
+  )
   const focusTrapOptions = useFocusTrapOptions(
     close,
     isRange ? [buttonRef, inputRef] : [buttonRef]

--- a/yarn.lock
+++ b/yarn.lock
@@ -17617,11 +17617,6 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-usehooks-ts@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/usehooks-ts/-/usehooks-ts-2.2.1.tgz#9bb9af81d4680cf9cdb9234331a37e4be39d1183"
-  integrity sha512-n6Rat52iF+Tz9CFU2IIuaFsm9uCXX4dU565lKaAKMEXLLGTg9qYwzDSpXkCPRnx9lTdkm8M+W+YJ36Lb13zjEA==
-
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"


### PR DESCRIPTION
## Related issue

n/a

## Overview

This component has been the source of build problems in downstream apps and is currently causing source map warnings.

This simply removes it as it was only being used in one place.

## Link to preview

https://red-playground.netlify.app/?path=/docs/date-picker--default

## Reason

This was causing source map warnings in CRA:

```
16:22 $ npm run build

> mod-cra-test@0.1.0 build
> react-scripts build

Creating an optimized production build...
Compiled with warnings.

Failed to parse source map from 'mod-cra-test/node_modules/usehooks-ts/src/index.ts' file: Error: ENOENT: no such file or directory, open 'mod-cra-test/node_modules/usehooks-ts/src/index.ts'

Failed to parse source map from '/mod-cra-test/node_modules/usehooks-ts/src/useBoolean/index.ts' file: Error: ENOENT: no such file or directory, open 'mod-cra-test/node_modules/usehooks-ts/src/useBoolean/index.ts'

Failed to parse source map from '/dev/mod-cra-test/node_modules/usehooks-ts/src/useBoolean/useBoolean.ts' file: Error: ENOENT: no such file or directory, open 'mod-cra-test/node_modules/usehooks-ts/src/useBoolean/useBoolean.ts'

Failed to parse source map from '/dev/mod-cra-test/node_modules/usehooks-ts/src/useClickAnyWhere/index.ts' file: Error: ENOENT: no such file or directory, open 'mod-cra-test/node_modules/usehooks-ts/src/useClickAnyWhere/index.ts'

...
```

## Work carried out

- [x] Remove dependency and replace usage
