### PR TITLE
chore(Docs): Update columnDef filter for numeric columns

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 import { spacing } from '@royalnavy/design-tokens'
 import { fn } from '@storybook/test'
@@ -67,13 +67,13 @@ const data: Order[] = [
   {
     id: 5,
     productName: 'Electronic Frozen Chips',
-    quantity: 79,
+    quantity: 11,
     price: '£837.00',
   },
   {
     id: 6,
     productName: 'Small Bronze Computer',
-    quantity: 86,
+    quantity: 111,
     price: '£694.00',
   },
   {
@@ -147,7 +147,7 @@ const subRowsData = [
     id: 8,
     productName: 'Intelligent Steel Ball',
     quantity: 14,
-    price: '£441.00',
+    price: '£111.00',
   },
   {
     id: 9,
@@ -175,6 +175,7 @@ const columns = [
     accessorKey: 'quantity',
     enableSorting: false,
     enableColumnFilter: false,
+    filterFn: 'equalsString',
   },
   {
     header: 'Price',

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -269,7 +269,7 @@ const StyledCell = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
 `
-const columnsWithArbitraryContent: ColumnDef<object>[] = columns.map((item) => {
+const columnsWithArbitraryContent = columns.map((item) => {
   if (item.accessorKey !== 'productName') {
     return {
       ...item,
@@ -685,7 +685,7 @@ export const ManualSorting: StoryFn<typeof DataGrid> = () => {
   return (
     <Wrapper>
       <DataGrid
-        columns={columnsWithSorting}
+        columns={columnsWithSorting as ColumnDef<Order>[]}
         data={sortedData}
         manualSorting
         onSortingChange={(updaterOrValue) => {

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
@@ -1000,12 +1000,19 @@ describe('DataGrid', () => {
         cell: (info) => info.getValue(),
         enableColumnFilter: false,
       },
+      {
+        accessorKey: 'numeric',
+        header: 'Numeric',
+        cell: (info) => info.getValue(),
+        enableColumnFilter: true,
+        filterFn: 'equalsString',
+      }
     ]
 
     const dataWithFiltering = [
-      { first: 'alpha', second: 'bravo', third: 'charlie' },
-      { first: 'delta', second: 'echo', third: 'foxtrot' },
-      { first: 'golf', second: 'hotel', third: 'india' },
+      { first: 'alpha', second: 'bravo', third: 'charlie', numeric: 11 },
+      { first: 'delta', second: 'echo', third: 'foxtrot', numeric: 111 },
+      { first: 'golf', second: 'hotel', third: 'india', numeric: 3 },
     ]
 
     it('renders filter buttons for columns with enableColumnFilter', () => {
@@ -1014,7 +1021,7 @@ describe('DataGrid', () => {
       )
 
       const filterButtons = screen.getAllByRole('button', { name: /filter/i })
-      expect(filterButtons).toHaveLength(2)
+      expect(filterButtons).toHaveLength(3)
     })
 
     it('opens filter input when filter button is clicked', async () => {
@@ -1031,6 +1038,26 @@ describe('DataGrid', () => {
 
       const filterInput = screen.getByPlaceholderText('Filter First')
       expect(filterInput).toBeInTheDocument()
+    })
+
+    it('filters numeric data', async () => {
+      render(
+        <DataGrid data={dataWithFiltering} columns={columnsWithFiltering} />
+      )
+
+      const filterButton = screen.getByRole('button', { name: 'Filter Numeric' })
+      userEvent.click(filterButton)
+
+      await hackyWaitFor()
+
+      const filterInput = screen.getByPlaceholderText('Filter Numeric')
+      userEvent.type(filterInput, '11')
+
+      await hackyWaitFor()
+
+      const rows = screen.getAllByRole('row')
+      expect(rows).toHaveLength(2)// Header row + 1 data row
+
     })
 
     it('filters data when input is provided', async () => {


### PR DESCRIPTION
## Related issue

#3902 

## Overview

Add the `includesString` filterFn for the numeric Qty columnDef in stories and tests for DataGrid

## Reason

It looked like a bug with filtering and numeric columns but we just needed to let the underlying component know how to filter the data

## Work carried out

- [x] Add filterFn to Stories and Tests

