### PR TITLE
fix(Toast): Add JSX type

### DIFF
--- a/packages/react-component-library/src/components/Toast/Toast.test.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.test.tsx
@@ -72,3 +72,25 @@ it('sets new props when `showToast` is called with new props', async () => {
     color: color('danger', '500'),
   })
 })
+
+it('sets the message when the message is JSX', async () => {
+  setup()
+
+  const expectedNewLabel = 'JSX'
+  const expectedNewMessage = (
+    <>
+      <p>one</p>
+      <p>two</p>
+    </>
+  )
+
+  showToast({
+    label: expectedNewLabel,
+    message: expectedNewMessage,
+  })
+
+  const lastToast = await getLastToast(expectedNewLabel)
+
+  expect(within(lastToast).getByText(expectedNewLabel)).toBeInTheDocument()
+  expect(within(lastToast).getAllByRole('paragraph')).toHaveLength(2)
+})

--- a/packages/react-component-library/src/components/Toast/Toast.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { isValidElement, useState } from 'react'
 import {
   IconInfo,
   IconWarning,
@@ -156,18 +156,28 @@ export const Toast = (props: ToastProps) => {
   )
 }
 
+type ToastContentProps = ToastProps & { message: string | JSX.Element }
+
 export const showToast = (
-  toastContent: string | (ToastProps & { message: string }),
+  toastContent: string | JSX.Element | ToastContentProps,
   duration = 4000,
   options = {}
 ) => {
   const isToastContentString = typeof toastContent === 'string'
-  const message = isToastContentString ? toastContent : toastContent.message
-  const toastContentProps = isToastContentString ? {} : toastContent
+  const isToastContentJsx = isValidElement(toastContent)
 
-  toast(message, {
-    duration,
-    ...options,
-    ...toastContentProps,
-  })
+  if (isToastContentString || isToastContentJsx) {
+    toast(toastContent, {
+      duration,
+      ...options,
+    })
+  } else {
+    const { message } = toastContent as ToastContentProps
+
+    toast(message, {
+      duration,
+      ...options,
+      ...toastContent,
+    })
+  }
 }


### PR DESCRIPTION
## Related issue
NA

## Overview
Allow message to be of JSX element type.

## Reason
It is possible for the message to be a string or a JSX element.

## Work carried out
- [x] Apply fix for JSX element
