### PR TITLE
feat(Alert): Allow arbitrary content in Alert

### DIFF
--- a/packages/react-component-library/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.stories.tsx
@@ -33,3 +33,25 @@ WithoutTitle.args = {
 }
 
 WithoutTitle.storyName = 'Without title'
+
+export const ArbitraryContent: StoryFn<typeof Alert> = ({
+  title,
+  children,
+  variant,
+}) => (
+  <Alert variant={variant} title={title}>
+    {children}
+  </Alert>
+)
+
+ArbitraryContent.args = {
+  title: 'Using arbitrary JSX as content',
+  children: (
+    <div>
+      <p>
+        Hello, <strong>world!</strong>
+      </p>
+    </div>
+  ),
+  variant: ALERT_VARIANT.INFO,
+}

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 
 import { render, RenderResult } from '@testing-library/react'
 
@@ -186,4 +187,23 @@ describe('Alert', () => {
       )
     })
   })
+
+  describe('Arbitrary Markup', () => {
+    let children: React.ReactElement
+
+      beforeEach(() => {
+      children = <div>Arbitrary JSX</div>
+
+      wrapper = render(<Alert>{children}</Alert>)
+    })
+
+
+    it('renders the arbitrary JSX in the correct place', () => {
+      expect(wrapper.getByTestId('content-description').innerHTML).toContain(
+        renderToStaticMarkup(children)
+      )
+    })
+
+  })
+
 })

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -37,7 +37,7 @@ export interface AlertProps {
   /**
    * Description text to display under the component title.
    */
-  children: string
+  children: React.ReactNode
   /**
    * Optional handler to be invoked when the component is closed.
    */

--- a/packages/react-component-library/src/components/Alert/partials/StyledDescription.tsx
+++ b/packages/react-component-library/src/components/Alert/partials/StyledDescription.tsx
@@ -5,7 +5,7 @@ import { ALERT_DESCRIPTION_COLOR } from '../constants'
 
 const { fontSize } = selectors
 
-export const StyledDescription = styled.p`
+export const StyledDescription = styled.div`
   color: ${ALERT_DESCRIPTION_COLOR};
   font-size: ${fontSize('base')};
   font-weight: 400;


### PR DESCRIPTION
## Related issue

#3734

## Overview

Changed `children` props of Alert component from string to `ReactNode` and changed container element from `<p>` to `<div>` 

## Reason
This allows Design System users to include arbitrary html in their alerts.

## Work carried out

- [x] Update props for Alert
- [x] Added unit tests
- [x] Added storybook example

## Screenshot

<img width="678" alt="image" src="https://github.com/Royal-Navy/design-system/assets/2064710/cd3f7e55-1fbe-4a75-a660-48102361ef78">

