### PR TITLE
fix(Exports): Set exports property in package.json for ESM packages

### DIFF
--- a/packages/icon-library/package.json
+++ b/packages/icon-library/package.json
@@ -13,6 +13,11 @@
   ],
   "types": "dist/types/index.d.ts",
   "sideEffects": false,
+  "exports": {
+    "types": "./dist/types/index.d.ts",
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Royal-Navy/design-system.git",

--- a/packages/react-component-library/package.json
+++ b/packages/react-component-library/package.json
@@ -20,6 +20,11 @@
   "sideEffects": false,
   "author": "Royal Navy",
   "license": "Apache-2.0",
+  "exports": {
+    "types": "./dist/types/src/index.d.ts",
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Royal-Navy/design-system.git",


### PR DESCRIPTION
## Overview

Sets the `exports` field in `package.json` for `@royalnavy/react-component-library` and `@royalnavy/icon-library`

## Reason

Required for some environments (e.g. vitest and Node.js) to use the ESM builds.

Packages without ESM builds have been left as they are.

## Work carried out

- [x] Add `exports` entry to `package.json` for packages with ESM entry points 

## Developer notes

vitest was using the CJS builds of the `@royalnavy/react-component-library` and `@royalnavy/icon-library` as the `exports` property wasn't set in `package.json` with an `import` entry: https://github.com/vitest-dev/vitest/discussions/4233

There are some guides to the field here:

- https://nodejs.org/api/packages.html#package-entry-points  (it is the conditional exports bit being used: https://nodejs.org/api/packages.html#conditional-exports)

- https://webpack.js.org/guides/package-exports/

Note that the order of the entries is important as they are tried in order when more than one could match.

(I also referenced some previous work on using exports here: https://github.com/defencedigital/moduk-frontend/blob/main/package.json)

Note that this might be considered a breaking change, as in some cases it will block importing of files or types directly from the `dist` directory (though those were always internal implementation details...)

Those imports can still be allowed by doing e.g.:

```json
  "exports": {
    ".": {
      "types": "./dist/types/src/index.d.ts",
      "import": "./dist/es/index.js",
      "require": "./dist/cjs/index.js"
    },
    "./dist/*": {
      "types": "./dist/*.d.ts",
      "default": "./dist/*"
    }
  },
```

@m7kvqbe1 What do you think – should importing things from the `dist` directory continue to be allowed?