### PR TITLE
feat(Masthead): Show version in badge

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.stories.tsx
@@ -183,11 +183,12 @@ WithNavigation.args = {
 }
 
 export const WithInlineNav = WithNavigation.bind({})
-WithInlineNav.storyName = 'Inline navigation'
+WithInlineNav.storyName = 'Inline navigation with version'
 WithInlineNav.args = {
   ...WithNavigation.args,
   hasInlineNav: true,
   user: userWithAvatar,
+  version: '1.0.0',
 }
 
 export const CustomLogo: StoryFn<typeof Masthead> = (props) => (

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.test.tsx
@@ -71,6 +71,7 @@ const props = {
       link={<Link href="/user-profile" />}
     />
   ),
+  version: '1.0.0',
 }
 
 describe('Masthead', () => {
@@ -251,6 +252,10 @@ describe('Masthead', () => {
         'role',
         'presentation'
       )
+    })
+
+    it('should render the version', () => {
+      expect(wrapper.getByText('1.0.0')).toBeInTheDocument()
     })
 
     it('should render the avatar', () => {

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/Masthead.tsx
@@ -23,6 +23,7 @@ import { StyledIconSearch } from './partials/StyledIconSearch'
 import { ValueOf } from '../../../helpers'
 import { StyledInlineNav } from './partials/StyledInlineNav'
 import { ClassificationProps } from '../../ClassificationBar'
+import { StyledVersion } from './partials/StyledVersion'
 
 export interface MastheadProps {
   /**
@@ -69,6 +70,10 @@ export interface MastheadProps {
    */
   user?: React.ReactElement<MastheadUserProps>
   /**
+   * Optional text to render the version number.
+   */
+  version?: string
+  /**
    * Whether to display the nav below (default) or within the masthead
    */
   hasInlineNav?: boolean
@@ -82,11 +87,17 @@ export interface MastheadProps {
   rightSlot?: React.ReactNode
 }
 
-function getServiceName(
-  Logo: React.ComponentType | null,
-  title: string,
+function getServiceName({
+  Logo,
+  title,
+  homeLink,
+  version,
+}: {
+  Logo: React.ComponentType | null
+  title: string
   homeLink?: React.ReactElement<LinkProps>
-) {
+  version?: string
+}) {
   const link = homeLink || <span />
   return React.cloneElement(link as React.ReactElement, {
     ...link.props,
@@ -99,6 +110,7 @@ function getServiceName(
         <StyledTitle $hasLogo={!!Logo} data-testid="masthead-servicename">
           {title}
         </StyledTitle>
+        {version && <StyledVersion>{version}</StyledVersion>}
       </StyledServiceName>
     ),
   })
@@ -118,6 +130,7 @@ export const Masthead = ({
   user,
   classificationBar,
   rightSlot,
+  version,
   ...rest
 }: MastheadProps) => {
   const searchButtonRef = useRef<HTMLButtonElement>(null)
@@ -148,7 +161,7 @@ export const Masthead = ({
           role="banner"
           $withInlineNav={hasInlineNav}
         >
-          {getServiceName(DisplayLogo, title, homeLink)}
+          {getServiceName({ Logo: DisplayLogo, title, homeLink, version })}
         </StyledBanner>
         {hasInlineNav ? (
           <StyledInlineNav data-testid="masthead-inline-nav">

--- a/packages/react-component-library/src/components/TopLevelNavigation/Masthead/partials/StyledVersion.ts
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Masthead/partials/StyledVersion.ts
@@ -1,0 +1,11 @@
+import { spacing } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+import { Badge, BADGE_COLOR_VARIANT, BADGE_VARIANT } from '../../../Badge'
+
+export const StyledVersion = styled(Badge).attrs({
+  colorVariant: BADGE_COLOR_VARIANT.FADED,
+  variant: BADGE_VARIANT.PILL,
+})`
+  margin-left: ${spacing('4')};
+`


### PR DESCRIPTION
## Related issue
NA

## Overview
Add optional version prop to show a version number in the badge next to the title.

## Reason
Useful for downstream applications and removes the need for them to hack the JSX.

## Work carried out
- [x] Add `version` prop to `Masthead`

## Screenshot
![Screenshot 2025-03-28 at 15 11 05](https://github.com/user-attachments/assets/75bd96ab-1a18-4d8a-904f-69ec98e77e62)
