### PR TITLE
fix(Autocomplete): Behave as controlled component

### DIFF
--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import {
   IconAgriculture,
   IconAnchor,
@@ -71,7 +71,7 @@ Disabled.args = {
 export const NoClearButton = Template.bind({})
 NoClearButton.args = {
   hideClearButton: true,
-  value: 'two',
+  initialValue: 'two',
 }
 
 export const Open = Template.bind({})
@@ -87,7 +87,7 @@ WithError.args = {
 
 export const WithValue = Template.bind({})
 WithValue.args = {
-  value: 'two',
+  initialValue: 'two',
 }
 
 export const WithIconsAndBadges = TemplateWithIconsAndBadges.bind({})

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
@@ -204,15 +204,93 @@ describe('Autocomplete', () => {
     })
   })
 
+  describe('when the component is controlled with "One" selected', () => {
+    const ControlledAutocomplete = () => {
+      const [value, setValue] = React.useState<string | null>('one')
+
+      return (
+        <Autocomplete
+          id="autocomplete-id"
+          label="Label"
+          onChange={(newValue) => setValue(newValue)}
+          value={value}
+        >
+          <AutocompleteOption value="one">One</AutocompleteOption>
+          <AutocompleteOption value="two">Two</AutocompleteOption>
+        </Autocomplete>
+      )
+    }
+
+    beforeEach(() => {
+      wrapper = render(<ControlledAutocomplete />)
+    })
+
+    it('has the value "One"', () => {
+      expect(wrapper.getByTestId('select-input')).toHaveValue('One')
+    })
+
+    describe('when the menu is opened and the second item clicked', () => {
+      beforeEach(async () => {
+        await userEvent.click(wrapper.getByTestId('select-arrow-button'))
+        return userEvent.click(wrapper.getByText('Two'))
+      })
+
+      it('has the value "Two"', () => {
+        expect(wrapper.getByTestId('select-input')).toHaveValue('Two')
+      })
+    })
+  })
+
+  describe('when the component is uncontrolled with "One" selected', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Autocomplete
+          id="autocomplete-id"
+          label="Label"
+          onChange={jest.fn()}
+          initialValue="one"
+        >
+          <AutocompleteOption value="one">One</AutocompleteOption>
+          <AutocompleteOption value="two">Two</AutocompleteOption>
+        </Autocomplete>
+      )
+    })
+
+    it('has the value "One"', () => {
+      expect(wrapper.getByTestId('select-input')).toHaveValue('One')
+    })
+
+    describe('when the menu is opened and the second item clicked', () => {
+      beforeEach(async () => {
+        await userEvent.click(wrapper.getByTestId('select-arrow-button'))
+        return userEvent.click(wrapper.getByText('Two'))
+      })
+
+      it('has the value "Two"', () => {
+        expect(wrapper.getByTestId('select-input')).toHaveValue('Two')
+      })
+    })
+  })
+
   describe('when options are added after the initial render', () => {
     beforeEach(() => {
       wrapper = render(
-        <Autocomplete id="autocomplete-id" label="Label" onChange={jest.fn()}>
+        <Autocomplete
+          id="autocomplete-id"
+          label="Label"
+          onChange={jest.fn()}
+          value="one"
+        >
           <>{}</>
         </Autocomplete>
       )
       wrapper.rerender(
-        <Autocomplete id="autocomplete-id" label="Label" onChange={jest.fn()}>
+        <Autocomplete
+          id="autocomplete-id"
+          label="Label"
+          onChange={jest.fn()}
+          value="one"
+        >
           <AutocompleteOption value="one">One</AutocompleteOption>
           <AutocompleteOption value="two">Two</AutocompleteOption>
         </Autocomplete>
@@ -227,12 +305,21 @@ describe('Autocomplete', () => {
       expect(options[1]).toHaveTextContent('Two')
       expect(options).toHaveLength(2)
     })
+
+    it('has the correct value', () => {
+      expect(wrapper.getByTestId('select-input')).toHaveValue('One')
+    })
   })
 
   describe('when options are added while the menu is open', () => {
     beforeEach(async () => {
       wrapper = render(
-        <Autocomplete id="autocomplete-id" label="Label" onChange={jest.fn()}>
+        <Autocomplete
+          id="autocomplete-id"
+          label="Label"
+          onChange={jest.fn()}
+          value="one"
+        >
           <>{}</>
         </Autocomplete>
       )
@@ -240,7 +327,12 @@ describe('Autocomplete', () => {
       await userEvent.click(wrapper.getByTestId('select-arrow-button'))
 
       wrapper.rerender(
-        <Autocomplete id="autocomplete-id" label="Label" onChange={jest.fn()}>
+        <Autocomplete
+          id="autocomplete-id"
+          label="Label"
+          onChange={jest.fn()}
+          value="one"
+        >
           <AutocompleteOption value="one">One</AutocompleteOption>
           <AutocompleteOption value="two">Two</AutocompleteOption>
         </Autocomplete>
@@ -253,6 +345,10 @@ describe('Autocomplete', () => {
       expect(options[0]).toHaveTextContent('One')
       expect(options[1]).toHaveTextContent('Two')
       expect(options).toHaveLength(2)
+    })
+
+    it('has the correct value', () => {
+      expect(wrapper.getByTestId('select-input')).toHaveValue('One')
     })
   })
 

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -5,7 +5,7 @@ import { useCombobox } from 'downshift'
 import { itemToString, SelectBaseProps, SelectLayout } from '../SelectBase'
 import { NoResults } from './NoResults'
 import { useHighlightedIndex } from './hooks/useHighlightedIndex'
-import { useAutocomplete } from './hooks/useAutocomplete'
+import { ItemsMap, useAutocomplete } from './hooks/useAutocomplete'
 import { useMenuVisibility } from '../SelectBase/hooks/useMenuVisibility'
 import { useExternalId } from '../../hooks/useExternalId'
 import { useToggleButton } from './hooks/useToggleButton'
@@ -20,16 +20,25 @@ export interface AutocompleteProps extends SelectBaseProps {
    * Called when the input loses focus.
    */
   onBlur?: (event: React.FocusEvent) => void
+  /**
+   * The initially selected item when the component is uncontrolled.
+   */
+  initialValue?: string | null
+}
+
+function getSelectedItem(value: string | null | undefined, itemsMap: ItemsMap) {
+  return !isNil(value) && value in itemsMap ? value : null
 }
 
 export const Autocomplete: React.FC<AutocompleteProps> = ({
   children,
   id: externalId,
   initialIsOpen,
+  initialValue,
   isInvalid = false,
   onBlur,
   onChange,
-  value = null,
+  value,
   ...rest
 }) => {
   const {
@@ -49,6 +58,8 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     onToggleButtonKeyDownHandler,
   } = useToggleButton(inputRef)
   const id = useExternalId('autocomplete', externalId)
+
+  const isControlled = value !== undefined
 
   const {
     getComboboxProps,
@@ -73,7 +84,6 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
         : '',
     onInputValueChange,
     onIsOpenChange,
-    initialSelectedItem: !isNil(value) && value in itemsMap ? value : null,
     onSelectedItemChange: (changes) => {
       onSelectedItemChange(changes)
 
@@ -84,6 +94,12 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
       }
 
       focusToggleButton()
+    },
+    ...{
+      [isControlled ? 'selectedItem' : 'initialSelectedItem']: getSelectedItem(
+        isControlled ? value : initialValue,
+        itemsMap
+      ),
     },
   })
 

--- a/packages/react-component-library/src/components/Autocomplete/helpers.ts
+++ b/packages/react-component-library/src/components/Autocomplete/helpers.ts
@@ -1,20 +1,12 @@
 import React from 'react'
 
-import {
-  SelectBaseOptionAsStringProps,
-  SelectChildWithStringType,
-} from '../SelectBase'
+import { SelectBaseOptionAsStringProps } from '../SelectBase'
 
 function findIndexOfInputValue(
-  items: SelectChildWithStringType[],
+  items: React.ReactElement<SelectBaseOptionAsStringProps>[],
   inputValue: string
 ): number {
-  return items.findIndex((child: SelectChildWithStringType) => {
-    return (
-      React.isValidElement<SelectBaseOptionAsStringProps>(child) &&
-      child.props.children === inputValue
-    )
-  })
+  return items.findIndex((child) => child.props.children === inputValue)
 }
 
 export { findIndexOfInputValue }

--- a/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
+++ b/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react'
-import { UseComboboxStateChange } from 'downshift'
+import { useCombobox, UseComboboxStateChange } from 'downshift'
 
 import { findIndexOfInputValue } from '../helpers'
 import {
@@ -7,7 +7,7 @@ import {
   SelectChildWithStringType,
 } from '../../SelectBase'
 
-type ItemsMap = {
+export type ItemsMap = {
   [id: string]: React.ReactElement<SelectBaseOptionAsStringProps>
 }
 
@@ -47,8 +47,12 @@ export function useAutocomplete(children: SelectChildWithStringType[]): {
   function onInputValueChange({
     inputValue,
     isOpen,
+    type,
   }: UseComboboxStateChange<string>) {
-    if (isOpen || !inputValue) {
+    const isControlledValueUpdate =
+      type === useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem
+
+    if (!inputValue || (isOpen && !isControlledValueUpdate)) {
       setFilterValue(inputValue || '')
     }
 

--- a/packages/react-component-library/src/components/Autocomplete/hooks/useHighlightedIndex.ts
+++ b/packages/react-component-library/src/components/Autocomplete/hooks/useHighlightedIndex.ts
@@ -1,13 +1,13 @@
 import React, { useCallback, useEffect } from 'react'
 
 import { findIndexOfInputValue } from '../helpers'
-import { SelectChildWithStringType } from '../../SelectBase'
+import { SelectBaseOptionAsStringProps } from '../../SelectBase'
 
 export function useHighlightedIndex(
   highlightedIndex: number,
   inputValue: string,
   isOpen: boolean,
-  items: SelectChildWithStringType[],
+  items: React.ReactElement<SelectBaseOptionAsStringProps>[],
   setHighlightedIndex: (index: number) => void,
   setInputValue: (value: string) => void
 ): {
@@ -35,11 +35,14 @@ export function useHighlightedIndex(
 
   const onInputTabKeyHandler = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Tab' && highlightedIndex !== -1) {
-        const item = React.Children.toArray(items)[highlightedIndex]
-        if (React.isValidElement(item)) {
-          setInputValue(item.props.children)
-        }
+      if (e.key !== 'Tab') {
+        return
+      }
+
+      const item = items[highlightedIndex]
+
+      if (item) {
+        setInputValue(item.props.children)
       }
     },
     [highlightedIndex, items, setInputValue]

--- a/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
+++ b/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
@@ -36,7 +36,7 @@ export interface SelectBaseProps extends ComponentWithClass {
    */
   onChange?: (value: string | null) => void
   /**
-   * Optional HTML `value` attribute to apply to the component.
+   * The selected value when the component is controlled.
    */
   value?: string | null
 }


### PR DESCRIPTION
## Related issue

Resolves #3437

## Overview

This:

- makes the Autocomplete component behave as a controlled component when the `value` prop is specified
- adds an `initialValue` prop for uncontrolled scenarios

## Link to preview

https://5e25c277526d380020b5e418-ivtmagqznw.chromatic.com/?path=/docs/autocomplete--default

## Reason

External changes to `children` and `value` weren't being properly reflected by the component.

## Work carried out

- [x] Refactor Downshift items to be strings
- [x] Use Downshift `selectedItem` properly instead of `initialSelectedItem`
- [x] Add `initialValue` prop for when the state is uncontrolled (passed to Downshift's `initialSelectedItem`)

## Demo

Loading options asynchronously with a value:

![Screencast_16_09_22_13:16:25](https://user-images.githubusercontent.com/66470099/190637019-068d5dd8-cc44-491b-9e02-789323eebcbc.gif)

## Developer notes

This required changing Downshift items to be strings (the values), as `children` was unstable between renders (causing various problems).

The same changes will need to be applied to the Select component separately.