### PR TITLE
fix(SearchBar): Fixed searchbar obscuring text

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/partials/StyledSearchBar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/partials/StyledSearchBar.tsx
@@ -6,9 +6,9 @@ interface StyledSearchBarProps {
 }
 
 export const StyledSearchBar = styled.div<StyledSearchBarProps>`
-  z-index: ${zIndex('dropdown', 1)};
+  z-index: ${zIndex('masthead', 1)};
   display: block;
   margin-top: -1px;
-  position: relative;
+  position: absolute;
   width: ${({ $width }) => $width};
 `

--- a/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/partials/StyledSearchBar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/SearchBar/partials/StyledSearchBar.tsx
@@ -9,6 +9,6 @@ export const StyledSearchBar = styled.div<StyledSearchBarProps>`
   z-index: ${zIndex('dropdown', 1)};
   display: block;
   margin-top: -1px;
-  position: absolute;
+  position: relative;
   width: ${({ $width }) => $width};
 `

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
@@ -23,6 +23,7 @@ import {
 import { Link } from '../../Link'
 import { Notification, Notifications } from '../NotificationPanel'
 import { ClassificationBar } from '../../ClassificationBar'
+import { Masthead } from '../Masthead'
 
 const disableColorContrastRule = {
   a11y: {
@@ -303,3 +304,26 @@ WithClassificationBar.args = {
   classificationBar: <ClassificationBar />,
 }
 WithClassificationBar.storyName = 'Classification bar'
+
+export const WithMastheadAndSidebar: StoryFn<typeof Sidebar> = (props) => {
+  const handleSearch = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+  }
+
+  return (
+    <>
+      <Masthead
+        homeLink={<Link href="#">Home</Link>}
+        title="Application Name"
+        onSearch={handleSearch}
+      />
+      <SidebarWrapper>
+        <StyledSidebar {...props}>
+          <SimpleSidebarNav />
+        </StyledSidebar>
+        <StyledMain>Hello, World!</StyledMain>
+      </SidebarWrapper>
+    </>
+  )
+}
+WithMastheadAndSidebar.storyName = 'Masthead and Sidebar'

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
@@ -304,26 +304,3 @@ WithClassificationBar.args = {
   classificationBar: <ClassificationBar />,
 }
 WithClassificationBar.storyName = 'Classification bar'
-
-export const WithMastheadAndSidebar: StoryFn<typeof Sidebar> = (props) => {
-  const handleSearch = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-  }
-
-  return (
-    <>
-      <Masthead
-        homeLink={<Link href="#">Home</Link>}
-        title="Application Name"
-        onSearch={handleSearch}
-      />
-      <SidebarWrapper>
-        <StyledSidebar {...props}>
-          <SimpleSidebarNav />
-        </StyledSidebar>
-        <StyledMain>Hello, World!</StyledMain>
-      </SidebarWrapper>
-    </>
-  )
-}
-WithMastheadAndSidebar.storyName = 'Masthead and Sidebar'

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
@@ -23,7 +23,6 @@ import {
 import { Link } from '../../Link'
 import { Notification, Notifications } from '../NotificationPanel'
 import { ClassificationBar } from '../../ClassificationBar'
-import { Masthead } from '../Masthead'
 
 const disableColorContrastRule = {
   a11y: {


### PR DESCRIPTION
## Related issue

[#3805](https://github.com/Royal-Navy/design-system/issues/3805)

## Overview

Changed the Z-index value of the masthead in the StyledSearchBar component so that the search bar will be infront of the sidebar

## Reason

Currently, when opening the search bar, the sidebar is obscuring the text being typed into the search bar. 

## Work carried out

**Example.**

- [x] Changed z-index value in the StyledSearchBar component to `z-index: ${zIndex('masthead', 1)};` 


## Screenshot

<img width="1171" alt="image" src="https://github.com/Royal-Navy/design-system/assets/117908269/fc875781-43ed-4a50-96a3-f6a10fd7e719">

## Developer notes

I have left the story in that I used to view both the masthead and sidebar at the same time but this will need to be removed before merging. 
