### PR TITLE
fix(Autocomplete): Handle changes to options list after initial render

### DIFF
--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
@@ -181,6 +181,58 @@ describe('Autocomplete', () => {
     })
   })
 
+  describe('when options are added after the initial render', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Autocomplete id="autocomplete-id" label="Label" onChange={jest.fn()}>
+          <>{}</>
+        </Autocomplete>
+      )
+      wrapper.rerender(
+        <Autocomplete id="autocomplete-id" label="Label" onChange={jest.fn()}>
+          <AutocompleteOption value="one">One</AutocompleteOption>
+          <AutocompleteOption value="two">Two</AutocompleteOption>
+        </Autocomplete>
+      )
+      return userEvent.click(wrapper.getByTestId('select-arrow-button'))
+    })
+
+    it('displays the items', () => {
+      const options = wrapper.getAllByTestId('select-option')
+
+      expect(options[0]).toHaveTextContent('One')
+      expect(options[1]).toHaveTextContent('Two')
+      expect(options).toHaveLength(2)
+    })
+  })
+
+  describe('when options are added while the menu is open', () => {
+    beforeEach(async () => {
+      wrapper = render(
+        <Autocomplete id="autocomplete-id" label="Label" onChange={jest.fn()}>
+          <>{}</>
+        </Autocomplete>
+      )
+
+      await userEvent.click(wrapper.getByTestId('select-arrow-button'))
+
+      wrapper.rerender(
+        <Autocomplete id="autocomplete-id" label="Label" onChange={jest.fn()}>
+          <AutocompleteOption value="one">One</AutocompleteOption>
+          <AutocompleteOption value="two">Two</AutocompleteOption>
+        </Autocomplete>
+      )
+    })
+
+    it('displays the items', () => {
+      const options = wrapper.getAllByTestId('select-option')
+
+      expect(options[0]).toHaveTextContent('One')
+      expect(options[1]).toHaveTextContent('Two')
+      expect(options).toHaveLength(2)
+    })
+  })
+
   describe('when the default `id` is used and the arrow button is clicked', () => {
     let initialId: string
 

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -33,8 +33,15 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
   value = null,
   ...rest
 }) => {
-  const { hasError, inputRef, items, onInputValueChange, onIsOpenChange } =
-    useAutocomplete(React.Children.toArray(children), isInvalid)
+  const {
+    hasError,
+    inputRef,
+    items,
+    onInputValueChange,
+    onIsOpenChange,
+    onSelectedItemChange,
+  } = useAutocomplete(React.Children.toArray(children), isInvalid)
+
   const {
     buttonRef,
     focusToggleButton,
@@ -64,7 +71,11 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     onInputValueChange,
     onIsOpenChange,
     initialSelectedItem: initialSelectedItem(children, value),
-    onSelectedItemChange: ({ selectedItem: newItem }) => {
+    onSelectedItemChange: (changes) => {
+      onSelectedItemChange(changes)
+
+      const { selectedItem: newItem } = changes
+
       if (onChange) {
         onChange(
           React.isValidElement<SelectBaseOptionAsStringProps>(newItem)


### PR DESCRIPTION
## Related issue

Resolves #3420

## Overview

This resolves a problem where Autocomplete options did not update if they changed after the initial render.

## Link to preview

https://red-playground.netlify.app/?path=/docs/autocomplete--default

## Reason

This is expected to work e.g. for loading options asynchronously.

## Work carried out

- [x] Remove options from state to fix the bug

## Developer notes

Changes to the option list after the initial render (e.g. loading options asynchronously) previously didn't work, as a copy of the options was kept in the state. As the options are made up of ReactElements (which also have ReactNodes within their props), it is also difficult to keep track of changes to them (simply adding a `useEffect` caused an infinite loop).

This changes how things work slightly so the filter state is tracked in the state, and not the items themselves, which fixes the problem.
