### PR TITLE
fix(Popover): Prevent pending timer being cleared early

### DIFF
--- a/packages/react-component-library/src/components/Popover/Popover.test.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.test.tsx
@@ -6,7 +6,9 @@ import {
   render,
   RenderResult,
   waitFor,
+  screen,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { Popover } from '.'
 
@@ -270,6 +272,42 @@ describe('Popover', () => {
     it('appends `onMouseOver` and `onMouseLeave` callbacks', () => {
       expect(onMouseEnterSpy).toHaveBeenCalledTimes(1)
       expect(onMouseLeaveSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when the user moves the mouse between adjacent Popover targets quickly', () => {
+    it('does not clear the pending timer, leaving the Popover visible', async () => {
+      jest.useFakeTimers()
+
+      render(
+        <>
+          <Popover content={<>foo</>} aria-label="Popover 1">
+            <div>Popover 1</div>
+          </Popover>
+          <Popover content={<>bar</>} aria-label="Popover 2">
+            <div>Popover 2</div>
+          </Popover>
+          <Popover content={<>baz</>} aria-label="Popover 3">
+            <div>Popover 3</div>
+          </Popover>
+          <Popover content={<>qux</>} aria-label="Popover 4">
+            <div>Popover 4</div>
+          </Popover>
+        </>
+      )
+
+      userEvent.hover(screen.getByText('Popover 1'))
+      userEvent.hover(screen.getByText('Popover 2'))
+      userEvent.hover(screen.getByText('Popover 3'))
+      userEvent.hover(screen.getByText('Popover 4'))
+
+      jest.runAllTimers()
+
+      expect(screen.queryByText('foo')).not.toBeInTheDocument()
+      expect(screen.queryByText('bar')).not.toBeInTheDocument()
+      expect(screen.queryByText('baz')).not.toBeInTheDocument()
+
+      expect(await screen.findByText('qux')).toBeVisible()
     })
   })
 })

--- a/packages/react-component-library/src/hooks/useHideShow.ts
+++ b/packages/react-component-library/src/hooks/useHideShow.ts
@@ -24,15 +24,21 @@ export function useHideShow(
   const floatingBoxChildrenRef = useRef(null)
 
   const hideElement = useCallback(() => {
-    if (isVisible) {
-      timerRef.current = setTimeout(() => {
-        timerRef.current = null
-        setIsVisible(false)
-      }, closeDelay)
+    if (!isVisible) {
+      return
     }
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      setIsVisible(false)
+    }, closeDelay)
   }, [closeDelay, isVisible])
 
   function showElement() {
+    if (isVisible) {
+      return
+    }
+
     if (timerRef.current !== null) {
       clearTimeout(timerRef.current)
     }


### PR DESCRIPTION
## Overview

Prevent pending `hideElement` timer from being wrongly cleared.

## Reason

Invocation of `onMouseEnter` handler exposed by `useHideShow` hook in quick succession has the potential to wrongly clear a pending timer set by `hideElement`. This is particularly apparent when multiple Popover instances are used adjacent to one another with small target elements. The end result would be Popovers left open when they should have closed.

## Work carried out

- [x] Add automated test
- [x] Add logic to return early

## Developer notes

This has already been tested downstream in a consuming application.
