### PR TITLE
fix(Group): Adjust align prop default value

### DIFF
--- a/packages/react-component-library/src/components/Group/Group.test.tsx
+++ b/packages/react-component-library/src/components/Group/Group.test.tsx
@@ -10,7 +10,7 @@ describe('Group', () => {
     expect(container.firstChild).toHaveStyleRule('display', 'flex')
     expect(container.firstChild).toHaveStyleRule('flex-direction', 'row')
     expect(container.firstChild).toHaveStyleRule('gap', spacing('0'))
-    expect(container.firstChild).toHaveStyleRule('align-items', 'stretch')
+    expect(container.firstChild).toHaveStyleRule('align-items', 'center')
     expect(container.firstChild).toHaveStyleRule(
       'justify-content',
       'flex-start'

--- a/packages/react-component-library/src/components/Group/Group.tsx
+++ b/packages/react-component-library/src/components/Group/Group.tsx
@@ -66,7 +66,7 @@ export const Group = ({
   className,
   el = 'div',
   gap = '0',
-  align = 'stretch',
+  align = 'center',
   justify = 'flex-start',
   wrap = 'wrap',
   grow = false,


### PR DESCRIPTION
## Related issue

Closes #3876

## Overview

This should be `center` but was wrongly set to `stretch`.

## Reason

Looks like a typo or maybe copilot autocomplete mistake.

## Work carried out

- [x] Update automated tests
- [x] Fix incorrect default value