### PR TITLE
feat(Masthead): Add slot for custom client jsx

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -8,6 +8,7 @@ import {
   IconSettings,
   IconHome,
 } from '@royalnavy/icon-library'
+import { spacing } from '@royalnavy/design-tokens'
 
 import { Link } from '../../Link'
 import {
@@ -20,6 +21,8 @@ import {
 import { Notification, Notifications } from '../NotificationPanel'
 import { MASTHEAD_SUBCOMPONENT } from './constants'
 import { ClassificationBar } from '../../ClassificationBar'
+
+import { TextE } from '../../Text'
 
 const StyledContainer = styled.div`
   min-height: 10rem;
@@ -322,3 +325,22 @@ WithClassificationBar.args = {
   classificationBar: <ClassificationBar />,
 }
 WithClassificationBar.storyName = 'Classification bar'
+
+const StyledClientComponent = styled.div`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: end;
+  padding-right: ${spacing('2')};
+`
+
+export const RightSlot = Default.bind({})
+RightSlot.storyName = 'Right slot'
+RightSlot.args = {
+  ...Default.args,
+  rightSlot: (
+    <StyledClientComponent>
+      <TextE>Arbitrary text</TextE>
+    </StyledClientComponent>
+  ),
+}

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
@@ -129,6 +129,15 @@ describe('Masthead', () => {
     })
   })
 
+  describe('custom client component', () => {
+    it('should render custom client component in right slot', () => {
+      wrapper = render(
+        <Masthead {...props} rightSlot={<div>Hello, World</div>} />
+      )
+      expect(wrapper.getByText('Hello, World')).toBeInTheDocument()
+    })
+  })
+
   describe('inline nav', () => {
     it('should render nav inline', () => {
       wrapper = render(<Masthead {...props} hasInlineNav />)

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
@@ -76,6 +76,10 @@ export interface MastheadProps {
    * Optional jsx to render the classification bar above the masthead.
    */
   classificationBar?: React.ReactElement<ClassificationProps>
+  /**
+   * Optional jsx to insert before the icons
+   */
+  rightSlot?: React.ReactNode
 }
 
 function getServiceName(
@@ -113,6 +117,7 @@ export const Masthead = ({
   title,
   user,
   classificationBar,
+  rightSlot,
   ...rest
 }: MastheadProps) => {
   const searchButtonRef = useRef<HTMLButtonElement>(null)
@@ -150,7 +155,7 @@ export const Masthead = ({
             {nav}
           </StyledInlineNav>
         ) : null}
-
+        {rightSlot}
         <StyledOptions
           $withInlineNav={hasInlineNav}
           data-testid="masthead-options"


### PR DESCRIPTION
## Related issue

#[issueid]

## Overview

Add an optional prop to masthead which allows the insertion of custom client jsx. 

## Reason

Vertical screen space is at a premium, especially on MODNET laptops. Sometimes it is a small as 570 available pixels.
This slot was added so that things like DatePickers can be inlined in the masthead to save space.

## Work carried out

- [x] New prop and slot in the masthead
- [x] Updated stories and tests


