### PR TITLE
feat(TabSet): Add an optional hasOverflow prop

### DIFF
--- a/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.stories.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
+import styled from 'styled-components'
+
 import { StoryFn as Story, Meta } from '@storybook/react'
 
 import { ScrollableTabSetProps, TabSetItem, TabSet, TabSetProps } from '.'
+import { Select, SelectOption } from '../Select'
+import { Stack } from '../Stack'
+import { Text } from '../Text'
 
 export default {
   component: TabSet,
@@ -175,3 +180,29 @@ export const Scrollable: Story<ScrollableTabSetProps> = (props) => (
 )
 
 Scrollable.storyName = 'Scrollable paged tabs'
+
+const StyledWrapper = styled.div`
+  height: 400px;
+  padding: 1rem;
+`
+
+export const HasOverflow: Story<TabSetProps> = (props) => (
+  <StyledWrapper>
+    <TabSet {...props}>
+      <TabSetItem title="Has Overflow">
+          <Stack gap="4">
+            <Text>Sometimes we need to allow the content to overflow:</Text>
+            <Select label="Select a colour">
+              <SelectOption value="r">Red</SelectOption>
+              <SelectOption value="g">Green</SelectOption>
+              <SelectOption value="b">Blue</SelectOption>
+            </Select>
+          </Stack>
+      </TabSetItem>
+    </TabSet>
+  </StyledWrapper>
+)
+
+HasOverflow.args = {
+  hasOverflow: true,
+}

--- a/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.test.tsx
@@ -362,5 +362,31 @@ describe('TabSet', () => {
     it('displays a right scroll button', () => {
       expect(wrapper.getByTestId('scroll-right')).toBeInTheDocument()
     })
+
+    it('does not have overflow visible by default', () => {
+      expect(wrapper.getByTestId('tabset-styledbody')).not.toHaveStyleRule(
+        'overflow',
+        'visible'
+      )
+    })
+  })
+
+  describe('when the tab set hasOverflow', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <TabSet hasOverflow>
+          <TabSetItem title="Title 1">Content 1</TabSetItem>
+          <TabSetItem title="Title 2">Content 2</TabSetItem>
+          <TabSetItem title="Title 3">Content 3</TabSetItem>
+        </TabSet>
+      )
+    })
+
+    it('should have overflow visible', () => {
+      expect(wrapper.getByTestId('tabset-styledbody')).toHaveStyleRule(
+        'overflow',
+        'visible'
+      )
+    })
   })
 })

--- a/packages/react-component-library/src/components/TabSet/TabSet.tsx
+++ b/packages/react-component-library/src/components/TabSet/TabSet.tsx
@@ -36,6 +36,10 @@ export interface TabSetProps extends ComponentWithClass {
    * Toggles whether to render the scrollable variant of the component.
    */
   isScrollable?: never
+  /**
+   * Toggles whether content can overflow the component. Defaults to false.
+   */
+  hasOverflow?: boolean
 }
 
 export interface ScrollableTabSetProps extends ComponentWithClass {
@@ -55,6 +59,10 @@ export interface ScrollableTabSetProps extends ComponentWithClass {
    * Toggles whether to render the scrollable variant of the component.
    */
   isScrollable?: boolean
+  /**
+   * Toggles whether content can overflow the component. Defaults to false.
+   */
+  hasOverflow?: never
 }
 
 export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
@@ -63,6 +71,7 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
   onChange,
   isFullWidth,
   isScrollable,
+  hasOverflow = false,
   ...rest
 }) => {
   function getActiveIndex(tabs: React.ReactNode | React.ReactNode[]): number {
@@ -157,7 +166,7 @@ export const TabSet: React.FC<TabSetProps | ScrollableTabSetProps> = ({
           </StyledScrollRight>
         )}
       </StyledHeader>
-      <StyledBody $isScrollable={isScrollable}>
+      <StyledBody $isScrollable={isScrollable} $hasOverflow={hasOverflow} data-testid="tabset-styledbody">
         {Children.map(
           children,
           (child: React.ReactElement<TabSetItemProps>, index: number) => {

--- a/packages/react-component-library/src/components/TabSet/partials/StyledBody.tsx
+++ b/packages/react-component-library/src/components/TabSet/partials/StyledBody.tsx
@@ -4,9 +4,13 @@ import { zIndex } from '@royalnavy/design-tokens'
 import { StyledTabSetProps } from './StyledTabSet'
 import { ACTIVE_TAB_BORDER } from '../../TabBase/partials/StyledTab'
 
-export const StyledBody = styled.div<StyledTabSetProps>`
+export interface StyledBodyProps extends StyledTabSetProps {
+  $hasOverflow?: boolean
+}
+
+export const StyledBody = styled.div<StyledBodyProps>`
   padding: 24px 16px;
-  overflow-y: auto;
+  overflow: ${({ $hasOverflow }) => ($hasOverflow ? 'visible' : 'auto')};
   border: ${ACTIVE_TAB_BORDER};
   position: relative;
   z-index: ${zIndex('header', 1)};


### PR DESCRIPTION
## Overview

Add a `hasOverflow` prop to the TabSet which allows content to overflow the container. Defaults to false

## Reason

When the hasOverflow property is set we can handle `Select` components within the content. Previously they would be constrained

## Work carried out


- [x] Add hasOverflow prop and drill through to StyledBody component
- [x] An example in Storybook

## Screenshot
![2025-04-29 13 25 29](https://github.com/user-attachments/assets/f03373e2-0212-4d4e-8d24-14cc6c0d50aa)

