### PR TITLE
fix(Sidebar): Prevent isActive prop leaking to DOM elements

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNavItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarNavItem.tsx
@@ -78,7 +78,7 @@ export const SidebarNavItem = ({
 
   return (
     <StyledNavItem
-      isActive={isActive}
+      $isActive={isActive}
       onMouseEnter={(_) => setHasMouseOver(true)}
       onMouseLeave={(_) => setHasMouseOver(false)}
     >

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledNavItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledNavItem.tsx
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components'
 import { color, spacing } from '@royalnavy/design-tokens'
 
 interface StyledNavItemProps {
-  isActive?: boolean
+  $isActive?: boolean
 }
 
 export const StyledNavItem = styled.div<StyledNavItemProps>`
@@ -17,8 +17,8 @@ export const StyledNavItem = styled.div<StyledNavItemProps>`
     width: 100%;
   }
 
-  ${({ isActive }) =>
-    isActive &&
+  ${({ $isActive }) =>
+    $isActive &&
     css`
       background-color: ${color('action', '500')};
 


### PR DESCRIPTION
## Related issue

DNADB-353

## Overview

NextJS is less forgiving at development time with props passed to styled components. 

## Work carried out

- [x] Rename isActive prop for style sidebar components to $isActive

## Screenshot

<img width="884" alt="image" src="https://github.com/user-attachments/assets/e51acef7-e10d-4511-b8a6-4c2941422368" />

