### PR TITLE
fix(Autocomplete): Resolve overflowing input text tooltip problems

### DIFF
--- a/packages/react-component-library/cypress/e2e/Autocomplete/index.cy.ts
+++ b/packages/react-component-library/cypress/e2e/Autocomplete/index.cy.ts
@@ -214,6 +214,24 @@ describe('Autocomplete', () => {
       it('sets the input `scrollLeft` to 0', () => {
         cy.get(selectors.select.input).invoke('scrollLeft').should('eq', 0)
       })
+
+      it('displays a tooltip when hovering on the input', () => {
+        cy.get(selectors.select.input).trigger('mouseover')
+
+        cy.get(selectors.select.tooltip).should('contain.text', 'This is a really')
+      })
+    })
+
+    describe('and overflowing text is typed', () => {
+      beforeEach(() => {
+        cy.get(selectors.select.input).type('A long piece of text that overflows the input')
+      })
+
+      it('does not display a tooltip when hovering on the input', () => {
+        cy.get(selectors.select.input).trigger('mouseover')
+
+        cy.get(selectors.select.tooltip).should('not.exist')
+      })
     })
 
     describe('and `*` is typed', () => {

--- a/packages/react-component-library/cypress/e2e/Select/index.cy.ts
+++ b/packages/react-component-library/cypress/e2e/Select/index.cy.ts
@@ -41,7 +41,7 @@ describe('Select', () => {
         })
 
         it('displays a tooltip', () => {
-          cy.get(selectors.select.tooltip).should('be.visible')
+          cy.get(selectors.select.tooltip).should('contain.text', 'This is a really')
         })
 
         it('gives the expand icon a hover appearance', () => {

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -1,3 +1,4 @@
+import { isNil } from 'lodash'
 import React, { useCallback } from 'react'
 import { useCombobox } from 'downshift'
 
@@ -40,6 +41,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
   const {
     filteredItems,
     hasError,
+    hasFilter,
     inputRef,
     itemsMap,
     onInputValueChange,
@@ -68,6 +70,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     isOpen = false,
     openMenu,
     reset,
+    selectedItem,
     setHighlightedIndex,
     setInputValue,
   } = useCombobox<string>({
@@ -115,6 +118,8 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
       [onBlur, onInputBlurHandler]
     )
 
+  const selectedItemText = isNil(selectedItem) || hasFilter ? '' : itemsMap[selectedItem].props.children
+
   return (
     <SelectLayout
       hasLabelFocus={isOpen}
@@ -144,6 +149,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
         },
         ref: buttonRef,
       })}
+      tooltipText={selectedItemText}
       {...rest}
     >
       {isOpen &&

--- a/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
+++ b/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
@@ -11,6 +11,7 @@ import {
 export function useAutocomplete(children: SelectChildWithStringType[]): {
   filteredItems: React.ReactElement<SelectBaseOptionAsStringProps>[]
   hasError: boolean
+  hasFilter: boolean
   inputRef: React.RefObject<HTMLInputElement>
   itemsMap: ItemsMap
   onInputValueChange: (changes: UseComboboxStateChange<string>) => void
@@ -93,6 +94,7 @@ export function useAutocomplete(children: SelectChildWithStringType[]): {
 
   return {
     filteredItems,
+    hasFilter: Boolean(filterValue),
     hasError,
     inputRef,
     itemsMap,

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -63,6 +63,8 @@ export const Select: React.FC<SelectBaseProps> = ({
 
   const { onMenuKeyDownHandler } = useSelectMenu(inputRef)
 
+  const selectedItemText = isNil(selectedItem) ? '' : itemsMap[selectedItem].props.children
+
   return (
     <SelectLayout
       hasSelectedItem={!isNil(selectedItem)}
@@ -79,7 +81,8 @@ export const Select: React.FC<SelectBaseProps> = ({
         reset()
       }}
       toggleButtonProps={getToggleButtonProps()}
-      value={isNil(selectedItem) ? '' : itemsMap[selectedItem].props.children}
+      tooltipText={selectedItemText}
+      value={selectedItemText}
       {...{
         readOnly: true,
         ...rest,

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -42,6 +42,7 @@ export interface SelectLayoutProps extends ComponentWithClass {
   toggleButtonProps:
     | ReturnType<ComboboxReturnValueType['getToggleButtonProps']>
     | ReturnType<SelectReturnValueType['getToggleButtonProps']>
+  tooltipText: string
   value?: string
 }
 
@@ -64,6 +65,7 @@ export const SelectLayout: React.FC<SelectLayoutProps> = ({
   menuProps,
   onClearButtonClick,
   toggleButtonProps,
+  tooltipText,
   value,
   ...rest
 }) => {
@@ -143,10 +145,10 @@ export const SelectLayout: React.FC<SelectLayoutProps> = ({
       <StyledFloatingBox
         placement="bottom"
         scheme="dark"
-        isVisible={hasHover && isEllipsisActive(floatingBoxTarget)}
+        isVisible={hasHover && Boolean(tooltipText) && isEllipsisActive(floatingBoxTarget)}
         targetElement={floatingBoxTarget}
       >
-        <StyledTooltip>{value}</StyledTooltip>
+        <StyledTooltip>{tooltipText}</StyledTooltip>
       </StyledFloatingBox>
     </>
   )


### PR DESCRIPTION
## Related issue

Resolves #3468

## Overview

This fixes a problem where tooltips for overflowing input text were empty in Autocomplete.

## Link to preview

https://5e25c277526d380020b5e418-ndukuhomwr.chromatic.com/?path=/docs/autocomplete--default

## Reason

It was a bug.

## Work carried out

- [x] Correct tooltip text for selected items

## Screenshot

### Before

![Screenshot from 2022-09-30 11-09-13](https://user-images.githubusercontent.com/66470099/193247766-9208c03c-f828-4c9f-9763-3774f231411b.png)

### After

![Screenshot from 2022-09-30 11-10-25](https://user-images.githubusercontent.com/66470099/193247898-0cd989a7-7942-4190-89e3-7ffc21037f0d.png)

## Notes

Tooltips aren't shown for overflowing filter text as it makes less sense, and can look like it's about the error when the menu is closed.
