### PR TITLE
docs(Storybook): Fix console warning when opening canvas in new tab

### DIFF
--- a/packages/react-component-library/.storybook/preview.js
+++ b/packages/react-component-library/.storybook/preview.js
@@ -32,7 +32,7 @@ function clickDocsButtonOnFirstLoad() {
   }
 }
 
-if (window.parent !== window)
+if (window.parent !== window && window.parent.document.evaluate)
   window.addEventListener('load', clickDocsButtonOnFirstLoad)
 
 export const parameters = {

--- a/packages/react-component-library/.storybook/preview.js
+++ b/packages/react-component-library/.storybook/preview.js
@@ -32,7 +32,8 @@ function clickDocsButtonOnFirstLoad() {
   }
 }
 
-window.addEventListener('load', clickDocsButtonOnFirstLoad)
+if (window.parent !== window)
+  window.addEventListener('load', clickDocsButtonOnFirstLoad)
 
 export const parameters = {
   jsx: {


### PR DESCRIPTION
## Overview

This resolves the 'Failed to set default Storybook tab' warning in Storybook when a canvas is opened in a new tab.

It also fixes console warnings in older browsers where the XPath API is unavailable.