### PR TITLE
build(GHA): Fix move labelled issues workflow

### DIFF
--- a/.github/workflows/project_issues.yml
+++ b/.github/workflows/project_issues.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled]
 
 env:
-  PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+  PAT_TOKEN: ${{ secrets.GH_ISSUES_TOKEN }}
   PROJECT_URL: https://github.com/orgs/Royal-Navy/projects/9
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
       - name: Move issues to project column
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_TOKEN }}
+          github-token: ${{ secrets.GH_ISSUES_TOKEN }}
           script: |
             const { moveIssues } = await import('${{ github.workspace }}/scripts/github-actions/moveIssues.mjs')
             await moveIssues({ github, context, core })

--- a/.github/workflows/project_issues.yml
+++ b/.github/workflows/project_issues.yml
@@ -4,15 +4,21 @@ on:
   issues:
     types: [labeled]
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PROJECT_URL: https://github.com/orgs/Royal-Navy/projects/9
+
 jobs:
-  Move_labelled_issues:
+  Move_labeled_issues:
     runs-on: ubuntu-latest
     steps:
-      - name: Move small/med labeled issues to Candidates column
-        uses: Royal-Navy/design-system-moveissue-action@master
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Move issues to project column
+        uses: actions/github-script@v6
         with:
-          action-token: '${{ secrets.GHA_ISSUES_TOKEN }}'
-          project-url: 'https://github.com/Royal-Navy/design-system/projects/6'
-          column-name: 'Candidates for Ready'
-          label-name: 'Size: Small,Size: Medium'
-          columns-to-ignore: 'Ready,In Progress,In Review,Done'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { moveIssues } = await import('${{ github.workspace }}/scripts/github-actions/moveIssues.mjs')
+            await moveIssues({ github, context, core })

--- a/.github/workflows/project_issues.yml
+++ b/.github/workflows/project_issues.yml
@@ -1,8 +1,6 @@
 name: Project Automation - Move Issues
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   issues:
     types: [labeled]
 
@@ -11,62 +9,6 @@ env:
   PROJECT_URL: https://github.com/orgs/Royal-Navy/projects/9
 
 jobs:
-  Test_issue_mover:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Create test issue
-        id: create_issue
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.PAT_TOKEN }}
-          script: |
-            const issue = await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: 'Test issue for PR #' + context.issue.number,
-              body: 'This is a test issue created to verify the issue mover script.',
-              labels: ['Size: Small']
-            });
-            console.log('Test issue created:', issue.data.html_url);
-            core.setOutput('issue_number', issue.data.number);
-            core.setOutput('issue_node_id', issue.data.node_id);
-
-      - name: Run issue mover script
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.PAT_TOKEN }}
-          script: |
-            const { moveIssues } = await import('${{ github.workspace }}/scripts/github-actions/moveIssues.mjs')
-            const issue = await github.rest.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ steps.create_issue.outputs.issue_number }}
-            });
-            issue.data.node_id = '${{ steps.create_issue.outputs.issue_node_id }}';
-            await moveIssues({
-              github,
-              context: { ...context, payload: { issue: issue.data } },
-              core,
-            })
-
-      - name: Clean up test issue
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.PAT_TOKEN }}
-          script: |
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ steps.create_issue.outputs.issue_number }},
-              state: 'closed'
-            });
-            console.log('Test issue closed');
-
   Move_labeled_issues:
     runs-on: ubuntu-latest
     if: github.event_name == 'issues'

--- a/.github/workflows/project_issues.yml
+++ b/.github/workflows/project_issues.yml
@@ -1,4 +1,4 @@
-name: Project Atuomation - Move Issues
+name: Project Automation - Move Issues
 
 on:
   pull_request:

--- a/.github/workflows/project_issues.yml
+++ b/.github/workflows/project_issues.yml
@@ -1,24 +1,83 @@
-name: Project Automation - move issues
+name: Project Atuomation - Move Issues
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   issues:
     types: [labeled]
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
   PROJECT_URL: https://github.com/orgs/Royal-Navy/projects/9
 
 jobs:
