### PR TITLE
fix(Toast): Use unique IDs when multiple toasts shown

### DIFF
--- a/packages/react-component-library/src/components/Toast/Toast.test.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.test.tsx
@@ -94,3 +94,30 @@ it('sets the message when the message is JSX', async () => {
   expect(within(lastToast).getByText(expectedNewLabel)).toBeInTheDocument()
   expect(within(lastToast).getAllByRole('paragraph')).toHaveLength(2)
 })
+
+it('sets unique IDs when there are multiple toasts', async () => {
+  setup()
+
+  showToast(MESSAGE)
+  showToast(MESSAGE)
+
+  const [toast1, toast2] = await screen.findAllByRole('status')
+
+  expect(toast1.getAttribute('aria-labelledby')).not.toEqual(
+    toast2.getAttribute('aria-labelledby')
+  )
+  expect(toast1.getAttribute('aria-describedby')).not.toEqual(
+    toast2.getAttribute('aria-describedby')
+  )
+})
+
+it('sets an accessible name when there is no message', async () => {
+  setup()
+
+  const label = 'toast-with-no-message'
+  showToast({ label, message: '' })
+
+  const toast = await getLastToast(label)
+
+  expect(toast).toHaveAccessibleName(new RegExp(label))
+})

--- a/packages/react-component-library/src/components/Toast/Toast.tsx
+++ b/packages/react-component-library/src/components/Toast/Toast.tsx
@@ -95,6 +95,8 @@ export const Toast = (props: ToastProps) => {
         const { id, height = 0, visible, message, ariaProps } = item
         const toastAppearance = item.appearance ?? appearance
         const toastLabel = item.label ?? label
+        const toastTitleId = `${titleId}-${item.id}`
+        const toastDescriptionId = `${descriptionId}-${item.id}`
 
         const offset = calculateOffset(item, {
           reverseOrder: true,
@@ -119,14 +121,14 @@ export const Toast = (props: ToastProps) => {
           >
             <StyledToast
               $appearance={toastAppearance}
-              aria-labelledby={message ? titleId : undefined}
-              aria-describedby={message ? descriptionId : undefined}
+              aria-labelledby={toastTitleId}
+              aria-describedby={message ? toastDescriptionId : undefined}
               data-testid="wrapper"
               {...rest}
               {...ariaProps}
             >
               <StyledHeader>
-                <StyledTitle id={titleId}>
+                <StyledTitle id={toastTitleId}>
                   {toastLabel && (
                     <StyledLabel>
                       <Icon aria-hidden data-testid="icon" />
@@ -144,7 +146,7 @@ export const Toast = (props: ToastProps) => {
                 </StyledButton>
               </StyledHeader>
               <StyledContent>
-                <StyledDescription id={descriptionId}>
+                <StyledDescription id={toastDescriptionId}>
                   {resolveValue(message, item)}
                 </StyledDescription>
               </StyledContent>


### PR DESCRIPTION
## Overview

This fixes a bug where duplicate IDs were used for `aria-labelledby` and `aria-describedby` (and the related elements) when multiple toasts were on screen.

It also removes the conditional setting of `aria-labelledby` based on whether there was a message, as that didn't make much sense (there is always some text in the label element, and it doesn't depend on whether there's a message).

## Link to preview

https://deploy-preview-3906--storybook-navy-digital-mod-uk.netlify.app/

## Reason

Duplicate IDs were causing toasts to have the wrong accessible names etc when multiple toasts were visible.

## Work carried out

- [x] Append toast ID to element IDs
- [x] Remove conditional setting of `aria-labelledby`
- [x] Update tests

## Screenshot

Previous duplicate IDs can be seem on https://storybook.design-system.navy.digital.mod.uk/?path=/docs/components-toast--docs by creating multiple toasts:

![image](https://github.com/user-attachments/assets/fdefa3ad-b7a8-447d-9d37-ee2bfff4dd95)

With the changes in, the IDs are unique:

![image](https://github.com/user-attachments/assets/77e5ec32-278f-47b6-a7fe-73562c47a5de)


