### PR TITLE
fix(Autocomplete): Don't clear external error state automatically

### DIFF
--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
@@ -1,10 +1,16 @@
-import { TypographyS } from '@defencedigital/design-tokens'
+import { ColorDanger800, TypographyS } from '@defencedigital/design-tokens'
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { COMPONENT_SIZE } from '../Forms'
+import { BORDER_WIDTH } from '../../styled-components'
 import { Autocomplete, AutocompleteOption } from '.'
+
+const ERROR_BOX_SHADOW = `0 0 0 ${
+  BORDER_WIDTH[COMPONENT_SIZE.FORMS]
+} ${ColorDanger800.toUpperCase()}`
 
 describe('Autocomplete', () => {
   let onBlurSpy: jest.Mock
@@ -306,6 +312,46 @@ describe('Autocomplete', () => {
       expect(
         wrapper.queryByTestId('select-clear-button')
       ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when the `isInvalid` prop is set', () => {
+    beforeEach(() => {
+      onBlurSpy = jest.fn()
+      onChangeSpy = jest.fn<void, [string | null]>()
+
+      wrapper = render(
+        <Autocomplete
+          id="autocomplete-id"
+          label="Label"
+          onBlur={onBlurSpy}
+          onChange={onChangeSpy}
+          isInvalid
+        >
+          <AutocompleteOption value="one">One</AutocompleteOption>
+        </Autocomplete>
+      )
+    })
+
+    it('has an error border', () => {
+      expect(wrapper.getByTestId('select-outer-wrapper')).toHaveStyleRule(
+        'box-shadow',
+        ERROR_BOX_SHADOW
+      )
+    })
+
+    describe('when the input is focused and blurred', () => {
+      beforeEach(() => {
+        wrapper.getByTestId('select-input').focus()
+        wrapper.getByTestId('select-input').blur()
+      })
+
+      it('still has an error border', () => {
+        expect(wrapper.getByTestId('select-outer-wrapper')).toHaveStyleRule(
+          'box-shadow',
+          ERROR_BOX_SHADOW
+        )
+      })
     })
   })
 

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -45,7 +45,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     onInputValueChange,
     onIsOpenChange,
     onSelectedItemChange,
-  } = useAutocomplete(React.Children.toArray(children), isInvalid)
+  } = useAutocomplete(React.Children.toArray(children))
 
   const {
     buttonRef,
@@ -130,7 +130,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
       inputWrapperProps={getComboboxProps({
         'aria-expanded': isOpen,
       })}
-      isInvalid={hasError}
+      isInvalid={hasError || isInvalid}
       isOpen={isOpen}
       menuProps={getMenuProps()}
       onClearButtonClick={() => {

--- a/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
+++ b/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
@@ -7,10 +7,7 @@ import {
   SelectChildWithStringType,
 } from '../../SelectBase'
 
-export function useAutocomplete(
-  children: SelectChildWithStringType[],
-  isInvalid: boolean
-): {
+export function useAutocomplete(children: SelectChildWithStringType[]): {
   hasError: boolean
   inputRef: React.RefObject<HTMLInputElement>
   items: SelectChildWithStringType[]
@@ -24,7 +21,7 @@ export function useAutocomplete(
     changes: UseComboboxStateChange<SelectChildWithStringType>
   ) => void
 } {
-  const [hasError, setHasError] = useState<boolean>(isInvalid)
+  const [hasError, setHasError] = useState<boolean>(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const [filterValue, setFilterValue] = useState<string>('')
 


### PR DESCRIPTION
## Related issue

Resolves #3438

## Overview

This stops an external error state being automatically cleared (e.g. on blur) in the Autocomplete component.

## Link to preview

https://5e25c277526d380020b5e418-hrvzlnpkuh.chromatic.com/?path=/docs/autocomplete--with-error

## Reason

The component doesn't know when the error has been fixed; only the parent component can indicate this by unsetting the prop.

## Work carried out

- [x] Update handling of `isInvalid` prop

## Demo

### Before

![Screencast_13_09_22_09:29:31](https://user-images.githubusercontent.com/66470099/189852596-d861e50e-bf58-46b6-a6b9-2ab76104a133.gif)

### After

![Screencast_13_09_22_09:30:44](https://user-images.githubusercontent.com/66470099/189852607-504c1338-4d33-4121-a3c6-c0fb3c8dc264.gif)

