### PR TITLE
fix(Popover): Avoid timeout usage for a 0 closeDelay

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
@@ -319,9 +319,7 @@ describe('Masthead', () => {
         })
 
         it('should hide the searchbar from view', () => {
-          return waitFor(() =>
-            expect(wrapper.queryByTestId('searchbar')).toBeNull()
-          )
+          waitFor(() => expect(wrapper.queryByTestId('searchbar')).toBeNull())
         })
       })
 
@@ -337,9 +335,7 @@ describe('Masthead', () => {
         })
 
         it('should not show the search bar', () => {
-          return waitFor(() =>
-            expect(wrapper.queryByTestId('searchbar')).toBeNull()
-          )
+          waitFor(() => expect(wrapper.queryByTestId('searchbar')).toBeNull())
         })
 
         it('should remove the rule on the wrapper so mobile scrolling is enabled again', () => {
@@ -393,7 +389,7 @@ describe('Masthead', () => {
         })
 
         it('should remove the rule on the wrapper so mobile scrolling is enabled again', () => {
-          return waitFor(() =>
+          waitFor(() =>
             expect(wrapper.queryByTestId('masthead')).not.toHaveClass(
               'rn-masthead--show-notifications'
             )
@@ -452,7 +448,7 @@ describe('Masthead', () => {
       })
 
       it('should show the links', () => {
-        return waitFor(() => {
+        waitFor(() => {
           expect(wrapper.getByText('Profile')).toBeVisible()
           expect(wrapper.getByText('Settings')).toBeVisible()
           expect(wrapper.getByText('Support')).toBeVisible()
@@ -473,7 +469,7 @@ describe('Masthead', () => {
         })
 
         it('should not show the links', () => {
-          return waitFor(() => {
+          waitFor(() => {
             expect(wrapper.queryByText('Profile')).not.toBeVisible()
             expect(wrapper.queryByText('Settings')).not.toBeVisible()
             expect(wrapper.queryByText('Support')).not.toBeVisible()
@@ -494,11 +490,11 @@ describe('Masthead', () => {
         })
 
         it('should not show the links', () => {
-          return waitFor(() => {
-            expect(wrapper.queryByText('Profile')).toBeVisible()
-            expect(wrapper.queryByText('Settings')).toBeVisible()
-            expect(wrapper.queryByText('Support')).toBeVisible()
-            expect(wrapper.queryByText('Logout')).toBeVisible()
+          waitFor(() => {
+            expect(wrapper.queryByText('Profile')).not.toBeInTheDocument()
+            expect(wrapper.queryByText('Settings')).not.toBeInTheDocument()
+            expect(wrapper.queryByText('Support')).not.toBeInTheDocument()
+            expect(wrapper.queryByText('Logout')).not.toBeInTheDocument()
           })
         })
       })

--- a/packages/react-component-library/src/hooks/useHideShow.ts
+++ b/packages/react-component-library/src/hooks/useHideShow.ts
@@ -16,7 +16,7 @@ export type HideShowMouseEvents =
 
 export function useHideShow(
   isClick: boolean,
-  closeDelay: number,
+  closeDelay = 0,
   initialIsVisible = false
 ) {
   const [isVisible, setIsVisible] = useState(initialIsVisible)
@@ -28,9 +28,14 @@ export function useHideShow(
       return
     }
 
-    timerRef.current = setTimeout(() => {
-      timerRef.current = null
+    if (!closeDelay) {
       setIsVisible(false)
+      return
+    }
+
+    timerRef.current = setTimeout(() => {
+      setIsVisible(false)
+      timerRef.current = null
     }, closeDelay)
   }, [closeDelay, isVisible])
 

--- a/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
+++ b/packages/react-component-library/src/primitives/FloatingBox/FloatingBox.tsx
@@ -66,7 +66,7 @@ export const FloatingBox: React.FC<FloatingBoxProps> = ({
   role = 'dialog',
   ...rest
 }) => {
-  const nodeRef = useRef(null)
+  const nodeRef = useRef<HTMLDivElement>(null)
   const contentId = useExternalId('floating-box', externalContentId)
   const {
     targetElementRef,


### PR DESCRIPTION
## Overview

Avoid redundant `setTimeout` usage for a `closeDelay` of 0.

## Reason

This was causing issues downstream where a large number of Popovers were used with small target elements.

In some instances Popovers would persist and no longer close.

## Work carried out

- [x] Resolve bug 
- [x] Fix wrongly implemented Masthead automated test