### PR TITLE
[WIP] build(GHA): Fix move labelled issues workflow

### DIFF
--- a/.github/workflows/project_issues.yml
+++ b/.github/workflows/project_issues.yml
@@ -1,4 +1,4 @@
-name: Test Issue Mover in Pull Requests
+name: Move Issues to Project Column
 
 on:
   pull_request:
@@ -32,7 +32,7 @@ jobs:
               labels: ['Size: Small']
             });
             console.log('Test issue created:', issue.data.html_url);
-            return issue.data.number;
+            return issue.data.node_id;
 
       - name: Run issue mover script
         uses: actions/github-script@v6
@@ -40,10 +40,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { moveIssues } = await import('${{ github.workspace }}/scripts/github-actions/moveIssues.mjs')
-            const issue = {number: ${{ steps.create_issue.outputs.result }}}
+            const issueNodeId = '${{ steps.create_issue.outputs.result }}'
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            issue.data.node_id = issueNodeId;
             await moveIssues({
               github,
-              context: {...context, payload: {issue}},
+              context: { ...context, payload: { issue: issue.data } },
               core,
             })
 
@@ -56,7 +62,7 @@ jobs:
             await github.rest.issues.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ steps.create_issue.outputs.result }},
+              issue_number: context.issue.number,
               state: 'closed'
             });
             console.log('Test issue closed');

--- a/.github/workflows/project_issues.yml
+++ b/.github/workflows/project_issues.yml
@@ -4,15 +4,21 @@ on:
   issues:
     types: [labeled]
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PROJECT_URL: https://github.com/orgs/Royal-Navy/projects/9
+
 jobs:
-  Move_labelled_issues:
+  Move_labeled_issues:
     runs-on: ubuntu-latest
     steps:
-      - name: Move small/med labeled issues to Candidates column
-        uses: Royal-Navy/design-system-moveissue-action@master
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Move issues to project column
+        uses: actions/github-script@v6
         with:
-          action-token: '${{ secrets.GHA_ISSUES_TOKEN }}'
-          project-url: 'https://github.com/Royal-Navy/design-system/projects/6'
-          column-name: 'Candidates for Ready'
-          label-name: 'Size: Small,Size: Medium'
-          columns-to-ignore: 'Ready,In Progress,In Review,Done'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { moveIssues } = await import('${{ github.workspace }}/scripts/github-actions/moveIssues.mjs')
+            await moveIssues({ github, context, core })

--- a/.github/workflows/project_issues.yml
+++ b/.github/workflows/project_issues.yml
@@ -1,6 +1,8 @@
-name: Project Automation - move issues
+name: Test Issue Mover in Pull Requests
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   issues:
     types: [labeled]
 
@@ -9,8 +11,59 @@ env:
   PROJECT_URL: https://github.com/orgs/Royal-Navy/projects/9
 
 jobs:
+  Test_issue_mover:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create test issue
+        id: create_issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Test issue for PR #' + context.issue.number,
+              body: 'This is a test issue created to verify the issue mover script.',
+              labels: ['Size: Small']
+            });
+            console.log('Test issue created:', issue.data.html_url);
+            return issue.data.number;
+
+      - name: Run issue mover script
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { moveIssues } = await import('${{ github.workspace }}/scripts/github-actions/moveIssues.mjs')
+            const issue = {number: ${{ steps.create_issue.outputs.result }}}
+            await moveIssues({
+              github,
+              context: {...context, payload: {issue}},
+              core,
+            })
+
+      - name: Clean up test issue
+        if: always()
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.create_issue.outputs.result }},
+              state: 'closed'
+            });
+            console.log('Test issue closed');
+
   Move_labeled_issues:
     runs-on: ubuntu-latest
+    if: github.event_name == 'issues'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/scripts/github-actions/moveIssues.mjs
+++ b/scripts/github-actions/moveIssues.mjs
@@ -1,88 +1,185 @@
 const targetLabels = ['Size: Small', 'Size: Medium']
-const targetColumn = 'Candidates for Ready'
-const ignoredColumns = ['Ready', 'In Progress', 'In Review', 'Done']
+const targetColumnName = 'Candidates for Ready'
+const ignoredColumnNames = ['Ready', 'In Progress', 'In Review', 'Done']
 
