### PR TITLE
chore(Deps): Update eslint-plugin-jest

### DIFF
--- a/packages/design-tokens/src/__tests__/selectors.test.tsx
+++ b/packages/design-tokens/src/__tests__/selectors.test.tsx
@@ -39,7 +39,7 @@ describe('mediaQuery / mq', () => {
         mq({ gte: 'foo', lt: 'bar' })`
           background-color: white;
         `
-      }).toThrowError(/Invalid breakpoints/)
+      }).toThrow(/Invalid breakpoints/)
     })
   })
 
@@ -134,7 +134,7 @@ describe('mediaQuery / mq', () => {
 describe('breakpoint', () => {
   describe('when the breakpoint is invalid', () => {
     it('throws a friendly error', () => {
-      expect(() => breakpoint('invalid' as BreakpointSize)).toThrowError(
+      expect(() => breakpoint('invalid' as BreakpointSize)).toThrow(
         'Invalid breakpoint token'
       )
     })
@@ -166,7 +166,7 @@ describe('breakpoint', () => {
 describe('animation', () => {
   describe('when the index is invalid', () => {
     it('throws a friendly error', () => {
-      expect(() => animation('invalid' as AnimationTiming)).toThrowError(
+      expect(() => animation('invalid' as AnimationTiming)).toThrow(
         'Invalid animation token'
       )
     })
@@ -193,7 +193,7 @@ describe('animation', () => {
 describe('color', () => {
   describe('when the group is invalid', () => {
     it('throws a friendly error', () => {
-      expect(() => color('invalid' as ColorGroup, '400')).toThrowError(
+      expect(() => color('invalid' as ColorGroup, '400')).toThrow(
         'Invalid color token'
       )
     })
@@ -201,7 +201,7 @@ describe('color', () => {
 
   describe('when the shade is invalid', () => {
     it('throws a friendly error', () => {
-      expect(() => color('action', 'invalid' as ColorShade)).toThrowError(
+      expect(() => color('action', 'invalid' as ColorShade)).toThrow(
         'Invalid color token'
       )
     })
@@ -228,7 +228,7 @@ describe('color', () => {
 describe('fontSize', () => {
   describe('when the size is invalid', () => {
     it('throws a friendly error', () => {
-      expect(() => fontSize('invalid' as TypographySize)).toThrowError(
+      expect(() => fontSize('invalid' as TypographySize)).toThrow(
         'Invalid typography token'
       )
     })
@@ -255,7 +255,7 @@ describe('fontSize', () => {
 describe('shadow', () => {
   describe('when the weight is invalid', () => {
     it('throws a friendly error', () => {
-      expect(() => shadow('invalid' as ShadowWeight)).toThrowError(
+      expect(() => shadow('invalid' as ShadowWeight)).toThrow(
         'Invalid shadow token'
       )
     })
@@ -282,7 +282,7 @@ describe('shadow', () => {
 describe('spacing', () => {
   describe('when the spacing value is invalid', () => {
     it('throws a friendly error', () => {
-      expect(() => spacing('invalid' as Spacing)).toThrowError(
+      expect(() => spacing('invalid' as Spacing)).toThrow(
         'Invalid spacing token'
       )
     })
@@ -309,7 +309,7 @@ describe('spacing', () => {
 describe('zIndex', () => {
   describe('when the group is invalid', () => {
     it('throws a friendly error', () => {
-      expect(() => zIndex('invalid' as ZIndexGroup, 1)).toThrowError(
+      expect(() => zIndex('invalid' as ZIndexGroup, 1)).toThrow(
         'Invalid z-index token'
       )
     })

--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -23,6 +23,7 @@ module.exports = {
     'import/no-extraneous-dependencies': 0,
     'import/no-unresolved': 0,
     'import/prefer-default-export': 0,
+    'jest/no-alias-methods': 1,
     'jsx-a11y/label-has-for': 0,
     'no-underscore-dangle': ['error', { allow: ['__typename'] }],
     'no-use-before-define': 0,

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -20,7 +20,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^26.1.3",
+    "eslint-plugin-jest": "^27.1.1",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.21.5",

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -151,7 +151,7 @@ describe('Alert', () => {
       })
 
       it('should call the callback once', () => {
-        expect(onCloseSpy).toBeCalledTimes(1)
+        expect(onCloseSpy).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -148,6 +148,6 @@ describe('Breadcrumbs', () => {
   })
 
   it('does not throw an error if there are no children', () => {
-    expect(() => render(<Breadcrumbs />)).not.toThrowError()
+    expect(() => render(<Breadcrumbs />)).not.toThrow()
   })
 })

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.test.tsx
@@ -319,7 +319,7 @@ describe('ContextMenu', () => {
     })
 
     it('fires the onShow event', () => {
-      expect(onShowSpy).toBeCalledTimes(1)
+      expect(onShowSpy).toHaveBeenCalledTimes(1)
       expect(onShowSpy).toHaveBeenCalledWith(
         expect.objectContaining({ isTrusted: false })
       )
@@ -331,7 +331,7 @@ describe('ContextMenu', () => {
       })
 
       it('fires the onHide event', () => {
-        expect(onHideSpy).toBeCalledTimes(1)
+        expect(onHideSpy).toHaveBeenCalledTimes(1)
         expect(onHideSpy).toHaveBeenCalledWith(
           expect.objectContaining({ isTrusted: false })
         )
@@ -401,7 +401,7 @@ describe('ContextMenu', () => {
     it('does not throw an error when clicking', () => {
       expect(() => {
         return userEvent.click(wrapper.getByText('Clickable area'))
-      }).not.toThrowError()
+      }).not.toThrow()
     })
   })
 })

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -1200,7 +1200,7 @@ describe('DatePicker', () => {
     const jsxToRender = <DatePicker startDate={new Date()} value={null} />
 
     it('does not throw an error', () => {
-      expect(() => render(jsxToRender)).not.toThrowError()
+      expect(() => render(jsxToRender)).not.toThrow()
     })
   })
 

--- a/packages/react-component-library/src/components/DismissibleBanner/DismissibleBanner.test.tsx
+++ b/packages/react-component-library/src/components/DismissibleBanner/DismissibleBanner.test.tsx
@@ -128,7 +128,7 @@ describe('DismissibleBanner', () => {
     it('does not throw an error when the dismiss button is clicked', () => {
       expect(() => {
         return userEvent.click(wrapper.getByTestId('dimissiblebanner-dismiss'))
-      }).not.toThrowError()
+      }).not.toThrow()
     })
   })
 })

--- a/packages/react-component-library/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-component-library/src/components/Dropdown/Dropdown.test.tsx
@@ -167,7 +167,7 @@ describe('Dropdown', () => {
     })
 
     it('does not throw an error when an option is clicked', () => {
-      expect(() => wrapper.getByText('Option 1').click()).not.toThrowError()
+      expect(() => wrapper.getByText('Option 1').click()).not.toThrow()
     })
   })
 })

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -2431,12 +2431,12 @@ describe('Timeline', () => {
     })
 
     it('should not rerender children if props have not changed', async () => {
-      expect(eventSpy).toBeCalledTimes(1)
+      expect(eventSpy).toHaveBeenCalledTimes(1)
       eventSpy.mockClear()
 
       await user.click(wrapper.getByText('Force update'))
       expect(await wrapper.findByText('Render: 2')).toBeInTheDocument()
-      expect(eventSpy).not.toBeCalled()
+      expect(eventSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.test.tsx
@@ -87,7 +87,7 @@ describe('Sidebar', () => {
         )
 
         fireEvent.mouseOver(wrapper.getByTestId('sidebar'))
-      }).not.toThrowError(/findDOMNode is deprecated in StrictMode/)
+      }).not.toThrow(/findDOMNode is deprecated in StrictMode/)
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8761,10 +8761,10 @@ eslint-plugin-import@^2.20.2, eslint-plugin-import@^2.22.1:
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
-eslint-plugin-jest@^26.1.3:
-  version "26.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.9.0.tgz#7931c31000b1c19e57dbfb71bbf71b817d1bf949"
-  integrity sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==
+eslint-plugin-jest@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.1.1.tgz#60f68dee15d4ffd9cdff65158d7fa46a65dbaaf5"
+  integrity sha512-vuSuXGKHHi/UAffIM46QKm4g0tQP+6n52nRxUpMq6x6x9rhnv5WM7ktSu3h9cTnXE4b0Y0ODQTgRlCm9rdRLvg==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 


### PR DESCRIPTION
## Overview

This updates eslint-plugin-jest and makes the now-recommended `jest/no-alias-methods` rule a warning (instead of an error) to avoid a breaking change.

