### PR TITLE
fix(DataGrid): Handle multiple fullSpanColumn cols

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/Body.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Body.tsx
@@ -79,25 +79,23 @@ const Row = <T extends object>({
         ))}
       </StyledRow>
 
-      {fullSpanCells.length > 0 && (
+      {fullSpanCells.map((cell, index) => (
         <StyledRow
-          key={`${row.id}-fullspan`}
-          id={`${row.id}-fullspan`}
+          key={`${cell.id}-fullspan`}
+          id={`${cell.id}-fullspan`}
           $fullSpanColumn
         >
-          {fullSpanCells.map((cell) => (
-            <StyledCell
-              key={cell.id}
-              as="td"
-              colSpan={totalColumns}
-              $alignment={cell.column.columnDef.meta?.align}
-              $hasBorder
-            >
-              {flexRender(cell.column.columnDef.cell, cell.getContext())}
-            </StyledCell>
-          ))}
+          <StyledCell
+            key={cell.id}
+            as="td"
+            colSpan={totalColumns}
+            $alignment={cell.column.columnDef.meta?.align}
+            $hasBorder={index === fullSpanCells.length - 1}
+          >
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+          </StyledCell>
         </StyledRow>
-      )}
+      ))}
     </>
   )
 }

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -520,6 +520,8 @@ const fullSpanColumnData = data.slice(0, 3).map((item) => {
     ...item,
     fullSpanColumn:
       'This is a full span column, it renders within a seperate row.',
+    fullSpanColumn2:
+      'This is a another full span column, it renders within a seperate row.',
   }
 })
 
@@ -556,6 +558,16 @@ FullSpanColumn.args = {
       cell: (info) => {
         const value = info.getValue() as string
         return <h2>{value}</h2>
+      },
+    },
+    {
+      accessorKey: 'fullSpanColumn2',
+      meta: {
+        fullSpanColumn: true,
+      },
+      cell: (info) => {
+        const value = info.getValue() as string
+        return <p>{value}</p>
       },
     },
   ],

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
@@ -888,6 +888,96 @@ describe('DataGrid', () => {
         ).not.toBeInTheDocument()
       })
     })
+
+    it('renders multiple fullSpanColumn cells correctly', () => {
+      const columnsWithMultipleFullSpan = [
+        {
+          accessorKey: 'first',
+          header: 'First',
+          cell: (info) => info.getValue(),
+        },
+        {
+          accessorKey: 'second',
+          header: 'Second',
+          cell: (info) => info.getValue(),
+        },
+        {
+          id: 'fullSpan1',
+          header: 'Full Span 1',
+          cell: () => 'Full Span Content 1',
+          meta: { fullSpanColumn: true },
+        },
+        {
+          id: 'fullSpan2',
+          header: 'Full Span 2',
+          cell: () => 'Full Span Content 2',
+          meta: { fullSpanColumn: true },
+        },
+      ]
+
+      const dataWithMultipleFullSpan = [
+        {
+          first: 'a1',
+          second: 'a2',
+        },
+        {
+          first: 'b1',
+          second: 'b2',
+        },
+      ]
+
+      render(
+        <DataGrid
+          data={dataWithMultipleFullSpan}
+          columns={columnsWithMultipleFullSpan}
+        />
+      )
+
+      const rows = screen.getAllByRole('row')
+
+      // Expected: 1 header row + 2 * (1 normal row + 2 fullSpan rows) = 7 rows total
+      expect(rows).toHaveLength(7)
+
+      // Check normal rows
+      expect(within(rows[1]).getByText('a1')).toBeInTheDocument()
+      expect(within(rows[1]).getByText('a2')).toBeInTheDocument()
+      expect(within(rows[4]).getByText('b1')).toBeInTheDocument()
+      expect(within(rows[4]).getByText('b2')).toBeInTheDocument()
+
+      // Check fullSpan rows
+      expect(
+        within(rows[2]).getByText('Full Span Content 1')
+      ).toBeInTheDocument()
+      expect(
+        within(rows[3]).getByText('Full Span Content 2')
+      ).toBeInTheDocument()
+      expect(
+        within(rows[5]).getByText('Full Span Content 1')
+      ).toBeInTheDocument()
+      expect(
+        within(rows[6]).getByText('Full Span Content 2')
+      ).toBeInTheDocument()
+
+      // Check that fullSpan cells are in separate rows
+      expect(
+        within(rows[2]).queryByText('Full Span Content 2')
+      ).not.toBeInTheDocument()
+      expect(
+        within(rows[3]).queryByText('Full Span Content 1')
+      ).not.toBeInTheDocument()
+      expect(
+        within(rows[5]).queryByText('Full Span Content 2')
+      ).not.toBeInTheDocument()
+      expect(
+        within(rows[6]).queryByText('Full Span Content 1')
+      ).not.toBeInTheDocument()
+
+      // Check colspan for fullSpan cells (should be 2 for normal columns)
+      const fullSpanCells = screen.getAllByText(/Full Span Content [12]/)
+      fullSpanCells.forEach((cell) => {
+        expect(cell.closest('td')).toHaveAttribute('colspan', '2')
+      })
+    })
   })
 
   describe('with column filtering', () => {


### PR DESCRIPTION
## Related issue

#[issueid]

## Overview

Ensure each column with fullSpanColumn meta is rendered within a separate row.

## Reason

DataGrid was rendering multiple fullSpanColumn columns within a single row.

## Work carried out

- [x] Add automated test
- [x] Update to render within separate rows

## Screenshot

![Screenshot 2024-09-05 at 08 43 26](https://github.com/user-attachments/assets/79191069-d2d6-4c20-be31-aff53f87dee4)
