### PR TITLE
feat(NumberInput): Add ability to increment decrement with keyboard

### DIFF
--- a/packages/react-component-library/src/components/NumberInput/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInput/Input.tsx
@@ -1,11 +1,11 @@
-import React, { KeyboardEventHandler, useCallback } from 'react'
+import React from 'react'
 import { isNil } from 'lodash'
-import { Decimal } from 'decimal.js'
 
 import { ComponentSizeType } from '../Forms'
 import { StyledInput } from '../TextInput/partials/StyledInput'
 import { StyledInputWrapper } from './partials/StyledInputWrapper'
 import { StyledLabel } from '../TextInput/partials/StyledLabel'
+import { useInputKeys } from './useInputKeys'
 
 export interface InputProps {
   hasFocus: boolean
@@ -40,44 +40,7 @@ export const Input: React.FC<InputProps> = ({
   ...rest
 }) => {
   const hasLabel = !!(label && label.length)
-
-  const KEY_ARROW_UP = 'ArrowUp'
-  const KEY_ARROW_DOWN = 'ArrowDown'
-
-  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
-    (event) => {
-      const {
-        code,
-        currentTarget: { value: eventValue },
-      } = event
-
-      if (![KEY_ARROW_UP, KEY_ARROW_DOWN].includes(code)) {
-        return
-      }
-
-      event.preventDefault()
-
-      // Do nothing if the value is e.g. only `-`
-      if (value && !Number.isFinite(parseFloat(value))) {
-        return
-      }
-
-      const decimal = new Decimal(eventValue || 0)
-
-      const newEvent = {
-        ...event,
-        currentTarget: {
-          ...event.currentTarget,
-          value: String(
-            code === KEY_ARROW_UP ? decimal.plus(step) : decimal.minus(step)
-          ),
-        },
-      }
-
-      onChange(newEvent)
-    },
-    [step, value, onChange]
-  )
+  const { handleKeyDown } = useInputKeys(step, onChange)
 
   return (
     <StyledInputWrapper>

--- a/packages/react-component-library/src/components/NumberInput/Input.tsx
+++ b/packages/react-component-library/src/components/NumberInput/Input.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { KeyboardEventHandler } from 'react'
 import { isNil } from 'lodash'
 
 import { ComponentSizeType } from '../Forms'
@@ -14,7 +14,11 @@ export interface InputProps {
   name: string
   onBeforeInput: (event: React.FormEvent<HTMLInputElement>) => void
   onBlur: (event: React.FormEvent<HTMLInputElement>) => void
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onChange: (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.KeyboardEvent<HTMLInputElement>
+  ) => void
   onFocus: (event: React.FormEvent<HTMLInputElement>) => void
   onPaste: (event: React.ClipboardEvent<HTMLInputElement>) => void
   placeholder?: string
@@ -29,9 +33,40 @@ export const Input: React.FC<InputProps> = ({
   label,
   size,
   value,
+  onChange,
   ...rest
 }) => {
   const hasLabel = !!(label && label.length)
+
+  const KEY_ARROW_UP = 'ArrowUp'
+  const KEY_ARROW_DOWN = 'ArrowDown'
+
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+    const {
+      code,
+      currentTarget: { value: eventValue },
+    } = event
+
+    if ([KEY_ARROW_UP, KEY_ARROW_DOWN].includes(code)) {
+      event.preventDefault()
+
+      const newEvent = {
+        ...event,
+        currentTarget: {
+          ...event.currentTarget,
+          value: String(
+            code === KEY_ARROW_UP
+              ? Number(eventValue) + 1
+              : Number(eventValue) - 1
+          ),
+        },
+      }
+
+      if (onChange) {
+        onChange(newEvent)
+      }
+    }
+  }
 
   return (
     <StyledInputWrapper>
@@ -53,6 +88,8 @@ export const Input: React.FC<InputProps> = ({
         disabled={isDisabled}
         id={id}
         value={value || ''}
+        onKeyDown={handleKeyDown}
+        onChange={onChange}
         {...rest}
       />
     </StyledInputWrapper>

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.test.tsx
@@ -18,7 +18,10 @@ import { NumberInput } from '.'
 const defaultProps = {
   name: 'number-input',
   onChange: (
-    _: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLButtonElement>
+    _:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLInputElement>
   ) => true,
 }
 
@@ -223,6 +226,24 @@ describe('NumberInput', () => {
 
       assertInputValue('123')
       assertOnChangeCall(123, 3)
+
+      describe('and the user presses the keyboard up arrow', () => {
+        beforeEach(async () => {
+          await userEvent.type(input, '{arrowup}')
+        })
+
+        assertInputValue('124')
+        assertOnChangeCall(124, 4)
+      })
+
+      describe('and the user presses the keyboard down arrow', () => {
+        beforeEach(async () => {
+          await userEvent.type(input, '{arrowdown}')
+        })
+
+        assertInputValue('122')
+        assertOnChangeCall(122, 4)
+      })
     })
 
     describe('and the user types a value with invalid characters', () => {

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -244,6 +244,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
           onFocus={onLocalFocus}
           placeholder={placeholder}
           size={size}
+          step={step}
           value={committedValue}
           {...rest}
         />

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.tsx
@@ -79,7 +79,8 @@ interface NumberInputBaseProps
   onChange: (
     event:
       | React.ChangeEvent<HTMLInputElement>
-      | React.MouseEvent<HTMLButtonElement>,
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLInputElement>,
     newValue: number | null
   ) => void
   /**

--- a/packages/react-component-library/src/components/NumberInput/useChangeHandlers.ts
+++ b/packages/react-component-library/src/components/NumberInput/useChangeHandlers.ts
@@ -10,7 +10,8 @@ export function useChangeHandlers(
   onChange: (
     event:
       | React.ChangeEvent<HTMLInputElement>
-      | React.MouseEvent<HTMLButtonElement>,
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLInputElement>,
     newValue: number | null
   ) => void,
   setCommittedValue: React.Dispatch<React.SetStateAction<string | null>>
@@ -19,10 +20,18 @@ export function useChangeHandlers(
     event: React.MouseEvent<HTMLButtonElement>,
     newValue: string
   ) => void
-  handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  handleInputChange: (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.KeyboardEvent<HTMLInputElement>
+  ) => void
 } {
   const handleInputChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
+    (
+      event:
+        | React.ChangeEvent<HTMLInputElement>
+        | React.KeyboardEvent<HTMLInputElement>
+    ) => {
       if (!isValueValid(event.currentTarget.value, isNegativeAllowed)) {
         return
       }

--- a/packages/react-component-library/src/components/NumberInput/useInputKeys.ts
+++ b/packages/react-component-library/src/components/NumberInput/useInputKeys.ts
@@ -1,0 +1,53 @@
+import React, { KeyboardEventHandler, useCallback } from 'react'
+import { Decimal } from 'decimal.js'
+import { cloneDeep, set } from 'lodash'
+
+const KEY_ARROW_UP = 'ArrowUp'
+const KEY_ARROW_DOWN = 'ArrowDown'
+
+export const useInputKeys = (
+  step: number,
+  onChange: (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.KeyboardEvent<HTMLInputElement>
+  ) => void
+): {
+  handleKeyDown: KeyboardEventHandler<HTMLInputElement>
+} => {
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      const {
+        key,
+        currentTarget: { value },
+      } = event
+
+      if (![KEY_ARROW_UP, KEY_ARROW_DOWN].includes(key)) {
+        return
+      }
+
+      event.preventDefault()
+
+      if (value && !Number.isFinite(parseFloat(value))) {
+        return
+      }
+
+      const decimal = new Decimal(value || 0)
+
+      const newEvent = cloneDeep(event)
+
+      set(
+        newEvent,
+        'currentTarget.value',
+        String(key === KEY_ARROW_UP ? decimal.plus(step) : decimal.minus(step))
+      )
+
+      onChange(newEvent)
+    },
+    [step, onChange]
+  )
+
+  return {
+    handleKeyDown,
+  }
+}

--- a/packages/react-component-library/src/forms/formik/formik.stories.tsx
+++ b/packages/react-component-library/src/forms/formik/formik.stories.tsx
@@ -200,7 +200,8 @@ const Example: React.FC<{ initialValues: FormValues }> = ({
                       onChange={(
                         _:
                           | React.ChangeEvent<HTMLInputElement>
-                          | React.MouseEvent<HTMLButtonElement>,
+                          | React.MouseEvent<HTMLButtonElement>
+                          | React.KeyboardEvent<HTMLInputElement>,
                         newValue: number | null
                       ) => {
                         setFieldValue('exampleNumberInput', newValue)

--- a/packages/react-component-library/src/forms/native/native.stories.tsx
+++ b/packages/react-component-library/src/forms/native/native.stories.tsx
@@ -162,7 +162,8 @@ const Example: React.FC<{
             onChange={(
               _:
                 | React.ChangeEvent<HTMLInputElement>
-                | React.MouseEvent<HTMLButtonElement>,
+                | React.MouseEvent<HTMLButtonElement>
+                | React.KeyboardEvent<HTMLInputElement>,
               newValue: number | null
             ) => {
               handleChange({

--- a/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
+++ b/packages/react-component-library/src/forms/react-hook-form/react-hook-form.stories.tsx
@@ -69,7 +69,8 @@ const Example: React.FC<{ initialValues: FormValues }> = ({
   const handleNumberInputChange = (
     _:
       | React.ChangeEvent<HTMLInputElement>
-      | React.MouseEvent<HTMLButtonElement>,
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLInputElement>,
     newValue: number | null
   ) => setValue('exampleNumberInput', newValue)
 


### PR DESCRIPTION
## Related issue

Closes #2976

## Overview

Add ability to increment and decrement the committed value via the `ArrowUp` and `ArrowDown` keys.

## Link to preview

https://6290970b73698a03f02ddfb6--vocal-melomakarona-4997f7.netlify.app

## Reason

>Pressing the ↑key will increase the current value by an amount equal to the preset step.
>Pressing the ↓key will decrease the current value by an amount equal to the preset step.

## Work carried out

- [x] Supplement existing automated tests
- [x] Implement keyboard behaviour when input is focussed

## Screenshot

![2022-05-27 10 12 57](https://user-images.githubusercontent.com/48086589/170669759-368ddd76-92d8-479b-9f61-a499549450c2.gif)
