### PR TITLE
ci(GHA): Improve build and test workflow

### DIFF
--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -1,5 +1,10 @@
 name: Set up Node.js and install dependencies
 description: Sets up Node.js and installs dependencies
+inputs:
+  unpack-prebuilt-libraries:
+    description: Whether to unpack pre-built icon-library and design-tokens bundles
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -26,3 +31,15 @@ runs:
       shell: bash
       run: |
         yarn install --frozen-lockfile
+
+    - name: Download icon-library and design-tokens
+      if: inputs.unpack-prebuilt-libraries
+      uses: actions/download-artifact@v3
+      with:
+        name: dist
+
+    - name: Unpack icon-library and design-tokens
+      if: inputs.unpack-prebuilt-libraries
+      shell: bash
+      run: |
+        tar -xzf dist.tar.gz && mv distil packages/icon-library/dist && mv distdt packages/design-tokens/dist

--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -1,0 +1,28 @@
+name: Set up Node.js and install dependencies
+description: Sets up Node.js and installs dependencies
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: yarn
+
+    - name: Cache Node modules
+      uses: actions/cache@v3
+      with:
+        path: '**/node_modules'
+        key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
+    - name: Cache Cypress binary
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/Cypress
+        key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          cypress-${{ runner.os }}-cypress-
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        yarn install --frozen-lockfile

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,23 +14,11 @@ jobs:
       - name: Git clone repository
         uses: actions/checkout@v3
 
-      - name: Cache Node modules
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Cache Cypress binary
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            cypress-${{ runner.os }}-cypress-
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
 
       - name: Build icon-library
         run: |
-          yarn install --frozen-lockfile
           yarn --cwd packages/icon-library build
 
       - name: Build design-tokens
@@ -65,11 +53,8 @@ jobs:
       - name: Git clone repository
         uses: actions/checkout@v3
 
-      - name: Cache Node modules
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
 
       - name: check commits
         run: |
@@ -82,15 +67,11 @@ jobs:
       - name: Git clone repository
         uses: actions/checkout@v3
 
-      - name: Cache Node modules
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
 
       - name: Get dependencies & run lint
         run: |
-          yarn install --frozen-lockfile
           yarn --cwd packages/react-component-library lint
 
   Test_react-component-library:
@@ -100,11 +81,8 @@ jobs:
       - name: Git clone repository
         uses: actions/checkout@v3
 
-      - name: Cache Node modules
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
 
       - name: Attach workspace
         uses: actions/download-artifact@v3
@@ -136,19 +114,8 @@ jobs:
       - name: Git clone repository
         uses: actions/checkout@v3
 
-      - name: Cache Node modules
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Cache Cypress binary
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            cypress-${{ runner.os }}-cypress-
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
 
       - name: Attach workspace
         uses: actions/download-artifact@v3
@@ -185,11 +152,8 @@ jobs:
       - name: Git clone repository
         uses: actions/checkout@v3
 
-      - name: Cache Node modules
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
 
       - name: Jest design-tokens
         run: |
@@ -206,11 +170,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache Node modules
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
 
       - name: Attach workspace
         uses: actions/download-artifact@v3
@@ -242,11 +203,8 @@ jobs:
       - name: Git clone repository
         uses: actions/checkout@v3
 
-      - name: Cache Node modules
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
 
       - name: Cache Playwright browsers
         uses: actions/cache@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,7 +47,6 @@ jobs:
 
   Check_commits:
     runs-on: ubuntu-latest
-    needs: Build_icon_library
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Git clone repository
@@ -147,7 +146,6 @@ jobs:
 
   Test_design-tokens:
     runs-on: ubuntu-latest
-    needs: [Build_icon_library]
     steps:
       - name: Git clone repository
         uses: actions/checkout@v3
@@ -163,7 +161,7 @@ jobs:
   # See post_built_and_test.yml for details about how this is used
   Build_storybook:
     runs-on: ubuntu-latest
-    needs: [Build_icon_library]
+    needs: [Build_icon_library, Lint_react-component-library]
     steps:
       - name: Git clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,6 +73,22 @@ jobs:
         run: |
           yarn --cwd packages/react-component-library lint
 
