### PR TITLE
feat(Select): Set `className` on root element

### DIFF
--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -25,7 +25,12 @@ describe('Select', () => {
       onChangeSpy = jest.fn()
 
       wrapper = render(
-        <Select id="select-id" label="Label" onChange={onChangeSpy}>
+        <Select
+          className="custom-class"
+          id="select-id"
+          label="Label"
+          onChange={onChangeSpy}
+        >
           <SelectOption value="one">One</SelectOption>
           <SelectOption value="two">Two</SelectOption>
           <SelectOption value="three">Three</SelectOption>
@@ -57,6 +62,10 @@ describe('Select', () => {
         'id',
         'select-id'
       )
+    })
+
+    it('sets the custom class name', () => {
+      expect(wrapper.getByTestId('select')).toHaveClass('custom-class')
     })
 
     it('renders the label', () => {

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -52,6 +52,7 @@ const isEllipsisActive = (el: HTMLInputElement | null): boolean => {
 
 export const SelectLayout = ({
   children,
+  className,
   hasLabelFocus = false,
   hasSelectedItem,
   id,
@@ -77,7 +78,11 @@ export const SelectLayout = ({
 
   return (
     <>
-      <StyledSelect data-testid="select" aria-labelledby={labelId}>
+      <StyledSelect
+        className={className}
+        data-testid="select"
+        aria-labelledby={labelId}
+      >
         <StyledTextInput data-testid="text-input-container">
           <StyledOuterWrapper
             $hasFocus={isOpen}


### PR DESCRIPTION
## Related issue
NA

## Overview
Set `className` on root element of `Select` component.

## Reason
It does not make sense that the `className` would be drilled all the way down to the `input` and setting it on the root element is more useful for `styled-components`.

## Work carried out
- [x] Set `className` on root element
