### PR TITLE
Fix `Select` a11y `aria-labelledby` issue

### DIFF
--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -74,6 +74,12 @@ NoClearButton.args = {
   value: 'two',
 }
 
+export const Open = Template.bind({})
+Open.storyName = 'Open'
+Open.args = {
+  initialIsOpen: true,
+}
+
 export const WithError = Template.bind({})
 WithError.args = {
   isInvalid: true,

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
@@ -72,6 +72,13 @@ describe('Autocomplete', () => {
       expect(wrapper.queryAllByTestId('select-option')).toHaveLength(0)
     })
 
+    it('sets `aria-expanded` on the input wrapper to `false`', () => {
+      expect(wrapper.getByTestId('select-input-wrapper')).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+    })
+
     it.skip('does not show the arrow button in a hover state', () => {
       expect(wrapper.getByTestId('select-arrow-button')).toHaveStyleRule(
         'background-color',
@@ -102,6 +109,13 @@ describe('Autocomplete', () => {
         expect(options[1]).toHaveTextContent('Two')
         expect(options[2]).toHaveTextContent('Three')
         expect(options).toHaveLength(3)
+      })
+
+      it('sets `aria-expanded` on the input wrapper to `true`', () => {
+        expect(wrapper.getByTestId('select-input-wrapper')).toHaveAttribute(
+          'aria-expanded',
+          'true'
+        )
       })
 
       describe('and the second item is clicked', () => {

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -26,6 +26,7 @@ export interface AutocompleteProps extends SelectBaseProps {
 export const Autocomplete: React.FC<AutocompleteProps> = ({
   children,
   id: externalId,
+  initialIsOpen,
   isInvalid = false,
   onChange,
   value = null,
@@ -49,13 +50,14 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     getToggleButtonProps,
     highlightedIndex,
     inputValue,
-    isOpen,
+    isOpen = false,
     openMenu,
     reset,
     selectedItem,
     setHighlightedIndex,
     setInputValue,
   } = useCombobox<SelectChildWithStringType>({
+    initialIsOpen,
     items,
     itemToString,
     onInputValueChange,
@@ -95,7 +97,9 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
         },
         ref: inputRef,
       })}
-      inputWrapperProps={getComboboxProps()}
+      inputWrapperProps={getComboboxProps({
+        'aria-expanded': isOpen,
+      })}
       isInvalid={hasError}
       isOpen={isOpen}
       menuProps={getMenuProps()}

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -82,6 +82,12 @@ NoClearButton.args = {
   value: 'two',
 }
 
+export const Open = Template.bind({})
+Open.storyName = 'Open'
+Open.args = {
+  initialIsOpen: true,
+}
+
 export const WithError = Template.bind({})
 WithError.args = {
   isInvalid: true,

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -46,6 +46,10 @@ describe('Select', () => {
         'aria-labelledby',
         labelId
       )
+      expect(wrapper.getByTestId('select-input')).toHaveAttribute(
+        'aria-labelledby',
+        labelId
+      )
     })
 
     it('sets the custom `id` of the input', () => {

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -15,6 +15,7 @@ import { useSelectMenu } from './hooks/useSelectMenu'
 export const Select: React.FC<SelectBaseProps> = ({
   children,
   id: externalId,
+  initialIsOpen,
   onChange,
   value = null,
   ...rest
@@ -32,6 +33,7 @@ export const Select: React.FC<SelectBaseProps> = ({
     selectedItem,
   } = useSelect<SelectChildWithStringType>({
     itemToString,
+    initialIsOpen,
     initialSelectedItem: initialSelectedItem(children, value),
     items: React.Children.toArray(children),
     onSelectedItemChange: ({ selectedItem: newItem }) => {

--- a/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
+++ b/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
@@ -12,6 +12,10 @@ export interface SelectBaseProps extends ComponentWithClass {
    */
   id?: string
   /**
+   * Toggles whether the list is open on first render.
+   */
+  initialIsOpen?: boolean
+  /**
    * Toggles whether the component is disabled or not (preventing user interaction).
    */
   isDisabled?: boolean

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -131,7 +131,13 @@ export const SelectLayout: React.FC<SelectLayoutProps> = ({
           </StyledOuterWrapper>
         </StyledTextInput>
         <StyledOptionsWrapper $isVisible={isOpen}>
-          <StyledOptions {...menuProps}>{children}</StyledOptions>
+          <StyledOptions
+            {...menuProps}
+            aria-labelledby={labelId}
+            data-testid="select-options"
+          >
+            {children}
+          </StyledOptions>
         </StyledOptionsWrapper>
       </StyledSelect>
       <StyledFloatingBox

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -84,7 +84,7 @@ export const SelectLayout: React.FC<SelectLayoutProps> = ({
             data-testid="select-outer-wrapper"
           >
             <StyledInputWrapper
-              data-testid="text-input-input-wrapper"
+              data-testid="select-input-wrapper"
               {...inputWrapperProps}
             >
               <StyledLabel


### PR DESCRIPTION
## Related issue
Closes #3349 

## Overview
When the `Select` is initially open there is an accessibility error relating to incorrectly set `aria-labelledby` attribute.

## Reason
A screenreader needs to know which label describes the list.

## Work carried out
- [x] Fix attribute setting
- [x] Add Open story for `Autocomplete`