### PR TITLE
fix(ContextMenu): Resolve accessibility problems

### DIFF
--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -55,7 +55,7 @@ export const Default: ComponentStory<typeof ContextMenu> = (props) => {
 
 Default.storyName = 'Default'
 
-export const WithIcons: ComponentStory<typeof ContextMenu> = (props) => {
+const WithIconsTemplate: ComponentStory<typeof ContextMenu> = (props) => {
   const ref = useRef<HTMLDivElement>(null)
 
   return (
@@ -95,4 +95,14 @@ export const WithIcons: ComponentStory<typeof ContextMenu> = (props) => {
   )
 }
 
+export const WithIcons = WithIconsTemplate.bind({})
 WithIcons.storyName = 'With icons'
+
+export const Open = WithIconsTemplate.bind({})
+Open.storyName = 'Open'
+Open.args = {
+  initialIsOpen: true,
+}
+Open.parameters = {
+  docs: { disable: true },
+}

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
@@ -62,6 +62,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
       css={styles.popper as CSSObject}
       {...attributes.popper}
       data-testid="context-menu"
+      role="menu"
       {...rest}
     >
       {children}

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenuDivider.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenuDivider.tsx
@@ -3,7 +3,12 @@ import React from 'react'
 import { StyledContextMenuDivider } from './partials/StyledContextMenuDivider'
 
 export const ContextMenuDivider: React.FC = () => {
-  return <StyledContextMenuDivider data-testid="context-menu-divider" />
+  return (
+    <StyledContextMenuDivider
+      data-testid="context-menu-divider"
+      role="separator"
+    />
+  )
 }
 
 ContextMenuDivider.displayName = 'ContextMenuDivider'

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenuItem.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenuItem.tsx
@@ -30,7 +30,7 @@ export const ContextMenuItem: React.FC<ContextMenuItemProps> = ({
     ),
   })
 
-  return <StyledContextMenuItem>{item}</StyledContextMenuItem>
+  return <StyledContextMenuItem role="menuitem">{item}</StyledContextMenuItem>
 }
 
 ContextMenuItem.displayName = 'ContextMenuItem'

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenuDivider.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenuDivider.tsx
@@ -3,7 +3,7 @@ import { selectors } from '@defencedigital/design-tokens'
 
 const { color, spacing } = selectors
 
-export const StyledContextMenuDivider = styled.div`
+export const StyledContextMenuDivider = styled.li`
   height: 1px;
   background-color: ${color('neutral', '100')};
   margin: ${spacing('2')} -${spacing('2')};

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledIcon.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledIcon.tsx
@@ -3,7 +3,7 @@ import { selectors } from '@defencedigital/design-tokens'
 
 const { spacing, color } = selectors
 
-export const StyledIcon = styled.div`
+export const StyledIcon = styled.span`
   display: inline-flex;
   align-items: center;
   margin-right: ${spacing('2')};

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledText.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledText.tsx
@@ -9,7 +9,8 @@ interface StyledTextProps {
 
 const { color, fontSize } = selectors
 
-export const StyledText = styled.div<StyledTextProps>`
+export const StyledText = styled.span<StyledTextProps>`
+  display: block;
   color: ${color('neutral', '400')};
   font-weight: 600;
   font-size: ${fontSize('base')};


### PR DESCRIPTION
## Related issue

Resolves #3403

## Overview

This resolves various accessibility problems with ContextMenu, related to ARIA roles and HTML tags.

## Link to preview

https://5e25c277526d380020b5e418-ccpmnubiqa.chromatic.com/?path=/story/context-menu--open

## Reason

To help ensure the component is accessible.

## Work carried out

- [x] Add new story
- [x] Resolve flagged errors

## Screenshot

![image](https://user-images.githubusercontent.com/66470099/188885030-f74b37de-27bc-497e-8791-c0b12bcc49c0.png)

## Developer notes

The `menu` and `menuitem` roles have been used, as these appear to be appropriate and match examples of context menus elsewhere.

~~A new Storybook interaction story was added to test an open ContextMenu.~~ This is hidden on the Docs tab.

Unfortunately, the Storybook interactions addon isn't compatible with IE11, and therefore wasn't able to be used, and a normal story has been added instead.