### PR TITLE
build(Tooling): Update to Node.js 18 LTS

### DIFF
--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version-file: .nvmrc
         cache: yarn
 
     - name: Cache Node modules

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -149,7 +149,7 @@ jobs:
         shard: [1/3, 2/3, 3/3]
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
@@ -157,7 +157,7 @@ jobs:
           unpack-prebuilt-libraries: true
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -177,9 +177,11 @@ jobs:
         run: tar -xzf /tmp/storybook-static-e2e.tar.gz
 
       - name: Run e2e tests
+        env:
+          NODE_OPTIONS: --dns-result-order=ipv4first
         run: yarn --cwd packages/react-component-library test:e2e --shard ${{ matrix.shard }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: playwright-test-results
@@ -264,6 +266,8 @@ jobs:
           npm exec --no -- playwright install --with-deps chromium
 
       - name: Run accessibility tests
+        env:
+          NODE_OPTIONS: --dns-result-order=ipv4first
         run: |
           npm exec --no -- concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
             "npm exec --no -- http-server packages/react-component-library/.static_storybook --port 6006 --silent" \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -142,11 +142,13 @@ jobs:
           retention-days: 1
 
   Test-e2e_react-component-library:
+    name: Test-e2e_react-component-library (${{ matrix.shard }}/${{ matrix.total_shards }})
     runs-on: ubuntu-latest
     needs: [Build_storybook_e2e]
     strategy:
       matrix:
-        shard: [1/3, 2/3, 3/3]
+        shard: [1, 2, 3]
+        total_shards: [3]
     steps:
       - name: Git clone repository
         uses: actions/checkout@v3
@@ -179,12 +181,12 @@ jobs:
       - name: Run e2e tests
         env:
           NODE_OPTIONS: --dns-result-order=ipv4first
-        run: yarn --cwd packages/react-component-library test:e2e --shard ${{ matrix.shard }}
+        run: yarn --cwd packages/react-component-library test:e2e --shard ${{ matrix.shard }}/${{ matrix.total_shards }}
 
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: playwright-test-results
+          name: playwright-test-results-${{ matrix.shard }}
           path: packages/react-component-library/e2e-output/
 
   Test_design-tokens:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: .nvmrc
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-16.13.0
+lts/hydrogen

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packages/design-tokens"
   ],
   "engines": {
-    "node": ">=12.18.3 <17"
+    "node": "^16.13.0 || ^18.12.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.2",

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -71,7 +71,7 @@
     "@babel/preset-react": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",
     "@defencedigital/eslint-config-react": "^3.13.8",
-    "@playwright/test": "^1.26.1",
+    "@playwright/test": "^1.28.1",
     "@storybook/addon-a11y": "^6.5.12",
     "@storybook/addon-actions": "^6.5.12",
     "@storybook/addon-controls": "^6.5.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3273,13 +3273,13 @@
   dependencies:
     esquery "^1.0.1"
 
-"@playwright/test@^1.26.1":
-  version "1.26.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.26.1.tgz#73ada4e70f618bca69ba7509c4ba65b5a41c4b10"
-  integrity sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==
+"@playwright/test@^1.28.1":
+  version "1.28.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.28.1.tgz#e5be297e024a3256610cac2baaa9347fd57c7860"
+  integrity sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.26.1"
+    playwright-core "1.28.1"
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.4"
@@ -9717,15 +9717,15 @@ focus-trap@^6.9.0:
   dependencies:
     tabbable "^5.3.1"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
-
-follow-redirects@^1.14.9, follow-redirects@^1.15.0:
+follow-redirects@^1.0.0, follow-redirects@^1.14.9, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
+follow-redirects@^1.14.0:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -14937,22 +14937,17 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-playwright-core@1.25.1, playwright-core@>=1.2.0:
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.25.1.tgz#abe56aec8bef645fba988320d9f9328fafab0446"
-  integrity sha512-lSvPCmA2n7LawD2Hw7gSCLScZ+vYRkhU8xH0AapMyzwN+ojoDqhkH/KIEUxwNu2PjPoE/fcE0wLAksdOhJ2O5g==
-
-playwright-core@1.26.1:
-  version "1.26.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.26.1.tgz#a162f476488312dcf12638d97685144de6ada512"
-  integrity sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==
+playwright-core@1.28.1, playwright-core@>=1.2.0:
+  version "1.28.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.28.1.tgz#8400be9f4a8d1c0489abdb9e75a4cc0ffc3c00cb"
+  integrity sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==
 
 "playwright@>= 1.0.0", playwright@^1.14.0:
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.25.1.tgz#23fe129ca05568a72ee2a3842baa0a1985d1b345"
-  integrity sha512-kOlW7mllnQ70ALTwAor73q/FhdH9EEXLUqjdzqioYLcSVC4n4NBfDqeCikGuayFZrLECLkU6Hcbziy/szqTXSA==
+  version "1.28.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.28.1.tgz#f23247f1de466ff73d7230d94df96271e5da6583"
+  integrity sha512-92Sz6XBlfHlb9tK5UCDzIFAuIkHHpemA9zwUaqvo+w7sFMSmVMGmvKcbptof/eJObq63PGnMhM75x7qxhTR78Q==
   dependencies:
-    playwright-core "1.25.1"
+    playwright-core "1.28.1"
 
 pnp-webpack-plugin@1.6.4:
   version "1.6.4"


### PR DESCRIPTION
## Overview

This updates to Node.js version 18 now it is in LTS. It also fixes Playwright artefacts from the shards overwriting each other on GitHub Actions.

## Reason

Node.js is the latest LTS version.

## Work carried out

- [x] Update `.nvmrc` and `package.json`
- [x] Update Playwright
- [x] Update GitHub Actions workflows
- [x] Configure Node.js to prefer IPv4 when resolving localhost on GitHub Actions
- [x] Preserve all Playwright shard artefacts on GitHub Actions

## Developer notes

[Node.js now prefers IPv6 during DNS resolutions](https://github.com/nodejs/node/pull/39987), and `http-server` doesn't support IPv6. This meant the end-to-end and accessibility tests didn't work on GitHub Actions.

This has been worked around by configured Node.js to prefer IPv4 again on GitHub Actions.
