### PR TITLE
fix(SideBar): Prevent isOpen prop leaking to DOM element

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNavItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNavItem.tsx
@@ -45,7 +45,7 @@ export const SidebarNavItem = ({
     ...link.props,
     children: (
       <>
-        {icon && <StyledNavItemIcon isOpen={isOpen}>{icon}</StyledNavItemIcon>}
+        {icon && <StyledNavItemIcon $isOpen={isOpen}>{icon}</StyledNavItemIcon>}
         <Transition
           nodeRef={nodeRef}
           in={isOpen}
@@ -56,7 +56,7 @@ export const SidebarNavItem = ({
             <StyledNavItemText
               ref={nodeRef}
               $transitionStatus={state}
-              isOpen={isOpen}
+              $isOpen={isOpen}
               data-testid="sidebar-nav-item-text"
             >
               {linkElement.props.children}

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNotifications.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNotifications.tsx
@@ -47,7 +47,7 @@ export const SidebarNotifications = ({
           aria-label="Show notifications"
           data-testid="notification-button"
           icon={<IconNotifications />}
-          isOpen={isOpen}
+          $isOpen={isOpen}
         >
           {hasUnreadNotification && (
             <StyledNotificationDot data-testid="not-read">

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledNavItemIcon.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledNavItemIcon.tsx
@@ -4,7 +4,7 @@ import { color } from '@royalnavy/design-tokens'
 import { StyledNavItem } from './StyledNavItem'
 
 interface StyledNavItemIconProps {
-  isOpen?: boolean
+  $isOpen?: boolean
 }
 
 export const StyledNavItemIcon = styled.div<StyledNavItemIconProps>`
@@ -24,8 +24,8 @@ export const StyledNavItemIcon = styled.div<StyledNavItemIconProps>`
     }
   }
 
-  ${({ isOpen }) =>
-    isOpen &&
+  ${({ $isOpen }) =>
+    $isOpen &&
     css`
       width: auto;
       padding: 0.55rem;

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledNavItemText.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledNavItemText.tsx
@@ -8,7 +8,7 @@ import {
 import { StyledNavItem } from './StyledNavItem'
 
 interface StyledTextProps extends TransitionProps {
-  isOpen?: boolean
+  $isOpen?: boolean
 }
 
 export const StyledNavItemText = styled.div<StyledTextProps>`
@@ -24,8 +24,8 @@ export const StyledNavItemText = styled.div<StyledTextProps>`
     color: ${color('neutral', 'white')};
   }
 
-  ${({ isOpen }) =>
-    !isOpen &&
+  ${({ $isOpen }) =>
+    !$isOpen &&
     css`
       display: none;
     `}

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledNotificationsSheetButton.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledNotificationsSheetButton.tsx
@@ -7,7 +7,7 @@ import { StyledNotificationDot } from './StyledNotificationDot'
 import { StyledNotificationsLabel } from './StyledNotificationsLabel'
 
 interface StyledNotificationsSheetButtonProps extends SheetButtonProps {
-  isOpen: boolean
+  $isOpen: boolean
 }
 
 export const StyledNotificationsSheetButton = styled<
@@ -25,8 +25,8 @@ export const StyledNotificationsSheetButton = styled<
     height: 20px;
   }
 
-  ${({ isOpen }) =>
-    isOpen &&
+  ${({ $isOpen }) =>
+    $isOpen &&
     css`
       width: 100%;
       padding: ${spacing('8')} ${spacing('7')};


### PR DESCRIPTION
## Related issue

## Overview

When using the Design System in a React 19 NextJS 15 app there is an error in development mode.

## Work carried out

- [x] Rename all `isOpen` props on Sidebar styled components to `$isOpen`


## Screenshot

<img width="957" alt="image" src="https://github.com/user-attachments/assets/a3f5a1fc-9343-41bc-aafc-6f9d5d8e9872" />

