### PR TITLE
chore(DataGrid): Align pagination to left for DataGrid

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/partials/StyledPagination.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledPagination.tsx
@@ -4,6 +4,6 @@ import { spacing } from '@royalnavy/design-tokens'
 import { Pagination } from '../../Pagination'
 
 export const StyledPagination = styled(Pagination)`
-  align-self: flex-end;
+  align-self: flex-start;
   margin: ${spacing('8')} 0 0 ${spacing('8')};
 `

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledPagination.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledPagination.tsx
@@ -5,5 +5,5 @@ import { Pagination } from '../../Pagination'
 
 export const StyledPagination = styled(Pagination)`
   align-self: flex-start;
-  margin: ${spacing('8')} 0 0 ${spacing('8')};
+  margin-top: ${spacing('8')};
 `


### PR DESCRIPTION
## Related issue

#3901 

## Overview

Align the pagination for DataGrid to the left and avoid the issue with it being rendered off screen for full width grid

## Work carried out

- [x] Change alignment from flex-end to flex-start

## Screenshot
![image](https://github.com/user-attachments/assets/cd7f111d-b1f3-4927-ab6c-a9110a894857)


