### PR TITLE
Allow setting of `id` and other attributes on `TextE`

### DIFF
--- a/packages/react-component-library/src/components/Text/Text.test.tsx
+++ b/packages/react-component-library/src/components/Text/Text.test.tsx
@@ -5,84 +5,80 @@ import { render } from '@testing-library/react'
 import { TextE } from '.'
 import { getTextStyles } from './textStyles'
 
-describe('Text', () => {
-  it('render with default styles', () => {
-    const { container } = render(<TextE>Content</TextE>)
-    expect(container).toHaveTextContent('Content')
-  })
+it('renders with default styles', () => {
+  const { container } = render(<TextE>Content</TextE>)
+  expect(container).toHaveTextContent('Content')
+})
 
-  describe('when I choose the type of text component', () => {
-    it('should calculate the text size for default body text', () => {
-      const result = getTextStyles('p', 'body')
-      expect(result.fontSize).toEqual(fontSize('m'))
-    })
+it('sets the line height', () => {
+  const { container } = render(<TextE>Content</TextE>)
+  expect(container.firstChild).toHaveStyleRule('line-height', '24px')
+})
 
-    it('should calculate heading sizes', () => {
-      const result = getTextStyles('h1')
-      expect(result.fontSize).toEqual(fontSize('xxl'))
-    })
+it('sets the size for default body text', () => {
+  const result = getTextStyles('p', 'body')
+  expect(result.fontSize).toEqual(fontSize('m'))
+})
 
-    it('should calculate the default line height', () => {
-      const { container } = render(<TextE>Content</TextE>)
-      expect(container.firstChild).toHaveStyleRule('line-height', '24px')
-    })
+it('sets the size for heading text', () => {
+  const result = getTextStyles('h1')
+  expect(result.fontSize).toEqual(fontSize('xxl'))
+})
 
-    test.each([
-      ['h1', '48px'],
-      ['h2', '48px'],
-      ['h3', '48px'],
-      ['h4', '48px'],
-      ['h5', '48px'],
-      ['h6', '48px'],
-      ['p', '24px'],
-      ['span', '24px'],
-    ])('calculates line height for %s', (el, expectedLineHeight) => {
-      // @ts-ignore
-      const { container } = render(<TextE el={el}>Content</TextE>)
-      expect(container.firstChild).toHaveStyleRule(
-        'line-height',
-        expectedLineHeight
-      )
-    })
+it.each([
+  ['h1', '48px'],
+  ['h2', '48px'],
+  ['h3', '48px'],
+  ['h4', '48px'],
+  ['h5', '48px'],
+  ['h6', '48px'],
+  ['p', '24px'],
+  ['span', '24px'],
+])('sets the line height for %s', (el, expectedLineHeight) => {
+  // @ts-ignore
+  const { container } = render(<TextE el={el}>Content</TextE>)
+  expect(container.firstChild).toHaveStyleRule(
+    'line-height',
+    expectedLineHeight
+  )
+})
 
-    test.each([
-      ['p', '24px'],
-      ['span', '24px'],
-    ])('calculates line height for small %s', (el, expectedLineHeight) => {
-      const { container } = render(
-        // @ts-ignore
-        <TextE el={el} variant="small">
-          Content
-        </TextE>
-      )
+it.each([
+  ['p', '24px'],
+  ['span', '24px'],
+])('sets the line height for small %s', (el, expectedLineHeight) => {
+  const { container } = render(
+    // @ts-ignore
+    <TextE el={el} variant="small">
+      Content
+    </TextE>
+  )
 
-      expect(container.firstChild).toHaveStyleRule(
-        'line-height',
-        expectedLineHeight
-      )
-    })
+  expect(container.firstChild).toHaveStyleRule(
+    'line-height',
+    expectedLineHeight
+  )
+})
 
-    test.each([
-      ['h1', '72px'],
-      ['h2', '48px'],
-      // h3 ... h6 are not available in display variant they are rendered as default
-      ['h3', '24px'],
-      ['h4', '24px'],
-      ['h5', '24px'],
-      ['h6', '24px'],
-      ['p', '48px'],
-    ])('calculates line height for display %s', (el, expectedLineHeight) => {
-      const { container } = render(
-        // @ts-ignore
-        <TextE el={el} variant="display">
-          Content
-        </TextE>
-      )
+it.each([
+  ['h1', '72px'],
+  ['h2', '48px'],
+  // h3 ... h6 are not available in display variant they are rendered as default
+  ['h3', '24px'],
+  ['h4', '24px'],
+  ['h5', '24px'],
+  ['h6', '24px'],
+  ['p', '48px'],
+])('sets the line height for display %s', (el, expectedLineHeight) => {
+  const { container } = render(
+    // @ts-ignore
+    <TextE el={el} variant="display">
+      Content
+    </TextE>
+  )
 
-      expect(container.firstChild).toHaveStyleRule(
-        'line-height',
-        expectedLineHeight
-      )
-    })
-  })
+  expect(container.firstChild).toHaveStyleRule(
+    'line-height',
+    expectedLineHeight
+  )
 })

--- a/packages/react-component-library/src/components/Text/Text.test.tsx
+++ b/packages/react-component-library/src/components/Text/Text.test.tsx
@@ -15,6 +15,16 @@ it('sets the line height', () => {
   expect(container.firstChild).toHaveStyleRule('line-height', '24px')
 })
 
+it('sets the arbitrary attribute', () => {
+  const { container } = render(<TextE data-arbitrary="value">Content</TextE>)
+  expect(container.firstChild).toHaveAttribute('data-arbitrary', 'value')
+})
+
+it('sets the id attribute', () => {
+  const { container } = render(<TextE id="value">Content</TextE>)
+  expect(container.firstChild).toHaveAttribute('id', 'value')
+})
+
 it('sets the size for default body text', () => {
   const result = getTextStyles('p', 'body')
   expect(result.fontSize).toEqual(fontSize('m'))

--- a/packages/react-component-library/src/components/Text/Text.tsx
+++ b/packages/react-component-library/src/components/Text/Text.tsx
@@ -19,11 +19,14 @@ export interface TextEProps extends ComponentWithClass {
    * The type of element to use for the root node, `'p'` by default.
    */
   el?: TextElement
+  /**
+   * Optional id attribute for the root node
+   */
+  id?: string
   /*
     The display variant to use, 'body' by default
    */
   variant?: TextVariant
-
   /**
    * Optional CSS color value for the text color
    */
@@ -44,9 +47,9 @@ export const TextE = ({
   el = 'p',
   color,
   backgroundColor = 'none',
-  className,
   variant,
   wordWrap = true,
+  ...rest
 }: TextEProps) => {
   const { fontSize, lineHeight, defaultColor, element, display } =
     getTextStyles(el, variant)
@@ -57,7 +60,6 @@ export const TextE = ({
   return (
     <StyledTextComponent
       as={element}
-      className={className}
       $align={align}
       $backgroundColor={backgroundColor}
       $lineHeight={lineHeight}
@@ -65,6 +67,7 @@ export const TextE = ({
       $size={fontSize}
       $textColor={textColor}
       style={extraStyles}
+      {...rest}
     >
       {children}
     </StyledTextComponent>


### PR DESCRIPTION
## Related issue
NA

## Overview
Allows setting of `id` and other attributes on the rendered element from `TextE`.

## Reason
Primarily required for setting `id` in downstream app.

## Work carried out
- [x] Refactor existing tests
- [x] Allow setting of attributes
