### PR TITLE
chore(Types): Resolve TypeScript 4.8 type errors

### DIFF
--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -4,6 +4,7 @@ import { useCombobox } from 'downshift'
 import {
   initialSelectedItem,
   itemToString,
+  SelectBaseOptionAsStringProps,
   SelectBaseProps,
   SelectChildWithStringType,
   SelectLayout,
@@ -65,7 +66,11 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     initialSelectedItem: initialSelectedItem(children, value),
     onSelectedItemChange: ({ selectedItem: newItem }) => {
       if (onChange) {
-        onChange(React.isValidElement(newItem) ? newItem.props.value : null)
+        onChange(
+          React.isValidElement<SelectBaseOptionAsStringProps>(newItem)
+            ? newItem.props.value
+            : null
+        )
       }
 
       focusToggleButton()
@@ -117,7 +122,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     >
       {isOpen &&
         React.Children.map(items, (child: SelectChildWithStringType, index) => {
-          if (!React.isValidElement(child)) {
+          if (!React.isValidElement<SelectBaseOptionAsStringProps>(child)) {
             return null
           }
 

--- a/packages/react-component-library/src/components/Autocomplete/helpers.ts
+++ b/packages/react-component-library/src/components/Autocomplete/helpers.ts
@@ -1,13 +1,19 @@
 import React from 'react'
 
-import { SelectChildWithStringType } from '../SelectBase'
+import {
+  SelectBaseOptionAsStringProps,
+  SelectChildWithStringType,
+} from '../SelectBase'
 
 function findIndexOfInputValue(
   items: SelectChildWithStringType[],
   inputValue: string
 ): number {
   return items.findIndex((child: SelectChildWithStringType) => {
-    return React.isValidElement(child) && child.props.children === inputValue
+    return (
+      React.isValidElement<SelectBaseOptionAsStringProps>(child) &&
+      child.props.children === inputValue
+    )
   })
 }
 

--- a/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
+++ b/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
@@ -2,7 +2,10 @@ import React, { useRef, useState } from 'react'
 import { UseComboboxStateChange } from 'downshift'
 
 import { findIndexOfInputValue } from '../helpers'
-import { SelectChildWithStringType } from '../../SelectBase'
+import {
+  SelectBaseOptionAsStringProps,
+  SelectChildWithStringType,
+} from '../../SelectBase'
 
 export function useAutocomplete(
   children: SelectChildWithStringType[],
@@ -29,7 +32,7 @@ export function useAutocomplete(
     if (isOpen) {
       setItems(
         children.filter((item) => {
-          if (!React.isValidElement(item)) {
+          if (!React.isValidElement<SelectBaseOptionAsStringProps>(item)) {
             return false
           }
           const filter = (inputValue as string).toLowerCase()

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -4,6 +4,7 @@ import { useSelect } from 'downshift'
 import {
   initialSelectedItem,
   itemToString,
+  SelectBaseOptionAsStringProps,
   SelectBaseProps,
   SelectChildWithStringType,
   SelectLayout,
@@ -38,7 +39,11 @@ export const Select: React.FC<SelectBaseProps> = ({
     items: React.Children.toArray(children),
     onSelectedItemChange: ({ selectedItem: newItem }) => {
       if (onChange) {
-        onChange(React.isValidElement(newItem) ? newItem.props.value : null)
+        onChange(
+          React.isValidElement<SelectBaseOptionAsStringProps>(newItem)
+            ? newItem.props.value
+            : null
+        )
       }
     },
   })
@@ -73,7 +78,7 @@ export const Select: React.FC<SelectBaseProps> = ({
         React.Children.map(
           children,
           (child: SelectChildWithStringType, index) => {
-            if (!React.isValidElement(child)) {
+            if (!React.isValidElement<SelectBaseOptionAsStringProps>(child)) {
               return null
             }
 

--- a/packages/react-component-library/src/components/SelectBase/helpers.ts
+++ b/packages/react-component-library/src/components/SelectBase/helpers.ts
@@ -1,9 +1,12 @@
 import React from 'react'
 
+import { SelectBaseOptionAsStringProps } from './SelectBaseOption'
 import { SelectChildrenType, SelectChildWithStringType } from './types'
 
 function itemToString(item: SelectChildWithStringType) {
-  return React.isValidElement(item) ? item.props.children : ''
+  return React.isValidElement<SelectBaseOptionAsStringProps>(item)
+    ? item.props.children
+    : ''
 }
 
 function initialSelectedItem(

--- a/packages/react-component-library/src/components/Switch/Switch.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.tsx
@@ -79,7 +79,7 @@ export const Switch: React.FC<SwitchProps> = ({
       )}
       <StyledContainer>
         {React.Children.map(children, (child: SwitchChildType) => {
-          if (!React.isValidElement(child)) {
+          if (!React.isValidElement<SwitchOptionProps>(child)) {
             return null
           }
 


### PR DESCRIPTION
## Related issue

Resolves #3417 

## Overview

This resolves various type errors that appeared after updating to TypeScript 4.8.

These errors were all internal to the code base.

## Reason

To get the build working again.

## Work carried out

- [x] Resolve type errors
