### PR TITLE
chore(Deps): Remove out-of-date resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "**/ansi-regex": "^5.0.1",
     "**/git-url-parse": "^13.1.0",
     "**/glob-parent": "^5.1.2",
-    "**/semver-regex": "^3.1.3",
     "**/trim": "^0.0.3",
     "**/trim-newlines": "^3.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -16316,11 +16316,6 @@ secure-compare@3.0.1:
   resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
   integrity sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==
 
-semver-regex@^3.1.3:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.4.tgz#13053c0d4aa11d070a2f2872b6b1e3ae1e1971b4"
-  integrity sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==
-
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"


### PR DESCRIPTION
## Overview

This removes an override for semver-regex as it's no longer in the dependency tree.
