### PR TITLE
docs: Add missing props to stories

### DIFF
--- a/packages/react-component-library/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.stories.tsx
@@ -3,9 +3,16 @@ import { StoryFn, Meta } from '@storybook/react'
 
 import { Alert, ALERT_VARIANT } from './index'
 
-export default { component: Alert, title: 'Components/Alert' } as Meta<
-  typeof Alert
->
+export default {
+  component: Alert,
+  title: 'Components/Alert',
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: Object.values(ALERT_VARIANT),
+    },
+  },
+} as Meta<typeof Alert>
 
 export const Default: StoryFn<typeof Alert> = ({
   title,

--- a/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/react-component-library/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -19,6 +19,11 @@ export default {
   args: {
     label: 'Some label',
   },
+  argTypes: {
+    hideClearButton: {
+      control: 'boolean',
+    },
+  },
 } as Meta<typeof Autocomplete>
 
 const StyledWrapper = styled.div<{ $isDisabled?: boolean }>`

--- a/packages/react-component-library/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react-component-library/src/components/Avatar/Avatar.stories.tsx
@@ -5,6 +5,12 @@ import { Avatar, AVATAR_VARIANT } from '.'
 
 export default {
   component: Avatar,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: Object.values(AVATAR_VARIANT),
+    },
+  },
   parameters: { layout: 'fullscreen' },
   title: 'Components/Avatar',
 } as Meta<typeof Avatar>

--- a/packages/react-component-library/src/components/Button/Button.stories.tsx
+++ b/packages/react-component-library/src/components/Button/Button.stories.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { Meta, StoryFn } from '@storybook/react'
 
-import { IconWifi } from '@royalnavy/icon-library'
+import { IconWifi, IconWeb, IconAnchor } from '@royalnavy/icon-library'
 import { spacing } from '@royalnavy/design-tokens'
 
 import { Button, ButtonProps } from './index'
@@ -14,7 +14,36 @@ import { COMPONENT_SIZE } from '../Forms'
 export default {
   argTypes: {
     icon: {
-      control: false,
+      type: 'select',
+      options: ['None', 'Wifi', 'Web', 'Anchor'],
+      mapping: {
+        None: null,
+        Wifi: <IconWifi />,
+        Web: <IconWeb />,
+        Anchor: <IconAnchor />,
+      },
+    },
+    isLoading: {
+      control: 'boolean',
+    },
+    iconPosition: {
+      control: 'select',
+      options: Object.values(BUTTON_ICON_POSITION),
+    },
+    size: {
+      control: 'select',
+      options: Object.values(COMPONENT_SIZE),
+    },
+    variant: {
+      control: 'select',
+      options: Object.values(BUTTON_VARIANT),
+    },
+    isDisabled: {
+      control: 'boolean',
+    },
+    type: {
+      control: 'select',
+      options: ['button', 'submit'],
     },
   },
   component: Button,

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,13 +1,36 @@
 import React from 'react'
 import { StoryFn, Meta } from '@storybook/react'
+import { color } from '@royalnavy/design-tokens'
 
 import { Checkbox, IndeterminateCheckbox, CheckboxProps } from '.'
 import { CHECKBOX_RADIO_VARIANT } from '../CheckboxRadioBase'
 
 export default {
   argTypes: {
+    checked: {
+      control: 'boolean',
+    },
+    variant: {
+      control: 'select',
+      options: Object.values(CHECKBOX_RADIO_VARIANT),
+    },
+    isDisabled: {
+      control: 'boolean',
+    },
     description: {
-      control: false,
+      control: 'select',
+      options: ['None', 'Plain text', 'Rich text'],
+      mapping: {
+        None: null,
+        'Plain text':
+          'She must have hidden the plans in the escape pod. Send a detachment down to retrieve them.',
+        // prettier-ignore
+        'Rich text': (
+          <div>
+            Marked up content with <strong>bold typefaces</strong>, <i>italics</i> and <span style={{color: color('action', '400')}}>colour</span>
+          </div>
+        ),
+      },
     },
   },
   component: Checkbox,

--- a/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/react-component-library/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -1,11 +1,13 @@
 import React, { useRef } from 'react'
 import { StoryFn, Meta } from '@storybook/react'
+import { color } from '@royalnavy/design-tokens'
 import styled from 'styled-components'
 
 import { IconEdit, IconDelete, IconAdd } from '@royalnavy/icon-library'
 
 import { ContextMenu, ContextMenuItem, ContextMenuDivider } from '.'
 import { Link } from '../Link'
+import { CLICK_BUTTON } from '../../hooks/useClickMenu'
 
 export default {
   component: ContextMenu,
@@ -14,19 +16,30 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
+  argTypes: {
+    clickType: {
+      control: 'select',
+      options: Object.values(CLICK_BUTTON),
+    },
+  },
 } as Meta<typeof ContextMenu>
+
+const StyledContainer = styled.div`
+  min-height: 14rem;
+`
 
 const ClickArea = styled.div`
   display: inline-block;
   padding: 1rem;
-  background-color: #c9c9c9;
+  color: ${color('neutral', '700')};
+  background-color: ${color('neutral', '100')};
 `
 
 export const Default: StoryFn<typeof ContextMenu> = (props) => {
   const ref = useRef<HTMLDivElement>(null)
 
   return (
-    <>
+    <StyledContainer>
       <ClickArea ref={ref} data-testid="storybook-context-menu-target">
         {props.clickType === 'left' ? 'Click on me' : 'Right click on me'}
       </ClickArea>
@@ -49,7 +62,7 @@ export const Default: StoryFn<typeof ContextMenu> = (props) => {
           }
         />
       </ContextMenu>
-    </>
+    </StyledContainer>
   )
 }
 

--- a/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
@@ -1,7 +1,7 @@
-import React, { useRef, useEffect } from 'react'
-import { StoryFn, Meta } from '@storybook/react'
+import React, { useEffect, useRef } from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import { color, spacing } from '@royalnavy/design-tokens'
 import styled from 'styled-components'
-import { spacing } from '@royalnavy/design-tokens'
 
 import { Dialog, DialogProps } from '.'
 import { ModalImperativeHandle } from '../Modal'
@@ -14,6 +14,30 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
     layout: 'fullscreen',
+  },
+  argTypes: {
+    description: {
+      control: 'select',
+      options: ['Plain text', 'ReactNode'],
+
+      mapping: {
+        ReactNode: (
+          <p style={{ textAlign: 'justify' }}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod <i>tempor incididunt ut labore et dolore magna</i> aliqua.
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+            <strong> nisi ut aliquip ex ea commodo </strong>. Duis aute irure
+            dolor in reprehenderit in voluptate velit esse cillum dolore eu
+            fugiat nulla pariatur.{' '}
+            <span style={{ color: color('warning', '800') }}>
+              Excepteur sint occaecat cupidatat
+            </span>{' '}
+            non proident, sunt in culpa qui officia deserunt mollit anim id est
+            laborum.
+          </p>
+        ),
+      },
+    },
   },
 } as Meta<typeof Dialog>
 
@@ -33,10 +57,19 @@ const Example = (props: DialogProps) => {
     }
   })
 
+  const dismissDialog = () => {
+    ref?.current?.close()
+  }
+
   return (
     <StyledWrapper>
       <Button onClick={() => ref?.current?.open()}>Open Dialog</Button>
-      <Dialog {...props} ref={ref} />
+      <Dialog
+        {...props}
+        ref={ref}
+        onCancel={dismissDialog}
+        onConfirm={dismissDialog}
+      />
     </StyledWrapper>
   )
 }

--- a/packages/react-component-library/src/components/DismissibleBanner/DismissibleBanner.stories.tsx
+++ b/packages/react-component-library/src/components/DismissibleBanner/DismissibleBanner.stories.tsx
@@ -9,6 +9,11 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
+  argTypes: {
+    hasCheckbox: {
+      control: 'boolean',
+    },
+  },
 } as Meta<typeof DismissibleBanner>
 
 export const Default: Story<DismissibleBannerWithTitleProps> = ({

--- a/packages/react-component-library/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.stories.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
-import { StoryFn, Meta } from '@storybook/react'
+import styled from 'styled-components'
+
+import { Meta, StoryFn } from '@storybook/react'
+import { color } from '@royalnavy/design-tokens'
 
 import { Drawer } from '.'
 
@@ -16,10 +19,17 @@ export default {
   },
 } as Meta<typeof Drawer>
 
+const StyledWrapper = styled.div`
+  min-height: 300px;
+  background-color: ${color('neutral', '000')};
+`
+
 export const Default: StoryFn<typeof Drawer> = (props) => (
-  <Drawer {...props}>
-    <pre css={{ padding: '0 1rem' }}>Arbitrary JSX</pre>
-  </Drawer>
+  <StyledWrapper>
+    <Drawer {...props}>
+      <pre css={{ padding: '0 1rem' }}>Arbitrary JSX</pre>
+    </Drawer>
+  </StyledWrapper>
 )
 
 Default.args = {

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -1,14 +1,50 @@
 import React from 'react'
-import { StoryFn, Meta } from '@storybook/react'
-import { IconBrightnessHigh } from '@royalnavy/icon-library'
-
+import { Meta, StoryFn } from '@storybook/react'
+import {
+  IconAnchor,
+  IconBrightnessHigh,
+  IconWeb,
+  IconWifi,
+} from '@royalnavy/icon-library'
 import { COMPONENT_SIZE } from '../Forms'
 import { NumberInput } from './NumberInput'
 
 export default {
   argTypes: {
     icon: {
-      control: false,
+      type: 'select',
+      options: ['None', 'Wifi', 'Web', 'Anchor'],
+      mapping: {
+        None: null,
+        Wifi: <IconWifi />,
+        Web: <IconWeb />,
+        Anchor: <IconAnchor />,
+      },
+    },
+    footnote: {
+      control: 'text',
+    },
+    isDisabled: {
+      control: 'boolean',
+    },
+    label: {
+      control: 'text',
+    },
+    max: {
+      control: 'number',
+    },
+    min: {
+      control: 'number',
+    },
+    placeholder: {
+      control: 'text',
+    },
+    size: {
+      control: 'select',
+      options: Object.values(COMPONENT_SIZE),
+    },
+    step: {
+      control: 'number',
     },
   },
   component: NumberInput,

--- a/packages/react-component-library/src/components/Panel/Panel.stories.tsx
+++ b/packages/react-component-library/src/components/Panel/Panel.stories.tsx
@@ -1,14 +1,35 @@
 import React from 'react'
-import { StoryFn, Meta } from '@storybook/react'
+import styled from 'styled-components'
+
+import { color, spacing } from '@royalnavy/design-tokens'
+import { Meta, StoryFn } from '@storybook/react'
 
 import { Panel } from './index'
 
-export default { component: Panel, title: 'Primitives/Panel' } as Meta<
-  typeof Panel
->
+export default {
+  component: Panel,
+  title: 'Primitives/Panel',
+  argTypes: {
+    children: {
+      control: 'text',
+      description: 'Arbitrary JSX or text',
+    },
+  },
+} as Meta<typeof Panel>
+
+const StyledContainer = styled.div`
+  min-height: 8rem;
+  width: 600px;
+  display: flex;
+  padding: ${spacing('8')};
+  gap: ${spacing('4')};
+  background-color: ${color('neutral', '100')};
+`
 
 export const Default: StoryFn<typeof Panel> = ({ children, ...rest }) => (
-  <Panel {...rest}>{children}</Panel>
+  <StyledContainer>
+    <Panel {...rest}>{children}</Panel>
+  </StyledContainer>
 )
 
 Default.args = {

--- a/packages/react-component-library/src/components/Radio/Radio.stories.tsx
+++ b/packages/react-component-library/src/components/Radio/Radio.stories.tsx
@@ -1,13 +1,35 @@
 import React from 'react'
 import { StoryFn, Meta } from '@storybook/react'
 
+import { color } from '@royalnavy/design-tokens'
 import { Radio, RadioProps } from '.'
 import { CHECKBOX_RADIO_VARIANT } from '../CheckboxRadioBase'
 
 export default {
   argTypes: {
+    variant: {
+      control: 'select',
+      options: Object.values(CHECKBOX_RADIO_VARIANT),
+    },
+    isInvalid: { control: 'boolean' },
     description: {
-      control: false,
+      control: 'select',
+      options: ['None', 'Plain text', 'Rich text'],
+      mapping: {
+        None: null,
+        'Plain text':
+          'She must have hidden the plans in the escape pod. Send a detachment down to retrieve them.',
+        // prettier-ignore
+        'Rich text': (
+          <div>
+            Marked up content with <strong>bold typefaces</strong>, <i>italics</i> and <span
+            style={{ color: color('action', '400') }}>colour</span>
+          </div>
+        ),
+      },
+    },
+    isDisabled: {
+      control: 'boolean',
     },
   },
   component: Radio,
@@ -22,8 +44,8 @@ const Template: StoryFn<typeof Radio> = (props) => <Radio {...props} />
 const MultipleItemsTemplate: StoryFn<typeof Radio> = (props) => {
   function getProps(i: number): RadioProps {
     return {
-      ...props,
       variant: CHECKBOX_RADIO_VARIANT.NO_CONTAINER,
+      ...props,
       label: `${props.label} ${i}`,
     }
   }

--- a/packages/react-component-library/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/react-component-library/src/components/TextArea/TextArea.stories.tsx
@@ -6,6 +6,10 @@ import { TextArea } from '.'
 export default {
   component: TextArea,
   title: 'Components/Text Area',
+  argTypes: {
+    isDisabled: { control: 'boolean' },
+    isInvalid: { control: 'boolean' },
+  },
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },

--- a/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
@@ -1,16 +1,33 @@
 import React from 'react'
 import { StoryFn, Meta } from '@storybook/react'
 
-import { IconSearch } from '@royalnavy/icon-library'
+import { IconSearch, IconSettings } from '@royalnavy/icon-library'
 import { TextInput } from '.'
 
 export default {
   argTypes: {
-    endAdornment: {
-      control: false,
-    },
     startAdornment: {
-      control: false,
+      // TODO - why doesn't this get picked up from the props
+      description:
+        'Optional adornment to display to the left of the input value.',
+      control: 'select',
+      options: ['None', 'Search', 'Settings'],
+      mapping: {
+        None: null,
+        Search: <IconSearch />,
+        Settings: <IconSettings />,
+      },
+    },
+    endAdornment: {
+      description:
+        'Optional adornment to display to the right of the input value.',
+      control: 'select',
+      options: ['None', 'Search', 'Settings'],
+      mapping: {
+        None: null,
+        Search: <IconSearch />,
+        Settings: <IconSettings />,
+      },
     },
     isDisabled: {
       control: 'boolean',
@@ -19,7 +36,24 @@ export default {
       control: 'boolean',
     },
     type: {
-      control: 'text',
+      control: 'select',
+      options: [
+        'color',
+        'date',
+        'datatime-local',
+        'email',
+        'file',
+        'image',
+        'month',
+        'number',
+        'password',
+        'search',
+        'tel',
+        'text',
+        'time',
+        'url',
+        'week',
+      ],
     },
   },
   component: TextInput,

--- a/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.stories.tsx
@@ -12,6 +12,15 @@ export default {
     startAdornment: {
       control: false,
     },
+    isDisabled: {
+      control: 'boolean',
+    },
+    isInvalid: {
+      control: 'boolean',
+    },
+    type: {
+      control: 'text',
+    },
   },
   component: TextInput,
   title: 'Components/Text Input',

--- a/packages/react-component-library/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.stories.tsx
@@ -10,6 +10,12 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
+  argTypes: {
+    appearance: {
+      control: 'select',
+      options: Object.values(TOAST_APPEARANCE),
+    },
+  },
 } as Meta<typeof Toast>
 
 const LABEL = 'Hello, World!'

--- a/packages/react-component-library/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-component-library/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,7 +1,8 @@
+import styled from 'styled-components'
 import React from 'react'
 import { StoryFn, Meta } from '@storybook/react'
 
-import { Tooltip } from '.'
+import { Tooltip, TOOLTIP_POSITION } from '.'
 
 export default {
   component: Tooltip,
@@ -9,12 +10,22 @@ export default {
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
+  argTypes: {
+    position: {
+      control: 'select',
+      options: Object.values(TOOLTIP_POSITION),
+    },
+  },
 } as Meta<typeof Tooltip>
 
+const StyledContainer = styled.div`
+  min-height: 8rem;
+`
+
 export const Default: StoryFn<typeof Tooltip> = ({ children, ...rest }) => (
-  <div css={{ height: '4rem' }}>
+  <StyledContainer>
     <Tooltip {...rest}>{children}</Tooltip>
-  </div>
+  </StyledContainer>
 )
 
 Default.args = {

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -43,6 +43,18 @@ export default {
     actions: { argTypesRegex: '^on.*' },
     layout: 'fullscreen',
   },
+  argTypes: {
+    initialOpenSubcomponent: {
+      control: false,
+    },
+    Logo: { control: false },
+    classificationBar: { control: false },
+    homeLink: { control: false },
+    nav: { control: false },
+    notifications: { control: false },
+    onSearch: { control: false },
+    user: { control: false },
+  },
 } as Meta<typeof Masthead>
 
 export const Default: StoryFn<typeof Masthead> = (props) => {


### PR DESCRIPTION
## Related issue

Closes #3438 

## Overview

Components were missing properties in the Storybook docs. This appears to have happened since Storybook 8.
This PR manually adds back some of this missing args using the `argTypes` configuration property.

