### PR TITLE
fix(NumberInput): Display initial value of zero correctly

### DIFF
--- a/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
@@ -679,6 +679,17 @@ describe('NumberInput', () => {
     })
   })
 
+  describe.each([
+    { value: null, expected: '' },
+    { value: 0, expected: '0' },
+  ])('when the initial value is `$value`', ({ value, expected }) => {
+    beforeEach(() => {
+      wrapper = render(<NumberInput {...defaultProps} value={value} />)
+    })
+
+    assertInputValue(expected)
+  })
+
   describe('when a CSS class name is specified', () => {
     beforeEach(() => {
       const props = {

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -177,7 +177,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   const inputId = useExternalId('number-input-input', externalId)
   const isNegativeAllowed = isNil(min) || min < 0
   const { committedValue, setCommittedValue } = useValue(
-    value ? String(value) : null
+    isNil(value) ? null : String(value)
   )
   const { hasFocus, onLocalFocus, onLocalBlur } = useFocus(onBlur)
   const { handleBeforeInput, handlePaste } =


### PR DESCRIPTION
## Related issue

Resolves #3284

## Overview

This makes an initial value of `0` display as `'0'`, rather than an empty string.


## Reason

`0` and null should be treated differently; `null` meaning no value, and `0` being the number 0.

## Work carried out

- [x] Correct handling of an initial value of `0`


