### PR TITLE
fix(CRATemplate): Fix installation error with React 18.2.0

### DIFF
--- a/packages/cra-template-defencedigital/template.json
+++ b/packages/cra-template-defencedigital/template.json
@@ -34,8 +34,8 @@
     },
     "overrides": {
       "nth-check": "^2.0.1",
-      "react": "^18.1.0",
-      "react-dom": "^18.1.0"
+      "react": "^18.2.0",
+      "react-dom": "^18.2.0"
     },
     "browserslist": {
       "production": [">0.2%", "not dead", "not op_mini all"],


### PR DESCRIPTION
## Related issue

Resolves #3322 

## Overview

This gets the CRA template and smoke test working again.

## Reason

The CRA template and smoke test starting failing since the release of React 18.2.0

## Work carried out

- [x] Investigate solutions
- [x] Update overrides in CRA template

## Developer notes

The CRA template and smoke test starting failing again since the release of React 18.2.0, because the overrides are for `react@^18.1.0` while the main React dependency injected by CRA is now `react@^18.2.0`.

There is a proper way to avoid this problem using references:

```
    "overrides": {
      "react": "$react",
      "react-dom": "$react-dom"
    },
```

However, this is currently not working and results in this error:

```
npm ERR! Unable to resolve reference $react
```

At first I thought this was due to how CRA installs packages, but that doesn't actually seem to be the case; it may be due to https://github.com/npm/cli/issues/4395

For now the only solution seems to be to manually keep the overrides up-to-date, unfortunately (until either `$react` is working or all peer dependency ranges in our tree are good).