### PR TITLE
fix(Checkbox): Adjust styling for no label variant

### DIFF
--- a/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { StoryFn, Meta } from '@storybook/react'
 
-import { Checkbox, CheckboxProps } from '.'
+import { Checkbox, IndeterminateCheckbox, CheckboxProps } from '.'
 import { CHECKBOX_RADIO_VARIANT } from '../CheckboxRadioBase'
 
 export default {
@@ -95,6 +95,25 @@ NoContainerDisabled.args = {
   label: 'Item without container',
   name: 'no-container',
   isDisabled: true,
+}
+
+export const NoLabel = Template.bind({})
+NoLabel.storyName = 'No label'
+NoLabel.args = {
+  id: undefined,
+  name: 'no-label',
+  // @ts-expect-error
+  'aria-label': 'No label',
+}
+
+export const Indeterminate: StoryFn<typeof IndeterminateCheckbox> = (props) => {
+  return <IndeterminateCheckbox {...props} />
+}
+Indeterminate.args = {
+  id: undefined,
+  name: 'indeterminate',
+  indeterminate: true,
+  'aria-label': 'Indeterminate',
 }
 
 export const WithDescription = Template.bind({})

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.tsx
@@ -6,12 +6,7 @@ import { StyledCheckbox } from './partials/StyledCheckbox'
 import { StyledCheckmark } from './partials/StyledCheckmark'
 import { StyledCheckmarkWrapper } from './partials/StyledCheckmarkWrapper'
 
-export type CheckboxProps = Omit<
-  CheckboxRadioBaseProps,
-  'type' | 'partials'
-> & {
-  indeterminate?: boolean
-}
+export type CheckboxProps = Omit<CheckboxRadioBaseProps, 'type' | 'partials'>
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   (props, ref) => {

--- a/packages/react-component-library/src/components/Checkbox/IndeterminateCheckbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/IndeterminateCheckbox.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, HTMLProps } from 'react'
 
-import { Checkbox } from '../Checkbox'
+import { Checkbox } from '.'
 import { CHECKBOX_RADIO_VARIANT } from '../CheckboxRadioBase'
 
 export const IndeterminateCheckbox = ({

--- a/packages/react-component-library/src/components/Checkbox/index.ts
+++ b/packages/react-component-library/src/components/Checkbox/index.ts
@@ -1,1 +1,2 @@
 export * from './Checkbox'
+export * from './IndeterminateCheckbox'

--- a/packages/react-component-library/src/components/Checkbox/partials/StyledCheckbox.tsx
+++ b/packages/react-component-library/src/components/Checkbox/partials/StyledCheckbox.tsx
@@ -47,6 +47,14 @@ export const StyledCheckbox = styled.div<CheckboxRootProps>`
       }
     `}
 
+  ${({ $hasLabel }) =>
+    !$hasLabel &&
+    css`
+      height: 20px;
+      width: 20px;
+      padding: unset;
+    `}
+
   ${({ $isDisabled, $hasContainer }) =>
     $isDisabled &&
     css`

--- a/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmarkWrapper.tsx
+++ b/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmarkWrapper.tsx
@@ -6,9 +6,19 @@ const CHECKMARK_HEIGHT = '18px'
 
 export const StyledCheckmarkWrapper = styled.span<CheckmarkWrapperProps>`
   display: block;
-  position: absolute;
-  top: calc((100% - ${CHECKMARK_HEIGHT}) / 2);
-  left: ${({ $hasContainer }) => ($hasContainer ? '12px' : '4px')};
   height: ${CHECKMARK_HEIGHT};
   width: 18px;
+  position: absolute;
+  top: calc((100% - ${CHECKMARK_HEIGHT}) / 2);
+  left: ${({ $hasContainer, $hasLabel }) => {
+    if ($hasContainer) {
+      return '12px'
+    }
+
+    if ($hasLabel) {
+      return '4px'
+    }
+
+    return '0px'
+  }};
 `

--- a/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBase.tsx
@@ -102,7 +102,8 @@ export const CheckboxRadioBase = React.forwardRef<
         <Root
           className={className}
           $isDisabled={isDisabled}
-          $hasContainer={hasContainer}
+          $hasContainer={hasContainer && !!label}
+          $hasLabel={!!label}
           $isInvalid={isInvalid}
           $isChecked={isChecked}
           onClick={handleClick}
@@ -111,13 +112,17 @@ export const CheckboxRadioBase = React.forwardRef<
         >
           <StyledInnerWrapper $hasContainer={hasContainer}>
             <StyledLabel
-              $hasContainer={hasContainer}
+              $hasContainer={hasContainer && !!label}
+              $hasLabel={!!label}
               $hasDescription={!!description}
               $isDisabled={isDisabled}
               htmlFor={id}
               data-testid={`${type}-label`}
             >
-              <CheckmarkWrapper $hasContainer={hasContainer}>
+              <CheckmarkWrapper
+                $hasContainer={hasContainer && !!label}
+                $hasLabel={!!label}
+              >
                 <StyledInput
                   defaultChecked={defaultChecked}
                   ref={mergeRefs([localRef, ref])}
@@ -133,7 +138,7 @@ export const CheckboxRadioBase = React.forwardRef<
                   {...rest}
                 />
                 <Checkmark
-                  $hasContainer={hasContainer}
+                  $hasContainer={hasContainer && !!label}
                   $isDisabled={isDisabled}
                 />
               </CheckmarkWrapper>

--- a/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBaseProps.ts
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/CheckboxRadioBaseProps.ts
@@ -6,6 +6,7 @@ import { CheckboxRadioVariantType } from './types'
 
 export interface CheckboxRootProps extends React.HTMLAttributes<HTMLElement> {
   $hasContainer?: boolean
+  $hasLabel?: boolean
   $isDisabled?: boolean
   $isInvalid?: boolean
   $isChecked?: boolean
@@ -18,7 +19,8 @@ export interface CheckmarkProps {
 }
 
 export interface CheckmarkWrapperProps {
-  $hasContainer: boolean
+  $hasContainer?: boolean
+  $hasLabel?: boolean
   children: ReactNode
 }
 

--- a/packages/react-component-library/src/components/CheckboxRadioBase/partials/StyledLabel.tsx
+++ b/packages/react-component-library/src/components/CheckboxRadioBase/partials/StyledLabel.tsx
@@ -5,6 +5,7 @@ const { color, fontSize } = selectors
 
 interface StyledLabelProps {
   $hasContainer?: boolean
+  $hasLabel?: boolean
   $hasDescription?: boolean
   $isDisabled: boolean
 }
@@ -26,5 +27,11 @@ export const StyledLabel = styled.label<StyledLabelProps>`
     $hasDescription &&
     css`
       padding: 12px 12px 12px 0;
+    `}
+
+  ${({ $hasLabel }) =>
+    !$hasLabel &&
+    css`
+      padding: unset;
     `}
 `

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.tsx
@@ -23,7 +23,7 @@ import {
   IconSortUnsorted,
 } from '@royalnavy/icon-library'
 
-import { IndeterminateCheckbox } from './IndeterminateCheckbox'
+import { IndeterminateCheckbox } from '../Checkbox/IndeterminateCheckbox'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { TABLE_SORT_ORDER } from './constants'
 import {

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledCell.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledCell.tsx
@@ -9,7 +9,7 @@ interface StyledCellProps {
 const { spacing, fontSize, color } = selectors
 
 export const StyledCell = styled.td<StyledCellProps>`
-  padding: ${spacing('4')} ${spacing('4')};
+  padding: ${spacing('4')} ${spacing('4')} ${spacing('4')} ${spacing('8')};
   width: ${({ $width }) => $width || 'auto'};
   font-size: ${fontSize('s')};
   color: ${color('neutral', '500')};

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledCol.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledCol.tsx
@@ -10,7 +10,7 @@ interface StyledColProps {
 }
 
 export const StyledCol = styled.th<StyledColProps>`
-  padding: ${spacing('8')} ${spacing('4')};
+  padding: ${spacing('8')} ${spacing('4')} ${spacing('8')} ${spacing('8')};
   width: ${({ $width }) => $width || 'auto'};
   text-align: left;
   font-size: ${fontSize('s')};

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledTable.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledTable.tsx
@@ -17,7 +17,11 @@ export const StyledTable = styled.table<StyledTableProps>`
     $hasRowSelection &&
     `
     th:first-child, td:first-child {
-      width: calc(24px + ${spacing('6')}) !important;
+      width: calc(22px + ${spacing('6')}) !important;
+
+      > * {
+        margin-top: -2px;
+      }
     }
   `}
 `


### PR DESCRIPTION
## Related issue

Closes #3759

## Overview

Fix styling when used in label free variant.

## Reason

Styling was broken Checkbox was used without a label.

## Work carried out

- [x] Fix styling when used without a label
- [x] Expose IndeterminateCheckbox
- [x] Add some additional Checkbox related stories

## Screenshot

![2024-04-30 13 10 31](https://github.com/Royal-Navy/design-system/assets/48086589/6d26eab3-706c-4a35-9366-af30a0cdfd72)
![Screenshot 2024-04-30 at 13 09 51](https://github.com/Royal-Navy/design-system/assets/48086589/7d11dd29-7c90-4902-bdbe-a046de3e8b55)

## Developer notes

We need to enable a label free variant of radio also.
