### PR TITLE
refactor(DatePicker): Break up, extract handlers, consolidate state

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/CalendarNavigation.tsx
+++ b/packages/react-component-library/src/components/DatePicker/CalendarNavigation.tsx
@@ -12,8 +12,8 @@ import {
 interface CalendarNavigationProps {
   month: Date
   onMonthChange: (increment: number) => void
-  onMonthPickerClick: () => void
-  onYearPickerClick: () => void
+  onMonthPickerClick: (event: React.MouseEvent<HTMLButtonElement>) => void
+  onYearPickerClick: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
 export const CalendarNavigation = ({

--- a/packages/react-component-library/src/components/DatePicker/FloatingCalendar.tsx
+++ b/packages/react-component-library/src/components/DatePicker/FloatingCalendar.tsx
@@ -1,0 +1,272 @@
+import {
+  addMonths,
+  setMonth as changeMonth,
+  setYear as changeYear,
+} from 'date-fns/fp'
+import { enGB } from 'date-fns/locale'
+import { format } from 'date-fns'
+import FocusTrap from 'focus-trap-react'
+import React, { memo, useCallback } from 'react'
+
+import { BUTTON_VARIANT } from '../Button'
+import {
+  CALENDAR_TABLE_VARIANT,
+  CalendarTableVariant,
+  DATE_VALIDITY,
+} from './constants'
+import { CalendarNavigation } from './CalendarNavigation'
+import { CalendarTable } from './CalendarTable'
+import { COMPONENT_SIZE } from '../Forms'
+import { DATEPICKER_ACTION } from './types'
+import { DatePickerProps } from './DatePicker'
+import { replaceInvalidDate } from './utils'
+import { StyledDayPicker } from './partials/StyledDayPicker'
+import { StyledFloatingBox } from './partials/StyledFloatingBox'
+import { StyledJumpToToday } from './partials/StyledJumpToToday'
+import { useDatePickerContext } from './useDatePickerContext'
+import { useFocusTrapOptions } from './useFocusTrapOptions'
+import { useProcessDayClick, calculateDateValidity } from './useProcessDayClick'
+import { useRangeHoverOrFocusDate } from './useRangeHoverOrFocusDate'
+
+const MODIFIERS_CLASS_NAMES = {
+  start: 'rdp-day_start',
+  end: 'rdp-day_end',
+}
+
+interface FloatingCalendarProps
+  extends Pick<
+    DatePickerProps,
+    | 'disabledDays'
+    | 'isRange'
+    | 'jumpToToday'
+    | 'navigateMonthYear'
+    | 'onChange'
+    | 'placement'
+    | 'today'
+  > {
+  buttonRef: React.RefObject<HTMLButtonElement>
+  inputRef: React.RefObject<HTMLInputElement>
+  floatingBoxId: string
+  titleId: string
+  floatingBoxTarget: Element | null
+}
+
+export const FloatingCalendar = memo(
+  ({
+    buttonRef,
+    disabledDays,
+    floatingBoxId,
+    floatingBoxTarget,
+    inputRef,
+    isRange = false,
+    jumpToToday,
+    navigateMonthYear,
+    onChange,
+    placement,
+    titleId,
+    today = new Date(),
+  }: FloatingCalendarProps) => {
+    const { state, dispatch } = useDatePickerContext()
+
+    const { startDate, endDate, currentMonth, calendarTableVariant, isOpen } =
+      state
+
+    const {
+      rangeHoverOrFocusDate,
+      handleDayFocusOrMouseEnter,
+      handleDayBlurOrMouseLeave,
+    } = useRangeHoverOrFocusDate(isRange)
+
+    const modifiers = {
+      start: replaceInvalidDate(startDate) || false,
+      end: replaceInvalidDate(endDate) || false,
+    }
+
+    const selected = {
+      from: replaceInvalidDate(startDate),
+      to: replaceInvalidDate(endDate) || rangeHoverOrFocusDate || undefined,
+    }
+
+    const focusTrapOptions = useFocusTrapOptions(
+      () =>
+        dispatch({
+          type: DATEPICKER_ACTION.UPDATE,
+          data: { isOpen: false },
+        }),
+      isRange ? [buttonRef, inputRef] : [buttonRef]
+    )
+
+    const handleDaySelection = useCallback(() => {
+      dispatch({ type: DATEPICKER_ACTION.REFRESH_HAS_ERROR })
+      dispatch({ type: DATEPICKER_ACTION.REFRESH_INPUT_VALUE })
+    }, [dispatch])
+
+    const processDayClick = useProcessDayClick(
+      state,
+      dispatch,
+      isRange,
+      disabledDays,
+      onChange
+    )
+
+    const handleDayClick = useCallback(
+      (day: Date, { disabled }: { disabled?: boolean } = {}) => {
+        if (disabled) {
+          return
+        }
+
+        const newState = processDayClick(day)
+
+        handleDaySelection()
+
+        if (newState.endDate || !isRange) {
+          setTimeout(() =>
+            dispatch({
+              type: DATEPICKER_ACTION.UPDATE,
+              data: { isOpen: false },
+            })
+          )
+        }
+      },
+      [dispatch, handleDaySelection, isRange, processDayClick]
+    )
+
+    const handleMonthClick = useCallback(
+      (monthIndex: number) => {
+        dispatch({
+          type: DATEPICKER_ACTION.UPDATE,
+          data: {
+            currentMonth: changeMonth(monthIndex, currentMonth),
+            calendarTableVariant: CALENDAR_TABLE_VARIANT.HIDE,
+          },
+        })
+      },
+      [dispatch, currentMonth]
+    )
+
+    const handleYearClick = useCallback(
+      (year: number) => {
+        dispatch({
+          type: DATEPICKER_ACTION.UPDATE,
+          data: {
+            currentMonth: changeYear(year, currentMonth),
+            calendarTableVariant: CALENDAR_TABLE_VARIANT.HIDE,
+          },
+        })
+      },
+      [dispatch, currentMonth]
+    )
+
+    const handleMonthChange = useCallback(
+      (increment: number) => {
+        dispatch({
+          type: DATEPICKER_ACTION.UPDATE,
+          data: { currentMonth: addMonths(increment, currentMonth) },
+        })
+      },
+      [dispatch, currentMonth]
+    )
+
+    const handleJumpToToday = useCallback(() => {
+      if (calculateDateValidity(today, disabledDays) !== DATE_VALIDITY.VALID) {
+        return
+      }
+
+      dispatch({
+        type: DATEPICKER_ACTION.UPDATE,
+        data: { currentMonth: today },
+      })
+
+      processDayClick(today)
+      handleDaySelection()
+    }, [dispatch, today, disabledDays, processDayClick, handleDaySelection])
+
+    const setTableVariant = useCallback(
+      (variant: CalendarTableVariant) => {
+        dispatch({
+          type: DATEPICKER_ACTION.UPDATE,
+          data: { calendarTableVariant: variant },
+        })
+      },
+      [dispatch]
+    )
+
+    const setCurrentMonth = useCallback(
+      (month: Date) => {
+        dispatch({
+          type: DATEPICKER_ACTION.UPDATE,
+          data: { currentMonth: month },
+        })
+      },
+      [dispatch]
+    )
+
+    return (
+      <StyledFloatingBox
+        aria-labelledby={titleId}
+        aria-live="polite"
+        aria-modal
+        id={floatingBoxId}
+        isVisible={isOpen}
+        placement={placement}
+        role="dialog"
+        targetElement={floatingBoxTarget}
+      >
+        <FocusTrap focusTrapOptions={focusTrapOptions}>
+          <div>
+            {calendarTableVariant !== CALENDAR_TABLE_VARIANT.HIDE && (
+              <CalendarTable
+                month={currentMonth}
+                onMonthClick={handleMonthClick}
+                onYearClick={handleYearClick}
+                variant={calendarTableVariant}
+              />
+            )}
+            {jumpToToday && (
+              <StyledJumpToToday
+                onClick={handleJumpToToday}
+                size={COMPONENT_SIZE.SMALL}
+                variant={BUTTON_VARIANT.TERTIARY}
+              >
+                Jump to today
+              </StyledJumpToToday>
+            )}
+            {navigateMonthYear && (
+              <CalendarNavigation
+                month={currentMonth}
+                onMonthChange={handleMonthChange}
+                onMonthPickerClick={() =>
+                  setTableVariant(CALENDAR_TABLE_VARIANT.MONTHS)
+                }
+                onYearPickerClick={() =>
+                  setTableVariant(CALENDAR_TABLE_VARIANT.YEARS)
+                }
+              />
+            )}
+            <StyledDayPicker
+              disabled={disabledDays}
+              formatters={{
+                formatWeekdayName: (date, options) =>
+                  format(date, 'ccc', options),
+              }}
+              initialFocus
+              locale={enGB}
+              mode="default"
+              modifiers={modifiers}
+              modifiersClassNames={MODIFIERS_CLASS_NAMES}
+              month={currentMonth}
+              onDayBlur={handleDayBlurOrMouseLeave}
+              onDayClick={handleDayClick}
+              onDayFocus={handleDayFocusOrMouseEnter}
+              onDayMouseEnter={handleDayFocusOrMouseEnter}
+              onDayMouseLeave={handleDayBlurOrMouseLeave}
+              onMonthChange={setCurrentMonth}
+              selected={selected}
+              today={today}
+            />
+          </div>
+        </FocusTrap>
+      </StyledFloatingBox>
+    )
+  }
+)

--- a/packages/react-component-library/src/components/DatePicker/Input.tsx
+++ b/packages/react-component-library/src/components/DatePicker/Input.tsx
@@ -1,0 +1,197 @@
+import { IconEvent } from '@royalnavy/icon-library'
+import React, { memo, useCallback } from 'react'
+
+import { CALENDAR_TABLE_VARIANT } from './constants'
+import { DATE_FORMAT } from '../../constants'
+import { DATEPICKER_ACTION } from './types'
+import { DatePickerProps } from './DatePicker'
+import { hasClass } from '../../helpers'
+import { InlineButton } from '../InlineButtons/InlineButton'
+import { isDateValid } from './utils'
+import { StyledDatePickerInput } from './partials/StyledDatePickerInput'
+import { StyledInlineButtons } from '../InlineButtons/partials/StyledInlineButtons'
+import { StyledInput } from '../TextInput/partials/StyledInput'
+import { StyledInputWrapper } from './partials/StyledInputWrapper'
+import { StyledLabel } from '../TextInput/partials/StyledLabel'
+import { StyledOuterWrapper } from './partials/StyledOuterWrapper'
+import { useDatePickerContext } from './useDatePickerContext'
+import { useExternalId } from '../../hooks/useExternalId'
+import { useFocus } from '../../hooks/useFocus'
+import { useInput } from './useInput'
+import { useProcessDayClick } from './useProcessDayClick'
+
+export interface InputProps
+  extends Pick<
+      DatePickerProps,
+      | 'disabledDays'
+      | 'format'
+      | 'id'
+      | 'isDisabled'
+      | 'isInvalid'
+      | 'isRange'
+      | 'label'
+      | 'onBlur'
+      | 'onChange'
+    >,
+    Omit<React.ComponentPropsWithoutRef<'input'>, 'onChange' | 'onBlur'> {
+  buttonRef: React.RefObject<HTMLButtonElement>
+  className?: string
+  floatingBoxId: string
+  inputRef: React.RefObject<HTMLInputElement>
+  setFloatingBoxTarget: React.Dispatch<React.SetStateAction<Element | null>>
+  titleId: string
+}
+
+export const Input = memo(
+  ({
+    buttonRef,
+    className,
+    disabledDays,
+    floatingBoxId,
+    format: datePickerFormat = DATE_FORMAT.SHORT,
+    id: externalId,
+    inputRef,
+    isDisabled = false,
+    isInvalid,
+    isRange = false,
+    label,
+    onBlur,
+    onChange,
+    setFloatingBoxTarget,
+    titleId,
+    ...rest
+  }: InputProps) => {
+    const id = useExternalId(externalId)
+
+    const { state, dispatch } = useDatePickerContext()
+
+    const { startDate, inputValue, hasError, isOpen } = state
+
+    const processDayClick = useProcessDayClick(
+      state,
+      dispatch,
+      isRange,
+      disabledDays,
+      onChange
+    )
+
+    const { handleKeyDown, handleInputBlur, handleInputChange } = useInput(
+      datePickerFormat,
+      isRange,
+      processDayClick,
+      dispatch
+    )
+
+    const { hasFocus, onLocalBlur, onLocalFocus } = useFocus()
+
+    const effectiveHasError =
+      hasError || isInvalid || hasClass(className, 'is-invalid')
+
+    const hasContent = Boolean(startDate)
+
+    const placeholder = !isRange ? datePickerFormat.toLowerCase() : undefined
+
+    const handleOnFocus = useCallback(() => {
+      onLocalFocus()
+
+      if (isRange) {
+        buttonRef.current?.focus()
+      }
+    }, [onLocalFocus, isRange, buttonRef])
+
+    const handleOnBlur = useCallback(
+      (event: React.FocusEvent<HTMLInputElement>) => {
+        onLocalBlur(event)
+        handleInputBlur()
+
+        if (isDateValid(startDate)) {
+          dispatch({
+            type: DATEPICKER_ACTION.UPDATE,
+            data: { currentMonth: startDate },
+          })
+        }
+
+        if (onBlur) {
+          onBlur(event)
+        }
+      },
+      [onLocalBlur, handleInputBlur, startDate, dispatch, onBlur]
+    )
+
+    const handleInputClick = useCallback(() => {
+      if (isRange) {
+        dispatch({ type: DATEPICKER_ACTION.TOGGLE_OPEN })
+      }
+    }, [isRange, dispatch])
+
+    const handleShowHideClick = useCallback(() => {
+      dispatch({
+        type: DATEPICKER_ACTION.UPDATE,
+        data: {
+          calendarTableVariant: CALENDAR_TABLE_VARIANT.HIDE,
+          isOpen: !isOpen,
+        },
+      })
+    }, [dispatch, isOpen])
+
+    return (
+      <StyledDatePickerInput
+        className={className}
+        data-testid="datepicker-input-wrapper"
+        $isDisabled={isDisabled}
+        ref={setFloatingBoxTarget}
+      >
+        <StyledOuterWrapper
+          data-testid="datepicker-outer-wrapper"
+          $hasFocus={hasFocus && !isRange}
+          $isInvalid={effectiveHasError}
+          $isDisabled={isDisabled}
+        >
+          <StyledInputWrapper $isRange={isRange}>
+            <StyledLabel
+              id={titleId}
+              $hasFocus={hasFocus && !isRange}
+              $hasContent={hasContent}
+              htmlFor={id}
+              data-testid="datepicker-label"
+            >
+              {label}
+              {placeholder && ` (${placeholder})`}
+            </StyledLabel>
+            <StyledInput
+              ref={inputRef}
+              $hasLabel={Boolean(label)}
+              aria-label="Choose date"
+              data-testid="datepicker-input"
+              id={id}
+              type="text"
+              disabled={isDisabled}
+              readOnly={isRange}
+              onChange={handleInputChange}
+              onKeyDown={handleKeyDown}
+              onBlur={handleOnBlur}
+              onFocus={handleOnFocus}
+              onClick={handleInputClick}
+              placeholder={placeholder}
+              value={inputValue}
+              {...rest}
+            />
+          </StyledInputWrapper>
+          <StyledInlineButtons>
+            <InlineButton
+              aria-expanded={isOpen}
+              aria-label={`${isOpen ? 'Hide' : 'Show'} day picker`}
+              aria-owns={floatingBoxId}
+              data-testid="datepicker-input-button"
+              isDisabled={isDisabled}
+              onClick={handleShowHideClick}
+              ref={buttonRef}
+            >
+              <IconEvent size={18} />
+            </InlineButton>
+          </StyledInlineButtons>
+        </StyledOuterWrapper>
+      </StyledDatePickerInput>
+    )
+  }
+)

--- a/packages/react-component-library/src/components/DatePicker/types.ts
+++ b/packages/react-component-library/src/components/DatePicker/types.ts
@@ -1,22 +1,27 @@
+import { CalendarTableVariant } from './constants'
+
 export interface DatePickerState {
   startDate: Date | null
   endDate: Date | null
   currentMonth: Date
-  inputValue: string
   datePickerFormat: string
   hasError: boolean
+  inputValue: string
+  isOpen: boolean
+  calendarTableVariant: CalendarTableVariant
 }
 
 export const DATEPICKER_ACTION = {
-  RESET: 'reset',
-  UPDATE: 'update',
-  REFRESH_HAS_ERROR: 'refreshHasError',
-  REFRESH_INPUT_VALUE: 'refreshInputValue',
+  RESET: 'RESET',
+  UPDATE: 'UPDATE',
+  REFRESH_HAS_ERROR: 'REFRESH_HAS_ERROR',
+  REFRESH_INPUT_VALUE: 'REFRESH_INPUT_VALUE',
+  TOGGLE_OPEN: 'TOGGLE_OPEN',
 } as const
 
 interface ResetAction {
   type: typeof DATEPICKER_ACTION.RESET
-  data: Omit<DatePickerState, 'hasError' | 'inputValue'>
+  data: Omit<DatePickerState, 'hasError' | 'inputValue' | 'isOpen'>
 }
 
 interface UpdateAction {
@@ -34,8 +39,14 @@ interface RefreshInputValueAction {
   data?: never
 }
 
+interface ToggleOpenAction {
+  type: typeof DATEPICKER_ACTION.TOGGLE_OPEN
+  data?: never
+}
+
 export type DatePickerAction =
   | ResetAction
   | UpdateAction
   | RefreshHasErrorAction
   | RefreshInputValueAction
+  | ToggleOpenAction

--- a/packages/react-component-library/src/components/DatePicker/useProcessDayClick.ts
+++ b/packages/react-component-library/src/components/DatePicker/useProcessDayClick.ts
@@ -1,6 +1,6 @@
 import { addHours, isValid, max, min, startOfDay } from 'date-fns'
-import React from 'react'
 import { DayPickerProps, isMatch, Matcher } from 'react-day-picker'
+import React from 'react'
 
 import {
   DatePickerDateValidityType,
@@ -70,14 +70,14 @@ function normaliseDate(date: Date | null): Date | null {
   return addHours(startOfDay(date), 12)
 }
 
-export const useHandleDayClick = (
+export const useProcessDayClick = (
   state: DatePickerState,
   dispatch: React.Dispatch<DatePickerAction>,
   isRange: boolean,
   disabledDays: DayPickerProps['disabled'],
   onChange?: (data: DatePickerOnChangeData) => void
 ): ((day: Date | null) => { startDate: Date | null; endDate: Date | null }) => {
-  function handleDayClick(day: Date | null) {
+  function processDayClick(day: Date | null) {
     const newState = getNewState(isRange, normaliseDate(day), state)
 
     dispatch({
@@ -99,5 +99,5 @@ export const useHandleDayClick = (
     return newState
   }
 
-  return handleDayClick
+  return processDayClick
 }


### PR DESCRIPTION
## Overview

Refactor DatePicker.

This is a boy scout step change, I'm not aiming for perfection (other things to move on to).

I'm also not fully convinced this is better. I feel like i've added more code and indirection.

## Reason

https://github.com/Royal-Navy/design-system/pull/3955#discussion_r1827789321

## Work carried out

- [x] Break up the `DatePicker` into `Input` and `FloatingCalendar` sub components
- [x] Extract handlers from JSX
- [x] Consolidate state within the reducer (`calendarTableVariant`, `isOpen`)
- [x] Expose reducer via context
- [x] Memoize where appropriate (note impact on speed of test suites)

## Developer notes

I'm using context to expose the reducer, which is naughty with mutable state but performance impact is limited:

1. State updates are naturally bounded to user interactions
2. Most state changes (like paging the calendar) require child components to re-render anyway
3. Context scope is limited to the relatively shallow DatePicker component tree only
4. Refactoring all of the state and introducing Zustand felt like overkill given the above