### PR TITLE
fix(CRATemplate): Improve compatibility with React 18

### DIFF
--- a/packages/cra-template-defencedigital/template.json
+++ b/packages/cra-template-defencedigital/template.json
@@ -6,7 +6,7 @@
       "lint": "eslint src --ext .ts --ext .tsx"
     },
     "dependencies": {
-      "@apollo/client": "^3.6.0-rc.1",
+      "@apollo/client": "^3.6.5",
       "@defencedigital/design-tokens": "latest",
       "@defencedigital/eslint-config-react": "latest",
       "@defencedigital/fonts": "latest",
@@ -18,7 +18,7 @@
       "@graphql-codegen/typescript-react-apollo": "^3.2.2",
       "@testing-library/jest-dom": "^5.5.0",
       "@testing-library/react": "^13.1.1",
-      "@testing-library/user-event": "^13.5.0",
+      "@testing-library/user-event": "^14.2.0",
       "@types/jest": "^27.0.3",
       "@types/node": "^16.11.13",
       "@types/react": "^18.0.0",

--- a/packages/cra-template-defencedigital/template.json
+++ b/packages/cra-template-defencedigital/template.json
@@ -27,7 +27,7 @@
       "@types/styled-components": "^5.1.18",
       "graphql": "^16.1.0",
       "jest-canvas-mock": "^2.3.0",
-      "react-router-dom": "^5.1.2",
+      "react-router-dom": "^6.3.0",
       "styled-components": "^5.3.3",
       "ts-node": "^10.4.0",
       "typescript": "^4.5.4"

--- a/packages/cra-template-defencedigital/template.json
+++ b/packages/cra-template-defencedigital/template.json
@@ -33,7 +33,9 @@
       "typescript": "^4.5.4"
     },
     "overrides": {
-      "nth-check": "^2.0.1"
+      "nth-check": "^2.0.1",
+      "react": "^18.1.0",
+      "react-dom": "^18.1.0"
     },
     "browserslist": {
       "production": [">0.2%", "not dead", "not op_mini all"],

--- a/packages/cra-template-defencedigital/template/src/index.tsx
+++ b/packages/cra-template-defencedigital/template/src/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import ReactDOM from 'react-dom/client'
 import '@defencedigital/fonts'
 import { GlobalStyleProvider } from '@defencedigital/react-component-library'
 import { Redirect, BrowserRouter as Router, Route } from 'react-router-dom'
@@ -8,7 +8,9 @@ import { ApolloProvider } from '@apollo/client/react'
 import { Home } from './pages'
 import { client } from './graphql/client'
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
+
+root.render(
   <GlobalStyleProvider>
     <ApolloProvider client={client}>
       <Router>
@@ -18,6 +20,5 @@ ReactDOM.render(
         <Route exact path="/home" component={Home} />
       </Router>
     </ApolloProvider>
-  </GlobalStyleProvider>,
-  document.getElementById('root')
+  </GlobalStyleProvider>
 )

--- a/packages/cra-template-defencedigital/template/src/index.tsx
+++ b/packages/cra-template-defencedigital/template/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import '@defencedigital/fonts'
 import { GlobalStyleProvider } from '@defencedigital/react-component-library'
-import { Redirect, BrowserRouter as Router, Route } from 'react-router-dom'
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import { ApolloProvider } from '@apollo/client/react'
 
 import { Home } from './pages'
@@ -13,12 +13,12 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <GlobalStyleProvider>
     <ApolloProvider client={client}>
-      <Router>
-        <Route exact path="/">
-          <Redirect to="/home" />
-        </Route>
-        <Route exact path="/home" component={Home} />
-      </Router>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Navigate to="/home" replace />} />
+          <Route path="/home" element={<Home />} />
+        </Routes>
+      </BrowserRouter>
     </ApolloProvider>
   </GlobalStyleProvider>
 )


### PR DESCRIPTION
## Related issue

Resolves #3270

## Overview

This gets the CRA template working again by resolving some compatibility problems with React 18.

## Reason

To make sure the CRA template works.

## Work carried out

- [x] Use `createRoot` API
- [x] Update React Router
- [x] Add npm overrides (due to dependencies with out-of-date peer dependency ranges)
- [x] Update other dependencies

## Screenshot

### Before

![image](https://user-images.githubusercontent.com/66470099/170727000-61b97de3-d1cd-4b61-a7d9-9e1019ac06bf.png)

### After

![image](https://user-images.githubusercontent.com/66470099/170726661-eb76f48b-be3e-4774-a9ff-cfafefffa187.png)

## Developer notes

Useful links:

- https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html
- https://reactrouter.com/docs/en/v6/upgrading/v5

Strict mode is still not enabled as there are currently some compatibility problems (at least partly relating to third-party dependencies).
