### PR TITLE
chore(Lerna): Use package manager workspaces

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "useWorkspaces": true,
   "version": "3.12.13",
   "npmClient": "yarn"
 }


### PR DESCRIPTION
## Overview

This configures Lerna to let the package manager resolve workspaces. This resolves the following warning:

```
lerna WARN EWORKSPACES Workspaces exist in the root package.json, but Lerna is not configured to use them.
lerna WARN EWORKSPACES To fix this and have Lerna use workspaces to resolve packages, set `useWorkspaces: true` in lerna.json.
```

See also: https://lerna.js.org/docs/api-reference/configuration#useworkspaces--packages.

