### PR TITLE
fix(ContextMenu): Fix incorrect initial positioning

### DIFF
--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import { RenderResult, render, fireEvent, act } from '@testing-library/react'
+import { RenderResult, render, act } from '@testing-library/react'
 import { IconSettings } from '@defencedigital/icon-library'
 import 'jest-styled-components'
 import userEvent from '@testing-library/user-event'
@@ -83,7 +83,7 @@ describe('ContextMenu', () => {
 
     describe('and the user left clicks on the target area', () => {
       beforeEach(() => {
-        fireEvent.click(wrapper.getByText('Left click me!'))
+        return userEvent.click(wrapper.getByText('Left click me!'))
       })
 
       it('is is rendered to the DOM', () => {
@@ -147,7 +147,9 @@ describe('ContextMenu', () => {
 
       wrapper = render(<ContextExample />)
 
-      fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+      return userEvent.pointer([
+        { keys: '[MouseRight]', target: wrapper.getByText('Right click me!') },
+      ])
     })
 
     it('should add margin to items', () => {
@@ -167,7 +169,7 @@ describe('ContextMenu', () => {
 
     describe('and the user clicks somewhere in the DOM', () => {
       beforeEach(() => {
-        fireEvent.click(wrapper.getByText('Right click me!'))
+        return userEvent.click(wrapper.getByText('Right click me!'))
       })
 
       it('hides the context menu', () => {
@@ -177,7 +179,7 @@ describe('ContextMenu', () => {
   })
 
   describe('With custom link and open', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       onClickSpy = jest.fn()
 
       const ContextExample = () => {
@@ -197,13 +199,14 @@ describe('ContextMenu', () => {
 
       wrapper = render(<ContextExample />)
 
-      act(() => {
-        fireEvent.contextMenu(wrapper.getByText('Right click me!'))
-      })
+      await userEvent.pointer([
+        {
+          keys: '[MouseRight]',
+          target: wrapper.getByText('Right click me!'),
+        },
+      ])
 
-      act(() => {
-        wrapper.getByTestId('context-menu-custom-link').click()
-      })
+      wrapper.getByTestId('context-menu-custom-link').click()
     })
 
     it('invokes the supplied onClick callback when the custom link is clicked', () => {
@@ -231,7 +234,9 @@ describe('ContextMenu', () => {
 
       wrapper = render(<ContextExample />)
 
-      fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+      return userEvent.pointer([
+        { keys: '[MouseRight]', target: wrapper.getByText('Right click me!') },
+      ])
     })
 
     it('should not add margin to items', () => {
@@ -267,7 +272,9 @@ describe('ContextMenu', () => {
 
       wrapper = render(<ContextExample />)
 
-      fireEvent.contextMenu(wrapper.getByText('Right click me!'))
+      return userEvent.pointer([
+        { keys: '[MouseRight]', target: wrapper.getByText('Right click me!') },
+      ])
     })
 
     it('renders the dividers', () => {
@@ -311,9 +318,7 @@ describe('ContextMenu', () => {
 
       wrapper = render(<ContextExample />)
 
-      act(() => {
-        fireEvent.click(wrapper.getByText('Click me!'))
-      })
+      return userEvent.click(wrapper.getByText('Click me!'))
     })
 
     it('fires the onShow event', () => {
@@ -325,9 +330,7 @@ describe('ContextMenu', () => {
 
     describe('when the user closes the context', () => {
       beforeEach(() => {
-        act(() => {
-          fireEvent.click(wrapper.getByText('Click elsewhere'))
-        })
+        return userEvent.click(wrapper.getByText('Click elsewhere'))
       })
 
       it('fires the onHide event', () => {

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.tsx
@@ -37,14 +37,13 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   onShow,
   ...rest
 }) => {
-  const { mousePointer, isOpen, floatingElementRef, styles, attributes } =
-    useClickMenu({
-      attachedToRef,
-      clickType,
-      initialIsOpen,
-      onHide,
-      onShow,
-    })
+  const { isOpen, floatingElementRef, styles, attributes } = useClickMenu({
+    attachedToRef,
+    clickType,
+    initialIsOpen,
+    onHide,
+    onShow,
+  })
 
   const hasIcons = useMemo(() => {
     return !!React.Children.toArray(children).filter(
@@ -57,8 +56,6 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
       ref={floatingElementRef}
       $hasIcons={hasIcons}
       $isOpen={isOpen}
-      left={mousePointer?.getBoundingClientRect().left}
-      top={mousePointer?.getBoundingClientRect().top}
       css={styles.popper as CSSObject}
       {...attributes.popper}
       data-testid="context-menu"

--- a/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenu.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/partials/StyledContextMenu.tsx
@@ -4,8 +4,6 @@ import styled, { css } from 'styled-components'
 import { StyledText } from './StyledText'
 
 interface StyledContextMenuProps {
-  top: number | undefined
-  left: number | undefined
   $hasIcons: boolean
   $isOpen: boolean
 }
@@ -14,8 +12,6 @@ const { color, spacing, zIndex } = selectors
 
 export const StyledContextMenu = styled.ol<StyledContextMenuProps>`
   position: fixed;
-  top: ${({ top }) => `${top}px`};
-  left: ${({ left }) => `${left}px`};
   min-width: 120px;
   max-width: 240px;
   padding: ${spacing('2')};

--- a/packages/react-component-library/src/hooks/useFloatingElement.ts
+++ b/packages/react-component-library/src/hooks/useFloatingElement.ts
@@ -10,7 +10,9 @@ export const useFloatingElement = (
   externalTargetElement: Element | VirtualElement | null = null
 ): {
   targetElementRef: Dispatch<SetStateAction<Element | null>>
+  floatingElement: HTMLElement | null
   floatingElementRef: Dispatch<SetStateAction<HTMLElement | null>>
+  forceUpdate: ReturnType<typeof usePopper>['forceUpdate']
   arrowElementRef: Dispatch<SetStateAction<HTMLElement | null>>
   styles: { [key: string]: React.CSSProperties }
   attributes: { [key: string]: { [key: string]: string } | undefined }
@@ -19,7 +21,7 @@ export const useFloatingElement = (
   const [floatingElement, floatingElementRef] = useStatefulRef<HTMLElement>()
   const [arrowElement, arrowElementRef] = useStatefulRef<HTMLElement>()
 
-  const { styles, attributes } = usePopper(
+  const { styles, attributes, forceUpdate } = usePopper(
     externalTargetElement || targetElement,
     floatingElement,
     {
@@ -39,7 +41,9 @@ export const useFloatingElement = (
 
   return {
     targetElementRef,
+    floatingElement,
     floatingElementRef,
+    forceUpdate,
     arrowElementRef,
     styles,
     attributes,


### PR DESCRIPTION
## Related issue

Resolves #3402

## Overview

This resolves a problem where the context menu would momentarily render at the wrong position.

## Link to preview

https://5e25c277526d380020b5e418-csspjlxvdg.chromatic.com/?path=/docs/context-menu--default

## Reason

It was a bug.

## Work carried out

- [x] Rework ContextMenu positioning and floating box logic
- [x] Tidy up tests

## Developer notes

Unfortunately, the original bug seems to require certain conditions for it to trigger and I'm only able to reproduce it in Netlify Storybook builds. For similar reasons, it wasn't possible to write a test triggering the incorrect behaviour.