-function hasTargetLabel(issue) {
-  return issue.labels.some((label) => targetLabels.includes(label.name))
-}
+async function getProjectData(github, projectUrl) {
+  const [orgName, projectNumber] = projectUrl.split('/').slice(-2)
 
-async function getTargetProject(github, core) {
-  const project = await github.rest.projects.listForOrg({
-    org: 'Royal-Navy',
-    per_page: 100,
-  })
+  const query = `
+    query($orgName: String!, $projectNumber: Int!) {
+      organization(login: $orgName) {
+        projectV2(number: $projectNumber) {
+          id
+          fields(first: 20) {
+            nodes {
+              ... on ProjectV2Field {
+                id
+                name
+              }
+              ... on ProjectV2SingleSelectField {
+                id
+                name
+                options {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
 
-  const targetProject = project.data.find(
-    (p) => p.html_url === process.env.PROJECT_URL
-  )
-
-  if (!targetProject) {
-    core.setFailed('Target project not found')
-    return null
+  const variables = {
+    orgName,
+    projectNumber: parseInt(projectNumber),
   }
 
-  return targetProject
+  const result = await github.graphql(query, variables)
+  console.log('Project data:', JSON.stringify(result, null, 2))
+  return result.organization.projectV2
 }
 
-async function getTargetColumnId(github, projectId, core) {
-  const columns = await github.rest.projects.listColumns({
-    project_id: projectId,
-  })
+async function getIssueItemData(github, projectId, issueId) {
+  const query = `
+    query($projectId: ID!, $issueId: ID!) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          items(first: 1, filter: {contentId: $issueId}) {
+            nodes {
+              id
+              fieldValues(first: 8) {
+                nodes {
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    field {
+                      ... on ProjectV2SingleSelectField {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
 
-  const targetColumnId = columns.data.find(
-    (column) => column.name === targetColumn
-  )?.id
-
-  if (!targetColumnId) {
-    core.setFailed('Target column not found')
-    return null
+  const variables = {
+    projectId,
+    issueId,
   }
 
-  return targetColumnId
+  const result = await github.graphql(query, variables)
+  console.log('Issue item data:', JSON.stringify(result, null, 2))
+  return result.node.items.nodes[0]
 }
 
-async function isIssueInIgnoredColumn(github, columnId, issue) {
-  const projectCards = await github.rest.projects.listCards({
-    column_id: columnId,
-  })
+async function updateIssueStatus(
+  github,
+  projectId,
+  itemId,
+  statusFieldId,
+  statusOptionId
+) {
+  const mutation = `
+    mutation($projectId: ID!, $itemId: ID!, $statusFieldId: ID!, $statusOptionId: String!) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $projectId
+          itemId: $itemId
+          fieldId: $statusFieldId
+          value: {
+            singleSelectOptionId: $statusOptionId
+          }
+        }
+      ) {
+        projectV2Item {
+          id
+        }
+      }
+    }
+  `
 
-  return projectCards.data.some(
-    (card) =>
-      card.content_url === issue.url &&
-      ignoredColumns.includes(card.column_name)
-  )
-}
+  const variables = {
+    projectId,
+    itemId,
+    statusFieldId,
+    statusOptionId,
+  }
 
-async function moveIssueToTargetColumn(github, columnId, issue) {
-  await github.rest.projects.createCard({
-    column_id: columnId,
-    content_id: issue.id,
-    content_type: 'Issue',
-  })
+  const result = await github.graphql(mutation, variables)
+  console.log('Update result:', JSON.stringify(result, null, 2))
 }
 
 export async function moveIssues({ github, context, core }) {
+  console.log('Starting moveIssues function')
+  console.log(`PROJECT_URL: ${process.env.PROJECT_URL}`)
+
   const issue = context.payload.issue
-
-  if (!hasTargetLabel(issue)) {
+  if (!issue || !issue.node_id) {
+    core.setFailed('Invalid or missing issue object')
     return
   }
 
-  const targetProject = await getTargetProject(github, core)
-  if (!targetProject) {
+  console.log(`Processing issue #${issue.number}`)
+
+  if (!issue.labels.some((label) => targetLabels.includes(label.name))) {
+    console.log(`Issue #${issue.number} does not have a target label`)
     return
   }
 
-  const targetColumnId = await getTargetColumnId(github, targetProject.id, core)
-  if (!targetColumnId) {
-    return
-  }
+  try {
+    const projectData = await getProjectData(github, process.env.PROJECT_URL)
+    const statusField = projectData.fields.nodes.find(
+      (field) => field.name === 'Status'
+    )
+    if (!statusField) {
+      core.setFailed('Status field not found in project')
+      return
+    }
 
-  if (await isIssueInIgnoredColumn(github, targetColumnId, issue)) {
-    console.log('Issue is already in an ignored column')
-    return
-  }
+    const targetStatusOption = statusField.options.find(
+      (option) => option.name === targetColumnName
+    )
+    if (!targetStatusOption) {
+      core.setFailed(`Target status "${targetColumnName}" not found in project`)
+      return
+    }
 
-  await moveIssueToTargetColumn(github, targetColumnId, issue)
-  console.log(`Moved issue #${issue.number} to ${targetColumn}`)
+    const issueItemData = await getIssueItemData(
+      github,
+      projectData.id,
+      issue.node_id
+    )
+    if (!issueItemData) {
+      core.setFailed(`Issue #${issue.number} not found in project`)
+      return
+    }
+
+    const currentStatus = issueItemData.fieldValues.nodes.find(
+      (node) => node.field?.name === 'Status'
+    )?.name
+    if (ignoredColumnNames.includes(currentStatus)) {
+      console.log(
+        `Issue #${issue.number} is in an ignored column (${currentStatus}). Skipping.`
+      )
+      return
+    }
+
+    await updateIssueStatus(
+      github,
+      projectData.id,
+      issueItemData.id,
+      statusField.id,
+      targetStatusOption.id
+    )
+    console.log(`Moved issue #${issue.number} to "${targetColumnName}"`)
+  } catch (error) {
+    core.setFailed(`Error moving issue: ${error.message}`)
+    console.log('Full error:', JSON.stringify(error, null, 2))
+  }
 }

--- a/scripts/github-actions/moveIssues.mjs
+++ b/scripts/github-actions/moveIssues.mjs
@@ -1,0 +1,88 @@
+const targetLabels = ['Size: Small', 'Size: Medium']
+const targetColumn = 'Candidates for Ready'
+const ignoredColumns = ['Ready', 'In Progress', 'In Review', 'Done']
+
+function hasTargetLabel(issue) {
+  return issue.labels.some((label) => targetLabels.includes(label.name))
+}
+
+async function getTargetProject(github, core) {
+  const project = await github.rest.projects.listForOrg({
+    org: 'Royal-Navy',
+    per_page: 100,
+  })
+
+  const targetProject = project.data.find(
+    (p) => p.html_url === process.env.PROJECT_URL
+  )
+
+  if (!targetProject) {
+    core.setFailed('Target project not found')
+    return null
+  }
+
+  return targetProject
+}
+
+async function getTargetColumnId(github, projectId, core) {
+  const columns = await github.rest.projects.listColumns({
+    project_id: projectId,
+  })
+
+  const targetColumnId = columns.data.find(
+    (column) => column.name === targetColumn
+  )?.id
+
+  if (!targetColumnId) {
+    core.setFailed('Target column not found')
+    return null
+  }
+
+  return targetColumnId
+}
+
+async function isIssueInIgnoredColumn(github, columnId, issue) {
+  const projectCards = await github.rest.projects.listCards({
+    column_id: columnId,
+  })
+
+  return projectCards.data.some(
+    (card) =>
+      card.content_url === issue.url &&
+      ignoredColumns.includes(card.column_name)
+  )
+}
+
+async function moveIssueToTargetColumn(github, columnId, issue) {
+  await github.rest.projects.createCard({
+    column_id: columnId,
+    content_id: issue.id,
+    content_type: 'Issue',
+  })
+}
+
+export async function moveIssues({ github, context, core }) {
+  const issue = context.payload.issue
+
+  if (!hasTargetLabel(issue)) {
+    return
+  }
+
+  const targetProject = await getTargetProject(github, core)
+  if (!targetProject) {
+    return
+  }
+
+  const targetColumnId = await getTargetColumnId(github, targetProject.id, core)
+  if (!targetColumnId) {
+    return
+  }
+
+  if (await isIssueInIgnoredColumn(github, targetColumnId, issue)) {
+    console.log('Issue is already in an ignored column')
+    return
+  }
+
+  await moveIssueToTargetColumn(github, targetColumnId, issue)
+  console.log(`Moved issue #${issue.number} to ${targetColumn}`)
+}


### PR DESCRIPTION
## Related issue

#[issueid]

## Overview

Fix the GHA 'Project Automation - move issues' workflow.

## Reason

This workflow had stopped working with the move to the latest version of GitHub Projects.

It was also using a fork of an unmaintained action. We've scrapped this in favour of our own script.

## Work carried out

- [x] Remove reliance on unmaintained GHA fork
- [x] Archive https://github.com/Royal-Navy/design-system-moveissue-action

## Developer notes

I'd usually test workflows using [act](https://github.com/nektos/act) but it's no good for testing interactions with the GitHub API. 

Workflow might be broken - I may need to merge it to test it properly - investigating options.
