### PR TITLE
test(Cypress): Skip Firefox for type

### DIFF
--- a/packages/react-component-library/cypress/e2e/Autocomplete/index.cy.ts
+++ b/packages/react-component-library/cypress/e2e/Autocomplete/index.cy.ts
@@ -16,7 +16,7 @@ describe('Autocomplete', () => {
     cy.visit('/iframe.html?id=autocomplete--default&viewMode=story')
   })
 
-  describe('when the component is focused', () => {
+  describe('when the component is focused', { browser: '!firefox' }, () => {
     beforeEach(() => {
       cy.get(selectors.select.outerWrapper).click()
     })

--- a/packages/react-component-library/cypress/e2e/Select/index.cy.ts
+++ b/packages/react-component-library/cypress/e2e/Select/index.cy.ts
@@ -8,7 +8,7 @@ describe('Select', () => {
     cy.visit('/iframe.html?id=select--default&viewMode=story')
   })
 
-  describe('when the component is focused', () => {
+  describe('when the component is focused', { browser: '!firefox' }, () => {
     before(() => {
       cy.get(selectors.select.outerWrapper).click()
     })

--- a/packages/react-component-library/cypress/e2e/forms/empty.cy.ts
+++ b/packages/react-component-library/cypress/e2e/forms/empty.cy.ts
@@ -75,45 +75,49 @@ describe('Form Examples (empty)', () => {
             })
           })
 
-          describe('when the user fills in the form successfully', () => {
-            before(() => {
-              cy.get(selectors.form.input.email).type('hello@world.com')
-              cy.get(selectors.form.input.password).type('password')
-              cy.get(selectors.form.input.description).type('Hello, World!')
-              cy.get(selectors.form.input.radio).eq(0).click()
-              cy.get(selectors.form.input.checkbox).eq(1).click()
-              cy.get(selectors.form.input.switchOption).eq(0).click()
-              cy.get(selectors.form.input.numberInputIncrease).click()
-              cy.get(selectors.form.input.datePickerInput).type('31/01/2022')
-              getSelect().type('th{enter}')
-              getAutocomplete().type('fo{downArrow}{enter}')
-              cy.get(selectors.form.input.rangeSliderRail).click(800, 0)
-            })
-
-            it('should not show any validation errors', () => {
-              cy.contains('Required').should('not.exist')
-            })
-
-            describe('when the user submits the form', () => {
+          describe(
+            'when the user fills in the form successfully',
+            { browser: '!firefox' },
+            () => {
               before(() => {
-                cy.get(selectors.form.submit).click()
+                cy.get(selectors.form.input.email).type('hello@world.com')
+                cy.get(selectors.form.input.password).type('password')
+                cy.get(selectors.form.input.description).type('Hello, World!')
+                cy.get(selectors.form.input.radio).eq(0).click()
+                cy.get(selectors.form.input.checkbox).eq(1).click()
+                cy.get(selectors.form.input.switchOption).eq(0).click()
+                cy.get(selectors.form.input.numberInputIncrease).click()
+                cy.get(selectors.form.input.datePickerInput).type('31/01/2022')
+                getSelect().type('th{enter}')
+                getAutocomplete().type('fo{downArrow}{enter}')
+                cy.get(selectors.form.input.rangeSliderRail).click(800, 0)
               })
 
-              it('should set the submit Button state to disabled', () => {
-                cy.get(selectors.form.submit).should('have.attr', 'disabled')
+              it('should not show any validation errors', () => {
+                cy.contains('Required').should('not.exist')
               })
 
-              it('should supply form the field values', () => {
-                cy.get(selectors.form.values)
-                  .invoke('text')
-                  .should((submittedData) => {
-                    expect(JSON.parse(submittedData)).to.deep.equal(
-                      expectedResult
-                    )
-                  })
+              describe('when the user submits the form', () => {
+                before(() => {
+                  cy.get(selectors.form.submit).click()
+                })
+
+                it('should set the submit Button state to disabled', () => {
+                  cy.get(selectors.form.submit).should('have.attr', 'disabled')
+                })
+
+                it('should supply form the field values', () => {
+                  cy.get(selectors.form.values)
+                    .invoke('text')
+                    .should((submittedData) => {
+                      expect(JSON.parse(submittedData)).to.deep.equal(
+                        expectedResult
+                      )
+                    })
+                })
               })
-            })
-          })
+            }
+          )
         })
       })
     }

--- a/packages/react-component-library/cypress/e2e/forms/prepopulated.cy.ts
+++ b/packages/react-component-library/cypress/e2e/forms/prepopulated.cy.ts
@@ -99,47 +99,53 @@ describe('Form Examples (pre-populated)', () => {
             })
           })
 
-          describe('when the user edits the form data', () => {
-            before(() => {
-              cy.get(selectors.form.input.email).type(
-                '{selectall}hello@world.com'
-              )
-              cy.get(selectors.form.input.password).type('{selectall}password')
-              cy.get(selectors.form.input.description).type(
-                '{selectall}Hello, World!'
-              )
-              cy.get(selectors.form.input.radio).eq(0).click()
-              cy.get(selectors.form.input.checkbox).eq(0).click()
-              cy.get(selectors.form.input.switchOption).eq(0).click()
-              cy.get(selectors.form.input.numberInputIncrease).click()
-              cy.get(selectors.form.input.datePickerInput).type(
-                '{selectall}31/01/2022'
-              )
-              getSelect().type('th{enter}')
-              getAutocomplete().type('{selectall}fo{downArrow}{enter}')
-              cy.get(selectors.form.input.rangeSliderRail).click(800, 0)
-            })
-
-            it('does not show any validation errors', () => {
-              cy.contains('Required').should('not.exist')
-            })
-
-            describe('when the user submits the form', () => {
+          describe(
+            'when the user edits the form data',
+            { browser: '!firefox' },
+            () => {
               before(() => {
-                cy.get(selectors.form.submit).click()
+                cy.get(selectors.form.input.email).type(
+                  '{selectall}hello@world.com'
+                )
+                cy.get(selectors.form.input.password).type(
+                  '{selectall}password'
+                )
+                cy.get(selectors.form.input.description).type(
+                  '{selectall}Hello, World!'
+                )
+                cy.get(selectors.form.input.radio).eq(0).click()
+                cy.get(selectors.form.input.checkbox).eq(0).click()
+                cy.get(selectors.form.input.switchOption).eq(0).click()
+                cy.get(selectors.form.input.numberInputIncrease).click()
+                cy.get(selectors.form.input.datePickerInput).type(
+                  '{selectall}31/01/2022'
+                )
+                getSelect().type('th{enter}')
+                getAutocomplete().type('{selectall}fo{downArrow}{enter}')
+                cy.get(selectors.form.input.rangeSliderRail).click(800, 0)
               })
 
-              it('submits the updated field values', () => {
-                cy.get(selectors.form.values)
-                  .invoke('text')
-                  .should((submittedData) => {
-                    const parsedData = JSON.parse(submittedData)
-                    parsedData.exampleCheckbox.sort()
-                    expect(parsedData).to.deep.equal(expectedEditedResult)
-                  })
+              it('does not show any validation errors', () => {
+                cy.contains('Required').should('not.exist')
               })
-            })
-          })
+
+              describe('when the user submits the form', () => {
+                before(() => {
+                  cy.get(selectors.form.submit).click()
+                })
+
+                it('submits the updated field values', () => {
+                  cy.get(selectors.form.values)
+                    .invoke('text')
+                    .should((submittedData) => {
+                      const parsedData = JSON.parse(submittedData)
+                      parsedData.exampleCheckbox.sort()
+                      expect(parsedData).to.deep.equal(expectedEditedResult)
+                    })
+                })
+              })
+            }
+          )
         })
       })
     }


### PR DESCRIPTION
## Related issue
Closes #3358 

## Overview
Firefox 102 and `cy.type` has issues.

## Reason
There is an issue with typing and Firefox 102 which needs to be temporarily skipped.

## Work carried out
- [x] Add conditional skip