### PR TITLE
fix(Popover): Respect existing callbacks

### DIFF
--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -249,4 +249,27 @@ describe('Popover', () => {
       )
     })
   })
+
+  describe('when the target element has `onMouseEnter` and `onMouseLeave` callbacks', () => {
+    const onMouseEnterSpy = jest.fn<void, []>()
+    const onMouseLeaveSpy = jest.fn<void, []>()
+
+    beforeEach(() => {
+      wrapper = render(
+        <Popover content={content} aria-label="Hello, World!">
+          <div onMouseEnter={onMouseEnterSpy} onMouseLeave={onMouseLeaveSpy}>
+            {HOVER_ON_ME}
+          </div>
+        </Popover>
+      )
+
+      fireEvent.mouseEnter(wrapper.getByText(HOVER_ON_ME))
+      fireEvent.mouseLeave(wrapper.getByText(HOVER_ON_ME))
+    })
+
+    it('appends `onMouseOver` and `onMouseLeave` callbacks', () => {
+      expect(onMouseEnterSpy).toHaveBeenCalledTimes(1)
+      expect(onMouseLeaveSpy).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Popover/Popover.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.tsx
@@ -9,7 +9,7 @@ import {
   FloatingBoxSchemeType,
 } from '../../primitives/FloatingBox'
 import { POPOVER_CLOSE_DELAY } from './constants'
-import { useHideShow } from '../../hooks/useHideShow'
+import { HideShowMouseEvents, useHideShow } from '../../hooks/useHideShow'
 import { useExternalId } from '../../hooks/useExternalId'
 
 export interface PopoverProps
@@ -43,6 +43,37 @@ export interface PopoverProps
   scheme?: FloatingBoxSchemeType
 }
 
+function getMouseEvents(
+  isClick: boolean,
+  item: React.ReactElement,
+  mouseEvents: HideShowMouseEvents
+) {
+  if (mouseEvents.onClick) {
+    return mouseEvents
+  }
+
+  return {
+    onMouseEnter: () => {
+      if (item.props.onMouseEnter) {
+        item.props.onMouseEnter()
+      }
+
+      if (mouseEvents.onMouseEnter) {
+        mouseEvents.onMouseEnter()
+      }
+    },
+    onMouseLeave: () => {
+      if (item.props.onMouseLeave) {
+        item.props.onMouseLeave()
+      }
+
+      if (mouseEvents.onMouseLeave) {
+        mouseEvents.onMouseLeave()
+      }
+    },
+  }
+}
+
 export const Popover: React.FC<PopoverProps> = ({
   children,
   closeDelay = POPOVER_CLOSE_DELAY,
@@ -63,7 +94,7 @@ export const Popover: React.FC<PopoverProps> = ({
   const PopoverTarget = () => {
     return React.Children.map(children, (item: React.ReactElement) =>
       React.cloneElement(item, {
-        ...mouseEvents,
+        ...getMouseEvents(isClick, item, mouseEvents),
       })
     )[0]
   }

--- a/packages/react-component-library/src/hooks/useHideShow.ts
+++ b/packages/react-component-library/src/hooks/useHideShow.ts
@@ -2,6 +2,18 @@ import { useCallback, useRef, useState } from 'react'
 
 import { useDocumentClick } from '.'
 
+export type HideShowMouseEvents =
+  | {
+      onClick?: never
+      onMouseEnter: () => void
+      onMouseLeave: () => void
+    }
+  | {
+      onClick: () => void
+      onMouseEnter?: never
+      onMouseLeave?: never
+    }
+
 export function useHideShow(
   isClick: boolean,
   closeDelay: number,


### PR DESCRIPTION
## Related issue
Fixes #3705 

## Overview
This change makes it so that existing callbacks are still called.

## Reason
Callbacks were being overridden.

## Work carried out
- [x] Fix `onMouseEnter` and `onMouseLeave` not respected
