### PR TITLE
docs(Storybook): Add `TabSet` and `TabNav` usage notes

### DIFF
--- a/packages/react-component-library/src/components/TabNav/TabNav.stories.tsx
+++ b/packages/react-component-library/src/components/TabNav/TabNav.stories.tsx
@@ -10,6 +10,12 @@ export default {
   title: 'Tab Nav',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
+    docs: {
+      description: {
+        component:
+          'Use this component to navigate between different pages or routes.',
+      },
+    },
   },
 } as ComponentMeta<typeof TabNav>
 

--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -9,6 +9,12 @@ export default {
   title: 'Tab Set',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
+    docs: {
+      description: {
+        component:
+          'Use this component to switch between visible areas within the confines of a page.',
+      },
+    },
     layout: 'fullscreen',
   },
 } as ComponentMeta<typeof TabSet>


### PR DESCRIPTION
## Related issue

Closes #2857

## Overview

Add usage notes to `TabSet` and `TabNav` Storybook docs pages.