### PR TITLE
docs(Storybook): Fix duplicated global styles on Docs tab

### DIFF
--- a/packages/react-component-library/.storybook/preview.js
+++ b/packages/react-component-library/.storybook/preview.js
@@ -1,6 +1,8 @@
+import { DocsPage } from '@storybook/addon-docs'
 import React from 'react'
 import '@defencedigital/fonts'
 import 'iframe-resizer/js/iframeResizer.contentWindow'
+import 'url-search-params-polyfill'
 import { withPerformance } from 'storybook-addon-performance/dist/cjs'
 
 import { GlobalStyleProvider } from '../src/styled-components/GlobalStyle'
@@ -46,6 +48,11 @@ export const parameters = {
       // there
       type: typeof WeakSet === undefined ? 'code' : 'auto',
     },
+    page: () => (
+      <GlobalStyleProvider>
+        <DocsPage />
+      </GlobalStyleProvider>
+    ),
   },
   options: {
     storySort: {
@@ -57,6 +64,14 @@ export const parameters = {
 
 export const decorators = [
   // https://github.com/storybookjs/storybook/issues/15223#issuecomment-1092837912
-  (Story) => <GlobalStyleProvider>{Story()}</GlobalStyleProvider>,
+  (Story) => {
+    const queryParams = new URLSearchParams(window.location.search)
+
+    if (queryParams.get('viewMode') === 'docs') {
+      return Story()
+    }
+
+    return <GlobalStyleProvider>{Story()}</GlobalStyleProvider>
+  },
   withPerformance,
 ]

--- a/packages/react-component-library/README.md
+++ b/packages/react-component-library/README.md
@@ -42,7 +42,10 @@ ReactDOM.render(<App />, document.querySelector('#app'))
 
 ## `<GlobalStyleProvider />`
 
-This context provider component applies global Defence Digital Design System styles to your application (resets, normalize and fonts). You should wrap the root of your app in this component.
+This context provider component applies global Defence Digital Design System styles
+to your application (resets, normalize and fonts). You should wrap the root of your
+app in a single instance of this component. (Take care to avoid having multiple
+instances mounted at once, as this will lead to duplicated global styles.)
 
 ### Theming
 
@@ -60,7 +63,7 @@ When utilising this pattern remember to extend a base token set:
 
 ### `useFloatingElement`
 
-This hook aids in the positioning of arbitrary elements relative to a target element. The positoning engine will intelligently position the element based on available screen real-estate.
+This hook aids in the positioning of arbitrary elements relative to a target element. The positioning engine will intelligently position the element based on available screen real-estate.
 
 ```javascript
 import { useFloatingElement } from '@defencedigital/react-component-library'

--- a/packages/react-component-library/cypress/specs/ContextMenu/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/ContextMenu/index.spec.ts
@@ -6,7 +6,7 @@ import selectors from '../../selectors'
 // https://github.com/storybookjs/storybook/issues/18232
 
 describe('ContextMenu', () => {
-  describe.skip('Storybook: Docs Mode', () => {
+  describe('Storybook: Docs Mode', () => {
     describe('the user opens the menu', () => {
       before(() => {
         cy.visit('/iframe.html?viewMode=docs&id=context-menu--default')

--- a/packages/react-component-library/cypress/specs/storybook/index.spec.ts
+++ b/packages/react-component-library/cypress/specs/storybook/index.spec.ts
@@ -1,0 +1,33 @@
+import { cy } from 'local-cypress'
+
+function getGlobalStyles($document, selectorText) {
+  return Array.prototype.flatMap
+    .call($document.styleSheets, (styleSheet) => [...styleSheet.cssRules])
+    .filter((rule) => rule.selectorText === selectorText)
+}
+
+describe('Storybook - global styles', () => {
+  describe('canvas tab', () => {
+    beforeEach(() => {
+      cy.visit('iframe.html?args=&id=button--default&viewMode=story')
+    })
+
+    it('renders the global styles once', () => {
+      cy.document().should(($document) => {
+        expect(getGlobalStyles($document, 'h1')).to.have.length(1)
+      })
+    })
+  })
+
+  describe('docs tab', () => {
+    beforeEach(() => {
+      cy.visit('iframe.html?args=&id=button--default&viewMode=docs')
+    })
+
+    it('renders the global styles once', () => {
+      cy.document().should(($document) => {
+        expect(getGlobalStyles($document, 'h1')).to.have.length(1)
+      })
+    })
+  })
+})

--- a/packages/react-component-library/cypress/support/consoleErrors.ts
+++ b/packages/react-component-library/cypress/support/consoleErrors.ts
@@ -1,5 +1,10 @@
 import { Cypress, cy } from 'local-cypress'
 
+const IGNORED_MESSAGES = [
+  // See https://github.com/storybookjs/storybook/issues/18103
+  'The pseudo class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type".',
+]
+
 function check() {
   let stub
 
@@ -9,9 +14,10 @@ function check() {
 
   Cypress.on('command:end', () => {
     if (stub && stub.called) {
-      chai
-        .expect(stub, 'There should be no console errors')
-        .to.have.callCount(0)
+      const calls = stub
+        .getCalls()
+        .filter((call) => !IGNORED_MESSAGES.includes(call.args[0]))
+      chai.expect(calls, 'There should be no console errors').to.have.length(0)
     }
   })
 }

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -134,6 +134,7 @@
     "styled-components": "^5.3.3",
     "timezone-mock": "^1.1.3",
     "typescript": "^4.1.2",
+    "url-search-params-polyfill": "^8.1.1",
     "webpack": "^5.52.1",
     "webpack-bundle-analyzer": "^4.2.0",
     "webpack-cli": "^4.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18559,6 +18559,11 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
+url-search-params-polyfill@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz#9e69e4dba300a71ae7ad3cead62c7717fd99329f"
+  integrity sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q==
+
 url-to-options@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"


### PR DESCRIPTION
## Related issue

Resolves #3259 

## Overview

This resolves a problem where GlobalStyleProvider was being rendered multiple times on the Docs tab.

## Link to preview

https://5e25c277526d380020b5e418-uyvvyyskvv.chromatic.com/

## Reason

This was causing duplicate global styles and was slowing down some pages.

## Work carried out

- [x] Use only one GlobalStyleProvider on Storybook docs tab
- [x] Add tests to make sure global style rules are loaded once in Storybook

## Screenshot

### Before

![image](https://user-images.githubusercontent.com/66470099/171435827-c5a9bbe8-a02e-4050-83b5-a24f7b8b3ef0.png)

### After

![image](https://user-images.githubusercontent.com/66470099/171440150-231a8168-516a-41b3-b770-9e2570956082.png)

## Developer notes

I amended the Cypress console error check to ignore the `:first-child` console errors were currently getting from Storybook, as they were being triggered in the new tests.