### PR TITLE
feat(DataGrid): Implement full span columns

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/DataGrid.d.ts
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.d.ts
@@ -6,6 +6,7 @@ import { ValueOf } from '../../helpers'
 declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
-    align: ValueOf<typeof TABLE_COLUMN_ALIGNMENT>
+    align?: ValueOf<typeof TABLE_COLUMN_ALIGNMENT>
+    fullSpanColumn?: boolean
   }
 }

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -501,6 +501,62 @@ Paginated.args = {
   pageSize: 5,
 }
 
+const fullSpanColumnData = data.slice(0, 3).map((item) => {
+  return {
+    ...item,
+    fullSpanColumn:
+      'This is a full span column, it renders within a seperate row.',
+  }
+})
+
+export const FullSpanColumn: StoryFn<typeof DataGrid> = (props) => {
+  return (
+    <Wrapper>
+      <DataGrid {...props} />
+    </Wrapper>
+  )
+}
+FullSpanColumn.storyName = 'Full span column'
+FullSpanColumn.args = {
+  columns: [
+    {
+      header: 'Product Name',
+      accessorKey: 'productName',
+      enableSorting: false,
+    },
+    {
+      header: 'Qty',
+      accessorKey: 'quantity',
+      enableSorting: false,
+    },
+    {
+      header: 'Price',
+      accessorKey: 'price',
+      enableSorting: false,
+    },
+    {
+      header: 'Actions',
+      accessorKey: 'actions',
+      enableSorting: false,
+      size: '100%',
+    },
+    {
+      accessorKey: 'fullSpanColumn',
+      meta: {
+        fullSpanColumn: true,
+      },
+      cell: (info) => {
+        const value = info.getValue() as string
+        return <h2>{value}</h2>
+      },
+    },
+  ],
+  data: fullSpanColumnData,
+  isFullWidth: true,
+  onSelectedRowsChange: fn(),
+  onExpandedChange: fn(),
+}
+
 const mergedColumns = groupedColumns.map((group) => ({
   ...group,
   columns: group.columns.map((column) => ({

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledCell.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledCell.tsx
@@ -1,9 +1,10 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { color, fontSize, spacing } from '@royalnavy/design-tokens'
 
 interface StyledCellProps {
   $alignment?: 'left' | 'right' | 'center'
   $width?: number
+  $hasBorder?: boolean
 }
 
 export const StyledCell = styled.td<StyledCellProps>`
@@ -12,7 +13,8 @@ export const StyledCell = styled.td<StyledCellProps>`
   font-size: ${fontSize('s')};
   color: ${color('neutral', '400')};
   text-align: ${({ $alignment }) => $alignment || 'left'};
-  border-bottom: 1px solid ${color('neutral', '200')};
+  border-bottom: ${({ $hasBorder }) =>
+    $hasBorder && css`1px solid ${color('neutral', '200')};`}
 
   &:last-of-type {
     border-right: unset;

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledRow.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledRow.tsx
@@ -6,6 +6,7 @@ interface StyledRowProps {
   $hasFocus?: boolean
   $depth?: number
   $isLastInBranch?: boolean
+  $fullSpanColumn?: boolean
 }
 
 export const StyledRow = styled.tr<StyledRowProps>`
@@ -18,6 +19,14 @@ export const StyledRow = styled.tr<StyledRowProps>`
       border-bottom: unset;
     }
   }
+
+  ${({ $fullSpanColumn }) =>
+    $fullSpanColumn &&
+    css`
+      td {
+        padding-top: unset;
+      }
+    `}
 
   ${({ $hasHover }) =>
     $hasHover &&


### PR DESCRIPTION
## Related issue

#[issueid]

## Overview

Add the ability to include a full span ghost column that renders in a separate row without a header.

## Reason

We need a way of displaying additional meta associated with a row of the data grid.

## Work carried out

- [x] Implement full span column feature
- [x] Add automated tests

## Screenshot

![Screenshot 2024-09-03 at 09 26 17](https://github.com/user-attachments/assets/3533df26-d9fc-44e7-9aa7-db3426af42ff)

## Developer notes

The column renders as a separate row.
