### PR TITLE
fix(Lerna): Resolve Pnpm and Lerna version issue 

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+link-workspace-packages=true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^8.0.1",
-    "lerna": "^8.1.2",
+    "lerna": "^8.1.3",
     "lint-staged": "^13.2.2",
     "prettier": "^2.0.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^8.0.1
         version: 8.0.3
       lerna:
-        specifier: ^8.1.2
-        version: 8.1.2(@swc/core@1.4.13)(encoding@0.1.13)
+        specifier: ^8.1.3
+        version: 8.1.3(@swc/core@1.4.13)(encoding@0.1.13)
       lint-staged:
         specifier: ^13.2.2
         version: 13.3.0(enquirer@2.3.6)
@@ -149,7 +149,7 @@ importers:
         version: 2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)
       eslint-plugin-jest:
         specifier: ^28.2.0
-        version: 28.2.0(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.8.0(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.12.12)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 28.2.0(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.8.0(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(jest@29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)))(typescript@5.4.5)
       eslint-plugin-jsx-a11y:
         specifier: ^6.8.0
         version: 6.8.0(eslint@9.0.0)
@@ -197,7 +197,7 @@ importers:
         version: 7.24.1(@babel/core@7.24.4)
       '@royalnavy/eslint-config-react':
         specifier: ^4.7.1
-        version: 4.7.1(@types/eslint@8.56.7)(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.12.12)(typescript@5.4.5)))(prettier@3.2.5)(typescript@5.4.5)
+        version: 4.7.1(@types/eslint@8.56.7)(eslint@9.0.0)(jest@29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)))(prettier@3.2.5)(typescript@5.4.5)
       '@svgr/cli':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.4.5)
@@ -1764,8 +1764,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@lerna/create@8.1.2':
-    resolution: {integrity: sha512-GzScCIkAW3tg3+Yn/MKCH9963bzG+zpjGz2NdfYDlYWI7p0f/SH46v1dqpPpYmZ2E/m3JK8HjTNNNL8eIm8/YQ==}
+  '@lerna/create@8.1.3':
+    resolution: {integrity: sha512-JFvIYrlvR8Txa8h7VZx8VIQDltukEKOKaZL/muGO7Q/5aE2vjOKHsD/jkWYe/2uFy1xv37ubdx17O1UXQNadPg==}
     engines: {node: '>=18.0.0'}
 
   '@mdx-js/react@3.0.1':
@@ -6093,8 +6093,8 @@ packages:
     resolution: {integrity: sha512-aXpZJRnTkpK6gQ/z4nk+ZBLd/Qdp118cvPruLSIQzQNRhKwEcdXCOzXuF55VDqIiuAaY3UGZ10DJtvZzDcvsxg==}
     engines: {node: '>=14.0.0'}
 
-  lerna@8.1.2:
-    resolution: {integrity: sha512-RCyBAn3XsqqvHbz3TxLfD7ylqzCi1A2UJnFEZmhURgx589vM3qYWQa/uOMeEEf565q6cAdtmulITciX1wgkAtw==}
+  lerna@8.1.3:
+    resolution: {integrity: sha512-Dg/r1dGnRCXKsOUC3lol7o6ggYTA6WWiPQzZJNKqyygn4fzYGuA3Dro2d5677pajaqFnFA72mdCjzSyF16Vi2Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -8003,10 +8003,6 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
-
-  tar@6.1.11:
-    resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
-    engines: {node: '>= 10'}
 
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
@@ -10013,6 +10009,42 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.12.12
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.5
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   '@jest/create-cache-key-function@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
@@ -10162,7 +10194,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@lerna/create@8.1.2(@swc/core@1.4.13)(encoding@0.1.13)(typescript@5.4.5)':
+  '@lerna/create@8.1.3(@swc/core@1.4.13)(encoding@0.1.13)(typescript@5.4.5)':
     dependencies:
       '@npmcli/run-script': 7.0.2
       '@nx/devkit': 18.3.4(nx@18.3.4(@swc/core@1.4.13))
@@ -10218,7 +10250,7 @@ snapshots:
       slash: 3.0.0
       ssri: 9.0.1
       strong-log-transformer: 2.1.0
-      tar: 6.1.11
+      tar: 6.2.1
       temp-dir: 1.0.0
       upath: 2.0.1
       uuid: 9.0.1
@@ -10554,7 +10586,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@royalnavy/eslint-config-react@4.7.1(@types/eslint@8.56.7)(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.12.12)(typescript@5.4.5)))(prettier@3.2.5)(typescript@5.4.5)':
+  '@royalnavy/eslint-config-react@4.7.1(@types/eslint@8.56.7)(eslint@9.0.0)(jest@29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)))(prettier@3.2.5)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.8.0(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(typescript@5.4.5)
       '@typescript-eslint/parser': 7.8.0(eslint@9.0.0)(typescript@5.4.5)
