### PR TITLE
build(Netlify): Add *.stories.tsx exclusion to tsconfig

### DIFF
--- a/packages/react-component-library/tsconfig.json
+++ b/packages/react-component-library/tsconfig.json
@@ -20,5 +20,6 @@
     "target": "esnext",
     "types": ["jest", "@testing-library/jest-dom"]
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.stories.tsx"]
 }


### PR DESCRIPTION
## Overview

Fix issue with Netlify build throwing tsc errors.

## Link to preview

https://app.netlify.com/sites/storybook-navy-digital-mod-uk/deploys/66a9f94e97da2f00088e2bb3

## Reason

Netlify build generates tsc errors when generating typings as part of the React Component Library build.

## Work carried out

- [x] Add exclusion for stories files for type generation.

## Developer notes

Unable to reproduce this locally (`tsc --version` matches @ `5.5.4`). This started happening out of the blue and impacts all of the history (tested with branches that previously generated green Netlify builds).

This fix doesn't stop your IDE from resolving typings and displaying type errors. Stories files are only utilised by Storybook, so there is no need to expose generated typings for them in the generated build artefacts.
