### PR TITLE
fix(Drawer): Handle scrolling content

### DIFF
--- a/packages/react-component-library/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.stories.tsx
@@ -5,6 +5,7 @@ import { Meta, StoryFn } from '@storybook/react'
 import { color } from '@royalnavy/design-tokens'
 
 import { Drawer } from '.'
+import { TextE } from '../Text'
 
 export default {
   component: Drawer,
@@ -20,7 +21,7 @@ export default {
 } as Meta<typeof Drawer>
 
 const StyledWrapper = styled.div`
-  min-height: 300px;
+  height: 300px;
   background-color: ${color('neutral', '000')};
 `
 
@@ -35,3 +36,31 @@ export const Default: StoryFn<typeof Drawer> = (props) => (
 Default.args = {
   isOpen: true,
 }
+
+export const WithScrollableContent: StoryFn<typeof Drawer> = (props) => (
+  <StyledWrapper>
+    <Drawer {...props}>
+      <TextE el="h1">Hello World</TextE>
+      <TextE>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+        facilisis, magna eget tempus ultrices, nulla enim posuere augue, quis
+        vehicula magna sapien vel diam. Phasellus orci lectus, ultricies vitae
+        fringilla ut, dapibus eget ipsum. Cras viverra hendrerit ex, id
+        sollicitudin nibh pulvinar at. Vestibulum facilisis sem in bibendum
+        ultricies. Aenean eu lacus ultricies, auctor lacus in, blandit eros.
+        Nunc maximus sodales est, ut convallis ipsum facilisis nec. Cras eu
+        accumsan massa. Sed tempus nunc vitae vulputate imperdiet. Sed commodo
+        feugiat sollicitudin. Cras at commodo turpis. In interdum dolor ut enim
+        posuere suscipit. Integer lacus metus, pulvinar at mi varius,
+        scelerisque porttitor enim. Quisque luctus scelerisque elit, ut accumsan
+        felis hendrerit id.
+      </TextE>
+    </Drawer>
+  </StyledWrapper>
+)
+
+WithScrollableContent.args = {
+  isOpen: true,
+}
+
+WithScrollableContent.storyName = 'With scrollable content'

--- a/packages/react-component-library/src/components/Drawer/Drawer.test.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.test.tsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
 import {
+  fireEvent,
   render,
   RenderResult,
-  fireEvent,
   waitFor,
 } from '@testing-library/react'
 
@@ -163,6 +163,23 @@ describe('Drawer', () => {
       expect(wrapper.getByTestId('drawer-content')).toHaveTextContent(
         'drawer-wrapper'
       )
+    })
+  })
+
+  describe('when drawer contents are taller than container height', () => {
+    beforeEach(() => {
+      children = <div style={{ height: '300px' }}>Arbitrary JSX</div>
+
+      wrapper = render(
+        <div style={{ height: '100px', overflow: 'hidden' }}>
+          <Drawer>{children}</Drawer>
+        </div>
+      )
+    })
+
+    it('should have 100% height', () => {
+      const inner = wrapper.getByTestId('drawer-inner')
+      expect(inner).toHaveStyleRule('height', '100%')
     })
   })
 

--- a/packages/react-component-library/src/components/Drawer/Drawer.tsx
+++ b/packages/react-component-library/src/components/Drawer/Drawer.tsx
@@ -35,7 +35,7 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
         ref={ref}
         {...rest}
       >
-        <StyledDrawerInner>
+        <StyledDrawerInner data-testid="drawer-inner">
           <StyledDrawerButton
             onClick={handleOnClose}
             data-testid="drawer-close"

--- a/packages/react-component-library/src/components/Drawer/partials/StyledDrawerInner.tsx
+++ b/packages/react-component-library/src/components/Drawer/partials/StyledDrawerInner.tsx
@@ -3,4 +3,5 @@ import styled from 'styled-components'
 export const StyledDrawerInner = styled.div`
   position: relative;
   width: 100%;
+  height: 100%;
 `


### PR DESCRIPTION
## Related issue

#[issueid]

When you have a large list within the drawer the content will not scroll as expected. This is because the outer container doesn't have a 100% height.

## Reason

Scrolling drawer content *may* be needed for the NLIMS dashboard.

## Work carried out

- [x] Update the styled component to have 100% height
- [x] Add a new story with lorem ipsum text to demonstrate scrolling