+  Build_react-component-library:
+    runs-on: ubuntu-latest
+    needs: [Build_icon_library, Lint_react-component-library]
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
+        with:
+          unpack-prebuilt-libraries: true
+
+      - name: Build
+        run: |
+          yarn --cwd packages/react-component-library build
+
   Test_react-component-library:
     runs-on: ubuntu-latest
     needs: [Build_icon_library, Lint_react-component-library]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -153,10 +153,14 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
 
-      - name: Jest design-tokens
-        run: |
-          yarn --cwd packages/design-tokens build
-          yarn --cwd packages/design-tokens test
+      - name: Lint
+        run: yarn --cwd packages/design-tokens lint
+
+      - name: Build
+        run: yarn --cwd packages/design-tokens build
+
+      - name: Run tests
+        run: yarn --cwd packages/design-tokens test
 
   # See post_built_and_test.yml for details about how this is used
   Build_storybook:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,18 +82,14 @@ jobs:
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
-
-      - name: Attach workspace
-        uses: actions/download-artifact@v3
         with:
-          name: dist
+          unpack-prebuilt-libraries: true
 
       - name: Jest
         env:
           JEST_JUNIT_OUTPUT_DIR: test-results/jest
           JEST_JUNIT_OUTPUT_NAME: react-component-results.xml
         run: |
-          tar -xzf dist.tar.gz && mv distil packages/icon-library/dist && mv distdt packages/design-tokens/dist
           yarn --cwd packages/react-component-library test --ci --coverage --silent --no-cache --reporters=default --reporters=jest-junit --runInBand --testResultsProcessor=jest-sonar-reporter
 
       - name: SonarCloud Scan
@@ -115,15 +111,8 @@ jobs:
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
-
-      - name: Attach workspace
-        uses: actions/download-artifact@v3
         with:
-          name: dist
-
-      - name: Unpack icon library & design tokens
-        run: |
-          tar -xzf dist.tar.gz && mv distil packages/icon-library/dist && mv distdt packages/design-tokens/dist
+          unpack-prebuilt-libraries: true
 
       - name: Confirm Cypress binary is installed
         run: |
@@ -174,11 +163,8 @@ jobs:
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
-
-      - name: Attach workspace
-        uses: actions/download-artifact@v3
         with:
-          name: dist
+          unpack-prebuilt-libraries: true
 
       - name: Build Storybook
         env:
@@ -186,7 +172,6 @@ jobs:
           CHROMATIC_BRANCH: ${{ github.head_ref || github.ref_name }}
           CHROMATIC_SLUG: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
-          tar -xzf dist.tar.gz && mv distil packages/icon-library/dist && mv distdt packages/design-tokens/dist
           yarn --cwd packages/react-component-library storybook:static
           echo "$CHROMATIC_SHA" > packages/react-component-library/.static_storybook/sha
           echo "$CHROMATIC_BRANCH" > packages/react-component-library/.static_storybook/branch

--- a/.github/workflows/npmsmoketest.yml
+++ b/.github/workflows/npmsmoketest.yml
@@ -14,15 +14,8 @@ jobs:
       - name: Git clone repository
         uses: actions/checkout@v3
 
-      - name: Cache Node modules
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install Dependencies
-        run: |
-          yarn install
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
 
       - name: Build design-tokens
         run: yarn --cwd packages/design-tokens build

--- a/.github/workflows/post_build_and_test.yml
+++ b/.github/workflows/post_build_and_test.yml
@@ -23,15 +23,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache Node modules
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install dependencies
-        run: |
-          yarn install --frozen-lockfile
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
 
       - name: Download pre-built Storybook
         uses: actions/github-script@v6


### PR DESCRIPTION
## Related issue

Resolves #3419

## Overview

This updates the GitHub Actions build and test workflow to:

- use a composition action to share steps between jobs
- use the actions/setup-node action (also registers a problem matcher for ESLint)
- tweak the dependencies of jobs
- add a step to lint packages/design-tokens
- add a step to build packages/react-component-library

## Reason

To

- make the workflow more robust
- reduce repetitiveness in the workflow
- test additional things that were being missed (such as types)

## Work carried out

See commits.
