### PR TITLE
feat(Dialog): Handle async action by disabling buttons and showing spinner

### DIFF
--- a/packages/react-component-library/src/components/Button/Button.tsx
+++ b/packages/react-component-library/src/components/Button/Button.tsx
@@ -35,7 +35,7 @@ interface ButtonBaseProps extends Omit<ComponentWithClass, 'children'> {
   /**
    * Optional handler called when the component is clicked.
    */
-  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>
   /**
    * Size of the component.
    */

--- a/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.stories.tsx
@@ -65,10 +65,10 @@ const Example = (props: DialogProps) => {
     <StyledWrapper>
       <Button onClick={() => ref?.current?.open()}>Open Dialog</Button>
       <Dialog
-        {...props}
         ref={ref}
         onCancel={dismissDialog}
         onConfirm={dismissDialog}
+        {...props}
       />
     </StyledWrapper>
   )
@@ -98,4 +98,15 @@ RichDescription.args = {
       Support Arbitrary JSX for <strong>rich</strong> description text.
     </div>
   ),
+}
+
+export const AsyncAction = Template.bind({})
+AsyncAction.storyName = 'Async loading'
+AsyncAction.args = {
+  title: 'Example Title',
+  description: 'Example description',
+  onConfirm: () =>
+    new Promise((resolve) => {
+      setTimeout(resolve, 2000)
+    }),
 }

--- a/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.test.tsx
@@ -1,211 +1,142 @@
 import React from 'react'
 
-import {
-  render,
-  RenderResult,
-  fireEvent,
-  waitFor,
-} from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { renderToStaticMarkup } from 'react-dom/server'
 
 import { Dialog } from '.'
 
