### PR TITLE
fix(Select): Behave as controlled component

### DIFF
--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import {
   IconAgriculture,
   IconAnchor,

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -1,11 +1,15 @@
-import { isNil } from 'lodash'
 import React, { useCallback } from 'react'
 import { useCombobox } from 'downshift'
 
-import { itemToString, SelectBaseProps, SelectLayout } from '../SelectBase'
+import {
+  getSelectedItem,
+  itemToString,
+  SelectBaseProps,
+  SelectLayout,
+} from '../SelectBase'
 import { NoResults } from './NoResults'
 import { useHighlightedIndex } from './hooks/useHighlightedIndex'
-import { ItemsMap, useAutocomplete } from './hooks/useAutocomplete'
+import { useAutocomplete } from './hooks/useAutocomplete'
 import { useMenuVisibility } from '../SelectBase/hooks/useMenuVisibility'
 import { useExternalId } from '../../hooks/useExternalId'
 import { useToggleButton } from './hooks/useToggleButton'
@@ -24,10 +28,6 @@ export interface AutocompleteProps extends SelectBaseProps {
    * The initially selected item when the component is uncontrolled.
    */
   initialValue?: string | null
-}
-
-function getSelectedItem(value: string | null | undefined, itemsMap: ItemsMap) {
-  return !isNil(value) && value in itemsMap ? value : null
 }
 
 export const Autocomplete: React.FC<AutocompleteProps> = ({
@@ -72,16 +72,12 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     isOpen = false,
     openMenu,
     reset,
-    selectedItem,
     setHighlightedIndex,
     setInputValue,
   } = useCombobox<string>({
     initialIsOpen,
     items: filteredItems.map((item) => item.props.value),
-    itemToString: (itemValue) =>
-      !isNil(itemValue) && itemValue in itemsMap
-        ? itemsMap[itemValue].props.children
-        : '',
+    itemToString: (item) => itemToString(item, itemsMap),
     onInputValueChange,
     onIsOpenChange,
     onSelectedItemChange: (changes) => {
@@ -152,7 +148,6 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
         },
         ref: buttonRef,
       })}
-      value={selectedItem ? itemToString(selectedItem) : ''}
       {...rest}
     >
       {isOpen &&

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -24,10 +24,6 @@ export interface AutocompleteProps extends SelectBaseProps {
    * Called when the input loses focus.
    */
   onBlur?: (event: React.FocusEvent) => void
-  /**
-   * The initially selected item when the component is uncontrolled.
-   */
-  initialValue?: string | null
 }
 
 export const Autocomplete: React.FC<AutocompleteProps> = ({

--- a/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
+++ b/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
@@ -3,13 +3,10 @@ import { useCombobox, UseComboboxStateChange } from 'downshift'
 
 import { findIndexOfInputValue } from '../helpers'
 import {
+  ItemsMap,
   SelectBaseOptionAsStringProps,
   SelectChildWithStringType,
 } from '../../SelectBase'
-
-export type ItemsMap = {
-  [id: string]: React.ReactElement<SelectBaseOptionAsStringProps>
-}
 
 export function useAutocomplete(children: SelectChildWithStringType[]): {
   filteredItems: React.ReactElement<SelectBaseOptionAsStringProps>[]

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -79,7 +79,7 @@ Disabled.args = {
 export const NoClearButton = Template.bind({})
 NoClearButton.args = {
   hideClearButton: true,
-  value: 'two',
+  initialValue: 'two',
 }
 
 export const Open = Template.bind({})
@@ -95,7 +95,7 @@ WithError.args = {
 
 export const WithValue = Template.bind({})
 WithValue.args = {
-  value: 'two',
+  initialValue: 'two',
 }
 
 export const WithIconsAndBadges = TemplateWithIconsAndBadges.bind({})

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -190,6 +190,134 @@ describe('Select', () => {
     })
   })
 
+  describe('when the component is controlled with "One" selected', () => {
+    const ControlledSelect = () => {
+      const [value, setValue] = React.useState<string | null>('one')
+
+      return (
+        <Select
+          id="select-id"
+          label="Label"
+          onChange={(newValue) => setValue(newValue)}
+          value={value}
+        >
+          <SelectOption value="one">One</SelectOption>
+          <SelectOption value="two">Two</SelectOption>
+        </Select>
+      )
+    }
+
+    beforeEach(() => {
+      wrapper = render(<ControlledSelect />)
+    })
+
+    it('has the value "One"', () => {
+      expect(wrapper.getByTestId('select-input')).toHaveValue('One')
+    })
+
+    describe('when the menu is opened and the second item clicked', () => {
+      beforeEach(async () => {
+        await userEvent.click(wrapper.getByTestId('select-arrow-button'))
+        return userEvent.click(wrapper.getByText('Two'))
+      })
+
+      it('has the value "Two"', () => {
+        expect(wrapper.getByTestId('select-input')).toHaveValue('Two')
+      })
+    })
+  })
+
+  describe('when the component is uncontrolled with "One" selected', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Select
+          id="select-id"
+          label="Label"
+          onChange={jest.fn()}
+          initialValue="one"
+        >
+          <SelectOption value="one">One</SelectOption>
+          <SelectOption value="two">Two</SelectOption>
+        </Select>
+      )
+    })
+
+    it('has the value "One"', () => {
+      expect(wrapper.getByTestId('select-input')).toHaveValue('One')
+    })
+
+    describe('when the menu is opened and the second item clicked', () => {
+      beforeEach(async () => {
+        await userEvent.click(wrapper.getByTestId('select-arrow-button'))
+        return userEvent.click(wrapper.getByText('Two'))
+      })
+
+      it('has the value "Two"', () => {
+        expect(wrapper.getByTestId('select-input')).toHaveValue('Two')
+      })
+    })
+  })
+
+  describe('when options are added after the initial render', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <Select id="select-id" label="Label" onChange={jest.fn()} value="one">
+          <>{}</>
+        </Select>
+      )
+      wrapper.rerender(
+        <Select id="select-id" label="Label" onChange={jest.fn()} value="one">
+          <SelectOption value="one">One</SelectOption>
+          <SelectOption value="two">Two</SelectOption>
+        </Select>
+      )
+      return userEvent.click(wrapper.getByTestId('select-arrow-button'))
+    })
+
+    it('displays the items', () => {
+      const options = wrapper.getAllByTestId('select-option')
+
+      expect(options[0]).toHaveTextContent('One')
+      expect(options[1]).toHaveTextContent('Two')
+      expect(options).toHaveLength(2)
+    })
+
+    it('has the correct value', () => {
+      expect(wrapper.getByTestId('select-input')).toHaveValue('One')
+    })
+  })
+
+  describe('when options are added while the menu is open', () => {
+    beforeEach(async () => {
+      wrapper = render(
+        <Select id="select-id" label="Label" onChange={jest.fn()} value="one">
+          <>{}</>
+        </Select>
+      )
+
+      await userEvent.click(wrapper.getByTestId('select-arrow-button'))
+
+      wrapper.rerender(
+        <Select id="select-id" label="Label" onChange={jest.fn()} value="one">
+          <SelectOption value="one">One</SelectOption>
+          <SelectOption value="two">Two</SelectOption>
+        </Select>
+      )
+    })
+
+    it('displays the items', () => {
+      const options = wrapper.getAllByTestId('select-option')
+
+      expect(options[0]).toHaveTextContent('One')
+      expect(options[1]).toHaveTextContent('Two')
+      expect(options).toHaveLength(2)
+    })
+
+    it('has the correct value', () => {
+      expect(wrapper.getByTestId('select-input')).toHaveValue('One')
+    })
+  })
+
   describe('when the default `id` is used and the arrow button is clicked', () => {
     let initialId: string
 

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -17,8 +17,9 @@ export const Select: React.FC<SelectBaseProps> = ({
   children,
   id: externalId,
   initialIsOpen,
+  initialValue,
   onChange,
-  value = null,
+  value,
   ...rest
 }) => {
   const id = useExternalId('select', externalId)
@@ -32,6 +33,8 @@ export const Select: React.FC<SelectBaseProps> = ({
     filteredItems.map((item) => [item.props.value, item])
   )
 
+  const isControlled = value !== undefined
+
   const {
     getItemProps,
     getMenuProps,
@@ -44,10 +47,15 @@ export const Select: React.FC<SelectBaseProps> = ({
   } = useSelect<string>({
     itemToString: (item) => itemToString(item, itemsMap),
     initialIsOpen,
-    initialSelectedItem: getSelectedItem(value, itemsMap),
     items,
     onSelectedItemChange: ({ selectedItem: newItem }) => {
       onChange?.(newItem ?? null)
+    },
+    ...{
+      [isControlled ? 'selectedItem' : 'initialSelectedItem']: getSelectedItem(
+        isControlled ? value : initialValue,
+        itemsMap
+      ),
     },
   })
 

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -1,12 +1,12 @@
 import React, { useRef } from 'react'
 import { useSelect } from 'downshift'
+import { isNil } from 'lodash'
 
 import {
-  initialSelectedItem,
+  getSelectedItem,
   itemToString,
   SelectBaseOptionAsStringProps,
   SelectBaseProps,
-  SelectChildWithStringType,
   SelectLayout,
 } from '../SelectBase'
 import { useExternalId } from '../../hooks/useExternalId'
@@ -23,6 +23,15 @@ export const Select: React.FC<SelectBaseProps> = ({
 }) => {
   const id = useExternalId('select', externalId)
   const inputRef = useRef<HTMLInputElement>(null)
+
+  const filteredItems = React.Children.toArray(children).filter(
+    React.isValidElement<SelectBaseOptionAsStringProps>
+  )
+  const items = filteredItems.map((child) => child.props.value)
+  const itemsMap = Object.fromEntries(
+    filteredItems.map((item) => [item.props.value, item])
+  )
+
   const {
     getItemProps,
     getMenuProps,
@@ -32,19 +41,13 @@ export const Select: React.FC<SelectBaseProps> = ({
     openMenu,
     reset,
     selectedItem,
-  } = useSelect<SelectChildWithStringType>({
-    itemToString,
+  } = useSelect<string>({
+    itemToString: (item) => itemToString(item, itemsMap),
     initialIsOpen,
-    initialSelectedItem: initialSelectedItem(children, value),
-    items: React.Children.toArray(children),
+    initialSelectedItem: getSelectedItem(value, itemsMap),
+    items,
     onSelectedItemChange: ({ selectedItem: newItem }) => {
-      if (onChange) {
-        onChange(
-          React.isValidElement<SelectBaseOptionAsStringProps>(newItem)
-            ? newItem.props.value
-            : null
-        )
-      }
+      onChange?.(newItem ?? null)
     },
   })
 
@@ -54,7 +57,7 @@ export const Select: React.FC<SelectBaseProps> = ({
 
   return (
     <SelectLayout
-      hasSelectedItem={!!selectedItem}
+      hasSelectedItem={!isNil(selectedItem)}
       id={id}
       inputProps={{
         onFocus: onInputFocusHandler,
@@ -68,32 +71,25 @@ export const Select: React.FC<SelectBaseProps> = ({
         reset()
       }}
       toggleButtonProps={getToggleButtonProps()}
-      value={selectedItem ? itemToString(selectedItem) : ''}
+      value={isNil(selectedItem) ? '' : itemsMap[selectedItem].props.children}
       {...{
         readOnly: true,
         ...rest,
       }}
     >
       {isOpen &&
-        React.Children.map(
-          children,
-          (child: SelectChildWithStringType, index) => {
-            if (!React.isValidElement<SelectBaseOptionAsStringProps>(child)) {
-              return null
-            }
-
-            return React.cloneElement(child, {
-              ...child.props,
-              ...getItemProps({
-                index,
-                item: child,
-                key: `select-option-${child.props.children}`,
-              }),
-              isHighlighted: highlightedIndex === index,
-              title: child.props.children,
-            })
-          }
-        )}
+        filteredItems.map((child, index) => {
+          return React.cloneElement(child, {
+            ...child.props,
+            ...getItemProps({
+              index,
+              item: child.props.value,
+              key: `select-option-${child.props.value}`,
+            }),
+            isHighlighted: highlightedIndex === index,
+            title: child.props.children,
+          })
+        })}
     </SelectLayout>
   )
 }

--- a/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
+++ b/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
@@ -16,6 +16,10 @@ export interface SelectBaseProps extends ComponentWithClass {
    */
   initialIsOpen?: boolean
   /**
+   * The initially selected item when the component is uncontrolled.
+   */
+  initialValue?: string | null
+  /**
    * Toggles whether the component is disabled or not (preventing user interaction).
    */
   isDisabled?: boolean

--- a/packages/react-component-library/src/components/SelectBase/helpers.ts
+++ b/packages/react-component-library/src/components/SelectBase/helpers.ts
@@ -1,25 +1,13 @@
-import React from 'react'
+import { isNil } from 'lodash'
 
-import { SelectBaseOptionAsStringProps } from './SelectBaseOption'
-import { SelectChildrenType, SelectChildWithStringType } from './types'
+import { ItemsMap } from './types'
 
-function itemToString(item: SelectChildWithStringType) {
-  return React.isValidElement<SelectBaseOptionAsStringProps>(item)
-    ? item.props.children
-    : ''
+function getSelectedItem(value: string | null | undefined, itemsMap: ItemsMap) {
+  return !isNil(value) && value in itemsMap ? value : null
 }
 
-function initialSelectedItem(
-  children: SelectChildrenType,
-  value: string | null
-) {
-  if (value === null) {
-    return null
-  }
-
-  return React.Children.toArray(children).find((child) => {
-    return React.isValidElement(child) ? child.props.value === value : null
-  })
+function itemToString(item: string | null, itemsMap: ItemsMap) {
+  return !isNil(item) && item in itemsMap ? itemsMap[item].props.children : ''
 }
 
-export { initialSelectedItem, itemToString }
+export { getSelectedItem, itemToString }

--- a/packages/react-component-library/src/components/SelectBase/types.ts
+++ b/packages/react-component-library/src/components/SelectBase/types.ts
@@ -18,3 +18,7 @@ export type SelectChildWithStringType =
 export type SelectChildrenType =
   | SelectChildType<SelectBaseOptionProps>
   | SelectChildType<SelectBaseOptionProps>[]
+
+export type ItemsMap = {
+  [id: string]: React.ReactElement<SelectBaseOptionAsStringProps>
+}


### PR DESCRIPTION
## Related issue

Resolves #3450

## Overview

This brings Select in line with recent changes to Autocomplete by making it behave as a controlled component when `value` is specified and adding an `initialValue` prop for uncontrolled scenarios.

## Link to preview

todo

## Reason

External changes to value weren't being properly reflected by the component.

## Work carried out

- [x] Refactor Downshift items to be strings
- [x] Use Downshift selectedItem properly instead of initialSelectedItem
- [x] Add initialValue prop for when the state is uncontrolled (passed to Downshift's initialSelectedItem)

## Developer notes

See also #3447.
