### PR TITLE
fix(Components): Update typings path

### DIFF
--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -16,7 +16,7 @@
   ],
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/src/index.d.ts",
   "sideEffects": false,
   "author": "Royal Navy",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Overview

We added some storybook hooks which caused the typescript compiler to restructure output paths.
This broke downstream user typings

## Work carried out

- [x] Update the path

## Developer notes

This is a quick fix. We should really move the hooks out of the storybook folder
