### PR TITLE
fix(Autocomplete): Fix <strong/> on empty string

### DIFF
--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.test.tsx
@@ -119,6 +119,7 @@ describe('Autocomplete', () => {
         expect(options[1]).toHaveTextContent('Two')
         expect(options[2]).toHaveTextContent('Three')
         expect(options).toHaveLength(3)
+        expect(wrapper.container.querySelectorAll('strong')).toHaveLength(0)
       })
 
       it('sets `aria-expanded` on the input wrapper to `true`', () => {
@@ -230,6 +231,23 @@ describe('Autocomplete', () => {
 
       it('has the value "Two"', () => {
         expect(wrapper.getByTestId('select-input')).toHaveValue('Two')
+      })
+    })
+
+    describe('when the menu is opened and "tw" is typed into the input', () => {
+      beforeEach(async () => {
+        await userEvent.clear(wrapper.getByTestId('select-input'))
+        await userEvent.type(wrapper.getByTestId('select-input'), 'tw')
+      })
+
+      it('has filters the options', () => {
+        expect(wrapper.getByRole('option')).toHaveTextContent('Two')
+      })
+
+      it('has wraps the match characters in a <strong> element', () => {
+        expect(wrapper.getByRole('option')).toContainHTML(
+          '<strong>Tw</strong>o'
+        )
       })
     })
   })

--- a/packages/react-component-library/src/components/Autocomplete/AutocompleteOption.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/AutocompleteOption.tsx
@@ -3,7 +3,6 @@ import reactStringReplace from 'react-string-replace'
 
 import { SelectBaseOption, SelectBaseOptionAsStringProps } from '../SelectBase'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AutocompleteOptionProps extends SelectBaseOptionAsStringProps {
   inputValue?: string
 }
@@ -14,9 +13,11 @@ export const AutocompleteOption = React.forwardRef<
 >(({ children, inputValue, ...rest }, ref) => {
   return (
     <SelectBaseOption ref={ref} {...rest}>
-      {reactStringReplace(children, inputValue, (match, i) => (
-        <strong key={i}>{match}</strong>
-      ))}
+      {inputValue
+        ? reactStringReplace(children, inputValue, (match, i) => (
+            <strong key={i}>{match}</strong>
+          ))
+        : children}
     </SelectBaseOption>
   )
 })

--- a/packages/react-component-library/src/components/SelectBase/SelectBaseOption.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectBaseOption.tsx
@@ -6,7 +6,7 @@ import { StyledOptionBadge } from './partials/StyledOptionBadge'
 import { StyledOptionText } from './partials/StyledOptionText'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 
-export interface SelectBaseOptionBaseProps extends ComponentWithClass {
+export interface SelectBaseOptionProps extends ComponentWithClass {
   badge?: string | number
   icon?: React.ReactNode
   isHighlighted?: boolean
@@ -14,19 +14,9 @@ export interface SelectBaseOptionBaseProps extends ComponentWithClass {
   title?: string
 }
 
-export interface SelectBaseOptionAsArrayProps
-  extends SelectBaseOptionBaseProps {
-  children: React.ReactNodeArray
-}
-
-export interface SelectBaseOptionAsStringProps
-  extends SelectBaseOptionBaseProps {
+export interface SelectBaseOptionAsStringProps extends SelectBaseOptionProps {
   children: string
 }
-
-export type SelectBaseOptionProps =
-  | SelectBaseOptionAsArrayProps
-  | SelectBaseOptionAsStringProps
 
 export const SelectBaseOption = React.forwardRef<
   HTMLLIElement,


### PR DESCRIPTION
## Related issue

Resolves #3572

## Overview

This PR adds tests for the filter and the expected HTML content. 
If the string is empty it will pass undefined so no replacements are made to the string

## Link to preview

[If you're on a project which auto-deploys branches, link to the branches preview link here]

## Reason
The package used to perform the replacement was matching an empty string
![image](https://user-images.githubusercontent.com/5575331/211872777-0b8c01b1-38e4-4664-a3ec-501811875df6.png)

## Work carried out


- [x] Check for an empty string
- [x]  Add additional test case


