### PR TITLE
feat(Alert): Add ability to hide Dismiss button

### DIFF
--- a/packages/react-component-library/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.stories.tsx
@@ -23,7 +23,6 @@ export const Default: StoryFn<typeof Alert> = ({
     {children}
   </Alert>
 )
-
 Default.args = {
   title: 'Example Title',
   children:
@@ -34,13 +33,11 @@ Default.args = {
 export const WithoutTitle: StoryFn<typeof Alert> = ({ children, variant }) => (
   <Alert variant={variant}>{children}</Alert>
 )
-
 WithoutTitle.args = {
   children:
     'The alert description provides context to the user, bringing attention to information that needs to be consumed.',
   variant: ALERT_VARIANT.INFO,
 }
-
 WithoutTitle.storyName = 'Without title'
 
 export const ArbitraryContent: StoryFn<typeof Alert> = ({
@@ -52,15 +49,32 @@ export const ArbitraryContent: StoryFn<typeof Alert> = ({
     {children}
   </Alert>
 )
-
 ArbitraryContent.args = {
-  title: 'Using arbitrary JSX as content',
+  title: 'Example Title',
   children: (
     <div>
       <p>
-        Hello, <strong>World!</strong>
+        <strong>Using arbitrary JSX as content.</strong>
       </p>
     </div>
   ),
   variant: ALERT_VARIANT.INFO,
 }
+ArbitraryContent.storyName = 'Arbitrary content'
+
+export const HideDismiss: StoryFn<typeof Alert> = ({
+  title,
+  children,
+  variant,
+}) => (
+  <Alert title={title} variant={variant} hideDismiss>
+    {children}
+  </Alert>
+)
+HideDismiss.args = {
+  title: 'Example Title',
+  children:
+    'The alert description provides context to the user, bringing attention to information that needs to be consumed.',
+  variant: ALERT_VARIANT.INFO,
+}
+HideDismiss.storyName = 'Hide dismiss button'

--- a/packages/react-component-library/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.stories.tsx
@@ -78,3 +78,20 @@ HideDismiss.args = {
   variant: ALERT_VARIANT.INFO,
 }
 HideDismiss.storyName = 'Hide dismiss button'
+
+export const HideBorder: StoryFn<typeof Alert> = ({
+  title,
+  children,
+  variant,
+}) => (
+  <Alert title={title} variant={variant} hideBorder>
+    {children}
+  </Alert>
+)
+HideBorder.args = {
+  title: 'Example Title',
+  children:
+    'The alert description provides context to the user, bringing attention to information that needs to be consumed.',
+  variant: ALERT_VARIANT.INFO,
+}
+HideBorder.storyName = 'Hide border'

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -1,57 +1,55 @@
 import React from 'react'
-import { renderToStaticMarkup } from 'react-dom/server'
-
-import { render, RenderResult } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { Alert, ALERT_VARIANT } from '.'
 
 describe('Alert', () => {
-  let wrapper: RenderResult
-
   describe('when minimal props are provided', () => {
     beforeEach(() => {
-      wrapper = render(<Alert>Description</Alert>)
+      render(<Alert>Description</Alert>)
     })
 
     it('should not set the `aria-labelledby` attribute', () => {
-      expect(wrapper.getByTestId('alert')).not.toHaveAttribute(
-        'aria-labelledby'
-      )
+      expect(screen.getByRole('alert')).not.toHaveAttribute('aria-labelledby')
     })
 
     it('should set the `role` attribute to `alert`', () => {
-      expect(wrapper.getByTestId('alert')).toHaveAttribute('role', 'alert')
+      expect(screen.getByRole('alert')).toBeInTheDocument()
     })
 
     it('should render the close button', () => {
-      expect(wrapper.getByTestId('close')).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /dismiss/i })
+      ).toBeInTheDocument()
     })
 
     it('should not render the content title', () => {
-      expect(wrapper.queryAllByTestId('content-title')).toHaveLength(0)
+      expect(screen.queryByRole('heading')).not.toBeInTheDocument()
     })
 
     it('should render the state icon', () => {
-      expect(wrapper.getByTestId('state-icon')).toBeInTheDocument()
+      const alert = screen.getByRole('alert')
+      expect(within(alert).getByTestId('state-icon')).toBeInTheDocument()
     })
 
     it('should render the default info icon', () => {
-      expect(wrapper.getByTestId('icon-info')).toBeInTheDocument()
+      const alert = screen.getByRole('alert')
+      const stateIcon = within(alert).getByTestId('state-icon')
+      expect(within(stateIcon).getByTestId('icon-info')).toBeInTheDocument()
     })
 
     it('should render the content description', () => {
-      expect(wrapper.getByTestId('content-description')).toHaveTextContent(
-        'Description'
-      )
+      expect(screen.getByText('Description')).toBeInTheDocument()
     })
 
     describe('when the close button is clicked', () => {
-      beforeEach(() => {
-        wrapper.getByTestId('close').click()
+      beforeEach(async () => {
+        await userEvent.click(screen.getByRole('button', { name: /dismiss/i }))
       })
 
       it('should hide the alert', () => {
-        expect(wrapper.queryAllByTestId('alert')).toHaveLength(0)
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
       })
     })
   })
@@ -64,13 +62,17 @@ describe('Alert', () => {
       ${ALERT_VARIANT.SUCCESS}
       ${ALERT_VARIANT.WARNING}
     `('should render the $variant icon', ({ variant }) => {
-      wrapper = render(
+      render(
         <Alert title="Title" variant={variant}>
           Description
         </Alert>
       )
 
-      expect(wrapper.getByTestId(`icon-${variant}`)).toBeInTheDocument()
+      const alert = screen.getByRole('alert')
+      const stateIcon = within(alert).getByTestId('state-icon')
+      expect(
+        within(stateIcon).getByTestId(`icon-${variant}`)
+      ).toBeInTheDocument()
     })
   })
 
@@ -80,7 +82,7 @@ describe('Alert', () => {
     beforeEach(() => {
       onCloseSpy = jest.fn()
 
-      wrapper = render(
+      render(
         <Alert
           data-arbitrary="arbitrary"
           onClose={onCloseSpy}
@@ -93,62 +95,42 @@ describe('Alert', () => {
     })
 
     it('should spread arbitrary props', () => {
-      expect(wrapper.getByTestId('alert')).toHaveAttribute(
+      expect(screen.getByRole('alert')).toHaveAttribute(
         'data-arbitrary',
         'arbitrary'
       )
     })
 
     it('should set the `aria-labelledby` attribute to the ID of the title', () => {
-      const titleId = wrapper.getByTestId('content-title').getAttribute('id')
-
-      expect(wrapper.getByTestId('alert')).toHaveAttribute(
-        'aria-labelledby',
-        titleId
-      )
-    })
-
-    it('should set the `aria-describedby` attribute to the ID of the content', () => {
-      const contentId = wrapper
-        .getByTestId('content-description')
-        .getAttribute('id')
-
-      expect(wrapper.getByTestId('alert')).toHaveAttribute(
-        'aria-describedby',
-        contentId
-      )
+      const alert = screen.getByRole('alert')
+      const title = screen.getByRole('heading')
+      expect(alert).toHaveAttribute('aria-labelledby', title.id)
     })
 
     it('should render the state icon', () => {
-      expect(wrapper.getByTestId('state-icon')).toBeInTheDocument()
-    })
-
-    it('should set the `aria-hidden` attribute on the state icon', () => {
-      expect(wrapper.getByTestId('state-icon')).toHaveAttribute(
-        'aria-hidden',
-        'true'
-      )
+      const alert = screen.getByRole('alert')
+      expect(within(alert).getByTestId('state-icon')).toBeInTheDocument()
     })
 
     it('should render the danger icon', () => {
+      const alert = screen.getByRole('alert')
+      const stateIcon = within(alert).getByTestId('state-icon')
       expect(
-        wrapper.getByTestId(`icon-${ALERT_VARIANT.DANGER}`)
+        within(stateIcon).getByTestId(`icon-${ALERT_VARIANT.DANGER}`)
       ).toBeInTheDocument()
     })
 
     it('should render the content title', () => {
-      expect(wrapper.getByTestId('content-title')).toHaveTextContent('Title')
+      expect(screen.getByRole('heading', { name: 'Title' })).toBeInTheDocument()
     })
 
     it('should render the content description', () => {
-      expect(wrapper.getByTestId('content-description')).toHaveTextContent(
-        'Description'
-      )
+      expect(screen.getByText('Description')).toBeInTheDocument()
     })
 
     describe('when the close button is clicked', () => {
-      beforeEach(() => {
-        wrapper.getByTestId('close').click()
+      beforeEach(async () => {
+        await userEvent.click(screen.getByRole('button', { name: /dismiss/i }))
       })
 
       it('should call the callback once', () => {
@@ -158,65 +140,64 @@ describe('Alert', () => {
   })
 
   describe('when the Alert content changes', () => {
-    let initialContentId: string
-    let initialTitleId: string | null
-
     const ExampleAlert = ({ content }: { content: string }) => (
       <Alert title="Example title">{content}</Alert>
     )
 
-    beforeEach(() => {
-      wrapper = render(<ExampleAlert content="initial content" />)
-      initialContentId = wrapper.getByTestId('content-description').id
-      initialTitleId = wrapper.getByTestId('content-title').id
+    it('does not generate new ids when content changes', () => {
+      const { rerender } = render(<ExampleAlert content="initial content" />)
 
-      wrapper.rerender(<ExampleAlert content="new content" />)
-    })
+      const initialAlert = screen.getByRole('alert')
+      const initialTitle = screen.getByRole('heading')
+      const initialTitleId = initialTitle.id
+      const initialLabelledBy = initialAlert.getAttribute('aria-labelledby')
 
-    it('does not generate a new content `id`', () => {
-      expect(wrapper.getByTestId('content-description')).toHaveAttribute(
-        'id',
-        initialContentId
-      )
-    })
+      rerender(<ExampleAlert content="new content" />)
 
-    it('does not generate a new title `id`', () => {
-      expect(wrapper.getByTestId('content-title')).toHaveAttribute(
-        'id',
-        initialTitleId
+      const updatedAlert = screen.getByRole('alert')
+      const updatedTitle = screen.getByRole('heading')
+
+      expect(updatedTitle.id).toBe(initialTitleId)
+      expect(updatedAlert.getAttribute('aria-labelledby')).toBe(
+        initialLabelledBy
       )
     })
   })
 
   describe('Arbitrary Markup', () => {
-    let children: React.ReactElement
-
-    beforeEach(() => {
-      children = <div>Arbitrary JSX</div>
-
-      wrapper = render(<Alert>{children}</Alert>)
-    })
-
     it('renders the arbitrary JSX in the correct place', () => {
-      expect(wrapper.getByTestId('content-description').innerHTML).toContain(
-        renderToStaticMarkup(children)
+      render(
+        <Alert>
+          <div>Arbitrary JSX</div>
+        </Alert>
       )
+
+      const alert = screen.getByRole('alert')
+      const content = within(alert).getByText('Arbitrary JSX')
+
+      expect(content).toBeInTheDocument()
+      expect(content.closest('div')).toContainHTML('<div>Arbitrary JSX</div>')
     })
   })
 
   describe('when hideDismiss prop is provided', () => {
     beforeEach(() => {
-      wrapper = render(<Alert hideDismiss>Description</Alert>)
+      render(<Alert hideDismiss>Description</Alert>)
     })
 
     it('should not render the close button', () => {
-      expect(wrapper.queryByTestId('close')).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /dismiss/i })
+      ).not.toBeInTheDocument()
     })
 
     it('should still render the alert content', () => {
-      expect(wrapper.getByTestId('content-description')).toHaveTextContent(
-        'Description'
-      )
+      expect(screen.getByText('Description')).toBeInTheDocument()
+    })
+
+    it('should render the state icon', () => {
+      const alert = screen.getByRole('alert')
+      expect(within(alert).getByTestId('state-icon')).toBeInTheDocument()
     })
   })
 })

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -200,4 +200,15 @@ describe('Alert', () => {
       expect(within(alert).getByTestId('state-icon')).toBeInTheDocument()
     })
   })
+
+  describe('when hideBorder prop is provided', () => {
+    beforeEach(() => {
+      render(<Alert hideBorder>Description</Alert>)
+    })
+
+    it('should not render the border', () => {
+      const alert = screen.getByRole('alert')
+      expect(alert).toHaveStyle('border: none')
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Alert/Alert.test.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.test.tsx
@@ -203,4 +203,20 @@ describe('Alert', () => {
       )
     })
   })
+
+  describe('when hideDismiss prop is provided', () => {
+    beforeEach(() => {
+      wrapper = render(<Alert hideDismiss>Description</Alert>)
+    })
+
+    it('should not render the close button', () => {
+      expect(wrapper.queryByTestId('close')).not.toBeInTheDocument()
+    })
+
+    it('should still render the alert content', () => {
+      expect(wrapper.getByTestId('content-description')).toHaveTextContent(
+        'Description'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -77,7 +77,6 @@ export const Alert = ({
       $variant={variant}
       aria-describedby={descriptionId}
       aria-labelledby={title ? titleId : undefined}
-      data-testid="alert"
       role="alert"
       {...rest}
     >
@@ -90,20 +89,14 @@ export const Alert = ({
       </StyledIcon>
       <StyledContent data-testid="content">
         {title && (
-          <StyledTitle
-            $variant={variant}
-            data-testid="content-title"
-            id={titleId}
-          >
+          <StyledTitle $variant={variant} id={titleId}>
             {title}
           </StyledTitle>
         )}
-        <StyledDescription data-testid="content-description" id={descriptionId}>
-          {children}
-        </StyledDescription>
+        <StyledDescription id={descriptionId}>{children}</StyledDescription>
         <StyledFooter>
           {!hideDismiss && (
-            <StyledCloseButton onClick={handleOnClose} data-testid="close">
+            <StyledCloseButton onClick={handleOnClose}>
               Dismiss
             </StyledCloseButton>
           )}

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -50,6 +50,10 @@ export interface AlertProps {
    * Type of component to display (style varies accordingly).
    */
   variant?: AlertVariantType
+  /**
+   * Optional flag to hide the Dismiss button.
+   */
+  hideDismiss?: boolean
 }
 
 export const Alert = ({
@@ -57,6 +61,7 @@ export const Alert = ({
   onClose,
   title,
   variant = ALERT_VARIANT.INFO,
+  hideDismiss = false,
   ...rest
 }: AlertProps) => {
   const { open, handleOnClose } = useOpenClose(true, onClose)
@@ -97,9 +102,11 @@ export const Alert = ({
           {children}
         </StyledDescription>
         <StyledFooter>
-          <StyledCloseButton onClick={handleOnClose} data-testid="close">
-            Dismiss
-          </StyledCloseButton>
+          {!hideDismiss && (
+            <StyledCloseButton onClick={handleOnClose} data-testid="close">
+              Dismiss
+            </StyledCloseButton>
+          )}
         </StyledFooter>
       </StyledContent>
     </StyledAlert>

--- a/packages/react-component-library/src/components/Alert/Alert.tsx
+++ b/packages/react-component-library/src/components/Alert/Alert.tsx
@@ -54,6 +54,10 @@ export interface AlertProps {
    * Optional flag to hide the Dismiss button.
    */
   hideDismiss?: boolean
+  /**
+   * Optional flag to render without a border.
+   */
+  hideBorder?: boolean
 }
 
 export const Alert = ({
@@ -62,6 +66,7 @@ export const Alert = ({
   title,
   variant = ALERT_VARIANT.INFO,
   hideDismiss = false,
+  hideBorder = false,
   ...rest
 }: AlertProps) => {
   const { open, handleOnClose } = useOpenClose(true, onClose)
@@ -78,6 +83,7 @@ export const Alert = ({
       aria-describedby={descriptionId}
       aria-labelledby={title ? titleId : undefined}
       role="alert"
+      $hideBorder={hideBorder}
       {...rest}
     >
       <StyledIcon

--- a/packages/react-component-library/src/components/Alert/partials/StyledAlert.tsx
+++ b/packages/react-component-library/src/components/Alert/partials/StyledAlert.tsx
@@ -1,5 +1,5 @@
-import styled from 'styled-components'
-import { mq, spacing } from '@royalnavy/design-tokens'
+import styled, { css } from 'styled-components'
+import { mq, spacing, shadow } from '@royalnavy/design-tokens'
 
 import { AlertVariantType } from '../Alert'
 
@@ -15,6 +15,7 @@ import {
 
 interface StyledAlertProps {
   $variant: AlertVariantType
+  $hideBorder?: boolean
 }
 
 const STATE_VARIANT_MAP = {
@@ -24,26 +25,41 @@ const STATE_VARIANT_MAP = {
   [ALERT_VARIANT.WARNING]: WARNING_ALERT_STATE_COLOR,
 }
 
+const getBorderStyles = ({ $hideBorder }: StyledAlertProps) => {
+  if ($hideBorder) {
+    return css`
+      border: none;
+      box-shadow: none;
+      border-radius: 0;
+    `
+  }
+
+  return css`
+    border: ${spacing('px')} solid ${ALERT_BORDER_COLOR};
+    box-shadow: ${shadow('1')};
+    border-radius: 4px;
+  `
+}
+
 export const StyledAlert = styled.div<StyledAlertProps>`
   background-color: ${ALERT_BACKGROUND_COLOR};
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
-  border: ${spacing('px')} solid ${ALERT_BORDER_COLOR};
-  border-radius: 4px;
   padding: ${spacing('4')} ${spacing('4')} ${spacing('4')} ${spacing('6')};
   position: relative;
   display: flex;
   align-items: flex-start;
+
+  ${getBorderStyles}
 
   ${mq({ gte: 'xs' })`
     padding-right: ${spacing('18')};
   `}
 
   &::before {
+    content: '';
     position: absolute;
     top: 8px;
     left: 8px;
     bottom: 8px;
-    content: '';
     width: 4px;
     background: ${({ $variant }) => STATE_VARIANT_MAP[$variant]};
     border-radius: 4px;


### PR DESCRIPTION
## Related issue

#[issueid]

## Overview

Add ability to hide the Alert Dismiss button.

## Reason

Emerging requirement from ADMS. We want to use persistent Alerts.

## Work carried out

- [x] Clean up some stories
- [x] Make Dismiss button optional via prop
- [x] Add automated tests
- [x] Refactor automated tests (remove reliance on test IDs)
- [x] Add hidden border variant

## Screenshot

![Screenshot 2024-09-10 at 11 07 20](https://github.com/user-attachments/assets/a8247b60-0674-4c8a-9272-6b3f1a0bdd04)
