### PR TITLE
feat(GlobalStyleProvider): Handle multiple instances gracefully

### DIFF
--- a/packages/react-component-library/src/hooks/useIsFirstInstance.ts
+++ b/packages/react-component-library/src/hooks/useIsFirstInstance.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
+
+const registries: {
+  [name: string]: { instances: Set<string>; callbacks: Set<() => void> }
+} = {}
+
+export function useIsFirstInstance(registryName: string) {
+  registries[registryName] ??= { instances: new Set(), callbacks: new Set() }
+  const registry = registries[registryName]
+
+  const [isFirstInstance, setIsFirstInstance] = useState(
+    registry.instances.size === 0
+  )
+  const idRef = useRef(uuidv4())
+  const id = idRef.current
+
+  registry.instances.add(id)
+
+  useEffect(() => {
+    const updateIsFirstInstance = () => {
+      setIsFirstInstance(registry.instances.values().next().value === id)
+    }
+    registry.callbacks.add(updateIsFirstInstance)
+
+    return () => {
+      registry.callbacks.delete(updateIsFirstInstance)
+      registry.instances.delete(id)
+
+      registry.callbacks.forEach((callback) => {
+        callback()
+      })
+    }
+  }, [id, registry])
+
+  return isFirstInstance
+}

--- a/packages/react-component-library/src/styled-components/GlobalStyle.test.tsx
+++ b/packages/react-component-library/src/styled-components/GlobalStyle.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { GlobalStyleProvider } from './GlobalStyle'
+
+describe('GlobalStyleProvider', () => {
+  describe('when rendered multiple times as siblings', () => {
+    beforeEach(() => {
+      render(
+        <>
+          <GlobalStyleProvider />
+          <GlobalStyleProvider />
+        </>
+      )
+    })
+
+    it('inserts the styles once', () => {
+      expect(
+        Array.prototype.filter.call(
+          document.styleSheets[0].cssRules,
+          (rule) => rule.selectorText === 'h1'
+        )
+      ).toHaveLength(1)
+    })
+  })
+
+  describe('when rendered multiple times nested', () => {
+    beforeEach(() => {
+      render(
+        <GlobalStyleProvider>
+          <GlobalStyleProvider />
+        </GlobalStyleProvider>
+      )
+    })
+
+    it('inserts the styles once', () => {
+      expect(
+        Array.prototype.filter.call(
+          document.styleSheets[0].cssRules,
+          (rule) => rule.selectorText === 'h1'
+        )
+      ).toHaveLength(1)
+    })
+  })
+
+  describe('when rerendered', () => {
+    beforeEach(() => {
+      jest.isolateModules(() => {
+        const { rerender } = render(<GlobalStyleProvider />)
+        rerender(<GlobalStyleProvider />)
+      })
+    })
+
+    it('retains the style rules', () => {
+      expect(
+        Array.prototype.filter.call(
+          document.styleSheets[0].cssRules,
+          (rule) => rule.selectorText === 'h1'
+        )
+      ).toHaveLength(1)
+    })
+  })
+
+  describe('when unmounted', () => {
+    beforeEach(() => {
+      const { unmount } = render(<GlobalStyleProvider />)
+      unmount()
+    })
+
+    it('removes the style rules', () => {
+      expect(document.styleSheets[0].cssRules).toHaveLength(0)
+    })
+  })
+
+  describe('when unmounted and remounted', () => {
+    beforeEach(() => {
+      const { unmount, rerender } = render(<GlobalStyleProvider />)
+      unmount()
+      rerender(<GlobalStyleProvider />)
+    })
+
+    it('retains the style rules', () => {
+      expect(
+        Array.prototype.filter.call(
+          document.styleSheets[0].cssRules,
+          (rule) => rule.selectorText === 'h1'
+        )
+      ).toHaveLength(1)
+    })
+  })
+
+  describe('when there are two instances and the first instance is removed', () => {
+    beforeEach(() => {
+      const { rerender } = render(
+        <>
+          <GlobalStyleProvider key={1} />
+          <GlobalStyleProvider key={2} />
+        </>
+      )
+      rerender(
+        // eslint-disable-next-line react/jsx-no-useless-fragment
+        <>
+          <GlobalStyleProvider key={2} />
+        </>
+      )
+    })
+
+    it('the styles are retained', () => {
+      expect(
+        Array.prototype.filter.call(
+          document.styleSheets[0].cssRules,
+          (rule) => rule.selectorText === 'h1'
+        )
+      ).toHaveLength(1)
+    })
+  })
+})

--- a/packages/react-component-library/src/styled-components/GlobalStyle.tsx
+++ b/packages/react-component-library/src/styled-components/GlobalStyle.tsx
@@ -3,6 +3,8 @@ import { createGlobalStyle, ThemeProvider } from 'styled-components'
 import { Normalize } from 'styled-normalize'
 import { selectors, lightTheme } from '@defencedigital/design-tokens'
 
+import { useIsFirstInstance } from '../hooks/useIsFirstInstance'
+
 export interface GlobalStyleContextDefaults {
   theme?: Record<string, any>
 }
@@ -108,6 +110,7 @@ export const GlobalStyleProvider: React.FC<GlobalStyleProviderProps> = ({
   children,
   theme = lightTheme,
 }) => {
+  const isFirstInstance = useIsFirstInstance('GlobalStyleProvider')
   const contextValue = useMemo(
     () => ({
       theme,
@@ -117,10 +120,14 @@ export const GlobalStyleProvider: React.FC<GlobalStyleProviderProps> = ({
 
   return (
     <GlobalStyleContext.Provider value={contextValue}>
-      <Normalize />
-      <BoxSizing />
-      <Hyperlinks />
-      <Fonts />
+      {isFirstInstance && (
+        <>
+          <Normalize />
+          <BoxSizing />
+          <Hyperlinks />
+          <Fonts />
+        </>
+      )}
       <ThemeProvider theme={theme}>{children}</ThemeProvider>
     </GlobalStyleContext.Provider>
   )

--- a/packages/react-component-library/src/styled-components/__mocks__/styled-components.js
+++ b/packages/react-component-library/src/styled-components/__mocks__/styled-components.js
@@ -1,0 +1,7 @@
+// For testing GlobalStyleProvider.
+//
+// Use the browser build of styled-components instead of the server build
+// to get global styles loaded.
+module.exports = jest.requireActual(
+  'styled-components/dist/styled-components.browser.cjs'
+)


### PR DESCRIPTION
## Related issue

Resolves #3259

## Overview

This adds logic to `GlobalStyleProvider` to stop it inserting duplicate styles when it is inserted into a page multiple times.

## Link to preview

https://5e25c277526d380020b5e418-okdsdrhdoc.chromatic.com/

## Reason

Avoid duplicate styles e.g. in Storybook on the Docs tab.

## Work carried out

- [x] Add first instance check to `GlobalStyleProvider`

## Screenshot

### Before

![image](https://user-images.githubusercontent.com/66470099/171436210-50a7dfb8-a617-41f0-ae31-72c1d088661f.png)

### After

![image](https://user-images.githubusercontent.com/66470099/171440363-b34c2d66-d144-483e-8a6f-da9490eded40.png)

## Developer notes

Note that there are many edge cases in trying to do this, in particular relating to the order different instances of `GlobalStyleProvider` are mounted and unmounted. Hence, I'm not convinced trying to do this is a good idea – though I've managed to come up with something that handles those edge cases.

#3308 is suggested as a simpler fix just for Storybook (where the problem originated).