-describe('Dialog', () => {
-  let wrapper: RenderResult
-  let title: string
-  let description: React.ReactElement
-  let onConfirm: (event: React.FormEvent<HTMLButtonElement>) => void
-  let onCancel: (event: React.FormEvent<HTMLButtonElement>) => void
+function setup({
+  ariaLabel,
+  onConfirmMock,
+  title,
+}: {
+  ariaLabel?: string
+  onConfirmMock?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => Promise<void>
+  title?: string
+}) {
+  const description = <span>Dialog description.</span>
+  const onConfirmSpy = jest.fn()
+  const onCancelSpy = jest.fn()
+  const user = userEvent.setup()
 
-  beforeEach(() => {
-    title = 'Dialog Title'
-    description = <span>Dialog description.</span>
-    onConfirm = jest.fn()
-    onCancel = jest.fn()
+  const { rerender } = render(
+    <Dialog
+      aria-label={ariaLabel}
+      data-arbitrary="arbitrary"
+      title={title}
+      description={description}
+      onConfirm={onConfirmMock ?? onConfirmSpy}
+      onCancel={onCancelSpy}
+      isOpen
+    />
+  )
+
+  return {
+    description,
+    onConfirmSpy,
+    onCancelSpy,
+    rerender,
+    user,
+  }
+}
+
+it('renders the dialog', () => {
+  const expectedTitle = 'Dialog title'
+  const { description } = setup({ title: expectedTitle })
+
+  expect(screen.getByRole('dialog')).toHaveAttribute(
+    'data-arbitrary',
+    'arbitrary'
+  )
+
+  const titleId = screen.getByTestId('dialog-title').getAttribute('id')
+  expect(screen.getByRole('dialog')).toHaveAttribute('aria-labelledby', titleId)
+
+  expect(screen.getByTestId('dialog-title')).toHaveTextContent(expectedTitle)
+
+  expect(screen.getByTestId('dialog-description').innerHTML).toContain(
+    renderToStaticMarkup(description)
+  )
+})
+
+it('invokes the `onConfirm` callback when the `Confirm` button is clicked', async () => {
+  const { onConfirmSpy, user } = setup({ title: 'Dialog title' })
+
+  await user.click(screen.getByRole('button', { name: 'Confirm' }))
+
+  expect(onConfirmSpy).toHaveBeenCalledTimes(1)
+})
+
+it('invokes the `onCancel` callback when the `Cancel` button is clicked', async () => {
+  const { onCancelSpy, user } = setup({ title: 'Dialog title' })
+
+  await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+  expect(onCancelSpy).toHaveBeenCalledTimes(1)
+})
+
+it('sets attributes correctly when aria-label but no title is set', () => {
+  const expectedAriaLabel = 'Accessible name'
+  setup({ ariaLabel: expectedAriaLabel })
+
+  expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-labelledby')
+  expect(screen.getByRole('dialog')).toHaveAttribute(
+    'aria-label',
+    expectedAriaLabel
+  )
+})
+
+it('does not generate new IDs when the description changes', () => {
+  const { rerender } = setup({ title: 'Dialog title' })
+
+  const initialTitleId = screen.getByTestId('dialog-title').id
+  const initialDescriptionId = screen.getByTestId('modal-body').id
+
+  rerender(
+    <Dialog description={<span>New description.</span>} title="New title" />
+  )
+
+  expect(screen.getByTestId('dialog-title')).toHaveAttribute(
+    'id',
+    initialTitleId
+  )
+  expect(screen.getByTestId('modal-body')).toHaveAttribute(
+    'id',
+    initialDescriptionId
+  )
+})
+
+it('disables the buttons when `onConfirm` is an async action and `Confirm` is clicked', async () => {
+  let resolvePromise: () => void = () => {}
+
+  const onConfirmMock: (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => Promise<void> = jest.fn(
+    () =>
+      new Promise((resolve) => {
+        resolvePromise = resolve
+      })
+  )
+
+  const { user } = setup({ onConfirmMock, title: 'Dialog title' })
+
+  await user.click(screen.getByRole('button', { name: 'Confirm' }))
+
+  expect(await screen.findByTestId('loading-icon')).toBeInTheDocument()
+
+  const buttons = screen.getAllByRole('button')
+  expect(buttons[0]).toBeDisabled()
+  expect(buttons[1]).toBeDisabled()
+
+  resolvePromise()
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('loading-icon')).not.toBeInTheDocument()
   })
 
-  describe('when props are provided for a standard dialog component', () => {
-    describe('and it is set to be initially open', () => {
-      beforeEach(() => {
-        wrapper = render(
-          <Dialog
-            data-arbitrary="arbitrary"
-            title={title}
-            description={description}
-            onConfirm={onConfirm}
-            onCancel={onCancel}
-            isOpen
-          />
-        )
-      })
-
-      it('should spread arbitrary props', () => {
-        expect(wrapper.getByRole('dialog')).toHaveAttribute(
-          'data-arbitrary',
-          'arbitrary'
-        )
-      })
-
-      it('should set the `aria-labelledby` attribute to the ID of the title', () => {
-        const titleId = wrapper.getByTestId('dialog-title').getAttribute('id')
-
-        expect(wrapper.getByRole('dialog')).toHaveAttribute(
-          'aria-labelledby',
-          titleId
-        )
-      })
-
-      it('should render the title', () => {
-        expect(wrapper.getByTestId('dialog-title')).toHaveTextContent(title)
-      })
-
-      it('should render the description', () => {
-        expect(wrapper.getByTestId('dialog-description').innerHTML).toContain(
-          renderToStaticMarkup(description)
-        )
-      })
-
-      describe('and the primary button is clicked', () => {
-        beforeEach(() => {
-          fireEvent(
-            wrapper.getByTestId('modal-primary'),
-            new MouseEvent('click', {
-              bubbles: true,
-              cancelable: true,
-            })
-          )
-        })
-
-        it('should invoke the onConfirm callback', () => {
-          expect(onConfirm).toHaveBeenCalled()
-        })
-      })
-
-      describe('and the secondary button is clicked', () => {
-        beforeEach(() => {
-          fireEvent(
-            wrapper.getByTestId('modal-secondary'),
-            new MouseEvent('click', {
-              bubbles: true,
-              cancelable: true,
-            })
-          )
-        })
-
-        it('should invoke the onCancel callback', () => {
-          expect(onCancel).toHaveBeenCalled()
-        })
-      })
-    })
-  })
-
-  describe('when aria-label but no title is set', () => {
-    beforeEach(() => {
-      wrapper = render(
-        <Dialog
-          aria-label="Accessible name"
-          data-arbitrary="arbitrary"
-          description={description}
-          onConfirm={onConfirm}
-          onCancel={onCancel}
-          isOpen
-        />
-      )
-    })
-
-    it('does not set the `aria-labelledby` attribute', () => {
-      expect(wrapper.getByRole('dialog')).not.toHaveAttribute('aria-labelledby')
-    })
-
-    it('sets the `aria-label` attribute', () => {
-      expect(wrapper.getByRole('dialog')).toHaveAttribute(
-        'aria-label',
-        'Accessible name'
-      )
-    })
-  })
-
-  describe('when the Dialog description changes', () => {
-    let initialTitleId: string
-    let initialDescriptionId: string
-
-    const ExampleDialog = ({
-      exampleDescription,
-    }: {
-      exampleDescription: string
-    }) => (
-      <Dialog title="Example title" description={exampleDescription} isOpen />
-    )
-
-    beforeEach(() => {
-      wrapper = render(<ExampleDialog exampleDescription="initial content" />)
-      initialTitleId = wrapper.getByTestId('dialog-title').id
-      initialDescriptionId = wrapper.getByTestId('modal-body').id
-
-      wrapper.rerender(<ExampleDialog exampleDescription="new content" />)
-    })
-
-    it('does not generate new a new title `id`', () => {
-      expect(wrapper.getByTestId('dialog-title')).toHaveAttribute(
-        'id',
-        initialTitleId
-      )
-    })
-
-    it('does not generate new a new description `id`', () => {
-      expect(wrapper.getByTestId('modal-body')).toHaveAttribute(
-        'id',
-        initialDescriptionId
-      )
-    })
-  })
-
-  describe('when onConfirm is async and the Confirm button is clicked', () => {
-    let resolvePromise: () => void
-
-    const onConfirmMock: (
-      event: React.MouseEvent<HTMLButtonElement>
-    ) => Promise<void> = jest.fn(
-      () =>
-        new Promise((resolve) => {
-          resolvePromise = resolve
-        })
-    )
-
-    beforeEach(() => {
-      wrapper = render(
-        <Dialog
-          title={title}
-          description={description}
-          onConfirm={onConfirmMock}
-          onCancel={onCancel}
-          isOpen
-        />
-      )
-
-      fireEvent(
-        wrapper.getByTestId('modal-primary'),
-        new MouseEvent('click', {
-          bubbles: true,
-          cancelable: true,
-        })
-      )
-    })
-
-    it('renders the buttons', async () => {
-      expect(await wrapper.findByTestId('loading-icon')).toBeInTheDocument()
-
-      const buttons = wrapper.getAllByRole('button')
-      expect(buttons[0]).toBeDisabled()
-      expect(buttons[1]).toBeDisabled()
-
-      resolvePromise()
-
-      await waitFor(() => {
-        expect(wrapper.queryByTestId('loading-icon')).not.toBeInTheDocument()
-        expect(buttons[0]).toBeEnabled()
-        expect(buttons[1]).toBeEnabled()
-      })
-    })
-  })
+  expect(buttons[0]).toBeEnabled()
+  expect(buttons[1]).toBeEnabled()
 })

--- a/packages/react-component-library/src/components/Dialog/Dialog.tsx
+++ b/packages/react-component-library/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { ButtonProps } from '../Button'
@@ -31,7 +31,9 @@ export interface DialogProps
   /**
    * Optional handler called when the Confirm button is clicked.
    */
-  onConfirm?: (event: React.MouseEvent<HTMLButtonElement>) => void
+  onConfirm?: (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => void | Promise<void>
   /**
    * Optional text title to display at the top of the component.
    *
@@ -53,16 +55,26 @@ export const Dialog = React.forwardRef<ModalImperativeHandle, DialogProps>(
     }: DialogProps,
     ref
   ) => {
+    const [isLoading, setIsLoading] = useState(false)
+
     const confirmButton: ButtonProps = {
-      onClick: onConfirm,
+      onClick: async (event) => {
+        setIsLoading(true)
+
+        await onConfirm?.(event)
+
+        setIsLoading(false)
+      },
       children: 'Confirm',
       variant: isDanger ? 'danger' : 'primary',
+      isLoading,
     }
 
     const cancelButton: ButtonProps = {
       onClick: onCancel,
       children: 'Cancel',
       variant: 'secondary',
+      isDisabled: isLoading,
     }
 
     const titleId = useExternalId('dialog-title')

--- a/packages/react-component-library/src/components/TextInput/Input.tsx
+++ b/packages/react-component-library/src/components/TextInput/Input.tsx
@@ -7,6 +7,7 @@ import { useExternalId } from '../../hooks/useExternalId'
 import { useInputValue } from '../../hooks/useInputValue'
 
 export interface InputProps extends ComponentWithClass {
+  autoComplete?: 'off' | 'on'
   hasFocus: boolean
   id?: string
   isDisabled?: boolean

--- a/packages/react-component-library/src/components/TextInput/TextInput.test.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.test.tsx
@@ -254,4 +254,19 @@ describe('TextInput', () => {
       )
     })
   })
+
+  describe('when autoComplete is set to off', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <TextInput autoComplete="off" label="label" name="name" />
+      )
+    })
+
+    it('sets autocomplete to off', () => {
+      expect(wrapper.getByLabelText('label')).toHaveAttribute(
+        'autocomplete',
+        'off'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/TextInput/TextInput.tsx
+++ b/packages/react-component-library/src/components/TextInput/TextInput.tsx
@@ -31,6 +31,10 @@ export interface TextInputProps
   extends ComponentWithClass,
     InputValidationProps {
   /**
+   * Toggle whether auto complete is enabled on the text input.
+   */
+  autoComplete?: 'off' | 'on'
+  /**
    * Toggle whether to auto focus the component upon initial render.
    */
   autoFocus?: boolean


### PR DESCRIPTION
## Overview
Makes the `Dialog` handle async actions so that the buttons are disabled and a spinner shows if a promise has not yet resolved.

## Reason
Required in downstream application so that the user knows background work is in progress and doesn't double submit the action.

## Work carried out
- [x] Handle async actions
- [x] Refactor `Dialog` tests
- [x] Address `TextInput` `autoComplete` tech debt (downstream app is using `@ts-expect-error`)

## Test instructions
Browse to http://localhost:6006/?path=/story/components-dialog--async-action
