### PR TITLE
build(Lerna): Remove deprecated useWorkspaces config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
-  "useWorkspaces": true,
   "version": "3.13.18",
   "npmClient": "yarn"
 }


### PR DESCRIPTION
This retired config option was preventing root commands like `lerna clean` from working.