### PR TITLE
fix(Select): Ensure Select menu listbox toggles correctly

### DIFF
--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { render, RenderResult } from '@testing-library/react'
+import { render, RenderResult, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ColorDanger800 } from '@royalnavy/design-tokens'
 import {
@@ -488,6 +488,78 @@ describe('Select', () => {
         expect(badges[1]).toHaveTextContent('2')
         expect(badges[2]).toHaveTextContent('3')
         expect(badges).toHaveLength(3)
+      })
+    })
+  })
+
+  describe('when clicking to open, close, and reopen', () => {
+    it('should toggle the dropdown on each click', async () => {
+      render(
+        <Select id="select-id" label="Label">
+          <SelectOption value="option1">Option 1</SelectOption>
+          <SelectOption value="option2">Option 2</SelectOption>
+          <SelectOption value="option3">Option 3</SelectOption>
+        </Select>
+      )
+
+      const input = screen.getByRole('textbox', { name: 'Label' })
+
+      await userEvent.click(input)
+      await waitFor(() => {
+        expect(screen.getByText('Option 1')).toBeVisible()
+        expect(screen.getByText('Option 2')).toBeVisible()
+        expect(screen.getByText('Option 3')).toBeVisible()
+      })
+
+      await userEvent.click(input)
+      await waitFor(() => {
+        expect(screen.queryByText('Option 1')).not.toBeInTheDocument()
+        expect(screen.queryByText('Option 2')).not.toBeInTheDocument()
+        expect(screen.queryByText('Option 3')).not.toBeInTheDocument()
+      })
+
+      await userEvent.click(input)
+      await waitFor(() => {
+        expect(screen.getByText('Option 1')).toBeVisible()
+        expect(screen.getByText('Option 2')).toBeVisible()
+        expect(screen.getByText('Option 3')).toBeVisible()
+      })
+    })
+  })
+
+  describe('when focusing with keyboard and then interacting', () => {
+    it('should open on focus and allow reopening after closing', async () => {
+      render(
+        <Select id="select-id" label="Label">
+          <SelectOption value="option1">Option 1</SelectOption>
+          <SelectOption value="option2">Option 2</SelectOption>
+          <SelectOption value="option3">Option 3</SelectOption>
+        </Select>
+      )
+
+      const input = screen.getByRole('textbox', { name: 'Label' })
+
+      await userEvent.tab()
+      expect(screen.getByRole('listbox', { name: 'Label' })).toHaveFocus()
+
+      await waitFor(() => {
+        expect(screen.getByText('Option 1')).toBeVisible()
+        expect(screen.getByText('Option 2')).toBeVisible()
+        expect(screen.getByText('Option 3')).toBeVisible()
+      })
+
+      await userEvent.keyboard('{Escape}')
+      await waitFor(() => {
+        expect(screen.queryByText('Option 1')).not.toBeInTheDocument()
+        expect(screen.queryByText('Option 2')).not.toBeInTheDocument()
+        expect(screen.queryByText('Option 3')).not.toBeInTheDocument()
+      })
+
+      await userEvent.click(input)
+      await waitFor(() => {
+        expect(screen.getByText('Option 1')).toBeVisible()
+        expect(screen.getByText('Option 2')).toBeVisible()
+        expect(screen.getByText('Option 3')).toBeVisible()
       })
     })
   })

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -72,8 +72,16 @@ export const Select = ({
       hasSelectedItem={!isNil(selectedItem)}
       id={id}
       inputProps={{
-        onFocus: onInputFocusHandler,
+        ...getToggleButtonProps({
+          onFocus: onInputFocusHandler,
+          onMouseDown: (event) => {
+            // This is crucial for correct focus and click behavior
+            // Without this, Downshift internal state gets mixed up
+            event.preventDefault()
+          },
+        }),
         ref: inputRef,
+        'aria-expanded': undefined,
       }}
       isOpen={isOpen}
       menuProps={getMenuProps({


### PR DESCRIPTION
## Related issue

Closes #3905

## Overview

Ensure Select menu listbox toggles open and closed correctly upon interaction.

## Reason

It was previously only possible to toggle the listbox open/closed once via click.

You would have to trigger a blur and refocus to be able to open it again.

## Work carried out

- [x] Add noop handler with `preventDefault` for `onMouseDown`
- [x] Supplement with additional automated tests

## Screenshot

![2024-10-14 16 36 38](https://github.com/user-attachments/assets/84d960c5-801d-451a-82b8-e755d487a591)

## Developer notes

This was a nightmare to fix.
