### PR TITLE
fix(PhaseBanner): Wrap text to the right of the phase badge

### DIFF
--- a/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.stories.tsx
+++ b/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { StoryFn, Meta } from '@storybook/react'
+import styled from 'styled-components'
 
 import { PhaseBanner } from '.'
 
@@ -39,3 +40,15 @@ export const FullWidth: StoryFn<typeof PhaseBanner> = () => (
 )
 
 FullWidth.storyName = 'Full width'
+
+const StyledNarrowContainer = styled.div`
+  padding-top: 1rem;
+  max-width: 360px;
+  margin: 0 auto;
+`
+
+export const NarrowScreen: StoryFn<typeof PhaseBanner> = () => (
+  <StyledNarrowContainer>
+    <PhaseBanner />
+  </StyledNarrowContainer>
+)

--- a/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.test.tsx
+++ b/packages/react-component-library/src/components/PhaseBanner/PhaseBanner.test.tsx
@@ -9,6 +9,22 @@ describe('PhaseBanner', () => {
   let wrapper: RenderResult
   let content: React.ReactElement
 
+  describe('default content', () => {
+    beforeEach(() => {
+      wrapper = render(<PhaseBanner />)
+    })
+
+    it('should use default feedback link', () => {
+      expect(
+        wrapper.getByRole('link', { name: 'Your feedback' })
+      ).toHaveAttribute('href', '/feedback')
+    })
+
+    it('should default to alpha phase', () => {
+      expect(wrapper.getByTestId('badge')).toHaveTextContent('alpha')
+    })
+  })
+
   describe('with custom content', () => {
     beforeEach(() => {
       content = (

--- a/packages/react-component-library/src/components/PhaseBanner/partials/StyledBadge.tsx
+++ b/packages/react-component-library/src/components/PhaseBanner/partials/StyledBadge.tsx
@@ -5,4 +5,5 @@ import { Badge } from '../../Badge'
 export const StyledBadge = styled(Badge)`
   margin: 0;
   text-transform: capitalize;
+  align-self: start;
 `

--- a/packages/react-component-library/src/components/PhaseBanner/partials/StyledText.tsx
+++ b/packages/react-component-library/src/components/PhaseBanner/partials/StyledText.tsx
@@ -4,9 +4,7 @@ import { selectors } from '@royalnavy/design-tokens'
 const { fontSize, spacing, color, animation } = selectors
 
 export const StyledText = styled.span`
-  display: inline-block;
   font-size: ${fontSize('base')};
-  vertical-align: middle;
   font-weight: 500;
   margin-left: ${spacing('4')};
   color: ${color('neutral', '400')};

--- a/packages/react-component-library/src/components/PhaseBanner/partials/StyledWrapper.tsx
+++ b/packages/react-component-library/src/components/PhaseBanner/partials/StyledWrapper.tsx
@@ -10,6 +10,8 @@ interface StyledWrapperProps {
 }
 
 export const StyledWrapper = styled.div<StyledWrapperProps>`
+  display: flex;
+  align-items: center;
   ${({ $isFullWidth }) =>
     !$isFullWidth &&
     css`


### PR DESCRIPTION
## Related issue

Closes #3733 

## Overview

Wrap the banner text away from the badge

## Reason
Better design treatment and consistency with GDS

## Work carried out

- [x] Add CSS to handle the wrapping
- [x] Add new story with narrow example 
- [x] Add unit tests

## Screenshot
<img width="410" alt="image" src="https://github.com/Royal-Navy/design-system/assets/2064710/659bce41-6678-4e1e-9fba-22244ad5119c">


