### PR TITLE
perf(ReactComponentLibrary): Optimise for rerenders

### DIFF
--- a/packages/react-component-library/jest/setupTests.js
+++ b/packages/react-component-library/jest/setupTests.js
@@ -1,8 +1,14 @@
+import React from 'react'
 import 'babel-polyfill'
 import 'jest-canvas-mock'
 import 'jest-styled-components'
 import { format } from 'util'
+import whyDidYouRender from '@welldone-software/why-did-you-render'
 
+/**
+ * Throw real errors for certain console errors
+ *
+ */
 const originalConsoleError = global.console.error
 
 global.console.error = (...args) => {
@@ -17,3 +23,31 @@ global.console.error = (...args) => {
     throw new Error(format(...args))
   }
 }
+
+/**
+ * Invoke `whyDidYouRender` for each Jest assertion
+ *
+ * - Set `Component.whyDidYouRender = true` property to enable for test suite
+ * - Uncomment the custom notifier to see ALL component rerenders (inc valid)
+ *
+ */
+let updateInfos = []
+
+beforeAll(() => {
+  whyDidYouRender(React, {
+    // logOnDifferentValues: true,
+    // notifier: (updateInfo) => updateInfos.push(updateInfo),
+  })
+})
+
+beforeEach(() => {
+  updateInfos = []
+})
+
+afterEach(() => {
+  if (updateInfos.length > 0) {
+    throw new Error(
+      `Component rerenders:\n\n${JSON.stringify(updateInfos, null, 2)}`
+    )
+  }
+})

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -92,6 +92,7 @@
     "@types/testing-library__react": "^10.0.1",
     "@types/uuid": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^5.3.1",
+    "@welldone-software/why-did-you-render": "^7.0.1",
     "babel-jest": "^28.0.1",
     "babel-loader": "^8.0.6",
     "babel-plugin-jsx-remove-data-test-id": "^3.0.0",

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -249,7 +249,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
       >
         <StyledOuterWrapper
           data-testid="datepicker-outer-wrapper"
-          $hasFocus={hasFocus}
+          $hasFocus={hasFocus && !isRange}
           $isInvalid={hasError}
           $isDisabled={isDisabled}
         >

