### PR TITLE
fix(Dropdown): Adjust disabled opacity

### DIFF
--- a/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.stories.tsx
@@ -36,7 +36,7 @@ const StyledWrapper = styled.div`
   height: 15rem;
 `
 
-export const Default: ComponentStory<typeof Dropdown> = (props) => {
+const Template: ComponentStory<typeof Dropdown> = (props) => {
   return (
     <StyledWrapper>
       <Dropdown {...props} />
@@ -44,8 +44,17 @@ export const Default: ComponentStory<typeof Dropdown> = (props) => {
   )
 }
 
+export const Default = Template.bind({})
 Default.args = {
   options,
+  label: 'Example label',
+}
+
+export const Open = Template.bind({})
+Open.storyName = 'Open'
+Open.args = {
+  options,
+  initialIsOpen: true,
   label: 'Example label',
 }
 

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.tsx
@@ -13,6 +13,10 @@ const { color, shadow, spacing } = selectors
 
 export interface DropdownProps {
   /**
+   * Toggles whether the list is open on first render.
+   */
+  initialIsOpen?: boolean
+  /**
    * Handler called when an option is clicked.
    */
   onSelect?: (value: string) => void
@@ -138,6 +142,7 @@ const StyledSelect = styled(Select)`
 `
 
 export const Dropdown: React.FC<DropdownProps> = ({
+  initialIsOpen,
   onSelect,
   options,
   label,
@@ -154,6 +159,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
       classNamePrefix="rn-dropdown"
       components={{ DropdownIndicator, Placeholder: DropdownPlaceholder }}
       controlShouldRenderValue={false}
+      defaultMenuIsOpen={initialIsOpen}
       formatOptionLabel={DropdownLabel}
       isSearchable={false}
       options={options}

--- a/packages/react-component-library/src/components/Dropdown/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/Dropdown/partials/StyledLabel.tsx
@@ -13,6 +13,7 @@ export const StyledLabel = styled.div<StyledLabelProps>`
   ${({ isDisabled }) =>
     isDisabled &&
     css`
-      opacity: 0.25;
+      cursor: not-allowed;
+      opacity: 0.7;
     `}
 `


### PR DESCRIPTION
## Related issue
Closes #3359 

## Overview
Increase opacity and adds `cursor: not-allowed` to disabled options.

## Reason
`Dropdown` fails accessibility.

## Work carried out
- [x] Update component

## Screenshot
<img width="211" alt="Screenshot 2022-07-13 at 13 52 41" src="https://user-images.githubusercontent.com/56078793/178738011-7c1d908b-4dbe-4801-acda-ba6e809a4823.png">

## Developer notes
Although the colour is less favourable there is a tradeoff as if it was left it would fail accessibility. In addition there has been a `cursor: not-allowed` added which makes it clear.