### PR TITLE
fix(Masthead): Resolve accessibility problems in expandable parts

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -252,3 +252,41 @@ WithNotificationsOpen.storyName = 'With notifications open'
 WithNotificationsOpen.parameters = {
   docs: { disable: true },
 }
+
+export const WithUserMenuOpen: ComponentStory<typeof Masthead> = (args) => {
+  const user = (
+    <MastheadUser initials="AB" initialIsOpen>
+      <MastheadUserItem
+        icon={<IconPerson />}
+        link={<Link href="#">Profile</Link>}
+      />
+      <MastheadUserItem
+        icon={<IconSettings />}
+        link={<Link href="#">Settings</Link>}
+      />
+    </MastheadUser>
+  )
+
+  const nav = (
+    <MastheadNav>
+      <MastheadNavItem link={<Link href="#">Get started</Link>} isActive />
+      <MastheadNavItem link={<Link href="#">Styles</Link>} />
+      <MastheadNavItem link={<Link href="#">Components</Link>} />
+      <MastheadNavItem link={<Link href="#">About</Link>} />
+    </MastheadNav>
+  )
+
+  return (
+    <div
+      css={css`
+        height: 10rem;
+      `}
+    >
+      <Masthead {...args} homeLink={<Link href="#" />} nav={nav} user={user} />
+    </div>
+  )
+}
+WithUserMenuOpen.storyName = 'With user options open'
+WithUserMenuOpen.parameters = {
+  docs: { disable: true },
+}

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -20,6 +20,9 @@ import { Notification, Notifications } from '../NotificationPanel'
 import { MASTHEAD_SUBCOMPONENT } from './constants'
 
 export default {
+  args: {
+    title: 'MOD.UK Design System',
+  },
   component: Masthead,
   subcomponents: {
     MastheadNav,
@@ -108,12 +111,11 @@ export const Default: ComponentStory<typeof Masthead> = (props) => {
 }
 
 Default.args = {
-  title: 'Defence Digital Design System',
   hasUnreadNotification: true,
 }
 
 export const CustomLogo: ComponentStory<typeof Masthead> = (props) => (
-  <Masthead {...props} title="Defence Digital Design System" Logo={IconHome} />
+  <Masthead {...props} Logo={IconHome} />
 )
 
 CustomLogo.storyName = 'Custom logo'
@@ -122,11 +124,7 @@ CustomLogo.args = {
 }
 
 export const WithoutLogo: ComponentStory<typeof Masthead> = (props) => (
-  <Masthead
-    {...props}
-    title="Defence Digital Design System"
-    hasDefaultLogo={false}
-  />
+  <Masthead {...props} hasDefaultLogo={false} />
 )
 
 WithoutLogo.storyName = 'Without logo'
@@ -135,7 +133,7 @@ WithoutLogo.args = {
 }
 
 export const WithSearch: ComponentStory<typeof Masthead> = (props) => (
-  <Masthead {...props} title="Defence Digital Design System" />
+  <Masthead {...props} />
 )
 
 WithSearch.storyName = 'With search'
@@ -162,9 +160,7 @@ export const WithAvatarLinks: ComponentStory<typeof Masthead> = (props) => {
     </MastheadUser>
   )
 
-  return (
-    <Masthead {...props} title="Defence Digital Design System" user={user} />
-  )
+  return <Masthead {...props} user={user} />
 }
 
 WithAvatarLinks.storyName = 'With avatar links'
@@ -182,14 +178,7 @@ export const WithNavigation: ComponentStory<typeof Masthead> = (props) => {
     </MastheadNav>
   )
 
-  return (
-    <Masthead
-      {...props}
-      homeLink={<Link href="#" />}
-      title="Defence Digital Design System"
-      nav={nav}
-    />
-  )
+  return <Masthead {...props} homeLink={<Link href="#" />} nav={nav} />
 }
 
 WithNavigation.storyName = 'With navigation'
