### PR TITLE
feat(DatePicker): Set aria-invalid attribute

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/Input.tsx
+++ b/packages/react-component-library/src/components/DatePicker/Input.tsx
@@ -167,6 +167,7 @@ export const Input = memo(
             <StyledInput
               ref={inputRef}
               $hasLabel={Boolean(label)}
+              aria-invalid={effectiveHasError}
               aria-label="Choose date"
               data-testid="datepicker-input"
               id={id}

--- a/packages/react-component-library/src/components/DatePicker/__tests__/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/__tests__/DatePicker.test.tsx
@@ -458,6 +458,11 @@ describe('DatePicker', () => {
               expect(
                 wrapper.getByTestId('datepicker-outer-wrapper')
               ).toHaveStyleRule('box-shadow', ERROR_BOX_SHADOW)
+
+              expect(wrapper.getByTestId('datepicker-input')).toHaveAttribute(
+                'aria-invalid',
+                'true'
+              )
             })
 
             it('calls the `onBlur` callback', () => {


### PR DESCRIPTION
## Related issue
NA

## Overview
Sets the `aria-invalid` attribute on the input when the `DatePicker` is in an invalid state.

## Reason
This meets accessibility requirements and is useful for a downstream application.

## Work carried out
- [x] Add `aria-invalid` attribute to input

