### PR TITLE
fix(Autocomplete): Allow cursor position

### DIFF
--- a/packages/react-component-library/cypress/selectors/Select.ts
+++ b/packages/react-component-library/cypress/selectors/Select.ts
@@ -2,6 +2,7 @@ export default {
   clearButton: '[data-testid="select-clear-button"]',
   input: '[data-testid="select-input"]',
   label: '[data-testid="select-label"]',
+  listBox: '[role="listbox"]',
   option: '[data-testid="select-option"]',
   outerWrapper: '[data-testid="select-outer-wrapper"]',
   toggleButton: '[data-testid="select-arrow-button"]',

--- a/packages/react-component-library/cypress/specs/Autocomplete/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/Autocomplete/index.spec.ts
@@ -83,6 +83,18 @@ describe('Autocomplete', () => {
               .should('have.css', 'background-color', hexToRgb(ColorNeutral100))
           })
         })
+
+        describe.skip('and the text is clicked in the middle', () => {
+          beforeEach(() => {
+            cy.get(selectors.select.input)
+              .click('bottomLeft', { force: true })
+              .type('more')
+          })
+
+          it('should set the text input correctly', () => {
+            cy.get(selectors.select.input).should('have.value', 'moreThree')
+          })
+        })
       })
 
       describe('and the user tabs out', () => {

--- a/packages/react-component-library/cypress/specs/Select/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/Select/index.spec.ts
@@ -17,10 +17,9 @@ describe('Select', () => {
       cy.get(selectors.select.option).should('have.length', 4)
     })
 
-    describe('and `th` is typed', () => {
+    describe('and `t` is typed', () => {
       before(() => {
-        cy.get(selectors.select.outerWrapper).type('Th{enter}')
-        cy.get('body').click()
+        cy.get(selectors.select.listBox).type('t{enter}')
       })
 
       it('sets the value as the item', () => {

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -55,7 +55,6 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     selectedItem,
     setHighlightedIndex,
     setInputValue,
-    toggleMenu,
   } = useCombobox<SelectChildWithStringType>({
     items,
     itemToString,
@@ -80,11 +79,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     setInputValue
   )
 
-  const { onInputFocusHandler, onInputMouseDownHandler } = useMenuVisibility(
-    isOpen,
-    openMenu,
-    toggleMenu
-  )
+  const { onInputFocusHandler } = useMenuVisibility(isOpen, openMenu)
 
   return (
     <SelectLayout
@@ -98,7 +93,6 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
           onInputTabKeyHandler(e)
           onInputEscapeKeyHandler(e)
         },
-        onMouseDown: onInputMouseDownHandler,
         ref: inputRef,
       })}
       inputWrapperProps={getComboboxProps()}

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -35,13 +35,13 @@ const Template: ComponentStory<typeof Select> = (args) => (
     style={{ height: args.isDisabled ? 'initial' : '18rem', maxWidth: '20rem' }}
   >
     <Select {...args}>
-      <SelectOption value="one">
+      <SelectOption value="one">A</SelectOption>
+      <SelectOption value="two">B</SelectOption>
+      <SelectOption value="three">
         This is a really, really long select option label that overflows the
         container when selected
       </SelectOption>
-      <SelectOption value="two">Two</SelectOption>
-      <SelectOption value="three">Three</SelectOption>
-      <SelectOption value="four">Four</SelectOption>
+      <SelectOption value="four">Three</SelectOption>
     </Select>
   </div>
 )

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -30,7 +30,6 @@ export const Select: React.FC<SelectBaseProps> = ({
     openMenu,
     reset,
     selectedItem,
-    toggleMenu,
   } = useSelect<SelectChildWithStringType>({
     itemToString,
     initialSelectedItem: initialSelectedItem(children, value),
@@ -42,11 +41,7 @@ export const Select: React.FC<SelectBaseProps> = ({
     },
   })
 
-  const { onInputFocusHandler, onInputMouseDownHandler } = useMenuVisibility(
-    isOpen,
-    openMenu,
-    toggleMenu
-  )
+  const { onInputFocusHandler } = useMenuVisibility(isOpen, openMenu)
 
   const { onMenuKeyDownHandler } = useSelectMenu(inputRef)
 
@@ -56,7 +51,6 @@ export const Select: React.FC<SelectBaseProps> = ({
       id={id}
       inputProps={{
         onFocus: onInputFocusHandler,
-        onMouseDown: onInputMouseDownHandler,
         ref: inputRef,
       }}
       isOpen={isOpen}

--- a/packages/react-component-library/src/components/SelectBase/hooks/useMenuVisibility.ts
+++ b/packages/react-component-library/src/components/SelectBase/hooks/useMenuVisibility.ts
@@ -1,12 +1,10 @@
-import React, { useCallback } from 'react'
+import { useCallback } from 'react'
 
 export function useMenuVisibility(
   isOpen: boolean,
-  openMenu: () => void,
-  toggleMenu: () => void
+  openMenu: () => void
 ): {
   onInputFocusHandler: () => void
-  onInputMouseDownHandler: (e: React.MouseEvent) => void
 } {
   const onInputFocusHandler = useCallback(() => {
     if (!isOpen) {
@@ -14,17 +12,7 @@ export function useMenuVisibility(
     }
   }, [isOpen, openMenu])
 
-  const onInputMouseDownHandler = useCallback(
-    (e: React.MouseEvent) => {
-      toggleMenu()
-      e.stopPropagation()
-      e.preventDefault()
-    },
-    [toggleMenu]
-  )
-
   return {
     onInputFocusHandler,
-    onInputMouseDownHandler,
   }
 }


### PR DESCRIPTION
## Related issue
Closes #3010 

## Overview
Allows the cursor to be positioned where the input is clicked.

## Reason
The cursor was being positioned at the end which is not good from a user perspective as you would expect the cursor to be positioned where the input is clicked as with other text inputs.

## Work carried out
- [x] Position cursor where input is clicked

## Screenshot
![2022-05-26 13 11 44](https://user-images.githubusercontent.com/56078793/170485536-e1775721-80d2-4a6c-90d2-b8ff679ca20c.gif)

## Developer notes
A test has been added with `skip` because of an [open issue](https://github.com/cypress-io/cypress/issues/5721) with Cypress.