### PR TITLE
fix(Sidebar): Sidebar now overlays page content

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.stories.tsx
@@ -57,6 +57,7 @@ const StyledMain = styled.main`
   padding: 2rem;
   background-color: #c9c9c9;
   width: 100%;
+  height: 30rem;
 `
 
 const SimpleSidebarNav = () => (

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/Sidebar.tsx
@@ -1,11 +1,11 @@
-import React, { useRef } from 'react'
+import React, { useRef, useContext, useLayoutEffect } from 'react'
 import { Transition } from 'react-transition-group'
 
 import { SidebarHandle } from './SidebarHandle'
 import { SidebarUserProps } from './SidebarUser'
 import { SidebarNotifications } from './SidebarNotifications'
 import { ComponentWithClass } from '../../../common/ComponentWithClass'
-import { SidebarContext, SidebarProvider } from './context'
+import { SidebarContext } from './context'
 import { NotificationsProps } from '../NotificationPanel'
 import { TRANSITION_TIMEOUT } from './constants'
 import { StyledSidebar } from './partials/StyledSidebar'
@@ -63,64 +63,53 @@ export const Sidebar = ({
   ...rest
 }: SidebarProps) => {
   const nodeRef = useRef(null)
+  const { isOpen, hasMouseOver, setHasMouseOver, setIsOpen } =
+    useContext(SidebarContext)
+
+  useLayoutEffect(() => {
+    setIsOpen(initialIsOpen)
+  }, [initialIsOpen, setIsOpen])
 
   return (
-    <SidebarProvider initialIsOpen={initialIsOpen}>
-      <SidebarContext.Consumer>
-        {({ isOpen, hasMouseOver, setHasMouseOver }) => (
-          <StyledSidebar
-            data-testid="sidebar"
-            isOpen={isOpen}
-            onMouseEnter={(_) => setHasMouseOver(true)}
-            onMouseLeave={(_) => setHasMouseOver(false)}
-            {...rest}
-          >
-            {classificationBar &&
-              React.cloneElement(classificationBar, {
-                isCondensed: !isOpen,
-                inSidebar: true,
-              })}
-            <Transition
-              nodeRef={nodeRef}
-              in={hasMouseOver}
-              timeout={0}
-              unmountOnExit
-            >
-              {(state) => (
-                <SidebarHandle ref={nodeRef} transitionStatus={state} />
-              )}
-            </Transition>
-            {title && (
-              <StyledHead data-testid="sidebar-head">
-                {icon && <StyledHeadIcon>{icon}</StyledHeadIcon>}
-                <Transition
-                  in={isOpen}
-                  timeout={TRANSITION_TIMEOUT}
-                  unmountOnExit
-                >
-                  {(state) => (
-                    <StyledHeadTitle $transitionStatus={state}>
-                      {title}
-                    </StyledHeadTitle>
-                  )}
-                </Transition>
-              </StyledHead>
+    <StyledSidebar
+      data-testid="sidebar"
+      $isOpen={isOpen}
+      onMouseEnter={(_) => setHasMouseOver(true)}
+      onMouseLeave={(_) => setHasMouseOver(false)}
+      {...rest}
+    >
+      {classificationBar &&
+        React.cloneElement(classificationBar, {
+          isCondensed: !isOpen,
+          inSidebar: true,
+        })}
+      <Transition nodeRef={nodeRef} in={hasMouseOver} timeout={0} unmountOnExit>
+        {(state) => <SidebarHandle ref={nodeRef} transitionStatus={state} />}
+      </Transition>
+      {title && (
+        <StyledHead data-testid="sidebar-head">
+          {icon && <StyledHeadIcon>{icon}</StyledHeadIcon>}
+          <Transition in={isOpen} timeout={TRANSITION_TIMEOUT} unmountOnExit>
+            {(state) => (
+              <StyledHeadTitle $transitionStatus={state}>
+                {title}
+              </StyledHeadTitle>
             )}
-            {children}
+          </Transition>
+        </StyledHead>
+      )}
+      {children}
 
-            {notifications && (
-              <SidebarNotifications
-                initialIsOpen={initialIsNotificationsOpen}
-                notifications={notifications}
-                hasUnreadNotification={hasUnreadNotification}
-              />
-            )}
+      {notifications && (
+        <SidebarNotifications
+          initialIsOpen={initialIsNotificationsOpen}
+          notifications={notifications}
+          hasUnreadNotification={hasUnreadNotification}
+        />
+      )}
 
-            {user}
-          </StyledSidebar>
-        )}
-      </SidebarContext.Consumer>
-    </SidebarProvider>
+      {user}
+    </StyledSidebar>
   )
 }
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarWrapper.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarWrapper.tsx
@@ -2,9 +2,14 @@ import React from 'react'
 
 import { ComponentWithClass } from '../../../common/ComponentWithClass'
 import { StyledWrapper } from './partials/StyledWrapper'
+import { SidebarProvider } from './context'
 
 export const SidebarWrapper = (props: ComponentWithClass) => {
-  return <StyledWrapper data-testid="sidebar-wrapper" {...props} />
+  return (
+    <SidebarProvider>
+      <StyledWrapper data-testid="sidebar-wrapper" {...props} />
+    </SidebarProvider>
+  )
 }
 
 SidebarWrapper.displayName = 'SidebarWrapper'

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/context.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/context.tsx
@@ -9,7 +9,6 @@ export interface SidebarContextDefaults {
 
 export interface SidebarProviderProps {
   children?: React.ReactNode
-  initialIsOpen?: boolean
 }
 
 const sidebarContextDefaults: SidebarContextDefaults = {
@@ -21,11 +20,8 @@ const sidebarContextDefaults: SidebarContextDefaults = {
 
 export const SidebarContext = createContext(sidebarContextDefaults)
 
-export const SidebarProvider = ({
-  children,
-  initialIsOpen = false,
-}: SidebarProviderProps) => {
-  const [isOpen, setIsOpen] = useState<boolean>(initialIsOpen)
+export const SidebarProvider = ({ children }: SidebarProviderProps) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false)
   const [hasMouseOver, setHasMouseOver] = useState<boolean>(false)
   const contextValue = useMemo(
     () => ({ isOpen, setIsOpen, hasMouseOver, setHasMouseOver }),

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledSidebar.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledSidebar.tsx
@@ -4,22 +4,26 @@ import { color, zIndex } from '@royalnavy/design-tokens'
 import { StyledContent } from '../../../../primitives/FloatingBox/partials/StyledContent'
 
 interface StyledSidebarProps {
-  isOpen?: boolean
+  $isOpen?: boolean
 }
+
+export const SIDEBAR_OPEN_WIDTH = '18rem'
+export const SIDEBAR_CLOSED_WIDTH = '3.75rem'
 
 export const StyledSidebar = styled.aside<StyledSidebarProps>`
   display: inline-flex;
   flex-direction: column;
-  position: relative;
+  position: fixed;
   z-index: ${zIndex('sidebar', 0)};
   flex-shrink: 0;
-  width: ${({ isOpen }) => (isOpen ? '18rem' : '3.75rem')};
+  width: ${({ $isOpen }) =>
+    $isOpen ? SIDEBAR_OPEN_WIDTH : SIDEBAR_CLOSED_WIDTH};
   height: 100vh;
   background-color: ${color('neutral', '700')};
   color: ${color('neutral', 'white')};
 
-  transition: ${({ isOpen }) =>
-    isOpen
+  transition: ${({ $isOpen }) =>
+    $isOpen
       ? '200ms width cubic-bezier(0.34, 1.56, 0.64, 1)'
       : '200ms width cubic-bezier(0.34, 1, 0.64, 1)'};
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledWrapper.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledWrapper.tsx
@@ -1,6 +1,12 @@
 import styled from 'styled-components'
 
+import { SIDEBAR_CLOSED_WIDTH } from './StyledSidebar'
+
 export const StyledWrapper = styled.div`
   display: flex;
   flex-direction: row;
+
+  > *:nth-child(2) {
+    margin-left: ${SIDEBAR_CLOSED_WIDTH};
+  }
 `


### PR DESCRIPTION
## Related issue

#[3826](https://github.com/Royal-Navy/design-system/issues/3826)

## Overview

I have changed the display property of the sidebar to absolute when it is open so that it overlays the page content rather than pushing it to one side. 

## Reason

Currently, there is a layout shift happening when the sidebar is opened as it pushes the content to the right. 

## Work carried ou

**Example.**

- [x] changed the display property of the sidebar to absolute when it is open

## Screenshot

Before:
<img width="567" alt="image" src="https://github.com/Royal-Navy/design-system/assets/117908269/54649c20-e6a6-4cc0-9768-a5ee452b9454">


After:
<img width="691" alt="image" src="https://github.com/Royal-Navy/design-system/assets/117908269/65ed12a6-d635-4bc2-b6aa-68dc1d7bbb93">

