### PR TITLE
fix(Autocomplete): Improve input overflow workaround in Firefox

### DIFF
--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.tsx
@@ -118,7 +118,22 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
       [onBlur, onInputBlurHandler]
     )
 
-  const selectedItemText = isNil(selectedItem) || hasFilter ? '' : itemsMap[selectedItem].props.children
+  const handleInputScroll: React.UIEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      const input = event.currentTarget
+
+      if (document.activeElement !== input && !hasFilter) {
+        // Scroll to the beginning of the input in Firefox
+        input.scrollLeft = 0
+      }
+    },
+    [hasFilter]
+  )
+
+  const selectedItemText =
+    isNil(selectedItem) || hasFilter
+      ? ''
+      : itemsMap[selectedItem].props.children
 
   return (
     <SelectLayout
@@ -132,6 +147,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
           onInputTabKeyHandler(e)
           onInputEscapeKeyHandler(e)
         },
+        onScroll: handleInputScroll,
         ref: inputRef,
       })}
       inputWrapperProps={getComboboxProps({

--- a/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
+++ b/packages/react-component-library/src/components/Autocomplete/hooks/useAutocomplete.ts
@@ -74,12 +74,10 @@ export function useAutocomplete(children: SelectChildWithStringType[]): {
     if (isOpen) {
       inputRef.current?.focus()
     } else {
-      setTimeout(() => {
-        if (!filterValue && inputRef.current) {
-          // Scroll to the beginning of the input in Firefox
-          inputRef.current.scrollLeft = 0
-        }
-      })
+      if (!filterValue && inputRef.current) {
+        // Scroll to the beginning of the input in Firefox
+        inputRef.current.scrollLeft = 0
+      }
 
       const newHasError = getHasError(inputValue)
       setHasError(newHasError)


### PR DESCRIPTION
## Related issue

Resolves #3469

## Overview

This makes the Firefox input overflow workaround added in #3470 more robust, after some inconsistent behaviour was observed when testing using Playwright.

## Link to preview

https://5e25c277526d380020b5e418-qsyeiasgdq.chromatic.com/?path=/docs/autocomplete--default

## Reason

To make the existing workaround more robust.

## Work carried out

- [x] Handle input `onScroll`
