### PR TITLE
fix(Timeline): Added title prop to timeline component

### DIFF
--- a/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react-component-library/src/components/Timeline/Timeline.stories.tsx
@@ -113,6 +113,7 @@ export const WithData: StoryFn<typeof Timeline> = (props) => (
           <TimelineEvent
             startDate={new Date(2020, 9, 14, 12)}
             endDate={new Date(2020, 9, 18, 12)}
+            title="Test Event"
           >
             Event 1
           </TimelineEvent>

--- a/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
+++ b/packages/react-component-library/src/components/Timeline/TimelineEvent.tsx
@@ -40,6 +40,10 @@ export interface TimelineEventWithRenderContentProps
    * The start date of the event.
    */
   startDate: Date
+  /**
+   * The title of the event.
+   */
+  title?: string
 }
 
 export interface TimelineEventWithChildrenProps extends ComponentWithClass {
@@ -63,6 +67,10 @@ export interface TimelineEventWithChildrenProps extends ComponentWithClass {
    * The start date of the event.
    */
   startDate: Date
+  /**
+   * The HTML title attribute associated with the event.
+   */
+  title?: string
 }
 
 export type TimelineEventProps =
@@ -78,6 +86,7 @@ function renderDefault({
   maxWidthPx,
   startsBeforeStart,
   endsAfterEnd,
+  title,
 }: {
   barColor?: string
   children: React.ReactNode
@@ -87,6 +96,7 @@ function renderDefault({
   maxWidthPx: string
   startsBeforeStart: boolean
   endsAfterEnd: boolean
+  title: string
 }) {
   return (
     <StyledEvent $leftPx={offsetPx} data-testid="timeline-event">
@@ -98,14 +108,23 @@ function renderDefault({
         $endsAfterEnd={endsAfterEnd}
         data-testid="timeline-event-bar"
       />
-      <StyledEventTitle data-testid="timeline-event-title">
+      <StyledEventTitle data-testid="timeline-event-title" title={title}>
         {children || `Task ${format(new Date(startDate), DATE_FORMAT.SHORT)}`}
       </StyledEventTitle>
     </StyledEvent>
   )
 }
 
-function getTitle(children: React.ReactNode, startDate: Date, endDate: Date) {
+function getTitle(
+  children: React.ReactNode,
+  startDate: Date,
+  endDate: Date,
+  title?: string
+) {
+  if (title) {
+    return title
+  }
+
   const start = isString(children) ? `${children} begins` : `Begins`
 
   return `${start} on ${format(
@@ -120,6 +139,7 @@ export const TimelineEvent = ({
   endDate,
   render,
   startDate,
+  title,
   ...rest
 }: TimelineEventProps) => {
   const {
@@ -135,6 +155,8 @@ export const TimelineEvent = ({
   if (startsAfterEnd || endsBeforeStart) {
     return null
   }
+
+  const eventTitle = getTitle(children, startDate, endDate, title)
 
   const event = render
     ? render({
@@ -155,15 +177,14 @@ export const TimelineEvent = ({
         maxWidthPx,
         startsBeforeStart,
         endsAfterEnd,
+        title: eventTitle,
       })
 
-  const title = getTitle(children, startDate, endDate)
-
   return (
-    <div data-testid="timeline-event-wrapper">
+    <div data-testid="timeline-event-wrapper" title={title}>
       {React.cloneElement(event as React.ReactElement, {
-        title,
-        'aria-label': title,
+        title: eventTitle,
+        'aria-label': eventTitle,
         role: 'cell',
         ...rest,
       })}

--- a/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
+++ b/packages/react-component-library/src/components/Timeline/__tests__/Timeline.test.tsx
@@ -61,6 +61,41 @@ describe('Timeline', () => {
     jest.clearAllMocks()
   })
 
+  describe('when the title attribute is provided', () => {
+    beforeEach(() => {
+      const startDate = new Date(2023, 0, 1)
+      const endDate = new Date(2023, 0, 2)
+      const title = 'Custom Event Title'
+
+      wrapper = render(
+        <Timeline startDate={startDate}>
+          <TimelineTodayMarker />
+          <TimelineMonths />
+          <TimelineWeeks />
+          <TimelineDays />
+          <TimelineRows>
+            <TimelineRow name="Row 1">
+              <TimelineEvents>
+                <TimelineEvent
+                  startDate={startDate}
+                  endDate={endDate}
+                  title={title}
+                >
+                  Event 1
+                </TimelineEvent>
+              </TimelineEvents>
+            </TimelineRow>
+          </TimelineRows>
+        </Timeline>
+      )
+    })
+
+    it('sets the title attribute correctly', () => {
+      const eventWrapper = wrapper.getByTestId('timeline-event-wrapper')
+      expect(eventWrapper).toHaveAttribute('title', 'Custom Event Title')
+    })
+  })
+
   describe('when a custom className is provided', () => {
     beforeEach(() => {
       wrapper = render(


### PR DESCRIPTION
## Related issue
https://github.com/Royal-Navy/design-system/issues/3654

## Overview

Added an optional title prop to the timeline event component so that it shows the html attribute when hovering over the event

## Reason

So that a title prop can be set

## Work carried out

**Example.**

- [x] Added the title prop to the timeline event component

## Screenshot

<img width="858" alt="image" src="https://github.com/user-attachments/assets/777c7fcb-102f-4348-b4dd-2530ff96f0c4">


## Developer notes

