### PR TITLE
fix(List): Allow arbitrary contents in List Item

### DIFF
--- a/packages/react-component-library/src/components/List/List.stories.tsx
+++ b/packages/react-component-library/src/components/List/List.stories.tsx
@@ -20,6 +20,9 @@ export const Default: StoryFn<typeof List> = (props) => (
     </ListItem>
     <ListItem title="List item 2">This is the description for item 2</ListItem>
     <ListItem title="List item 3">This is the description for item 3</ListItem>
-    <ListItem title="List item 4">This is the description for item 4</ListItem>
+    <ListItem title="List item 4">
+      This is the&nbsp;
+      <strong>description for item 4</strong>
+    </ListItem>
   </List>
 )

--- a/packages/react-component-library/src/components/List/List.test.tsx
+++ b/packages/react-component-library/src/components/List/List.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 
 import {
   fireEvent,
@@ -300,6 +301,32 @@ describe('List', () => {
       expect(wrapper.getAllByTestId('list-item')[0]).toHaveAttribute(
         'data-arbitrary',
         'arbitrary-list-item'
+      )
+    })
+  })
+
+  describe('Arbitrary Markup', () => {
+    let children: React.ReactElement
+
+    beforeEach(() => {
+      children = <div>Arbitrary JSX</div>
+
+      wrapper = render(
+        <List data-arbitrary="arbitrary-list">
+          <ListItem
+            data-arbitrary="arbitrary-list-item"
+            onClick={onClickSpy1}
+            title="List item"
+          >
+            {children}
+          </ListItem>
+        </List>
+      )
+    })
+
+    it('renders the arbitrary JSX in the correct place', () => {
+      expect(wrapper.getAllByTestId('list-item')[0].innerHTML).toContain(
+        renderToStaticMarkup(children)
       )
     })
   })

--- a/packages/react-component-library/src/components/List/ListItem.tsx
+++ b/packages/react-component-library/src/components/List/ListItem.tsx
@@ -11,9 +11,9 @@ import { useExternalId } from '../../hooks/useExternalId'
 
 export interface ListItemProps extends ComponentWithClass {
   /**
-   * Description text to display for an individual item.
+   * Description to display for an individual item.
    */
-  children: string | string[]
+  children: React.ReactNode
   /**
    * Toggles whether the item is in an active state.
    */

--- a/packages/react-component-library/src/components/List/partials/StyledItemDescription.tsx
+++ b/packages/react-component-library/src/components/List/partials/StyledItemDescription.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 const { color, fontSize } = selectors
 
-export const StyledItemDescription = styled.p`
+export const StyledItemDescription = styled.div`
   color: ${color('neutral', '400')};
   font-size: ${fontSize('base')};
   font-weight: 400;


### PR DESCRIPTION
## Related issue

#3682

## Overview

Change to `ListItem` props to allow arbitrary contents.

## Reason

Taken from the Issue
> Accoring to the [ListItem documentation](https://storybook.design-system.digital.mod.uk/?path=/docs/list--default) a ListItem should accept (string | string[]) & ReactNode as children. However, in the [Type definition](https://github.com/defencedigital/mod-uk-design-system/blob/9eb0eb2597b4cbcba88d0e1c2a158ec0e3a9c3ba/packages/react-component-library/src/components/List/ListItem.tsx) only string | string[] are allowed, dramatically reducing the customisation possible in a ListItem

## Work carried out
- [x] Change `ListItem` props to accept `ReactNode`
- [x] Unit tests
- [x] Update to storybook 

## Screenshot
<img width="950" alt="image" src="https://github.com/Royal-Navy/design-system/assets/2064710/1f459c11-f9d7-487a-a4ad-dc78b95e7ce5">

