### PR TITLE
chore(Deps): Remove @types/jsdom dependency

### DIFF
--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -80,7 +80,6 @@
     "@testing-library/user-event": "^14.1.1",
     "@types/classnames": "^2.2.9",
     "@types/jest": "^27.4.1",
-    "@types/jsdom": "^16.2.0",
     "@types/lodash": "^4.14.149",
     "@types/node": "^16.3.3",
     "@types/react": "^17.0.38",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4480,7 +4480,7 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/jsdom@^16.2.0", "@types/jsdom@^16.2.4":
+"@types/jsdom@^16.2.4":
   version "16.2.14"
   resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-16.2.14.tgz#26fe9da6a8870715b154bb84cd3b2e53433d8720"
   integrity sha512-6BAy1xXEmMuHeAJ4Fv4yXKwBDTGTOseExKE3OaHiNycdHdZw59KfYzrt0DkDluvwmik1HRt6QS7bImxUmpSy+w==


### PR DESCRIPTION
## Related issue

Resolves #3382

## Overview

This removes the dependency on `@types/jsdom`.

## Reason

A dependency on `@types/jsdom` isn't needed as there is no direct dependency on `jsdom` and `jest-environment-jsdom` has  appropriate types included already.

## Work carried out

- [x] Removes the dependency on `@types/jsdom`
