### PR TITLE
docs(Button): Add single page documenting all button variants

### DIFF
--- a/packages/react-component-library/src/components/Button/LoadingButtons.tsx
+++ b/packages/react-component-library/src/components/Button/LoadingButtons.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react'
+
+import { Button } from './Button'
+import { BUTTON_VARIANT } from './constants'
+import { COMPONENT_SIZE, ComponentSizeType } from '../Forms'
+
+const allVariants = [
+  BUTTON_VARIANT.PRIMARY,
+  BUTTON_VARIANT.SECONDARY,
+  BUTTON_VARIANT.TERTIARY,
+  BUTTON_VARIANT.DANGER,
+]
+
+export const LoadingButtons = ({
+  size = COMPONENT_SIZE.FORMS,
+}: {
+  size: ComponentSizeType
+}) => {
+  const [isLoading, setIsLoading] = useState(allVariants)
+
+  useEffect(() => {
+    const handleInterval = () => {
+      if (!isLoading.length) {
+        setIsLoading(allVariants)
+        return
+      }
+
+      setIsLoading((current) => {
+        return current.slice(1)
+      })
+    }
+
+    const interval = window.setInterval(handleInterval, 1000)
+
+    return () => window.clearInterval(interval)
+  }, [isLoading])
+
+  return (
+    <>
+      <Button
+        size={size}
+        isLoading={isLoading.some((_) => _ === BUTTON_VARIANT.PRIMARY)}
+        title="Primary loading"
+      >
+        Primary
+      </Button>
+      &nbsp;
+      <Button
+        size={size}
+        isLoading={isLoading.some((_) => _ === BUTTON_VARIANT.SECONDARY)}
+        variant={BUTTON_VARIANT.SECONDARY}
+      >
+        Secondary
+      </Button>
+      &nbsp;
+      <Button
+        size={size}
+        isLoading={isLoading.some((_) => _ === BUTTON_VARIANT.TERTIARY)}
+        variant={BUTTON_VARIANT.TERTIARY}
+      >
+        Tertiary
+      </Button>
+      &nbsp;
+      <Button
+        size={size}
+        isLoading={isLoading.some((_) => _ === BUTTON_VARIANT.DANGER)}
+        variant={BUTTON_VARIANT.DANGER}
+      >
+        Danger
+      </Button>
+    </>
+  )
+}

--- a/packages/react-component-library/src/components/Button/Variants.mdx
+++ b/packages/react-component-library/src/components/Button/Variants.mdx
@@ -1,0 +1,122 @@
+import { Meta } from '@storybook/blocks'
+import { IconSettings, } from '@royalnavy/icon-library'
+
+import { COMPONENT_SIZE } from '../Forms'
+import { Button, BUTTON_ICON_POSITION, BUTTON_VARIANT } from '.'
+import { LoadingButtons } from './LoadingButtons'
+
+<Meta title="Components/Button/Variants" />
+
+# Button Components
+
+> Use standard size buttons by default
+
+### Defaults
+<Button>Primary</Button>
+<Button variant={BUTTON_VARIANT.SECONDARY}>Secondary</Button>
+<Button variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+---
+<Button isDisabled>Primary</Button>
+<Button isDisabled variant={BUTTON_VARIANT.SECONDARY}>Secondary</Button>
+<Button isDisabled variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button isDisabled variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+
+### With icons left
+<Button iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />}>Primary</Button>
+<Button iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />}>Secondary</Button>
+<Button iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+---
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />}>Primary</Button>
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />}>Secondary</Button>
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+### With icons right
+<Button iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />}>Primary</Button>
+<Button iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />}>Secondary</Button>
+<Button iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+---
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />}>Primary</Button>
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />}>Secondary</Button>
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+### Icons only
+<Button iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} />
+<Button iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />} />
+<Button iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY} />
+<Button iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER} />
+
+---
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} />
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />} />
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY} />
+<Button isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER} />
+
+### Loading
+<LoadingButtons />
+
+---
+
+## Small
+> Smaller sized buttons should be used sparingly
+
+
+### Defaults
+<Button size={COMPONENT_SIZE.SMALL}>Small primary</Button>
+<Button size={COMPONENT_SIZE.SMALL} variant={BUTTON_VARIANT.SECONDARY}>Secondary</Button>
+<Button size={COMPONENT_SIZE.SMALL} variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button size={COMPONENT_SIZE.SMALL} variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+---
+<Button isDisabled size={COMPONENT_SIZE.SMALL}>Small primary</Button>
+<Button isDisabled size={COMPONENT_SIZE.SMALL} variant={BUTTON_VARIANT.SECONDARY}>Secondary</Button>
+<Button isDisabled size={COMPONENT_SIZE.SMALL} variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button isDisabled size={COMPONENT_SIZE.SMALL} variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+
+### With icons left
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />}>Primary</Button>
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />}>Secondary</Button>
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+---
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />}>Primary</Button>
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />}>Secondary</Button>
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+### With icons right
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />}>Primary</Button>
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />}>Secondary</Button>
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+---
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />}>Primary</Button>
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />}>Secondary</Button>
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY}>Tertiary</Button>
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.RIGHT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER}>Danger</Button>
+
+### Icons only
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} />
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />} />
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY} />
+<Button size={COMPONENT_SIZE.SMALL} iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER} />
+
+---
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} />
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.SECONDARY} icon={<IconSettings />} />
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.TERTIARY} />
+<Button size={COMPONENT_SIZE.SMALL} isDisabled iconPosition={BUTTON_ICON_POSITION.LEFT} icon={<IconSettings />} variant={BUTTON_VARIANT.DANGER} />
+
+### Loading
+<LoadingButtons size={COMPONENT_SIZE.SMALL} />

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.projectName=Design System
 # Path to sources
 sonar.sources=packages/react-component-library/src
 sonar.exclusions=**/*.test.ts,**/*.test.tsx*,**/*.stories.tsx*
-sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx*,**/*.stories.tsx*,packages/react-component-library/src/forms/**/*,packages/react-component-library/src/intro/**/*,packages/react-component-library/src/tokens/**/*
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx*,**/*.stories.tsx*,packages/react-component-library/src/forms/**/*,packages/react-component-library/src/intro/**/*,packages/react-component-library/src/tokens/**/*,packages/react-component-library/src/components/Button/LoadingButtons.tsx
 
 # Path to tests
 sonar.javascript.lcov.reportPaths=packages/react-component-library/coverage/lcov.info


### PR DESCRIPTION
## Overview

Add a single mdx page with all variants of buttons in place. It makes it easier to compare future changes to button styling

## Work carried out

**Example.**

- [x] New layout page for buttons 
- [x] Custom loading component

## Screenshot
<img width="522" alt="image" src="https://github.com/Royal-Navy/design-system/assets/2064710/ce50213b-b323-4883-bafa-255eaa55424c">


