### PR TITLE
build(Pnpm): Release workflow changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         run: git fetch --all --tags
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
         # pulls all tags (needed for lerna / semantic release to correctly version)
         run: git fetch --all --tags
 
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9.1.1
+          run_install: false
+          standalone: true
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "lerna:version": "pnpm run lerna:run-version --conventional-graduate --create-release github -m \"chore(Release): %v\"",
     "lerna:run-version": "lerna version --force-publish=* --tag-version-prefix=''",
     "audit": "./scripts/audit/audit.sh",
-    "prepare": "husky install"
+    "prepack": "husky install"
   }
 }

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -22,7 +22,7 @@
     "build:dict": "node ./build-dictionary.js",
     "build:cjs": "webpack --config=webpack/prod.js",
     "types": "tsc --emitDeclarationOnly --declarationMap --declaration --noEmit false --allowJs false --outDir dist/types",
-    "prepare": "pnpm run build",
+    "prepack": "pnpm run build",
     "test": "jest",
     "lint": "eslint src --ext .js --ext .jsx --ext .ts --ext .tsx --ext .json --max-warnings 0 --resolve-plugins-relative-to ../eslint-config-react"
   },

--- a/packages/icon-library/package.json
+++ b/packages/icon-library/package.json
@@ -26,7 +26,7 @@
     "svgr-silhouettes": "rm -rf src/silhouettes; svgr -d src/silhouettes -- src/assets/silhouettes/; rm src/silhouettes/index.ts",
     "exports": "./generate-exports.sh",
     "types": "tsc --emitDeclarationOnly --declarationMap --declaration --noEmit false --allowJs false --outDir dist/types",
-    "prepare": "pnpm run build"
+    "prepack": "pnpm run build"
   },
   "lint-staged": {
     "*.@(js|jsx|ts|tsx)": "prettier --write"

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -33,7 +33,7 @@
     "build:cjs:dev": "BABEL_ENV=cjs RNDS_LOG_LEVEL=debug webpack --config=webpack/dev.js",
     "chromatic": "chromatic --build-script-name storybook:static",
     "lint": "eslint src e2e --ext .js --ext .jsx --ext .ts --ext .tsx --max-warnings 0 --resolve-plugins-relative-to ../eslint-config-react --ignore-pattern \"*.d.ts\"",
-    "prepare": "pnpm run build",
+    "prepack": "pnpm run build",
     "storybook": "BABEL_ENV=es RNDS_LOG_LEVEL=debug storybook dev -p 6006",
     "storybook:static": "BABEL_ENV=es storybook build -c .storybook -o .static_storybook --webpack-stats-json",
     "storybook:static:test": "BABEL_ENV=storybook-test storybook build -c .storybook -o .static_storybook --test",


### PR DESCRIPTION
## Overview

- Change to prepack to prevent a prod build automatically running upon install.

>Choose prepare if you need the script to run in more scenarios, including local installs. Choose prepack if you only need the script to run before packing and publishing.

- Add missing pnpm setup step in release workflow

- Update setup-node action to latest