### PR TITLE
feat(Toast): Add ability to update all props when calling `showToast`

### DIFF
--- a/packages/react-component-library/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.stories.tsx
@@ -33,7 +33,7 @@ const ToastButton = (props: ToastProps) => {
       <Toast {...props} />
       <Button
         onClick={(_: React.FormEvent<HTMLButtonElement>) => {
-          showToast(DESCRIPTION)
+          showToast({ label: 'another', message: DESCRIPTION })
         }}
       >
         Show Toast

--- a/packages/react-component-library/src/components/Toast/Toast.test.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.test.tsx
@@ -5,63 +5,32 @@ import { render, screen } from '@testing-library/react'
 import { TOAST_APPEARANCE, Toast, showToast } from '.'
 
 const LABEL = 'Example label'
-const DESCRIPTION = 'This is an example toast message'
+const MESSAGE = 'This is an example toast message'
 
-describe('Toast', () => {
-  beforeEach(() => {
-    render(
-      <Toast
-        appearance={TOAST_APPEARANCE.INFO}
-        label={LABEL}
-        data-arbitrary="foo"
-      />
-    )
-  })
+function setup() {
+  render(
+    <Toast
+      appearance={TOAST_APPEARANCE.INFO}
+      label={LABEL}
+      data-arbitrary="foo"
+    />
+  )
+}
 
-  describe('default props', () => {
-    showToast(DESCRIPTION)
+it('renders the toast', async () => {
+  setup()
 
-    it('should spread arbitrary props', async () => {
-      expect(screen.getByTestId('wrapper')).toHaveAttribute(
-        'data-arbitrary',
-        'foo'
-      )
-    })
+  showToast(MESSAGE)
 
-    it('should set the `role` attribute to `alert`', () => {
-      expect(screen.getByTestId('wrapper')).toHaveAttribute('role', 'status')
-    })
+  const wrapper = await screen.findByRole('status')
+  expect(wrapper).toHaveAttribute('data-arbitrary', 'foo')
 
-    it('should set the `aria-labelledby` attribute to the ID of the title', () => {
-      const titleId = screen
-        ?.getByText(LABEL)
-        ?.parentElement?.getAttribute('id')
+  const titleId = screen?.getByText(LABEL)?.parentElement?.getAttribute('id')
+  expect(wrapper).toHaveAttribute('aria-labelledby', titleId)
 
-      expect(screen.getByTestId('wrapper')).toHaveAttribute(
-        'aria-labelledby',
-        titleId
-      )
-    })
+  const contentId = screen.getByText(MESSAGE).getAttribute('id')
+  expect(wrapper).toHaveAttribute('aria-describedby', contentId)
 
-    it('should set the `aria-describedby` attribute to the ID of the content', () => {
-      const contentId = screen.getByText(DESCRIPTION).getAttribute('id')
-
-      expect(screen.getByTestId('wrapper')).toHaveAttribute(
-        'aria-describedby',
-        contentId
-      )
-    })
-
-    it('should set the `aria-hidden` attribute on the state icon', () => {
-      expect(screen.getByTestId('icon')).toHaveAttribute('aria-hidden', 'true')
-    })
-
-    it('renders the toast to the DOM', () => {
-      expect(screen.queryByTestId('wrapper')).toBeInTheDocument()
-    })
-
-    it('displays the label text', () => {
-      expect(screen.queryByText(LABEL)).toBeInTheDocument()
-    })
-  })
+  expect(screen.getByTestId('icon')).toHaveAttribute('aria-hidden', 'true')
+  expect(screen.getByText(LABEL)).toBeInTheDocument()
 })

--- a/packages/react-component-library/src/components/Toast/Toast.test.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-
-import { render, screen } from '@testing-library/react'
+import { color } from '@royalnavy/design-tokens'
+import { render, screen, waitFor, within } from '@testing-library/react'
 
 import { TOAST_APPEARANCE, Toast, showToast } from '.'
 
@@ -17,20 +17,58 @@ function setup() {
   )
 }
 
+/* Added this function to resolve an issue when running tests for
+ * the whole of this file and more than one toast is shown */
+async function getLastToast(lastToastLabel: string) {
+  await waitFor(() => {
+    expect(screen.getByText(lastToastLabel)).toBeInTheDocument()
+  })
+
+  return screen.getAllByRole('status')[0]
+}
+
 it('renders the toast', async () => {
   setup()
 
   showToast(MESSAGE)
 
-  const wrapper = await screen.findByRole('status')
-  expect(wrapper).toHaveAttribute('data-arbitrary', 'foo')
+  const lastToast = await getLastToast(LABEL)
+  expect(lastToast).toHaveAttribute('data-arbitrary', 'foo')
 
   const titleId = screen?.getByText(LABEL)?.parentElement?.getAttribute('id')
-  expect(wrapper).toHaveAttribute('aria-labelledby', titleId)
+  expect(lastToast).toHaveAttribute('aria-labelledby', titleId)
 
   const contentId = screen.getByText(MESSAGE).getAttribute('id')
-  expect(wrapper).toHaveAttribute('aria-describedby', contentId)
+  expect(lastToast).toHaveAttribute('aria-describedby', contentId)
 
-  expect(screen.getByTestId('icon')).toHaveAttribute('aria-hidden', 'true')
+  expect(within(lastToast).getByTestId('icon')).toHaveAttribute(
+    'aria-hidden',
+    'true'
+  )
+  expect(within(lastToast).getByTestId('icon')).toHaveStyle({
+    color: color('action', '500'),
+  })
+
   expect(screen.getByText(LABEL)).toBeInTheDocument()
+})
+
+it('sets new props when `showToast` is called with new props', async () => {
+  setup()
+
+  const expectedNewLabel = 'New label'
+  const expectedNewMessage = 'New message'
+
+  showToast({
+    appearance: TOAST_APPEARANCE.ERROR,
+    label: expectedNewLabel,
+    message: expectedNewMessage,
+  })
+
+  const lastToast = await getLastToast(expectedNewLabel)
+
+  expect(within(lastToast).getByText(expectedNewLabel)).toBeInTheDocument()
+  expect(within(lastToast).getByText(expectedNewMessage)).toBeInTheDocument()
+  expect(within(lastToast).getByTestId('icon')).toHaveStyle({
+    color: color('danger', '500'),
+  })
 })

--- a/packages/react-component-library/src/components/Toast/Toast.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.tsx
@@ -6,7 +6,12 @@ import {
   IconCheckCircle,
 } from '@royalnavy/icon-library'
 import { spacing, zIndex } from '@royalnavy/design-tokens'
-import { useToaster, toast, resolveValue } from 'react-hot-toast'
+import {
+  useToaster,
+  toast,
+  resolveValue,
+  Toast as HotToast,
+} from 'react-hot-toast'
 
 import { StyledToast } from './partials/StyledToast'
 import { StyledHeader } from './partials/StyledHeader'
@@ -86,8 +91,10 @@ export const Toast = (props: ToastProps) => {
         zIndex: zIndex('overlay', 999),
       }}
     >
-      {toasts.map((item) => {
+      {toasts.map((item: HotToast & ToastProps) => {
         const { id, height = 0, visible, message, ariaProps } = item
+        const toastAppearance = item.appearance ?? appearance
+        const toastLabel = item.label ?? label
 
         const offset = calculateOffset(item, {
           reverseOrder: true,
@@ -111,7 +118,7 @@ export const Toast = (props: ToastProps) => {
             ref={ref}
           >
             <StyledToast
-              $appearance={appearance}
+              $appearance={toastAppearance}
               aria-labelledby={message ? titleId : undefined}
               aria-describedby={message ? descriptionId : undefined}
               data-testid="wrapper"
@@ -120,10 +127,10 @@ export const Toast = (props: ToastProps) => {
             >
               <StyledHeader>
                 <StyledTitle id={titleId}>
-                  {label && (
+                  {toastLabel && (
                     <StyledLabel>
                       <Icon aria-hidden data-testid="icon" />
-                      {label}
+                      {toastLabel}
                     </StyledLabel>
                   )}
                   <StyledTime>{time}</StyledTime>
@@ -149,9 +156,18 @@ export const Toast = (props: ToastProps) => {
   )
 }
 
-export const showToast = (message: string, duration = 4000, options = {}) => {
+export const showToast = (
+  toastContent: string | (ToastProps & { message: string }),
+  duration = 4000,
+  options = {}
+) => {
+  const isToastContentString = typeof toastContent === 'string'
+  const message = isToastContentString ? toastContent : toastContent.message
+  const toastContentProps = isToastContentString ? {} : toastContent
+
   toast(message, {
     duration,
     ...options,
+    ...toastContentProps,
   })
 }


### PR DESCRIPTION
## Related issue
NA

## Overview
Adds the ability to update all `Toast` props when calling `showToast`.

## Reason
Currently can only update the `message`.

## Work carried out
- [x] Refactor tests to align with new patterns
- [x] Update `showToast` signature to update all props

## Developer notes
Open to other ideas, this was a first stab and conscious of breaking changes so would be good to make sure this is mostly right.
