### PR TITLE
fix(Autocomplete): Work around input overflow handling in Firefox

### DIFF
--- a/packages/react-component-library/cypress/e2e/Autocomplete/index.cy.ts
+++ b/packages/react-component-library/cypress/e2e/Autocomplete/index.cy.ts
@@ -202,6 +202,20 @@ describe('Autocomplete', () => {
       })
     })
 
+    describe('and an overflowing option is clicked', () => {
+      beforeEach(() => {
+        cy.contains(selectors.select.option, 'This is a really').click()
+      })
+
+      it('sets the value', () => {
+        cy.get(selectors.select.input).should('have.value', 'This is a really, really long select option label that overflows the container when selected')
+      })
+
+      it('sets the input `scrollLeft` to 0', () => {
+        cy.get(selectors.select.input).invoke('scrollLeft').should('eq', 0)
+      })
+    })
+
     describe('and `*` is typed', () => {
       beforeEach(() => {
         cy.get(selectors.select.input).type('*')

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -23,6 +23,7 @@ export default {
 
 const StyledWrapper = styled.div<{ $isDisabled?: boolean }>`
   height: ${({ $isDisabled }) => ($isDisabled ? 'initial' : '18rem')};
+  max-width: 20rem;
 `
 
 const Template: ComponentStory<typeof Autocomplete> = (args) => (
@@ -31,7 +32,10 @@ const Template: ComponentStory<typeof Autocomplete> = (args) => (
       <AutocompleteOption value="one">One</AutocompleteOption>
       <AutocompleteOption value="two">Two</AutocompleteOption>
       <AutocompleteOption value="three">Three</AutocompleteOption>
-      <AutocompleteOption value="four">Four</AutocompleteOption>
+      <AutocompleteOption value="long">
+        This is a really, really long select option label that overflows the
+        container when selected
+      </AutocompleteOption>
     </Autocomplete>
   </StyledWrapper>
 )

--- a/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
+++ b/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
@@ -73,6 +73,13 @@ export function useAutocomplete(children: SelectChildWithStringType[]): {
     if (isOpen) {
       inputRef.current?.focus()
     } else {
+      setTimeout(() => {
+        if (!filterValue && inputRef.current) {
+          // Scroll to the beginning of the input in Firefox
+          inputRef.current.scrollLeft = 0
+        }
+      })
+
       const newHasError = getHasError(inputValue)
       setHasError(newHasError)
 


### PR DESCRIPTION
## Related issue

Resolves #3469

## Overview

This makes the Autocomplete input scroll to the beginning when the menu is collapsed and no filter value has been manually entered.

## Link to preview

https://5e25c277526d380020b5e418-lcqzfqinwb.chromatic.com/?path=/story/autocomplete--default

## Reason

It makes more sense to see the beginning of the input text when the menu is closed, and this makes Firefox more consistent with Chrome.

## Work carried out

- [x] Scroll input to the left when menu is closed and no filter text has been typed

## Screenshot

### Before

![Screencast_30_09_22_09:46:49](https://user-images.githubusercontent.com/66470099/193231300-c83191d7-99fe-43a9-8edc-a19dffb3b83d.gif)

### After

![Screencast_30_09_22_09:41:58](https://user-images.githubusercontent.com/66470099/193230731-6182a565-e450-42f9-9611-97e8fc9fbecf.gif)

## Developer notes

Cypress Autocomplete tests are currently disabled in Firefox. So this will be properly tested after the migration to Playwright.
