### PR TITLE
fix(Autocomplete): Add missing onBlur prop

### DIFF
--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
@@ -7,17 +7,24 @@ import userEvent from '@testing-library/user-event'
 import { Autocomplete, AutocompleteOption } from '.'
 
 describe('Autocomplete', () => {
-  let onChangeSpy: (value: string | null) => void
+  let onBlurSpy: jest.Mock
+  let onChangeSpy: jest.Mock<void, [string | null]>
   let wrapper: RenderResult
 
   describe('when using the default prop values', () => {
     beforeEach(() => {
       const canShowFourthOption = false
 
-      onChangeSpy = jest.fn()
+      onBlurSpy = jest.fn()
+      onChangeSpy = jest.fn<void, [string | null]>()
 
       wrapper = render(
-        <Autocomplete id="autocomplete-id" label="Label" onChange={onChangeSpy}>
+        <Autocomplete
+          id="autocomplete-id"
+          label="Label"
+          onBlur={onBlurSpy}
+          onChange={onChangeSpy}
+        >
           <AutocompleteOption value="one">One</AutocompleteOption>
           <AutocompleteOption value="two">Two</AutocompleteOption>
           <AutocompleteOption value="three">Three</AutocompleteOption>
@@ -102,6 +109,10 @@ describe('Autocomplete', () => {
         expect(wrapper.getByTestId('select-input')).toHaveFocus()
       })
 
+      it('does not call `onBlur`', () => {
+        expect(onBlurSpy).not.toHaveBeenCalled()
+      })
+
       it('displays the items', () => {
         const options = wrapper.getAllByTestId('select-option')
 
@@ -121,6 +132,12 @@ describe('Autocomplete', () => {
       describe('and the second item is clicked', () => {
         beforeEach(() => {
           return userEvent.click(wrapper.getByText('Two'))
+        })
+
+        it('calls `onBlur`', () => {
+          // This is called twice when an item is clicked on – this is due to
+          // Downshift forcibly focusing the input when an item is clicked.
+          expect(onBlurSpy).toHaveBeenCalled()
         })
 
         it('hides the items', () => {

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { useCombobox } from 'downshift'
 
 import {
@@ -22,6 +22,10 @@ export interface AutocompleteProps extends SelectBaseProps {
    * be cleared by manually deleting the text in the input.)
    */
   hideClearButton?: boolean
+  /**
+   * Called when the input loses focus.
+   */
+  onBlur?: (event: React.FocusEvent) => void
 }
 
 export const Autocomplete: React.FC<AutocompleteProps> = ({
@@ -29,6 +33,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
   id: externalId,
   initialIsOpen,
   isInvalid = false,
+  onBlur,
   onChange,
   value = null,
   ...rest
@@ -99,13 +104,22 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
 
   const { onInputFocusHandler } = useMenuVisibility(isOpen, openMenu)
 
+  const handleInputBlur: React.FocusEventHandler<HTMLInputElement> =
+    useCallback(
+      (...args) => {
+        onInputBlurHandler()
+        onBlur?.(...args)
+      },
+      [onBlur, onInputBlurHandler]
+    )
+
   return (
     <SelectLayout
       hasLabelFocus={isOpen}
       hasSelectedItem={!!inputValue}
       id={id}
       inputProps={getInputProps({
-        onBlur: onInputBlurHandler,
+        onBlur: handleInputBlur,
         onFocus: onInputFocusHandler,
         onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
           onInputTabKeyHandler(e)


### PR DESCRIPTION
## Related issue

Resolves #3421

## Overview

Adds an `onBlur` prop to `Autocomplete` (called when the input is blurred).

## Reason

This is required when integrating with certain Form libraries.

## Work carried out

- [x] Add prop

## Developer notes

Unfortunately, this is called twice when an item is clicked on – this is due to Downshift forcibly focusing the input when an item is clicked.