### PR TITLE
feat(Text): Deprecate TextE in favour of Text

### DIFF
--- a/packages/react-component-library/src/components/Text/Text.stories.tsx
+++ b/packages/react-component-library/src/components/Text/Text.stories.tsx
@@ -2,12 +2,12 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 
 import { Meta, StoryFn } from '@storybook/react'
-import { textAlignments, TextE } from './Text'
+import { textAlignments, Text } from './Text'
 import { allowedElements } from './textStyles'
 
 export default {
-  component: TextE,
-  title: 'Experimental/Text',
+  component: Text,
+  title: 'Utility/Text',
   parameters: {
     actions: { argTypesRegex: '^on.*' },
   },
@@ -34,7 +34,7 @@ export default {
       description: 'Show vertical text baseline',
     },
   },
-} as Meta<typeof TextE>
+} as Meta<typeof Text>
 
 const StyledContainerWithBaseline = styled.div<{ $showBaseline: boolean }>`
   ${({ $showBaseline }) =>
@@ -53,8 +53,8 @@ const StyledContainerWithBaseline = styled.div<{ $showBaseline: boolean }>`
 
 export const Default: StoryFn<typeof Text> = (props) => (
   <StyledContainerWithBaseline $showBaseline={props.showBaseline}>
-    <TextE {...props} />
-    <TextE {...props} />
+    <Text {...props} />
+    <Text {...props} />
   </StyledContainerWithBaseline>
 )
 

--- a/packages/react-component-library/src/components/Text/Text.test.tsx
+++ b/packages/react-component-library/src/components/Text/Text.test.tsx
@@ -2,26 +2,26 @@ import React from 'react'
 import { fontSize } from '@royalnavy/design-tokens'
 import { render } from '@testing-library/react'
 
-import { TextE } from '.'
+import { Text } from '.'
 import { getTextStyles } from './textStyles'
 
 it('renders with default styles', () => {
-  const { container } = render(<TextE>Content</TextE>)
+  const { container } = render(<Text>Content</Text>)
   expect(container).toHaveTextContent('Content')
 })
 
 it('sets the line height', () => {
-  const { container } = render(<TextE>Content</TextE>)
+  const { container } = render(<Text>Content</Text>)
   expect(container.firstChild).toHaveStyleRule('line-height', '24px')
 })
 
 it('sets the arbitrary attribute', () => {
-  const { container } = render(<TextE data-arbitrary="value">Content</TextE>)
+  const { container } = render(<Text data-arbitrary="value">Content</Text>)
   expect(container.firstChild).toHaveAttribute('data-arbitrary', 'value')
 })
 
 it('sets the id attribute', () => {
-  const { container } = render(<TextE id="value">Content</TextE>)
+  const { container } = render(<Text id="value">Content</Text>)
   expect(container.firstChild).toHaveAttribute('id', 'value')
 })
 
@@ -46,7 +46,7 @@ it.each([
   ['span', '24px'],
 ])('sets the line height for %s', (el, expectedLineHeight) => {
   // @ts-ignore
-  const { container } = render(<TextE el={el}>Content</TextE>)
+  const { container } = render(<Text el={el}>Content</Text>)
   expect(container.firstChild).toHaveStyleRule(
     'line-height',
     expectedLineHeight
@@ -59,9 +59,9 @@ it.each([
 ])('sets the line height for small %s', (el, expectedLineHeight) => {
   const { container } = render(
     // @ts-ignore
-    <TextE el={el} variant="small">
+    <Text el={el} variant="small">
       Content
-    </TextE>
+    </Text>
   )
 
   expect(container.firstChild).toHaveStyleRule(
@@ -82,9 +82,9 @@ it.each([
 ])('sets the line height for display %s', (el, expectedLineHeight) => {
   const { container } = render(
     // @ts-ignore
-    <TextE el={el} variant="display">
+    <Text el={el} variant="display">
       Content
-    </TextE>
+    </Text>
   )
 
   expect(container.firstChild).toHaveStyleRule(

--- a/packages/react-component-library/src/components/Text/Text.tsx
+++ b/packages/react-component-library/src/components/Text/Text.tsx
@@ -13,7 +13,7 @@ export const textAlignments = {
 
 export type Alignment = (typeof textAlignments)[keyof typeof textAlignments]
 
-export interface TextEProps extends ComponentWithClass {
+export interface TextProps extends ComponentWithClass {
   align?: Alignment
   /**
    * The type of element to use for the root node, `'p'` by default.
@@ -41,7 +41,7 @@ export interface TextEProps extends ComponentWithClass {
   wordWrap?: boolean
 }
 
-export const TextE = ({
+export const Text = ({
   children,
   align = 'start',
   el = 'p',
@@ -50,7 +50,7 @@ export const TextE = ({
   variant,
   wordWrap = true,
   ...rest
-}: TextEProps) => {
+}: TextProps) => {
   const { fontSize, lineHeight, defaultColor, element, display } =
     getTextStyles(el, variant)
 
@@ -73,3 +73,13 @@ export const TextE = ({
     </StyledTextComponent>
   )
 }
+
+/**
+ * @deprecated Use Text instead
+ */
+export const TextE = Text
+
+/**
+ * @deprecated Use TextProps instead
+ */
+export type TextEProps = TextProps

--- a/packages/react-component-library/src/components/Text/index.ts
+++ b/packages/react-component-library/src/components/Text/index.ts
@@ -1,2 +1,2 @@
-export type { Alignment, TextEProps } from './Text'
-export { TextE } from './Text'
+export type { Alignment, TextProps, TextEProps } from './Text'
+export { Text, TextE } from './Text'

--- a/packages/react-component-library/src/tokens/typography.mdx
+++ b/packages/react-component-library/src/tokens/typography.mdx
@@ -4,7 +4,7 @@ import { KitchenSink } from './TypographyKitchenSink'
 import { GlobalStyleProvider } from '../styled-components'
 
 
-<Meta title="Experimental/Typography" />
+<Meta title="Tokens/Typography" />
 
 <Unstyled>
   <GlobalStyleProvider />


### PR DESCRIPTION
## Related issue

DNADB-80. The creation of a new webapp repo which will leverage RNDS components

## Overview

Renamed references from TextE to Text in components, unit tests, stories, and docs
Added new TextE and TextEProps as aliased to Text / TextProps with deprecated flag

## Reason

The TextE component is in use in production systems.

## Work carried out

- [x] Update TextE to Text
- [x] Update TextProps to TextProps
- [x] Add deprecated TextE and TextEProps aliases

