### PR TITLE
docs(Stories): Fix incorrect argTypes properties

### DIFF
--- a/packages/react-component-library/src/components/Button/Button.stories.tsx
+++ b/packages/react-component-library/src/components/Button/Button.stories.tsx
@@ -14,7 +14,7 @@ import { COMPONENT_SIZE } from '../Forms'
 export default {
   argTypes: {
     icon: {
-      type: 'select',
+      control: 'select',
       options: ['None', 'Wifi', 'Web', 'Anchor'],
       mapping: {
         None: null,

--- a/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react-component-library/src/components/Checkbox/Checkbox.stories.tsx
@@ -125,6 +125,7 @@ NoLabel.storyName = 'No label'
 NoLabel.args = {
   id: undefined,
   name: 'no-label',
+  // @ts-ignore
   'aria-label': 'No label',
 }
 

--- a/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/react-component-library/src/components/NumberInput/NumberInput.stories.tsx
@@ -12,7 +12,7 @@ import { NumberInput } from './NumberInput'
 export default {
   argTypes: {
     icon: {
-      type: 'select',
+      control: 'select',
       options: ['None', 'Wifi', 'Web', 'Anchor'],
       mapping: {
         None: null,


### PR DESCRIPTION
## Overview

`argTypes` was using previous syntax for the control type. This caused intermittent build failures on CI pipelines. Not reproducible running locally.

## Work carried out

- [x] Use `control` instead of `type` within argType properties

