### PR TITLE
feat(DatePicker): Created jump to today button on DatePicker 

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -55,13 +55,14 @@ Disabled.args = {
 export const DisabledDays = Template.bind({})
 DisabledDays.storyName = 'Disabled days'
 DisabledDays.args = {
-  initialStartDate: parseISO('2021-04-01'),
+  initialStartDate: parseISO('2024-01-01'),
   disabledDays: [
-    parseISO('2021-04-12'),
-    parseISO('2021-04-02'),
+    parseISO('2024-06-12'),
+    parseISO('2024-06-18'),
+    new Date(),
     {
-      after: parseISO('2021-03-20'),
-      before: parseISO('2021-03-25'),
+      after: parseISO('2024-12-31'),
+      before: parseISO('2024-01-01'),
     },
   ],
 }

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.test.tsx
@@ -345,8 +345,9 @@ describe('DatePicker', () => {
       )
     })
 
-    describe('when Shift-Tab is pressed twice', () => {
+    describe('when Shift-Tab is pressed three times', () => {
       beforeEach(async () => {
+        await user.tab({ shift: true })
         await user.tab({ shift: true })
         await user.tab({ shift: true })
       })
@@ -356,13 +357,14 @@ describe('DatePicker', () => {
       })
 
       describe('and Tab is then pressed once', () => {
-        beforeEach(() => {
-          return user.tab()
+        beforeEach(async () => {
+          await user.tab({ shift: true })
         })
 
         it('still traps the focus within the picker', () => {
-          const dayPicker =
-            wrapper.container.querySelectorAll('.DayPicker-wrapper')[0]
+          const dayPicker = wrapper.container.querySelectorAll(
+            '.DayPicker-NavButton--next'
+          )[0]
           expect(dayPicker).toHaveFocus()
         })
       })

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -11,7 +11,7 @@ import { DATEPICKER_ACTION } from './types'
 import { hasClass, ValueOf } from '../../helpers'
 import { InlineButton } from '../InlineButtons/InlineButton'
 import { InputValidationProps } from '../../common/InputValidationProps'
-import { isDateValid } from './utils'
+import { isDateValid, isDateDisabled } from './utils'
 import { StyledLabel } from '../TextInput/partials/StyledLabel'
 import { StyledDatePickerInput } from './partials/StyledDatePickerInput'
 import { StyledDayPicker } from './partials/StyledDayPicker'
@@ -218,6 +218,12 @@ export const DatePicker = ({
     disabledDays,
     onChange
   )
+
+  const handleDaySelection = () => {
+    dispatch({ type: DATEPICKER_ACTION.REFRESH_HAS_ERROR })
+    dispatch({ type: DATEPICKER_ACTION.REFRESH_INPUT_VALUE })
+  }
+
   const { startDate, endDate } = state
   const hasError =
     state.hasError || isInvalid || hasClass(className, 'is-invalid')
@@ -335,6 +341,15 @@ export const DatePicker = ({
         <FocusTrap focusTrapOptions={focusTrapOptions}>
           <StyledDayPicker
             firstDayOfWeek={1}
+            todayButton="Jump to today"
+            onTodayButtonClick={(day) => {
+              if (isDateDisabled(day, disabledDays)) {
+                return
+              }
+
+              handleDayClick(day)
+              handleDaySelection()
+            }}
             weekdaysShort={WEEKDAY_TITLES}
             selectedDays={[
               {
@@ -349,10 +364,7 @@ export const DatePicker = ({
               }
 
               const newState = handleDayClick(day)
-
-              dispatch({ type: DATEPICKER_ACTION.REFRESH_HAS_ERROR })
-              dispatch({ type: DATEPICKER_ACTION.REFRESH_INPUT_VALUE })
-
+              handleDaySelection()
               if (newState.endDate || !isRange) {
                 setTimeout(() => close())
               }

--- a/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/partials/StyledDayPicker.tsx
@@ -27,9 +27,10 @@ export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
   }
 
   .DayPicker-wrapper {
+    display: flex;
     position: relative;
-    flex-direction: row;
-    padding-bottom: ${spacing('8')};
+    flex-direction: column-reverse;
+    padding: ${spacing('6')};
     user-select: none;
     border-radius: 15px;
     outline: none;
@@ -56,7 +57,7 @@ export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
       $variant: BUTTON_VARIANT.TERTIARY,
     })};
     position: absolute;
-    top: ${spacing('6')};
+    top: ${spacing('15')};
     width: 38px;
     background-position: center;
     background-size: 18px;
@@ -195,5 +196,20 @@ export const StyledDayPicker = styled(DayPicker)<StyledDayPickerProps>`
   .DayPicker-Day--disabled {
     color: ${color('neutral', '200')};
     pointer-events: none;
+  }
+
+  .DayPicker-TodayButton {
+    ${getButtonStyles({
+      $size: COMPONENT_SIZE.SMALL,
+      $variant: BUTTON_VARIANT.TERTIARY,
+    })};
+    width: 100%;
+    margin-bottom: ${spacing('6')};
+  }
+
+  .DayPicker-NavBar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
 `

--- a/packages/react-component-library/src/components/DatePicker/utils/index.ts
+++ b/packages/react-component-library/src/components/DatePicker/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './areDatesEqual'
 export * from './formatDatesForInput'
 export * from './isDateValid'
+export * from './isDateDisabled'

--- a/packages/react-component-library/src/components/DatePicker/utils/isDateDisabled.test.ts
+++ b/packages/react-component-library/src/components/DatePicker/utils/isDateDisabled.test.ts
@@ -1,0 +1,82 @@
+import { isDateDisabled } from './isDateDisabled'
+
+describe('isDateDisabled', () => {
+  const date = new Date(2023, 5, 25) // June 25, 2023
+  const testCases = [
+    {
+      description: 'the date is an exact match',
+      disabledDays: new Date(2023, 5, 25),
+      expectedResult: true,
+    },
+    {
+      description: 'the date is not an exact match',
+      disabledDays: new Date(2023, 5, 26),
+      expectedResult: false,
+    },
+    {
+      description: 'the date is after a certain date',
+      disabledDays: { after: new Date(2023, 5, 24) },
+      expectedResult: true,
+    },
+    {
+      description: 'the date is not after a certain date',
+      disabledDays: { after: new Date(2023, 5, 25) },
+      expectedResult: false,
+    },
+    {
+      description: 'the date is before a certain date',
+      disabledDays: { before: new Date(2023, 5, 26) },
+      expectedResult: true,
+    },
+    {
+      description: 'the date is not before a certain date',
+      disabledDays: { before: new Date(2023, 5, 25) },
+      expectedResult: false,
+    },
+    {
+      description: 'the date is within a range',
+      disabledDays: { from: new Date(2023, 5, 24), to: new Date(2023, 5, 26) },
+      expectedResult: true,
+    },
+    {
+      description: 'the date is not within a range',
+      disabledDays: { from: new Date(2023, 5, 26), to: new Date(2023, 5, 27) },
+      expectedResult: false,
+    },
+    {
+      description: 'the date is a specific day of the week',
+      disabledDays: { daysOfWeek: [0, 1, 2, 3, 4, 5, 6] },
+      expectedResult: true,
+    },
+    {
+      description: 'the date is not a specific day of the week',
+      disabledDays: { daysOfWeek: [1, 2, 3, 4, 5, 6] },
+      expectedResult: false,
+    },
+    {
+      description: 'any conditions in an array are met',
+      disabledDays: [
+        { before: new Date(2023, 5, 24) },
+        { after: new Date(2023, 5, 26) },
+        new Date(2023, 5, 25),
+      ],
+      expectedResult: true,
+    },
+    {
+      description: 'none of the conditions in an array are met',
+      disabledDays: [
+        { before: new Date(2023, 5, 24) },
+        { after: new Date(2023, 5, 26) },
+        new Date(2023, 5, 27),
+      ],
+      expectedResult: false,
+    },
+  ]
+
+  it.each(testCases)(
+    'should return $expectedResult if $description',
+    ({ disabledDays, expectedResult }) => {
+      expect(isDateDisabled(date, disabledDays)).toBe(expectedResult)
+    }
+  )
+})

--- a/packages/react-component-library/src/components/DatePicker/utils/isDateDisabled.ts
+++ b/packages/react-component-library/src/components/DatePicker/utils/isDateDisabled.ts
@@ -1,0 +1,52 @@
+import {
+  isAfter,
+  isBefore,
+  isEqual,
+  isWithinInterval,
+  startOfDay,
+} from 'date-fns'
+import { type Modifier } from 'react-day-picker'
+
+export const isDateDisabled = (
+  date: Date,
+  disabledDays: Modifier | Modifier[]
+) => {
+  const disabledDaysArray = Array.isArray(disabledDays)
+    ? disabledDays
+    : [disabledDays]
+
+  return disabledDaysArray.some((disabledDay) => {
+    if (!disabledDay) {
+      return false
+    }
+
+    const isExactMatch =
+      disabledDay instanceof Date && isEqual(date, startOfDay(disabledDay))
+
+    const isAfterDate =
+      'after' in disabledDay && isAfter(date, startOfDay(disabledDay.after))
+
+    const isBeforeDate =
+      'before' in disabledDay && isBefore(date, startOfDay(disabledDay.before))
+
+    const isWithinRange =
+      'from' in disabledDay &&
+      'to' in disabledDay &&
+      isWithinInterval(date, {
+        start: startOfDay(disabledDay.from!),
+        end: startOfDay(disabledDay.to!),
+      })
+
+    const isDayOfWeek =
+      'daysOfWeek' in disabledDay &&
+      disabledDay.daysOfWeek.includes(date.getDay())
+
+    return (
+      isExactMatch ||
+      isAfterDate ||
+      isBeforeDate ||
+      isWithinRange ||
+      isDayOfWeek
+    )
+  })
+}


### PR DESCRIPTION
## Related issue

https://github.com/Royal-Navy/design-system/issues/3662

## Overview

I have added a button that has functionality to jump to today's date when clicked and enters that date into the input.

## Reason

So that we can have this feature.

## Work carried out

[A list of work you have done, use markdown checklist format, if you leave any boxes unchecked, be sure to set this PR as a WIP]

**Example.**

- [x] Created jump to today button
- [x] Created tests for function that checks if days are disabled.
- [ ] A bit of work I did not complete

## Screenshot

<img width="288" alt="image" src="https://github.com/Royal-Navy/design-system/assets/117908269/be2bf95b-4977-45f1-b13f-d87412c37c6d">

## Developer notes

[Sometimes, extra notes are needed to add clarity to a PR, add them here]