@@ -10562,7 +10594,7 @@ snapshots:
       eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0))(eslint-plugin-jsx-a11y@6.8.0(eslint@9.0.0))(eslint-plugin-react-hooks@4.6.0(eslint@9.0.0))(eslint-plugin-react@7.34.1(eslint@9.0.0))(eslint@9.0.0)
       eslint-config-prettier: 9.1.0(eslint@9.0.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)
-      eslint-plugin-jest: 28.2.0(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.8.0(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.12.12)(typescript@5.4.5)))(typescript@5.4.5)
+      eslint-plugin-jest: 28.2.0(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.8.0(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(jest@29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)))(typescript@5.4.5)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@9.0.0)
       eslint-plugin-prettier: 5.1.3(@types/eslint@8.56.7)(eslint-config-prettier@9.1.0(eslint@9.0.0))(eslint@9.0.0)(prettier@3.2.5)
       eslint-plugin-react: 7.34.1(eslint@9.0.0)
@@ -13636,6 +13668,22 @@ snapshots:
       - supports-color
       - ts-node
 
+  create-jest@29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   create-require@1.1.1: {}
 
   cross-spawn@6.0.5:
@@ -14397,13 +14445,13 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@28.2.0(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.8.0(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.12.12)(typescript@5.4.5)))(typescript@5.4.5):
+  eslint-plugin-jest@28.2.0(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.8.0(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(jest@29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       '@typescript-eslint/utils': 6.21.0(eslint@9.0.0)(typescript@5.4.5)
       eslint: 9.0.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.8.0(eslint@9.0.0)(typescript@5.4.5))(eslint@9.0.0)(typescript@5.4.5)
-      jest: 29.7.0(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.12.12)(typescript@5.4.5))
+      jest: 29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -15933,6 +15981,26 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5))
+      exit: 0.1.2
+      import-local: 3.1.0
+      jest-config: 29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   jest-config@29.7.0(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.12.12)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.24.4
@@ -15963,6 +16031,70 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+
+  jest-config@29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)):
+    dependencies:
+      '@babel/core': 7.24.4
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.24.4)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.12.12
+      ts-node: 10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    optional: true
+
+  jest-config@29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)):
+    dependencies:
+      '@babel/core': 7.24.4
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.24.4)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.5.1
+      ts-node: 10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    optional: true
 
   jest-diff@29.7.0:
     dependencies:
@@ -16282,6 +16414,19 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest@29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5))
+      '@jest/types': 29.6.3
+      import-local: 3.1.0
+      jest-cli: 29.7.0(@types/node@20.5.1)(ts-node@10.9.2(@swc/core@1.4.13)(@types/node@20.5.1)(typescript@5.4.5))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   joi@17.12.3:
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -16435,9 +16580,9 @@ snapshots:
       dotenv: 16.4.5
       dotenv-expand: 10.0.0
 
-  lerna@8.1.2(@swc/core@1.4.13)(encoding@0.1.13):
+  lerna@8.1.3(@swc/core@1.4.13)(encoding@0.1.13):
     dependencies:
-      '@lerna/create': 8.1.2(@swc/core@1.4.13)(encoding@0.1.13)(typescript@5.4.5)
+      '@lerna/create': 8.1.3(@swc/core@1.4.13)(encoding@0.1.13)(typescript@5.4.5)
       '@npmcli/run-script': 7.0.2
       '@nx/devkit': 18.3.4(nx@18.3.4(@swc/core@1.4.13))
       '@octokit/plugin-enterprise-rest': 6.0.1
@@ -16500,7 +16645,7 @@ snapshots:
       slash: 3.0.0
       ssri: 9.0.1
       strong-log-transformer: 2.1.0
-      tar: 6.1.11
+      tar: 6.2.1
       temp-dir: 1.0.0
       typescript: 5.4.5
       upath: 2.0.1
@@ -18690,15 +18835,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-
-  tar@6.1.11:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 3.3.6
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
 
   tar@6.2.1:
     dependencies:


### PR DESCRIPTION
## Overview

Resolve broken release workflow.

Pnpm was not respecting local versions of monorepo packages and flagging that the incremented version did not exist (because it hadn't yet been published):

https://github.com/Royal-Navy/design-system/actions/runs/9094408002/job/24995417211

![Screenshot 2024-05-15 at 12 47 45](https://github.com/Royal-Navy/design-system/assets/48086589/cd5d1bf5-d6f8-44a1-b01e-56888fe79392)

https://pnpm.io/npmrc#link-workspace-packages

>If this is enabled, locally available packages are linked to node_modules instead of being downloaded from the registry. This is very convenient in a monorepo. If you need local packages to also be linked to subdependencies, you can use the deep setting.