--- a/packages/react-component-library/src/components/Pagination/Pagination.tsx
+++ b/packages/react-component-library/src/components/Pagination/Pagination.tsx
@@ -106,3 +106,4 @@ export const Pagination: React.FC<PaginationProps> = ({
 }
 
 Pagination.displayName = 'Pagination'
+// Pagination.whyDidYouRender = true

--- a/packages/react-component-library/src/components/Pagination/partials/StyledTextInput.tsx
+++ b/packages/react-component-library/src/components/Pagination/partials/StyledTextInput.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import styled from 'styled-components'
 import { selectors } from '@defencedigital/design-tokens'
 
@@ -6,7 +7,7 @@ import { StyledInput } from '../../TextInput/partials/StyledInput'
 
 const { spacing } = selectors
 
-export const StyledTextInput = styled(TextInput)`
+export const StyledTextInput = memo(styled(TextInput)`
   width: 51px;
   margin: 0;
 
@@ -14,4 +15,4 @@ export const StyledTextInput = styled(TextInput)`
     height: 31px;
     padding: 0 0 0 ${spacing('6')};
   }
-`
+`)

--- a/packages/react-component-library/src/components/Pagination/usePageChange.tsx
+++ b/packages/react-component-library/src/components/Pagination/usePageChange.tsx
@@ -41,25 +41,28 @@ export const usePageChange = (
     [changePage]
   )
 
-  function onKeyDown(event: React.KeyboardEvent) {
-    setHasError(false)
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      setHasError(false)
 
-    if (event.key === 'Enter') {
-      const { value } = event.target as HTMLInputElement
+      if (event.key === 'Enter') {
+        const { value } = event.target as HTMLInputElement
 
-      if (!Number.isNaN(value)) {
-        const valueNumber = Number(value)
-        const isAtLeastZero = valueNumber >= 0
-        const isNoMoreThanTotal = valueNumber <= totalPages
-        if (isAtLeastZero && isNoMoreThanTotal) {
-          changePage(event, valueNumber)
-          return
+        if (!Number.isNaN(value)) {
+          const valueNumber = Number(value)
+          const isAtLeastZero = valueNumber >= 0
+          const isNoMoreThanTotal = valueNumber <= totalPages
+          if (isAtLeastZero && isNoMoreThanTotal) {
+            changePage(event, valueNumber)
+            return
+          }
         }
-      }
 
-      setHasError(true)
-    }
-  }
+        setHasError(true)
+      }
+    },
+    [changePage, totalPages]
+  )
 
   return {
     currentPage,

--- a/packages/react-component-library/src/components/TextInput/TextInput.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { memo } from 'react'
 
 import { Input } from './Input'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
@@ -83,7 +83,7 @@ export interface TextInputProps
   value?: string
 }
 
-export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
+const Component = React.forwardRef<HTMLInputElement, TextInputProps>(
   (
     {
       className,
@@ -128,6 +128,8 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
     )
   }
 )
+
+export const TextInput = memo(Component)
 
 TextInput.displayName = 'TextInput'
 // TextInput.whyDidYouRender = true

--- a/packages/react-component-library/src/components/TextInput/TextInput.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.tsx
@@ -130,3 +130,4 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 )
 
 TextInput.displayName = 'TextInput'
+// TextInput.whyDidYouRender = true

--- a/packages/react-component-library/src/hooks/useFocus.ts
+++ b/packages/react-component-library/src/hooks/useFocus.ts
@@ -4,7 +4,9 @@ export function useFocus(onBlur?: (event: React.FormEvent) => void) {
   const [hasFocus, setHasFocus] = useState(false)
 
   const onLocalBlur = (event: React.FormEvent) => {
-    setHasFocus(false)
+    if (hasFocus) {
+      setHasFocus(false)
+    }
 
     if (onBlur) {
       onBlur(event)
@@ -12,7 +14,9 @@ export function useFocus(onBlur?: (event: React.FormEvent) => void) {
   }
 
   const onLocalFocus = () => {
-    setHasFocus(true)
+    if (!hasFocus) {
+      setHasFocus(true)
+    }
   }
 
   return {

--- a/packages/react-component-library/src/hooks/useFocus.ts
+++ b/packages/react-component-library/src/hooks/useFocus.ts
@@ -1,23 +1,26 @@
-import React, { useState } from 'react'
+import React, { useState, useCallback } from 'react'
 
 export function useFocus(onBlur?: (event: React.FormEvent) => void) {
   const [hasFocus, setHasFocus] = useState(false)
 
-  const onLocalBlur = (event: React.FormEvent) => {
-    if (hasFocus) {
-      setHasFocus(false)
-    }
+  const onLocalBlur = useCallback(
+    (event: React.FormEvent) => {
+      if (hasFocus) {
+        setHasFocus(false)
+      }
 
-    if (onBlur) {
-      onBlur(event)
-    }
-  }
+      if (onBlur) {
+        onBlur(event)
+      }
+    },
+    [hasFocus, onBlur]
+  )
 
-  const onLocalFocus = () => {
+  const onLocalFocus = useCallback(() => {
     if (!hasFocus) {
       setHasFocus(true)
     }
-  }
+  }, [hasFocus])
 
   return {
     hasFocus,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5866,6 +5866,13 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.7.0.tgz#e1993689ac42d2b16e9194376cfb6753f6254db1"
   integrity sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
 
+"@welldone-software/why-did-you-render@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@welldone-software/why-did-you-render/-/why-did-you-render-7.0.1.tgz#09f487d84844bd8e66435843c2e0305702e61efb"
+  integrity sha512-Qe/8Xxa2G+LMdI6VoazescPzjjkHYduCDa8aHOJR50e9Bgs8ihkfMBY+ev7B4oc3N59Zm547Sgjf8h5y0FOyoA==
+  dependencies:
+    lodash "^4"
+
 "@xstate/react@^1.5.1":
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.6.3.tgz#706f3beb7bc5879a78088985c8fd43b9dab7f725"
@@ -13233,7 +13240,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
+lodash@^4, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Related issue

Closes #2599

## Overview

Enable `whyDidYouRender` for Jest tests and prevent redundant `TextInput` and `Pagination` rerenders.

## Reason

>Lets check why components are rerendering and optimise where possible.

## Work carried out

- [x] Enable `whyDidYouRender` for Jest tests
- [x] Optimise `TextInput` rerenders
- [x] Optimise `Pagination` rerenders
- [x] Fix `DatePicker` regression on range variant focus 

## Screenshot

![Screenshot 2022-07-13 at 09 52 14](https://user-images.githubusercontent.com/48086589/178699024-d0b02069-106f-4dba-9408-f054d6e5c88d.png)
![Screenshot 2022-07-13 at 10 00 32](https://user-images.githubusercontent.com/48086589/178699036-bd497587-4706-458a-8e09-ca180ace1ec9.png)

## Developer notes

Next step is to go through each and every component and optimise based on the flagged whyDidYouRender warnings from RTL tests. I'm currently battling to get it playing nice with Storybook. Doesn't seem to want to work.