### PR TITLE
feat(Masthead): Add slot to display client content in the masthead

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -21,6 +21,8 @@ import { Notification, Notifications } from '../NotificationPanel'
 import { MASTHEAD_SUBCOMPONENT } from './constants'
 import { ClassificationBar } from '../../ClassificationBar'
 
+import { TextE } from '../../Text'
+
 const StyledContainer = styled.div`
   min-height: 10rem;
 `
@@ -322,3 +324,20 @@ WithClassificationBar.args = {
   classificationBar: <ClassificationBar />,
 }
 WithClassificationBar.storyName = 'Classification bar'
+
+const StyledClientComponent = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: end;
+`
+
+export const WithCustomClientComponent = Default.bind({})
+WithCustomClientComponent.args = {
+  ...Default.args,
+  customClientComponent: (
+    <StyledClientComponent>
+      <TextE>Arbitrary text</TextE>
+    </StyledClientComponent>
+  ),
+}

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
@@ -129,6 +129,15 @@ describe('Masthead', () => {
     })
   })
 
+  describe('custom client component', () => {
+    it('should render custom client component', () => {
+      wrapper = render(
+        <Masthead {...props} customClientComponent={<div>Hello world</div>} />
+      )
+      expect(wrapper.getByText('Hello world')).toBeInTheDocument()
+    })
+  })
+
   describe('inline nav', () => {
     it('should render nav inline', () => {
       wrapper = render(<Masthead {...props} hasInlineNav />)

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
@@ -76,6 +76,10 @@ export interface MastheadProps {
    * Optional jsx to render the classification bar above the masthead.
    */
   classificationBar?: React.ReactElement<ClassificationProps>
+  /**
+   * Optional jsx to insert after the before the icons
+   */
+  customClientComponent?: React.ReactNode
 }
 
 function getServiceName(
@@ -113,6 +117,7 @@ export const Masthead = ({
   title,
   user,
   classificationBar,
+  customClientComponent,
   ...rest
 }: MastheadProps) => {
   const searchButtonRef = useRef<HTMLButtonElement>(null)
@@ -150,7 +155,7 @@ export const Masthead = ({
             {nav}
           </StyledInlineNav>
         ) : null}
-
+        {!!customClientComponent && customClientComponent}
         <StyledOptions
           $withInlineNav={hasInlineNav}
           data-testid="masthead-options"


### PR DESCRIPTION
## Related issue

#[issueid]

## Overview

Add an optional prop to masthead which allows the insertion of custom client jsx. 

## Reason

Vertical screen space is at a premium, especially on MODNET laptops. Sometimes it is a small as 570 available pixels.
This slot was added so that things like DatePickers can be inlined in the masthead to save space.

## Work carried out

- [x] New prop and slot in the masthead
- [x] Updated stories and tests


