### PR TITLE
fix(Select): Allow options to be disabled

### DIFF
--- a/packages/react-component-library/.storybook/main.js
+++ b/packages/react-component-library/.storybook/main.js
@@ -20,6 +20,28 @@ module.exports = {
     ${head}
     ${process.env.NETLIFY ? newRelic.script : ''}
   `,
+  webpackFinal: (config) => {
+    // Transpile Downshift for IE11 compatibility
+    return {
+      ...config,
+      module: {
+        ...config.module,
+        rules: [
+          ...config.module.rules,
+          {
+            test: /\.m?js$/,
+            include: /node_modules\/downshift\//,
+            use: {
+              loader: 'babel-loader',
+              options: {
+                presets: ['@babel/preset-env'],
+              },
+            },
+          },
+        ],
+      },
+    }
+  },
   stories: ['../src/**/*.stories.tsx'],
   reactOptions: {
     strictMode: process.env.REACT_STRICT_MODE === '1',

--- a/packages/react-component-library/e2e/Select/default.spec.ts
+++ b/packages/react-component-library/e2e/Select/default.spec.ts
@@ -1,4 +1,4 @@
-import { ColorAction000 } from '@defencedigital/design-tokens'
+import { ColorAction000, ColorNeutral100 } from '@defencedigital/design-tokens'
 
 import { hexToRgb } from '../helpers'
 import { expect, test } from '../test'
@@ -61,6 +61,33 @@ test.describe('Select, default', () => {
             hexToRgb(ColorAction000)
           )
         })
+      })
+    })
+
+    test.describe('and ArrowUp is pressed', () => {
+      test.beforeEach(async ({ page }) => {
+        await page.keyboard.press('ArrowUp')
+      })
+
+      test('highlights the third option', async ({ page }) => {
+        await expect(page.locator(selectors.option).nth(2)).toHaveCSS(
+          'background-color',
+          hexToRgb(ColorNeutral100)
+        )
+      })
+    })
+
+    test.describe('and the disabled option is clicked', () => {
+      test.beforeEach(async ({ page }) => {
+        await page.locator(selectors.option, { hasText: 'disabled' }).click()
+      })
+
+      test('does not close the menu', async ({ page }) => {
+        await expect(page.locator(selectors.listBox)).toBeVisible()
+      })
+
+      test('does not update the input value', async ({ page }) => {
+        await expect(page.locator(selectors.input)).toHaveValue('')
       })
     })
   })

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -160,7 +160,7 @@
     "classnames": "^2.2.6",
     "date-fns": "^2.9.0",
     "decimal.js": "^10.3.1",
-    "downshift": "^6.1.7",
+    "downshift": "^6.1.12",
     "focus-trap": "^6.9.0",
     "focus-trap-react": "^8.11.0",
     "lodash": "^4.17.21",

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -41,11 +41,13 @@ const Template: ComponentStory<typeof Select> = (args) => (
     <Select {...args}>
       <SelectOption value="one">A</SelectOption>
       <SelectOption value="two">B</SelectOption>
-      <SelectOption value="three">
+      <SelectOption value="long">
         This is a really, really long select option label that overflows the
         container when selected
       </SelectOption>
-      <SelectOption value="four">Three</SelectOption>
+      <SelectOption value="three" isDisabled>
+        Three (disabled)
+      </SelectOption>
     </Select>
   </StyledWrapper>
 )

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -5,13 +5,13 @@ import { isNil } from 'lodash'
 import {
   getSelectedItem,
   itemToString,
-  SelectBaseOptionAsStringProps,
   SelectBaseProps,
   SelectLayout,
 } from '../SelectBase'
 import { useExternalId } from '../../hooks/useExternalId'
 import { useMenuVisibility } from '../SelectBase/hooks/useMenuVisibility'
 import { useSelectMenu } from './hooks/useSelectMenu'
+import { SelectOptionProps } from './SelectOption'
 
 export const Select: React.FC<SelectBaseProps> = ({
   children,
@@ -26,7 +26,7 @@ export const Select: React.FC<SelectBaseProps> = ({
   const inputRef = useRef<HTMLInputElement>(null)
 
   const filteredItems = React.Children.toArray(children).filter(
-    React.isValidElement<SelectBaseOptionAsStringProps>
+    React.isValidElement<SelectOptionProps>
   )
   const items = filteredItems.map((child) => child.props.value)
   const itemsMap = Object.fromEntries(
@@ -96,6 +96,7 @@ export const Select: React.FC<SelectBaseProps> = ({
             ...child.props,
             ...getItemProps({
               index,
+              disabled: child.props.isDisabled,
               item: child.props.value,
               key: `select-option-${child.props.value}`,
             }),

--- a/packages/react-component-library/src/components/Select/SelectOption.tsx
+++ b/packages/react-component-library/src/components/Select/SelectOption.tsx
@@ -2,9 +2,10 @@ import React from 'react'
 
 import { SelectBaseOption, SelectBaseOptionAsStringProps } from '../SelectBase'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SelectOptionProps
-  extends Omit<SelectBaseOptionAsStringProps, 'title'> {}
+  extends Omit<SelectBaseOptionAsStringProps, 'title'> {
+  isDisabled?: boolean
+}
 
 export const SelectOption = React.forwardRef<HTMLLIElement, SelectOptionProps>(
   (props, ref) => <SelectBaseOption {...props} ref={ref} />

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledOption.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledOption.tsx
@@ -16,11 +16,16 @@ export const StyledOption = styled.li<StyledOptionsProps>`
   display: flex;
   align-items: center;
   cursor: pointer;
-  color: ${color('neutral', '400')};
+  color: ${color('neutral', '900')};
   font-size: ${fontSize('m')};
 
-  &:hover {
+  &:hover:not([disabled]) {
     background-color: ${color('neutral', '100')};
+  }
+
+  &[disabled] {
+    color: ${color('neutral', '400')};
+    cursor: not-allowed;
   }
 
   ${({ $isHighlighted }) =>

--- a/packages/react-component-library/webpack/common.js
+++ b/packages/react-component-library/webpack/common.js
@@ -27,6 +27,17 @@ module.exports = {
         use: ['babel-loader', 'source-map-loader'],
         exclude: /node_modules/,
       },
+      // Transpile Downshift for IE11 compatibility
+      {
+        test: /\.m?js$/,
+        include: /node_modules\/downshift\//,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env'],
+          },
+        },
+      },
       {
         test: /\.(png|woff|woff2|eot|ttf)$/,
         use: ['url-loader?limit=100000'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8527,10 +8527,10 @@ dotenv@~10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
-downshift@^6.1.7:
-  version "6.1.7"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-6.1.7.tgz#fdb4c4e4f1d11587985cd76e21e8b4b3fa72e44c"
-  integrity sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==
+downshift@^6.1.12:
+  version "6.1.12"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-6.1.12.tgz#f14476b41a6f6fd080c340bad1ddf449f7143f6f"
+  integrity sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==
   dependencies:
     "@babel/runtime" "^7.14.8"
     compute-scroll-into-view "^1.0.17"


### PR DESCRIPTION
## Related issue

Resolves #3508 

## Overview

This exposes missing functionality in Select to allow options to be disabled.

## Link to preview

https://5e25c277526d380020b5e418-ftekgwmned.chromatic.com/?path=/story/select--default

## Reason

> In v2 of the `Select` it was possible to disable options because an `isDisabled` flag was being passed to `react-select`. v3 of the `Select` needs the ability to pass an `isDisabled` prop to an option. Early investigation seems to be that this can be done through Downshift's `getItemProps`, in particular there is a `disabled` but there are potentially knock on effects with styling.
> 
> Note that this is required for feature parity between v2 and v3.

## Work carried out

- [x] Add `isDisabled` prop to `SelectOption`
- [x] Update Downshift
- [x] Transpile Downshift in Storybook and CJS bundles

## Screenshot

![image](https://user-images.githubusercontent.com/66470099/199963214-74761846-533e-4e0b-a785-28d8f94fc2b5.png)

## Notes

There was no lighter colour in the neutral palette available with sufficient contrast, so the text of non-disabled options was made darker.

A newer versions of Downshift was needed as it contains a bug fix for disabled items. However, newer versions of Downshift are no longer transpiled to ES5. This was worked around by transpiling it in our own bundles.