-  Move_labeled_issues:
+  Test_issue_mover:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Create test issue
+        id: create_issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Test issue for PR #' + context.issue.number,
+              body: 'This is a test issue created to verify the issue mover script.',
+              labels: ['Size: Small']
+            });
+            console.log('Test issue created:', issue.data.html_url);
+            core.setOutput('issue_number', issue.data.number);
+            core.setOutput('issue_node_id', issue.data.node_id);
+
+      - name: Run issue mover script
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const { moveIssues } = await import('${{ github.workspace }}/scripts/github-actions/moveIssues.mjs')
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.create_issue.outputs.issue_number }}
+            });
+            issue.data.node_id = '${{ steps.create_issue.outputs.issue_node_id }}';
+            await moveIssues({
+              github,
+              context: { ...context, payload: { issue: issue.data } },
+              core,
+            })
+
+      - name: Clean up test issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.create_issue.outputs.issue_number }},
+              state: 'closed'
+            });
+            console.log('Test issue closed');
+
+  Move_labeled_issues:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issues'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Move issues to project column
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT_TOKEN }}
           script: |
             const { moveIssues } = await import('${{ github.workspace }}/scripts/github-actions/moveIssues.mjs')
             await moveIssues({ github, context, core })

--- a/.github/workflows/project_notify.yml
+++ b/.github/workflows/project_notify.yml
@@ -1,4 +1,4 @@
-name: Project Automation - notify
+name: Project Automation - Notify
 
 on:
   schedule:

--- a/.github/workflows/project_stale_issues.yml
+++ b/.github/workflows/project_stale_issues.yml
@@ -1,4 +1,4 @@
-name: Project Automation - stale issues
+name: Project Automation - Stale Issues
 
 on:
   schedule:

