### PR TITLE
docs(DatePicker): Use fixed today date in Open story

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -76,6 +76,8 @@ export const Open = Template.bind({})
 Open.storyName = 'Open'
 Open.args = {
   initialIsOpen: true,
+  initialMonth: parseISO('2022-06-01'),
+  today: parseISO('2022-06-15'),
 }
 
 export const Range = Template.bind({})

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -1,7 +1,7 @@
 import { format, isValid } from 'date-fns'
 import React, { useState } from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import { ColorDanger800 } from '@defencedigital/design-tokens'
+import { ColorDanger800, ColorWarning800 } from '@defencedigital/design-tokens'
 import {
   fireEvent,
   render,
@@ -161,6 +161,14 @@ describe('DatePicker', () => {
       it('displays the container', () => {
         return waitFor(() => {
           expect(wrapper.getByTestId('floating-box')).toBeVisible()
+        })
+      })
+
+      it('colours the current date', () => {
+        return waitFor(() => {
+          expect(wrapper.getByText(/^5$/)).toHaveStyle({
+            color: ColorWarning800,
+          })
         })
       })
 
@@ -958,6 +966,26 @@ describe('DatePicker', () => {
 
     it('displays the picker as open on initial render', () => {
       expect(wrapper.getByTestId('floating-box')).toBeVisible()
+    })
+  })
+
+  describe('when the today prop is set', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <DatePicker initialIsOpen today={new Date(2019, 11, 15)} />
+      )
+    })
+
+    it('colours the override date', () => {
+      expect(wrapper.getByText(/^15$/)).toHaveStyle({
+        color: ColorWarning800,
+      })
+    })
+
+    it('does not colour the actual current date', () => {
+      expect(wrapper.getByText(/^5$/)).not.toHaveStyle({
+        color: ColorWarning800,
+      })
     })
   })
 

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -146,6 +146,11 @@ export interface DatePickerProps
    */
   placement?: Placement
   /**
+   * Optional override for the date marked as today in the picker.
+   * Can be used for e.g. visual regression testing.
+   */
+  today?: Date
+  /**
    * Not used. Use `startDate` and `endDate` instead.
    */
   value?: never
@@ -173,6 +178,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   initialEndDate = null,
   placement = 'bottom-start',
   onBlur,
+  today,
   // Formik can pass value – drop it to stop it being forwarded to the input
   value: _,
   ...rest
@@ -233,6 +239,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   const modifiers = {
     start: replaceInvalidDate(startDate),
     end: replaceInvalidDate(endDate),
+    ...(today ? { today } : {}),
   }
 
   const hasContent = Boolean(startDate)


### PR DESCRIPTION
## Related issue

Resolves #3365

## Overview

This adds the ability to override the today date in DatePicker, and makes the Open story do this (and also use a fixed initial month).

## Link to preview

https://red-playground.netlify.app/?path=/docs/date-picker--open

## Reason

The Open story was changing on a daily basis (due to the current date changing), causing Chromatic to repeatedly flag the story. Consumers may have also had the same problem if they had their own visual regression tests (without having a decent workaround).

## Work carried out

- [x] Add today prop to DatePicker
- [x] Update Open story

## Screenshot

### Before

![image](https://user-images.githubusercontent.com/66470099/179943543-07c5a17e-11b2-48d5-b79a-64798bbbc216.png)

### After

![image](https://user-images.githubusercontent.com/66470099/179943738-11e74dda-d186-4acf-9a43-c974dc87f438.png)

