### PR TITLE
build(Storybook): Fix upload artefacts error

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -246,6 +246,8 @@ jobs:
         with:
           name: storybook-static
           path: packages/react-component-library/.static_storybook
+          if-no-files-found: error
+          include-hidden-files: true
 
   Test_a11y:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Related issue

#[issueid]

## Overview

Upload artefact action was failing. Previously hidden files were uploaded by default

