### PR TITLE
fix(Masthead): Correctly support form as a link

### DIFF
--- a/packages/react-component-library/src/common/Link.ts
+++ b/packages/react-component-library/src/common/Link.ts
@@ -13,7 +13,15 @@ export interface RouterLinkProps extends ComponentWithClass {
 export interface AnchorLinkProps
   extends AnchorHTMLAttributes<HTMLAnchorElement> {}
 
-export type LinkProps = NextLinkProps | RouterLinkProps | AnchorLinkProps
+export interface FormType extends ComponentWithClass {
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void
+}
+
+export type LinkProps =
+  | NextLinkProps
+  | RouterLinkProps
+  | AnchorLinkProps
+  | FormType
 
 export type LinkType = React.ReactElement<LinkProps>
 

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -105,7 +105,11 @@ const userWithAvatar = (
     />
     <MastheadUserItem
       icon={<IconExitToApp />}
-      link={<Link href="#">Logout</Link>}
+      link={
+        <form action="#">
+          <button type="submit">Sign out</button>
+        </form>
+      }
     />
   </MastheadUser>
 )
@@ -127,7 +131,11 @@ export const Default: StoryFn<typeof Masthead> = (props) => {
       />
       <MastheadUserItem
         icon={<IconExitToApp />}
-        link={<Link href="#">Logout</Link>}
+        link={
+          <form action="#">
+            <button type="submit">Sign out</button>
+          </form>
+        }
       />
     </MastheadUser>
   )

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/partials/StyledUserItemWrapper.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/partials/StyledUserItemWrapper.tsx
@@ -5,8 +5,9 @@ import { StyledUserItemIcon } from './StyledUserItemIcon'
 import { StyledUserItemText } from './StyledUserItemText'
 
 export const StyledUserItemWrapper = styled.div`
-  a,
-  a:hover {
+  position: relative;
+
+  a {
     color: ${color('neutral', 'white')};
     text-decoration: none;
   }
@@ -15,6 +16,25 @@ export const StyledUserItemWrapper = styled.div`
     ${StyledUserItemIcon},
     ${StyledUserItemText} {
       color: ${color('action', '500')};
+    }
+  }
+
+  > form button {
+    margin: unset;
+    padding: unset;
+    border: unset;
+    background: unset;
+    color: inherit;
+    cursor: pointer;
+
+    &:hover {
+      color: inherit;
+    }
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
     }
   }
 `


### PR DESCRIPTION
## Related issue

#[issueid]

## Overview

Add form support to the link prop within Masthead.

## Reason

Sometimes downstream consumers want to submit a native form as a link type.

## Work carried out

- [x] Fix a false negative test
- [x] Add support for form to MastheadUserItem link prop
- [x] Update automated tests

## Screenshot

![2024-10-14 09 52 02](https://github.com/user-attachments/assets/09a32416-23a4-4bca-8f76-3ed4524e57d6)

## Developer notes

Sidebar doesn't yet support the same.
