### PR TITLE
feat(Dialog): Enhance to support rich description content

### DIFF
--- a/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
@@ -49,3 +49,14 @@ Danger.args = {
   isDanger: true,
   isOpen: true,
 }
+
+export const RichDescription = Template.bind({})
+RichDescription.args = {
+  title: 'Example Title',
+  description: (
+    <div>
+      Support Arbitrary JSX for <strong>rich</strong> description text.
+    </div>
+  ),
+  isOpen: true,
+}

--- a/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
@@ -1,20 +1,21 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, RenderResult, fireEvent } from '@testing-library/react'
+import { renderToStaticMarkup } from 'react-dom/server'
 
 import { Dialog } from '.'
 
 describe('Modal', () => {
   let wrapper: RenderResult
   let title: string
-  let description: string
+  let description: React.ReactElement
   let onConfirm: (event: React.FormEvent<HTMLButtonElement>) => void
   let onCancel: (event: React.FormEvent<HTMLButtonElement>) => void
   let isOpen: boolean
 
   beforeEach(() => {
     title = 'Dialog Title'
-    description = 'Dialog description.'
+    description = <span>Dialog description.</span>
     isOpen = true
     onConfirm = jest.fn()
     onCancel = jest.fn()
@@ -56,8 +57,8 @@ describe('Modal', () => {
       })
 
       it('should render the description', () => {
-        expect(wrapper.getByTestId('dialog-description')).toHaveTextContent(
-          description
+        expect(wrapper.getByTestId('dialog-description').innerHTML).toContain(
+          renderToStaticMarkup(description)
         )
       })
 

--- a/packages/react-component-library/src/components/Dialog/Dialog.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.tsx
@@ -14,9 +14,9 @@ export interface DialogProps extends ComponentWithClass {
    */
   'aria-label'?: string
   /**
-   * Optional text description to display under the component title.
+   * Arbitrary JSX representing a description to display under the component title.
    */
-  description?: string
+  description?: React.ReactNode
   /**
    * Toggles whether to display the type of the component (style varies accordingly).
    */

--- a/packages/react-component-library/src/components/Dialog/partials/StyledDescription.tsx
+++ b/packages/react-component-library/src/components/Dialog/partials/StyledDescription.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 const { color, fontSize, mq } = selectors
 
-export const StyledDescription = styled.p`
+export const StyledDescription = styled.div`
   font-size: ${fontSize('m')};
   color: ${color('neutral', '400')};
 


### PR DESCRIPTION
## Related issue

#3630

## Overview

Enhance to support rich description content (arbitrary JSX).

## Reason

>Currently any content passed to a Dialog component via the description prop is wrapped in a p element and it only accepts strings. This flags React warnings downstream when we supply rich content (design requirement).

## Work carried out

- [x] Loosen the typings
- [x] Update wrapping element
- [x] Update tests and add new story

## Screenshot

<img width="1460" alt="Screenshot 2023-05-25 at 11 31 27" src="https://github.com/defencedigital/mod-uk-design-system/assets/48086589/c8bd0192-967d-4e78-95af-d182e8b40dbc">