--- a/scripts/github-actions/moveIssues.mjs
+++ b/scripts/github-actions/moveIssues.mjs
@@ -1,0 +1,263 @@
+const TARGET_LABELS = ['Size: Small', 'Size: Medium']
+const TARGET_COLUMN = 'Candidates for Ready'
+const IGNORED_COLUMNS = ['Ready', 'In Progress', 'In Review', 'Done']
+
+const parseProjectUrl = (url) => {
+  const parts = url.split('/')
+
+  return {
+    orgName: parts[parts.length - 3],
+    projectUrl: url,
+  }
+}
+
+const fetchAllProjects = async (
+  github,
+  orgName,
+  cursor = null,
+  allProjects = []
+) => {
+  const query = `
+    query($orgName: String!, $cursor: String) {
+      organization(login: $orgName) {
+        projectsV2(first: 100, after: $cursor) {
+          nodes { id, url, number }
+          pageInfo { hasNextPage, endCursor }
+        }
+      }
+    }
+  `
+
+  const {
+    organization: { projectsV2 },
+  } = await github.graphql(query, { orgName, cursor })
+
+  const updatedProjects = [...allProjects, ...projectsV2.nodes]
+
+  if (projectsV2.pageInfo.hasNextPage) {
+    return fetchAllProjects(
+      github,
+      orgName,
+      projectsV2.pageInfo.endCursor,
+      updatedProjects
+    )
+  }
+
+  return updatedProjects
+}
+
+const getProjectData = async (github, projectUrl) => {
+  const { orgName, projectUrl: fullProjectUrl } = parseProjectUrl(projectUrl)
+  const allProjects = await fetchAllProjects(github, orgName)
+  const project = allProjects.find((p) => p.url === fullProjectUrl)
+
+  if (!project) {
+    throw new Error(`Project not found: ${fullProjectUrl}`)
+  }
+
+  return project
+}
+
+const fetchProjectItems = async (
+  github,
+  projectId,
+  cursor = null,
+  allItems = []
+) => {
+  const query = `
+    query($projectId: ID!, $cursor: String) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          items(first: 100, after: $cursor) {
+            nodes {
+              id
+              content { ... on Issue { id } }
+              fieldValues(first: 8) {
+                nodes {
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    field { ... on ProjectV2SingleSelectField { name } }
+                  }
+                }
+              }
+            }
+            pageInfo { hasNextPage, endCursor }
+          }
+        }
+      }
+    }
+  `
+
+  const result = await github.graphql(query, { projectId, cursor })
+  const updatedItems = [...allItems, ...result.node.items.nodes]
+
+  if (result.node.items.pageInfo.hasNextPage) {
+    return fetchProjectItems(
+      github,
+      projectId,
+      result.node.items.pageInfo.endCursor,
+      updatedItems
+    )
+  }
+
+  return updatedItems
+}
+
+const getIssueItemData = async (github, projectId, issueId) => {
+  const allItems = await fetchProjectItems(github, projectId)
+  return allItems.find((item) => item.content && item.content.id === issueId)
+}
+
+const updateIssueStatus = async (
+  github,
+  projectId,
+  itemId,
+  statusFieldId,
+  statusOptionId
+) => {
+  const mutation = `
+    mutation($projectId: ID!, $itemId: ID!, $statusFieldId: ID!, $statusOptionId: String!) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $projectId
+          itemId: $itemId
+          fieldId: $statusFieldId
+          value: { singleSelectOptionId: $statusOptionId }
+        }
+      ) {
+        projectV2Item { id }
+      }
+    }
+  `
+
+  await github.graphql(mutation, {
+    projectId,
+    itemId,
+    statusFieldId,
+    statusOptionId,
+  })
+}
+
+const addIssueToProject = async (github, projectId, issueId) => {
+  const mutation = `
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+        item { id }
+      }
+    }
+  `
+
+  const result = await github.graphql(mutation, {
+    projectId,
+    contentId: issueId,
+  })
+
+  return result.addProjectV2ItemById.item
+}
+
+const getStatusField = async (github, projectId) => {
+  const query = `
+    query($projectId: ID!) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          fields(first: 20) {
+            nodes {
+              ... on ProjectV2SingleSelectField {
+                id
+                name
+                options { id, name }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const result = await github.graphql(query, { projectId })
+
+  return result.node.fields.nodes.find((field) => field.name === 'Status')
+}
+
+const getCurrentStatus = (issueItemData) => {
+  return issueItemData.fieldValues?.nodes.find(
+    (node) => node.field?.name === 'Status'
+  )?.name
+}
+
+const validateIssue = (issue) => {
+  if (!issue || !issue.node_id) {
+    throw new Error('Invalid or missing issue object')
+  }
+
+  if (!issue.labels.some((label) => TARGET_LABELS.includes(label.name))) {
+    throw new Error(`Issue #${issue.number} does not have a target label`)
+  }
+
+  return true
+}
+
+const getTargetStatusOption = (statusField) => {
+  const targetStatusOption = statusField.options.find(
+    (option) => option.name === TARGET_COLUMN
+  )
+
+  if (!targetStatusOption) {
+    throw new Error(`Target status "${TARGET_COLUMN}" not found in project`)
+  }
+
+  return targetStatusOption
+}
+
+const processIssueItem = async (github, projectData, issue) => {
+  const statusField = await getStatusField(github, projectData.id)
+  const targetStatusOption = getTargetStatusOption(statusField)
+
+  let issueItemData = await getIssueItemData(
+    github,
+    projectData.id,
+    issue.node_id
+  )
+
+  if (!issueItemData) {
+    issueItemData = await addIssueToProject(
+      github,
+      projectData.id,
+      issue.node_id
+    )
+  }
+
+  const currentStatus = getCurrentStatus(issueItemData)
+
+  if (IGNORED_COLUMNS.includes(currentStatus)) {
+    console.log(
+      `Issue #${issue.number} is in an ignored column (${currentStatus}). Skipping.`
+    )
+    return
+  }
+
+  await updateIssueStatus(
+    github,
+    projectData.id,
+    issueItemData.id,
+    statusField.id,
+    targetStatusOption.id
+  )
+
+  console.log(`Moved issue #${issue.number} to "${TARGET_COLUMN}"`)
+}
+
+export const moveIssues = async ({ github, context, core }) => {
+  const issue = context.payload.issue
+
+  try {
+    if (!validateIssue(issue)) {
+      return
+    }
+
+    const projectData = await getProjectData(github, process.env.PROJECT_URL)
+    await processIssueItem(github, projectData, issue)
+  } catch (error) {
+    core.setFailed(`Error moving issue: ${error.message}`)
+  }
+}


### PR DESCRIPTION
## Related issue

#[issueid]

## Overview

Fix the GHA 'Project Automation - move issues' workflow.

## Reason

This workflow had stopped working with the move to the latest version of GitHub Projects.

It was also using a fork of an unmaintained action. 

I couldn't find another action in the marketplace that works with V2 Projects.

## Screenshot

![Screenshot 2024-10-10 at 12 13 06](https://github.com/user-attachments/assets/13bded56-d623-4ed2-b823-a3d69641740b)

## Work carried out

- [x] Update workflow to use custom script
- [x] Archive https://github.com/Royal-Navy/design-system-moveissue-action

## Developer notes

I'd test the workflow using [act](https://github.com/nektos/act) but it's no good for testing interactions with the GitHub API so i've added a temp job:

https://github.com/Royal-Navy/design-system/actions/runs/11272955294/job/31348947177?pr=3917

[Published it as an action to the marketplace.](https://github.com/marketplace/actions/move-issue-to-project-column) Could update accordingly post review, or not.