@@ -227,13 +216,7 @@ export const WithNotifications: ComponentStory<typeof Masthead> = (props) => {
     </Notifications>
   )
 
-  return (
-    <Masthead
-      {...props}
-      title="Defence Digital Design System"
-      notifications={notifications}
-    />
-  )
+  return <Masthead {...props} notifications={notifications} />
 }
 
 WithNotifications.storyName = 'With notifications'

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -17,6 +17,7 @@ import {
   MastheadUserItem,
 } from '.'
 import { Notification, Notifications } from '../NotificationPanel'
+import { MASTHEAD_SUBCOMPONENT } from './constants'
 
 export default {
   component: Masthead,
@@ -238,4 +239,13 @@ export const WithNotifications: ComponentStory<typeof Masthead> = (props) => {
 WithNotifications.storyName = 'With notifications'
 WithNotifications.args = {
   onSearch: null,
+}
+
+export const WithSearchOpen = Default.bind({})
+WithSearchOpen.args = {
+  initialOpenSubcomponent: MASTHEAD_SUBCOMPONENT.SEARCH,
+}
+WithSearchOpen.storyName = 'With search open'
+WithSearchOpen.parameters = {
+  docs: { disable: true },
 }

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -7,6 +7,7 @@ import {
   IconSettings,
   IconHome,
 } from '@defencedigital/icon-library'
+import { css } from 'styled-components'
 
 import { Link } from '../../Link'
 import {
@@ -230,5 +231,24 @@ WithSearchOpen.args = {
 }
 WithSearchOpen.storyName = 'With search open'
 WithSearchOpen.parameters = {
+  docs: { disable: true },
+}
+
+export const WithNotificationsOpen: ComponentStory<typeof Masthead> = (
+  args
+) => (
+  <div
+    css={css`
+      height: 25rem;
+    `}
+  >
+    <Default {...args} />
+  </div>
+)
+WithNotificationsOpen.args = {
+  initialOpenSubcomponent: MASTHEAD_SUBCOMPONENT.NOTIFICATIONS,
+}
+WithNotificationsOpen.storyName = 'With notifications open'
+WithNotificationsOpen.parameters = {
   docs: { disable: true },
 }

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
@@ -154,6 +154,7 @@ export const Masthead: React.FC<MastheadProps> = ({
 
           {notifications && (
             <Sheet
+              aria-label="Notifications"
               button={
                 <StyledOption
                   aria-label="Show notifications"
@@ -165,6 +166,9 @@ export const Masthead: React.FC<MastheadProps> = ({
                     <StyledNotRead data-testid="not-read" />
                   )}
                 </StyledOption>
+              }
+              initialIsOpen={
+                initialOpenSubcomponent === MASTHEAD_SUBCOMPONENT.NOTIFICATIONS
               }
               placement="bottom"
             >

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react'
 
 import { Logo as DefaultLogo } from './Logo'
 import { LinkTypes } from '../../../common/Link'
+import { MASTHEAD_SUBCOMPONENT } from './constants'
 import { MastheadUserProps } from './index'
 import { Nav, NavItem } from '../../../common/Nav'
 import { NotificationsProps } from '../NotificationPanel'
@@ -20,6 +21,7 @@ import { SearchBar } from '../SearchBar/SearchBar'
 import { StyledNotRead } from '../NotificationPanel/partials/StyledNotRead'
 import { StyledIconNotifications } from './partials/StyledIconNotifications'
 import { StyledIconSearch } from './partials/StyledIconSearch'
+import { ValueOf } from '../../../helpers'
 
 export interface MastheadProps {
   /**
@@ -34,6 +36,11 @@ export interface MastheadProps {
    * Link component for when a user clicks on the logo / app name.
    */
   homeLink?: React.ReactElement<LinkTypes>
+  /**
+   * Which subcomponent is initially open.
+   * @private
+   */
+  initialOpenSubcomponent?: ValueOf<typeof MASTHEAD_SUBCOMPONENT>
   /**
    * Optional custom logo component (SVG reccomended).
    */
@@ -88,6 +95,7 @@ export const Masthead: React.FC<MastheadProps> = ({
   hasDefaultLogo = true,
   hasUnreadNotification,
   homeLink = null,
+  initialOpenSubcomponent,
   Logo,
   nav,
   notifications,
@@ -100,11 +108,13 @@ export const Masthead: React.FC<MastheadProps> = ({
 
   const {
     containerWidth,
-    mastheadContainerRef,
+    mastheadRef,
     setShowSearch,
     showSearch,
     toggleSearch,
-  } = useMastheadSearch()
+  } = useMastheadSearch(
+    initialOpenSubcomponent === MASTHEAD_SUBCOMPONENT.SEARCH
+  )
 
   const DisplayLogo = Logo ?? (hasDefaultLogo ? DefaultLogo : null)
 
@@ -114,7 +124,7 @@ export const Masthead: React.FC<MastheadProps> = ({
   }
 
   return (
-    <StyledMastHead data-testid="masthead" ref={mastheadContainerRef} {...rest}>
+    <StyledMastHead data-testid="masthead" ref={mastheadRef} {...rest}>
       <StyledMain>
         <StyledBanner data-testid="masthead-banner" role="banner">
           {getServiceName(homeLink, DisplayLogo, title)}

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
@@ -21,6 +21,10 @@ export interface MastheadUserWithItemsProps extends Nav<MastheadUserItemProps> {
    * Link component to apply to the user avatar.
    */
   link?: never
+  /**
+   * @private
+   */
+  initialIsOpen?: boolean
 }
 
 export interface MastheadUserWithLinkProps extends ComponentWithClass {
@@ -58,8 +62,11 @@ const MastheadUserWithLink: React.FC<MastheadUserWithLinkProps> = ({
 const MastheadUserWithItems: React.FC<MastheadUserWithItemsProps> = ({
   children,
   initials,
+  initialIsOpen,
 }) => (
   <Sheet
+    aria-label="User options"
+    initialIsOpen={initialIsOpen}
     button={
       <StyledOption
         aria-label="Show user options"

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/constants.ts
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/constants.ts
@@ -3,6 +3,7 @@
  */
 const MASTHEAD_SUBCOMPONENT = {
   SEARCH: 'search',
+  NOTIFICATIONS: 'notifications',
 } as const
 
 export { MASTHEAD_SUBCOMPONENT }

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/constants.ts
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * @private
+ */
+const MASTHEAD_SUBCOMPONENT = {
+  SEARCH: 'search',
+} as const
+
+export { MASTHEAD_SUBCOMPONENT }

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/useMastheadSearch.ts
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/useMastheadSearch.ts
@@ -1,14 +1,22 @@
-import React, { useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 
-export function useMastheadSearch() {
-  const [showSearch, setShowSearch] = useState(false)
+export function useMastheadSearch(initialIsOpen: boolean) {
+  const [showSearch, setShowSearch] = useState(initialIsOpen)
   const [containerWidth, setContainerWidth] = useState(0)
-  const mastheadContainerRef = useRef<HTMLDivElement>(null)
+  const mastheadRefObject = useRef<HTMLDivElement | null>(null)
+
+  const mastheadRef = useCallback((element) => {
+    mastheadRefObject.current = element
+
+    if (element) {
+      setContainerWidth(element.offsetWidth)
+    }
+  }, [])
 
   function toggleSearch(
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) {
-    if (!mastheadContainerRef.current) {
+    if (!mastheadRefObject.current) {
       return
     }
 
@@ -19,7 +27,7 @@ export function useMastheadSearch() {
     // as the width of the searchbar so that it does not spill
     // over to other parts of the page, such as the sidebar.
     if (newShowSearch) {
-      setContainerWidth(mastheadContainerRef.current.offsetWidth)
+      setContainerWidth(mastheadRefObject.current.offsetWidth)
     }
 
     setShowSearch(!showSearch)
@@ -27,7 +35,7 @@ export function useMastheadSearch() {
 
   return {
     containerWidth,
-    mastheadContainerRef,
+    mastheadRef,
     setShowSearch,
     showSearch,
     toggleSearch,

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.test.tsx
@@ -44,6 +44,10 @@ describe('Notification', () => {
       expect(wrapper.getByText('TS')).toBeTruthy()
     })
 
+    it('adds the aria-hidden attribute to the initials', () => {
+      expect(wrapper.getByText('TS')).toHaveAttribute('aria-hidden')
+    })
+
     it('should render the not-read indicator', () => {
       expect(wrapper.getByTestId('not-read-item')).toBeTruthy()
     })

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.tsx
@@ -83,19 +83,19 @@ export const Notification: React.FC<NotificationProps> = ({
             <StyledItem
               aria-describedby={contentId}
               data-testid="notification-row"
-              role="row"
             >
-              <StyledAvatar role="gridcell">
-                <Avatar variant={AVATAR_VARIANT.DARK}>
+              <StyledAvatar>
+                <Avatar variant={AVATAR_VARIANT.DARK} aria-hidden>
                   {getInitials(name)}
                 </Avatar>
-                {!isRead && <StyledItemNotRead data-testid="not-read-item" />}
+                {!isRead && (
+                  <StyledItemNotRead
+                    title="Unread"
+                    data-testid="not-read-item"
+                  />
+                )}
               </StyledAvatar>
-              <StyledContent
-                data-testid="notification-content"
-                id={contentId}
-                role="gridcell"
-              >
+              <StyledContent data-testid="notification-content" id={contentId}>
                 <strong>{name}</strong>
                 {` ${action} `}
                 <strong>{on}</strong>

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.test.tsx
@@ -47,13 +47,6 @@ describe('Notifications', () => {
       )
     })
 
-    it('should set the `role` attribute on the notification sheet to `grid`', () => {
-      expect(wrapper.getByTestId('notifications-sheet')).toHaveAttribute(
-        'role',
-        'grid'
-      )
-    })
-
     it('should render the items', () => {
       const items = wrapper.getAllByTestId('notification')
       expect(items).toHaveLength(2)
@@ -67,20 +60,6 @@ describe('Notifications', () => {
       const items = wrapper.getAllByTestId('notification-row')
       items.forEach((item, i) => {
         expect(item).toHaveAttribute('aria-describedby', contentIds[i])
-      })
-    })
-
-    it('should set the `role` attribute of each notification row to `row`', () => {
-      const items = wrapper.getAllByTestId('notification-row')
-      items.forEach((item) => {
-        expect(item).toHaveAttribute('role', 'row')
-      })
-    })
-
-    it('should set the `role` attribute of each notification content to `gridcell`', () => {
-      const items = wrapper.getAllByTestId('notification-content')
-      items.forEach((item) => {
-        expect(item).toHaveAttribute('role', 'gridcell')
       })
     })
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.tsx
@@ -25,7 +25,7 @@ export const Notifications: React.FC<NotificationsProps> = ({
   link,
   ...rest
 }) => (
-  <StyledNotifications data-testid="notifications-sheet" role="grid" {...rest}>
+  <StyledNotifications data-testid="notifications-sheet" {...rest}>
     <StyledList data-testid="notifications">{children}</StyledList>
     <StyledViewAll>
       {React.cloneElement(link as ReactElement, {

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/partials/StyledAvatar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/partials/StyledAvatar.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 
-export const StyledAvatar = styled.div`
+export const StyledAvatar = styled.span`
   position: relative;
+  display: block;
 `

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/partials/StyledContent.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/partials/StyledContent.tsx
@@ -3,7 +3,8 @@ import { selectors } from '@defencedigital/design-tokens'
 
 const { spacing, fontSize, color } = selectors
 
-export const StyledContent = styled.div`
+export const StyledContent = styled.span`
+  display: block;
   margin-left: ${spacing('6')};
   font-size: ${fontSize('s')};
   line-height: 1.3;

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/partials/StyledItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/partials/StyledItem.tsx
@@ -3,7 +3,7 @@ import { selectors } from '@defencedigital/design-tokens'
 
 const { color, spacing } = selectors
 
-export const StyledItem = styled.div`
+export const StyledItem = styled.span`
   display: flex;
   border-bottom: 1px solid ${color('neutral', '600')};
   margin: ${spacing('6')};

--- a/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/SearchBar.tsx
@@ -55,6 +55,7 @@ export const SearchBar: React.FC<SearchbarProps> = ({
     >
       <StyledForm data-testid="searchbar-form" onSubmit={onSubmit}>
         <TextInput
+          aria-label="Search terms"
           autoFocus
           id="term"
           name="term"

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sheet/Sheet.tsx
@@ -16,6 +16,7 @@ export interface SheetProps extends ComponentWithClass {
   placement?: Placement
   closeDelay?: number
   id?: string
+  initialIsOpen?: boolean
 }
 
 export const Sheet: React.FC<SheetProps> = ({
@@ -24,11 +25,14 @@ export const Sheet: React.FC<SheetProps> = ({
   placement = FLOATING_BOX_PLACEMENT.RIGHT,
   closeDelay = 250,
   id: externalId,
+  initialIsOpen = false,
+  ...rest
 }) => {
   const id = useExternalId('sheet', externalId)
   const { floatingBoxChildrenRef, isVisible, mouseEvents } = useHideShow(
     true,
-    closeDelay
+    closeDelay,
+    initialIsOpen
   )
 
   const SheetTarget = () => {
@@ -46,11 +50,11 @@ export const Sheet: React.FC<SheetProps> = ({
       placement={placement}
       renderTarget={<SheetTarget />}
       scheme="dark"
+      {...rest}
     >
       <div ref={floatingBoxChildrenRef}>
         {React.cloneElement(children, {
           id,
-          'aria-expanded': isVisible,
         })}
       </div>
     </FloatingBox>

--- a/packages/react-component-library/src/hooks/useHideShow.ts
+++ b/packages/react-component-library/src/hooks/useHideShow.ts
@@ -2,8 +2,12 @@ import { useCallback, useRef, useState } from 'react'
 
 import { useDocumentClick } from '.'
 
-export function useHideShow(isClick: boolean, closeDelay: number) {
-  const [isVisible, setIsVisible] = useState(false)
+export function useHideShow(
+  isClick: boolean,
+  closeDelay: number,
+  initialIsVisible = false
+) {
+  const [isVisible, setIsVisible] = useState(initialIsVisible)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const floatingBoxChildrenRef = useRef(null)
 


### PR DESCRIPTION
## Related issue

#2570 

## Overview

This updates Masthead to:

- adds stories (hidden on the docs tab) with the search bar, notifications list and user options expanded
- fixes revealed accessibility problems flagged by axe
- changes Defence Digital Design System to MOD.UK Design System in stories

## Link to preview

https://5e25c277526d380020b5e418-mmyxyptgbt.chromatic.com/?path=/story/masthead--with-search-open

## Reason

To:

- make sure these expandable elements are covered by visual regression and automated accessibility testing
- resolve accessibility problems
- correct the name of the design system in Masthead stories

## Work carried out

- [x] Update title in existing stories
- [x] Add private props for initially showing search bar, notifications and user options
- [x] Add stories with search bar, notifications and user options shown

## Developer notes

The `grid` role previously used for the notifications panel did not seem appropriate based on the description of the role:

> The grid role is a composite widget containing a collection of one or more rows with one or more cells where some or all cells in the grid are focusable by using methods of two-dimensional navigation, such as directional arrow keys.

Since `ol` and `li` are already being used (plus the `dialog` role), it's not clear any more roles are needed.