### PR TITLE
fix(TabNav): Make full TabNav tab clickable

### DIFF
--- a/packages/react-component-library/e2e/Masthead/default.spec.ts
+++ b/packages/react-component-library/e2e/Masthead/default.spec.ts
@@ -15,8 +15,7 @@ test.describe('Masthead', () => {
     await expect(page.locator(selectors.banner)).toBeVisible()
   })
 
-  // eslint-disable-next-line playwright/no-skipped-test
-  test.skip('shows the buttons', async ({ page }) => {
+  test('shows the buttons', async ({ page }) => {
     await expect(page.locator(selectors.buttons.search)).toBeVisible()
     await expect(page.locator(selectors.buttons.notifications)).toBeVisible()
     await expect(page.locator(selectors.buttons.user)).toBeVisible()
@@ -29,6 +28,7 @@ test.describe('Masthead', () => {
       'border-top',
       `6px solid ${hexToRgb(ColorAction500)}`
     )
+
     await expect(navigationButtons.nth(1)).toHaveCSS('border-top-style', 'none')
     await expect(navigationButtons.nth(2)).toHaveCSS('border-top-style', 'none')
     await expect(navigationButtons.nth(3)).toHaveCSS('border-top-style', 'none')

--- a/packages/react-component-library/e2e/Masthead/selectors.ts
+++ b/packages/react-component-library/e2e/Masthead/selectors.ts
@@ -6,6 +6,6 @@ export default {
     user: '[data-testid="user-button"]',
   },
   navigation: {
-    button: '[data-testid="tab-nav-tab-button"]',
+    button: '[data-testid="masthead-nav-item"] a[data-testid="link"] span',
   },
 } as const

--- a/packages/react-component-library/e2e/TabNav/selectors.ts
+++ b/packages/react-component-library/e2e/TabNav/selectors.ts
@@ -1,3 +1,3 @@
 export default {
-  tabItemButton: '[data-testid="tab-nav-tab-button"]',
+  tabItemButton: 'a[data-testid="link"] span',
 } as const

--- a/packages/react-component-library/src/common/Link.ts
+++ b/packages/react-component-library/src/common/Link.ts
@@ -1,11 +1,23 @@
+import { AnchorHTMLAttributes } from 'react'
 import { ComponentWithClass } from './ComponentWithClass'
 
-export interface AnchorType extends ComponentWithClass {
+export interface NextLinkProps extends ComponentWithClass {
   href: string
+  as?: string
 }
 
-export interface LinkType extends ComponentWithClass {
+export interface RouterLinkProps extends ComponentWithClass {
   to: string
 }
 
-export type LinkTypes = AnchorType | LinkType
+export interface AnchorLinkProps
+  extends AnchorHTMLAttributes<HTMLAnchorElement> {}
+
+export type LinkProps = NextLinkProps | RouterLinkProps | AnchorLinkProps
+
+export type LinkType = React.ReactElement<LinkProps>
+
+/**
+ * @deprecated Use LinkProps instead
+ */
+export type LinkTypes = LinkProps

--- a/packages/react-component-library/src/common/Nav.ts
+++ b/packages/react-component-library/src/common/Nav.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { ComponentWithClass } from './ComponentWithClass'
-import { LinkTypes } from './Link'
+import { LinkProps } from './Link'
 
 export interface Nav<T> extends ComponentWithClass {
   children?: React.ReactElement<T> | React.ReactElement<T>[]
@@ -15,5 +15,5 @@ export interface NavItem {
   /**
    * Link component (custom implementation welcome).
    */
-  link: React.ReactElement<LinkTypes>
+  link: React.ReactElement<LinkProps>
 }

--- a/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/react-component-library/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react'
 
-import { LinkTypes } from '../../common/Link'
+import { LinkProps } from '../../common/Link'
 import { StyledBreadcrumbsItem } from './partials/StyledBreadcrumbsItem'
 import { StyledEndTitle } from './partials/StyledEndTitle'
 import { StyledIcon } from './partials/StyledIcon'
@@ -23,7 +23,7 @@ export interface BreadcrumbsItemWithLinkProps extends BreadcrumbsItemBaseProps {
   /**
    * Optional Link component to use for the item (redundant if `href` is used).
    */
-  link: React.ReactElement<LinkTypes>
+  link: React.ReactElement<LinkProps>
   href?: never
 }
 
@@ -41,7 +41,7 @@ export type BreadcrumbsItemProps =
 
 function getText(
   isLast: boolean,
-  link?: React.ReactElement<LinkTypes>,
+  link?: React.ReactElement<LinkProps>,
   href?: string,
   children?: React.ReactNode
 ): React.ReactElement {

--- a/packages/react-component-library/src/components/Link/Link.tsx
+++ b/packages/react-component-library/src/components/Link/Link.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 
-import { AnchorType } from '../../common/Link'
+import { AnchorLinkProps } from '../../common/Link'
 
 export const Link = ({
   children,
   className = '',
   href,
   ...rest
-}: AnchorType) => (
+}: AnchorLinkProps) => (
   <a className={className} href={href} data-testid="link" {...rest}>
     {children}
   </a>

--- a/packages/react-component-library/src/components/TabBase/partials/StyledTabItem.tsx
+++ b/packages/react-component-library/src/components/TabBase/partials/StyledTabItem.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components'
+import { color } from '@royalnavy/design-tokens'
 
 import { StyledTabSetProps } from '../../TabSet/partials/StyledTabSet'
 
@@ -17,5 +18,9 @@ export const StyledTabItem = styled.li<StyledTabItemProps>`
 
   &:not(:last-child) {
     padding-right: 6px;
+  }
+
+  a {
+    color: ${color('neutral', 'black')};
   }
 `

--- a/packages/react-component-library/src/components/TabNav/TabNav.test.tsx
+++ b/packages/react-component-library/src/components/TabNav/TabNav.test.tsx
@@ -1,30 +1,56 @@
 import React from 'react'
-
-import { render, RenderResult } from '@testing-library/react'
+import { color } from '@royalnavy/design-tokens'
+import { render, screen } from '@testing-library/react'
 
 import { Link } from '../Link'
 import { TabNav, TabNavItem } from '.'
 
-describe('TabNav', () => {
-  let wrapper: RenderResult
+function setup() {
+  render(
+    <TabNav>
+      <TabNavItem link={<Link href="/foo">Foo</Link>} />
+      <TabNavItem link={<Link href="/bar">Bar</Link>} isActive />
+      <TabNavItem link={<Link href="/baz">Baz</Link>} />
+    </TabNav>
+  )
+}
 
-  describe('with props', () => {
-    beforeEach(() => {
-      wrapper = render(
-        <TabNav>
-          <TabNavItem link={<Link href="/thing1">Thing 1</Link>} />
-          <TabNavItem link={<Link href="/thing2">Thing 2</Link>} isActive />
-          <TabNavItem link={<Link href="/thing3">Thing 3</Link>} />
-        </TabNav>
-      )
-    })
+it('correctly renders the links', () => {
+  setup()
 
-    it('should render the tabs', () => {
-      const tabs = wrapper.queryAllByTestId('tab-nav-tab')
-      expect(tabs[0]).toHaveTextContent('Thing 1')
-      expect(tabs[1]).toHaveTextContent('Thing 2')
-      expect(tabs[2]).toHaveTextContent('Thing 3')
-      expect(tabs).toHaveLength(3)
-    })
+  expect(screen.getAllByRole('link')).toHaveLength(3)
+
+  expect(screen.getByRole('link', { name: 'Foo' })).toHaveAttribute(
+    'href',
+    '/foo'
+  )
+  expect(screen.getByRole('link', { name: 'Bar' })).toHaveAttribute(
+    'href',
+    '/bar'
+  )
+  expect(screen.getByRole('link', { name: 'Baz' })).toHaveAttribute(
+    'href',
+    '/baz'
+  )
+})
+
+it('anchor takes up full space of tab', () => {
+  setup()
+
+  expect(screen.getByRole('link', { name: 'Foo' })).toHaveStyle({
+    display: 'block',
+    width: '100%',
+    height: '100%',
   })
+})
+
+it('applies styles to indicate an active tab', () => {
+  setup()
+
+  const activeTab = screen.getByText('Bar')
+
+  expect(activeTab).toHaveStyleRule(
+    'border-top',
+    `6px solid ${color('action', '500')}`
+  )
 })

--- a/packages/react-component-library/src/components/TabNav/TabNavItem.tsx
+++ b/packages/react-component-library/src/components/TabNav/TabNavItem.tsx
@@ -3,15 +3,18 @@ import React from 'react'
 import { NavItem } from '../../common/Nav'
 import { StyledTabItem } from '../TabBase/partials/StyledTabItem'
 import { StyledTabNavTab } from './partials/StyledTabNavTab'
+import { LinkProps } from '../../common/Link'
 
 export const TabNavItem = ({ isActive, link, ...rest }: NavItem) => (
-  <StyledTabItem data-testid="tab-nav-tab" {...rest}>
-    <StyledTabNavTab
-      as="div"
-      $isActive={isActive}
-      data-testid="tab-nav-tab-button"
-    >
-      {link}
-    </StyledTabNavTab>
+  <StyledTabItem {...rest}>
+    {React.cloneElement(link as React.ReactElement<LinkProps>, {
+      ...link.props,
+      style: { display: 'block', width: '100%', height: '100%' },
+      children: (
+        <StyledTabNavTab as="span" $isActive={isActive}>
+          {link.props.children}
+        </StyledTabNavTab>
+      ),
+    })}
   </StyledTabItem>
 )

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -60,36 +60,57 @@ export default {
   },
 } as Meta<typeof Masthead>
 
-export const Default: StoryFn<typeof Masthead> = (props) => {
-  const notifications = (
-    <Notifications link={<Link href="#" />}>
-      <Notification
-        link={<Link href="#" />}
-        name="Thomas Stephens"
-        action="added a new comment to your"
-        on="review"
-        when={new Date('2019-11-05T14:25:02.178Z')}
-        description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
-      />
-      <Notification
-        link={<Link href="#" />}
-        name="Thomas Stephens"
-        action="added a new comment to your"
-        on="review"
-        when={new Date('2019-11-05T14:25:02.178Z')}
-        description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
-      />
-      <Notification
-        link={<Link href="#" />}
-        name="Thomas Stephens"
-        action="added a new comment to your"
-        on="review"
-        when={new Date('2019-11-05T14:25:02.178Z')}
-        description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
-      />
-    </Notifications>
-  )
+const notifications = (
+  <Notifications link={<Link href="#" />}>
+    <Notification
+      link={<Link href="#" />}
+      name="Thomas Stephens"
+      action="added a new comment to your"
+      on="review"
+      when={new Date('2019-11-05T14:25:02.178Z')}
+      description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+    />
+    <Notification
+      link={<Link href="#" />}
+      name="Thomas Stephens"
+      action="added a new comment to your"
+      on="review"
+      when={new Date('2019-11-05T14:25:02.178Z')}
+      description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+    />
+    <Notification
+      link={<Link href="#" />}
+      name="Thomas Stephens"
+      action="added a new comment to your"
+      on="review"
+      when={new Date('2019-11-05T14:25:02.178Z')}
+      description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
+    />
+  </Notifications>
+)
 
+const userWithAvatar = (
+  <MastheadUser initials="RN">
+    <MastheadUserItem
+      icon={<IconPerson />}
+      link={<Link href="#">Profile</Link>}
+    />
+    <MastheadUserItem
+      icon={<IconSettings />}
+      link={<Link href="#">Settings</Link>}
+    />
+    <MastheadUserItem
+      icon={<IconChatBubble />}
+      link={<Link href="#">Support</Link>}
+    />
+    <MastheadUserItem
+      icon={<IconExitToApp />}
+      link={<Link href="#">Logout</Link>}
+    />
+  </MastheadUser>
+)
+
+export const Default: StoryFn<typeof Masthead> = (props) => {
   const user = (
     <MastheadUser initials="RN">
       <MastheadUserItem
@@ -132,63 +153,8 @@ export const Default: StoryFn<typeof Masthead> = (props) => {
     </StyledContainer>
   )
 }
-
 Default.args = {
   hasUnreadNotification: true,
-}
-
-export const CustomLogo: StoryFn<typeof Masthead> = (props) => (
-  <Masthead {...props} Logo={IconHome} />
-)
-
-CustomLogo.storyName = 'Custom logo'
-CustomLogo.args = {
-  onSearch: null,
-}
-
-export const WithoutLogo: StoryFn<typeof Masthead> = (props) => (
-  <Masthead {...props} hasDefaultLogo={false} />
-)
-
-WithoutLogo.storyName = 'Without logo'
-WithoutLogo.args = {
-  onSearch: null,
-}
-
-export const WithSearch: StoryFn<typeof Masthead> = (props) => (
-  <Masthead {...props} />
-)
-
-WithSearch.storyName = 'Search'
-
-const userWithAvatar = (
-  <MastheadUser initials="RN">
-    <MastheadUserItem
-      icon={<IconPerson />}
-      link={<Link href="#">Profile</Link>}
-    />
-    <MastheadUserItem
-      icon={<IconSettings />}
-      link={<Link href="#">Settings</Link>}
-    />
-    <MastheadUserItem
-      icon={<IconChatBubble />}
-      link={<Link href="#">Support</Link>}
-    />
-    <MastheadUserItem
-      icon={<IconExitToApp />}
-      link={<Link href="#">Logout</Link>}
-    />
-  </MastheadUser>
-)
-
-export const WithAvatarLinks: StoryFn<typeof Masthead> = (props) => {
-  return <Masthead {...props} user={userWithAvatar} />
-}
-
-WithAvatarLinks.storyName = 'Avatar links'
-WithAvatarLinks.args = {
-  onSearch: null,
 }
 
 export const WithNavigation: StoryFn<typeof Masthead> = (props) => {
@@ -203,7 +169,6 @@ export const WithNavigation: StoryFn<typeof Masthead> = (props) => {
 
   return <Masthead {...props} homeLink={<Link href="#" />} nav={nav} />
 }
-
 WithNavigation.storyName = 'Navigation'
 WithNavigation.args = {
   onSearch: null,
@@ -217,39 +182,38 @@ WithInlineNav.args = {
   user: userWithAvatar,
 }
 
-export const WithNotifications: StoryFn<typeof Masthead> = (props) => {
-  const notifications = (
-    <Notifications link={<Link href="#" />}>
-      <Notification
-        link={<Link href="#" />}
-        name="Thomas Stephens"
-        action="added a new comment to your"
-        on="review"
-        when={new Date('2019-11-05T14:25:02.178Z')}
-        description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
-      />
-      <Notification
-        link={<Link href="#" />}
-        name="Thomas Stephens"
-        action="added a new comment to your"
-        on="review"
-        when={new Date('2019-11-05T14:25:02.178Z')}
-        description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
-      />
-      <Notification
-        link={<Link href="#" />}
-        name="Thomas Stephens"
-        action="added a new comment to your"
-        on="review"
-        when={new Date('2019-11-05T14:25:02.178Z')}
-        description="At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores"
-      />
-    </Notifications>
-  )
-
-  return <Masthead {...props} notifications={notifications} />
+export const CustomLogo: StoryFn<typeof Masthead> = (props) => (
+  <Masthead {...props} Logo={IconHome} />
+)
+CustomLogo.storyName = 'Custom logo'
+CustomLogo.args = {
+  onSearch: null,
 }
 
+export const WithoutLogo: StoryFn<typeof Masthead> = (props) => (
+  <Masthead {...props} hasDefaultLogo={false} />
+)
+WithoutLogo.storyName = 'Without logo'
+WithoutLogo.args = {
+  onSearch: null,
+}
+
+export const WithSearch: StoryFn<typeof Masthead> = (props) => (
+  <Masthead {...props} />
+)
+WithSearch.storyName = 'Search'
+
+export const WithAvatarLinks: StoryFn<typeof Masthead> = (props) => {
+  return <Masthead {...props} user={userWithAvatar} />
+}
+WithAvatarLinks.storyName = 'Avatar links'
+WithAvatarLinks.args = {
+  onSearch: null,
+}
+
+export const WithNotifications: StoryFn<typeof Masthead> = (props) => {
+  return <Masthead {...props} notifications={notifications} />
+}
 WithNotifications.storyName = 'Notifications'
 WithNotifications.args = {
   onSearch: null,
@@ -319,12 +283,13 @@ WithUserMenuOpen.parameters = {
   docs: { disable: true },
 }
 
-export const WithClassificationBar = Default.bind({})
-WithClassificationBar.args = {
-  ...Default.args,
-  classificationBar: <ClassificationBar />,
-}
+export const WithClassificationBar: StoryFn<typeof Masthead> = (props) => (
+  <Masthead {...props} classificationBar={<ClassificationBar />} />
+)
 WithClassificationBar.storyName = 'Classification bar'
+WithClassificationBar.args = {
+  onSearch: null,
+}
 
 const StyledClientComponent = styled.div`
   flex: 1;
@@ -334,13 +299,17 @@ const StyledClientComponent = styled.div`
   padding-right: ${spacing('2')};
 `
 
-export const RightSlot = Default.bind({})
+export const RightSlot: StoryFn<typeof Masthead> = (props) => (
+  <Masthead
+    {...props}
+    rightSlot={
+      <StyledClientComponent>
+        <TextE>Arbitrary text</TextE>
+      </StyledClientComponent>
+    }
+  />
+)
 RightSlot.storyName = 'Right slot'
 RightSlot.args = {
-  ...Default.args,
-  rightSlot: (
-    <StyledClientComponent>
-      <TextE>Arbitrary text</TextE>
-    </StyledClientComponent>
-  ),
+  onSearch: null,
 }

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
@@ -1,11 +1,11 @@
 // @ts-nocheck
 import React from 'react'
-
 import {
   fireEvent,
   render,
   RenderResult,
   waitFor,
+  screen,
 } from '@testing-library/react'
 
 import { Link } from '../../Link'
@@ -313,10 +313,12 @@ describe('Masthead', () => {
     })
 
     it('should render the nav items', () => {
-      expect(wrapper.getByText('First').getAttribute('href')).toEqual('/first')
-      expect(wrapper.getByText('Second').getAttribute('href')).toEqual(
-        '/second'
-      )
+      expect(
+        screen.getByText('First').closest('a').getAttribute('href')
+      ).toEqual('/first')
+      expect(
+        screen.getByText('Second').closest('a').getAttribute('href')
+      ).toEqual('/second')
     })
 
     describe('when the user clicks on the search option', () => {

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react'
 
 import { Logo as DefaultLogo } from './Logo'
-import { LinkTypes } from '../../../common/Link'
+import { LinkProps } from '../../../common/Link'
 import { MASTHEAD_SUBCOMPONENT } from './constants'
 import { MastheadUserProps } from './index'
 import { Nav, NavItem } from '../../../common/Nav'
@@ -36,7 +36,7 @@ export interface MastheadProps {
   /**
    * Link component for when a user clicks on the logo / app name.
    */
-  homeLink?: React.ReactElement<LinkTypes>
+  homeLink?: React.ReactElement<LinkProps>
   /**
    * Which subcomponent is initially open.
    * @private
@@ -85,7 +85,7 @@ export interface MastheadProps {
 function getServiceName(
   Logo: React.ComponentType | null,
   title: string,
-  homeLink?: React.ReactElement<LinkTypes>
+  homeLink?: React.ReactElement<LinkProps>
 ) {
   const link = homeLink || <span />
   return React.cloneElement(link as React.ReactElement, {

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/MastheadUser.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from 'react'
 
 import { Avatar, AVATAR_VARIANT } from '../../Avatar'
 import { ComponentWithClass } from '../../../common/ComponentWithClass'
-import { LinkTypes } from '../../../common/Link'
+import { LinkProps } from '../../../common/Link'
 import { MastheadUserItemProps } from './MastheadUserItem'
 import { Nav } from '../../../common/Nav'
 import { Sheet } from '../Sheet/Sheet'
@@ -36,7 +36,7 @@ export interface MastheadUserWithLinkProps extends ComponentWithClass {
   /**
    * Link component to apply to the user avatar.
    */
-  link: React.ReactElement<LinkTypes>
+  link: React.ReactElement<LinkProps>
 }
 
 export type MastheadUserProps =

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notification.tsx
@@ -5,7 +5,7 @@ import format from 'date-fns/format'
 
 import { Avatar, AVATAR_VARIANT } from '../../Avatar'
 import { getInitials } from '../../../helpers'
-import { LinkTypes } from '../../../common/Link'
+import { LinkProps } from '../../../common/Link'
 import { StyledNotification } from './partials/StyledNotification'
 import { StyledWrapper } from './partials/StyledWrapper'
 import { StyledItem } from './partials/StyledItem'
@@ -20,7 +20,7 @@ export interface NotificationProps {
   /**
    * Link component for the notification item.
    */
-  link: React.ReactElement<LinkTypes>
+  link: React.ReactElement<LinkProps>
   /**
    * Text name for the notification.
    */

--- a/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/NotificationPanel/Notifications.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react'
 import { IconKeyboardArrowRight } from '@royalnavy/icon-library'
 
-import { LinkTypes } from '../../../common/Link'
+import { LinkProps } from '../../../common/Link'
 import { NotificationProps } from './index'
 import { StyledNotifications } from './partials/StyledNotifications'
 import { StyledList } from './partials/StyledList'
@@ -17,7 +17,7 @@ export interface NotificationsProps {
   /**
    * Link component for 'View all notifications'.
    */
-  link: React.ReactElement<LinkTypes>
+  link: React.ReactElement<LinkProps>
 }
 
 export const Notifications = ({

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
@@ -14,7 +14,7 @@ import {
   StyledUserText,
 } from './partials'
 import { ComponentWithClass } from '../../../common/ComponentWithClass'
-import { LinkTypes } from '../../../common/Link'
+import { LinkProps } from '../../../common/Link'
 
 export interface SidebarUserProps extends ComponentWithClass {
   children?: never
@@ -30,11 +30,11 @@ export interface SidebarUserProps extends ComponentWithClass {
   /**
    * Link component to apply to the user avatar.
    */
-  userLink?: React.ReactElement<LinkTypes>
+  userLink?: React.ReactElement<LinkProps>
   /**
    * Link component to apply to the exit icon.
    */
-  exitLink?: React.ReactElement<LinkTypes>
+  exitLink?: React.ReactElement<LinkProps>
   /**
    * Full name of the end user (e.g. Joe Bloggs).
    */


### PR DESCRIPTION
## Related issue

Closes #3891

## Overview

Ensure that the entire tab area within TabNav is a clickable anchor.

## Reason

Previously a user would have to click on the anchor text to register a click.

## Work carried out

- [x] Ensure anchor takes full space of Tab
- [x] Supplement TabNav with additional automated tests
- [x] Enable skipped Playwright test within Masthead suite
- [x] Improve display of Masthead stories within docs tab

## Screenshot

![2024-10-14 13 04 37](https://github.com/user-attachments/assets/e9d2e7db-c52a-40aa-a21f-08c5e070075c)

![Screenshot 2024-10-14 at 13 08 16](https://github.com/user-attachments/assets/5827f71d-afc7-458a-824c-da2f952b5282)

## Developer notes

There is a trade off here - _I think_ we've improved the a11y however i've also had to disable a rule 😬.

Let me know what you all think - alternative is to strip out the ARIA attr and `tablist, tab` roles.
