### PR TITLE
fix(Sidebar): Add accessible names to sheets

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
@@ -215,7 +215,7 @@ export const WithUserMenu: ComponentStory<typeof Sidebar> = (props) => {
 
 WithUserMenu.storyName = 'With user menu'
 
-export const WithNotifications: ComponentStory<typeof Sidebar> = (props) => {
+const WithNotificationsTemplate: ComponentStory<typeof Sidebar> = (props) => {
   const notifications = (
     <Notifications link={<Link href="#" />}>
       <Notification
@@ -259,4 +259,39 @@ export const WithNotifications: ComponentStory<typeof Sidebar> = (props) => {
   )
 }
 
+export const WithNotifications = WithNotificationsTemplate.bind({})
 WithNotifications.storyName = 'With notifications'
+
+export const WithUserMenuOpen: ComponentStory<typeof Sidebar> = (props) => {
+  const userWithLinks = (
+    <SidebarUser
+      initials="HN"
+      name="Horatio Nelson"
+      userLink={<Link href="#">Profile</Link>}
+      exitLink={<Link href="#">Logout</Link>}
+      initialIsOpen
+    />
+  )
+
+  return (
+    <SidebarWrapper>
+      <StyledSidebar {...props} user={userWithLinks}>
+        <SimpleSidebarNav />
+      </StyledSidebar>
+      <StyledMain>Hello, World!</StyledMain>
+    </SidebarWrapper>
+  )
+}
+WithUserMenuOpen.parameters = {
+  docs: { disable: true },
+}
+WithUserMenuOpen.storyName = 'With user menu open'
+
+export const WithNotificationsOpen = WithNotifications.bind({})
+WithNotificationsOpen.args = {
+  initialIsNotificationsOpen: true,
+}
+WithNotificationsOpen.parameters = {
+  docs: { disable: true },
+}
+WithNotificationsOpen.storyName = 'With notifications open'

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
@@ -58,40 +58,42 @@ const StyledMain = styled.main`
   width: 100%;
 `
 
-export const Default: ComponentStory<typeof Sidebar> = (props) => {
-  const sidebarNav = (
-    <SidebarNav>
-      <SidebarNavItem
-        icon={<IconHome />}
-        link={<Link href="#">Dashboard</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconVerifiedUser />}
-        link={<Link href="#">Reports</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconLocalShipping />}
-        link={<Link href="#">Platforms</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconFeedback />}
-        link={<Link href="#">Data&nbsp;Feed</Link>}
-      />
-      <SidebarNavItem
-        isActive
-        icon={<IconMessage />}
-        link={<Link href="#">Messages</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconSettings />}
-        link={<Link href="#">Settings</Link>}
-      />
-    </SidebarNav>
-  )
+const SimpleSidebarNav: React.FC = () => (
+  <SidebarNav>
+    <SidebarNavItem
+      icon={<IconHome />}
+      link={<Link href="#">Dashboard</Link>}
+    />
+    <SidebarNavItem
+      icon={<IconVerifiedUser />}
+      link={<Link href="#">Reports</Link>}
+    />
+    <SidebarNavItem
+      icon={<IconLocalShipping />}
+      link={<Link href="#">Platforms</Link>}
+    />
+    <SidebarNavItem
+      icon={<IconFeedback />}
+      link={<Link href="#">Data&nbsp;Feed</Link>}
+    />
+    <SidebarNavItem
+      isActive
+      icon={<IconMessage />}
+      link={<Link href="#">Messages</Link>}
+    />
+    <SidebarNavItem
+      icon={<IconSettings />}
+      link={<Link href="#">Settings</Link>}
+    />
+  </SidebarNav>
+)
 
+export const Default: ComponentStory<typeof Sidebar> = (props) => {
   return (
     <SidebarWrapper>
-      <StyledSidebar {...props}>{sidebarNav}</StyledSidebar>
+      <StyledSidebar {...props}>
+        <SimpleSidebarNav />
+      </StyledSidebar>
       <StyledMain>Hello, World!</StyledMain>
     </SidebarWrapper>
   )
@@ -100,40 +102,10 @@ export const Default: ComponentStory<typeof Sidebar> = (props) => {
 Default.args = {}
 
 export const InitiallyOpen: ComponentStory<typeof Sidebar> = (props) => {
-  const sidebarNav = (
-    <SidebarNav>
-      <SidebarNavItem
-        icon={<IconHome />}
-        link={<Link href="#">Dashboard</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconVerifiedUser />}
-        link={<Link href="#">Reports</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconLocalShipping />}
-        link={<Link href="#">Platforms</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconFeedback />}
-        link={<Link href="#">Data&nbsp;Feed</Link>}
-      />
-      <SidebarNavItem
-        isActive
-        icon={<IconMessage />}
-        link={<Link href="#">Messages</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconSettings />}
-        link={<Link href="#">Settings</Link>}
-      />
-    </SidebarNav>
-  )
-
   return (
     <SidebarWrapper>
       <StyledSidebar {...props} initialIsOpen>
-        {sidebarNav}
+        <SimpleSidebarNav />
       </StyledSidebar>
       <StyledMain>Hello, World!</StyledMain>
     </SidebarWrapper>
@@ -209,40 +181,10 @@ export const WithSubNavigation: ComponentStory<typeof Sidebar> = (props) => {
 WithSubNavigation.storyName = 'With sub-navigation'
 
 export const WithHeader: ComponentStory<typeof Sidebar> = (props) => {
-  const sidebarNav = (
-    <SidebarNav>
-      <SidebarNavItem
-        icon={<IconHome />}
-        link={<Link href="#">Dashboard</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconVerifiedUser />}
-        link={<Link href="#">Reports</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconLocalShipping />}
-        link={<Link href="#">Platforms</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconFeedback />}
-        link={<Link href="#">Data&nbsp;Feed</Link>}
-      />
-      <SidebarNavItem
-        isActive
-        icon={<IconMessage />}
-        link={<Link href="#">Messages</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconSettings />}
-        link={<Link href="#">Settings</Link>}
-      />
-    </SidebarNav>
-  )
-
   return (
     <SidebarWrapper>
       <StyledSidebar {...props} icon={<IconGrain />} title="Application Name">
-        {sidebarNav}
+        <SimpleSidebarNav />
       </StyledSidebar>
       <StyledMain>Hello, World!</StyledMain>
     </SidebarWrapper>
@@ -261,40 +203,10 @@ export const WithUserMenu: ComponentStory<typeof Sidebar> = (props) => {
     />
   )
 
-  const sidebarNav = (
-    <SidebarNav>
-      <SidebarNavItem
-        icon={<IconHome />}
-        link={<Link href="#">Dashboard</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconVerifiedUser />}
-        link={<Link href="#">Reports</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconLocalShipping />}
-        link={<Link href="#">Platforms</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconFeedback />}
-        link={<Link href="#">Data&nbsp;Feed</Link>}
-      />
-      <SidebarNavItem
-        isActive
-        icon={<IconMessage />}
-        link={<Link href="#">Messages</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconSettings />}
-        link={<Link href="#">Settings</Link>}
-      />
-    </SidebarNav>
-  )
-
   return (
     <SidebarWrapper>
       <StyledSidebar {...props} user={userWithLinks}>
-        {sidebarNav}
+        <SimpleSidebarNav />
       </StyledSidebar>
       <StyledMain>Hello, World!</StyledMain>
     </SidebarWrapper>
@@ -333,36 +245,6 @@ export const WithNotifications: ComponentStory<typeof Sidebar> = (props) => {
     </Notifications>
   )
 
-  const sidebarNav = (
-    <SidebarNav>
-      <SidebarNavItem
-        icon={<IconHome />}
-        link={<Link href="#">Dashboard</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconVerifiedUser />}
-        link={<Link href="#">Reports</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconLocalShipping />}
-        link={<Link href="#">Platforms</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconFeedback />}
-        link={<Link href="#">Data&nbsp;Feed</Link>}
-      />
-      <SidebarNavItem
-        isActive
-        icon={<IconMessage />}
-        link={<Link href="#">Messages</Link>}
-      />
-      <SidebarNavItem
-        icon={<IconSettings />}
-        link={<Link href="#">Settings</Link>}
-      />
-    </SidebarNav>
-  )
-
   return (
     <SidebarWrapper>
       <StyledSidebar
@@ -370,7 +252,7 @@ export const WithNotifications: ComponentStory<typeof Sidebar> = (props) => {
         notifications={notifications}
         hasUnreadNotification
       >
-        {sidebarNav}
+        <SimpleSidebarNav />
       </StyledSidebar>
       <StyledMain>Hello, World!</StyledMain>
     </SidebarWrapper>

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.tsx
@@ -35,6 +35,11 @@ export interface SidebarProps extends ComponentWithClass {
    */
   notifications?: React.ReactElement<NotificationsProps>
   /**
+   * Whether the notifications list is initially open.
+   * @private
+   */
+  initialIsNotificationsOpen?: boolean
+  /**
    * Initial `isOpen` state on first render.
    */
   initialIsOpen?: boolean
@@ -47,6 +52,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   user,
   hasUnreadNotification,
   notifications,
+  initialIsNotificationsOpen,
   initialIsOpen = false,
   ...rest
 }) => {
@@ -93,6 +99,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
             {notifications && (
               <SidebarNotifications
+                initialIsOpen={initialIsNotificationsOpen}
                 notifications={notifications}
                 hasUnreadNotification={hasUnreadNotification}
               />

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNotifications.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNotifications.tsx
@@ -17,12 +17,17 @@ export interface SidebarNotificationsProps extends ComponentWithClass {
    */
   hasUnreadNotification?: boolean
   /**
+   * Whether the sheet is initially open.
+   */
+  initialIsOpen?: boolean
+  /**
    * Collection of Notification item components.
    */
   notifications?: React.ReactElement<NotificationsProps>
 }
 
 export const SidebarNotifications: React.FC<SidebarNotificationsProps> = ({
+  initialIsOpen,
   notifications,
   hasUnreadNotification,
 }) => {
@@ -34,6 +39,7 @@ export const SidebarNotifications: React.FC<SidebarNotificationsProps> = ({
 
   return (
     <StyledNotificationsSheet
+      aria-label="Notifications"
       button={
         <StyledNotificationsSheetButton
           aria-label="Show notifications"
@@ -55,6 +61,7 @@ export const SidebarNotifications: React.FC<SidebarNotificationsProps> = ({
           </Transition>
         </StyledNotificationsSheetButton>
       }
+      initialIsOpen={initialIsOpen}
       placement="right"
     >
       {notifications}

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
@@ -21,6 +21,11 @@ export interface SidebarUserProps extends ComponentWithClass {
    */
   initials: string
   /**
+   * Whether the user options sheet is initially open.
+   * @private
+   */
+  initialIsOpen?: boolean
+  /**
    * Link component to apply to the user avatar.
    */
   userLink?: React.ReactElement<LinkTypes>
@@ -38,10 +43,12 @@ type SidebarAvatarWithItemsProps = Omit<SidebarUserProps, 'link'>
 
 const SidebarAvatarWithItems: React.FC<SidebarAvatarWithItemsProps> = ({
   initials,
+  initialIsOpen,
   userLink,
   exitLink,
 }) => (
   <Sheet
+    aria-label="User options"
     button={
       <StyledUserSheetButton
         aria-label="Show user options"
@@ -53,6 +60,7 @@ const SidebarAvatarWithItems: React.FC<SidebarAvatarWithItemsProps> = ({
         }
       />
     }
+    initialIsOpen={initialIsOpen}
     placement="right"
   >
     <StyledSheetList>
@@ -64,6 +72,7 @@ const SidebarAvatarWithItems: React.FC<SidebarAvatarWithItemsProps> = ({
 
 export const SidebarUser: React.FC<SidebarUserProps> = ({
   initials,
+  initialIsOpen,
   userLink,
   exitLink,
   name,
@@ -75,6 +84,7 @@ export const SidebarUser: React.FC<SidebarUserProps> = ({
       <StyledUser data-testid="sidebar-user-closed-children">
         <SidebarAvatarWithItems
           initials={initials}
+          initialIsOpen={initialIsOpen}
           userLink={userLink}
           exitLink={exitLink}
         />


### PR DESCRIPTION
## Related issue

Resolves #2570
Resolves #1928 

## Overview

This adds accessible labels for the user options and notifications sheets in the sidebar.

It also adds sidebar stories with the user options and notifications sheets open to make sure these are covered by accessibility and visual regression tests.

## Link to preview

https://5e25c277526d380020b5e418-ncoqodfqsu.chromatic.com/?path=/story/sidebar--with-user-menu-open

## Reason

To help ensure the Sidebar sheets are accessible and covered by visual regression tests.

## Work carried out

- [x] Refactor Sidebar stories
- [x] Add additional stories
- [x] Add accessible names to notifications and user options sheets

