### PR TITLE
feat(DataGrid): Scroll contents within the DataGrid

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { spacing } from '@royalnavy/design-tokens'
 import { fn } from '@storybook/test'
 import { Meta, StoryFn } from '@storybook/react'
@@ -250,8 +250,13 @@ const columns = [
   },
 ]
 
-const Wrapper = styled.div`
-  padding: ${spacing('4')};
+const Wrapper = styled.div<{ $hasScrolling?: boolean }>`
+  ${({ $hasScrolling }) =>
+    $hasScrolling &&
+    css`
+      height: 420px;
+    `};
+  padding: 0 ${spacing('4')} 2rem ${spacing('4')};
 `
 
 export default {
@@ -268,11 +273,21 @@ export default {
       },
     },
   },
+  argTypes: {
+    columns: {
+      control: false,
+    },
+    data: { control: false },
+    layout: {
+      control: 'select',
+      options: ['scroll', 'autoHeight'],
+    },
+  },
 } as Meta<typeof DataGrid>
 
 export const Default: StoryFn<typeof DataGrid> = (props) => {
   return (
-    <Wrapper>
+    <Wrapper $hasScrolling={props.layout === 'scroll'}>
       <DataGrid {...props} />
     </Wrapper>
   )
@@ -286,6 +301,16 @@ Default.args = {
   onExpandedChange: fn(),
   onColumnFiltersChange: fn(),
 }
+
+export const ScrollingContent: StoryFn<typeof DataGrid> = (props) => {
+  return (
+    <Wrapper $hasScrolling>
+      <DataGrid {...props} />
+    </Wrapper>
+  )
+}
+
+ScrollingContent.args = { ...Default.args, layout: 'scroll' }
 
 const columnsWithSorting = columns.map((item) => ({
   ...item,

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -256,7 +256,7 @@ const Wrapper = styled.div<{ $hasScrolling?: boolean }>`
     css`
       height: 420px;
     `};
-  padding: 0 ${spacing('4')} 2rem ${spacing('4')};
+  padding: ${spacing('4')};
 `
 
 export default {

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -31,7 +31,7 @@ const disableEmptyTableHeaderRule = {
   },
 }
 
-const generateRandomData = (length: number, seed? = 123): Order[] => {
+const generateRandomData = (length: number, seed = 123): Order[] => {
   faker.seed(seed)
   return Array.from({ length }, (_, i) => {
     return {

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useState } from 'react'
 import styled, { css } from 'styled-components'
+import { faker } from '@faker-js/faker'
 import { spacing } from '@royalnavy/design-tokens'
 import { fn } from '@storybook/test'
 import { Meta, StoryFn } from '@storybook/react'
 import type {
   ColumnDef,
-  SortingState,
   PaginationState,
+  SortingState,
 } from '@tanstack/react-table'
 
 import { storyAccessibilityConfig } from '../../a11y/storyAccessibilityConfig'
@@ -30,203 +31,24 @@ const disableEmptyTableHeaderRule = {
   },
 }
 
-// const generateRandomData = (length: number): Order[] => {
-//   const data: Order[] = Array.from({ length }, (_, i) => {
-//     return {
-//       id: i + 1,
-//       productName: faker.commerce.productName(),
-//       quantity: faker.number.int({ min: 1, max: 100 }),
-//       price: `£${faker.commerce.price()}`,
-//     }
-//   })
+const generateRandomData = (length: number, seed? = 123): Order[] => {
+  faker.seed(seed)
+  return Array.from({ length }, (_, i) => {
+    return {
+      id: i + 1,
+      productName: faker.commerce.productName(),
+      quantity: faker.number.int({ min: 1, max: 100 }),
+      price: `£${faker.commerce.price()}`,
+    }
+  })
+}
 
-//   return data
-// }
+const data: Order[] = generateRandomData(20)
 
-// Static copy from Faker (play nice with Chromatic snapshots)
-const data: Order[] = [
-  {
-    id: 1,
-    productName: 'Unbranded Steel Sausages',
-    quantity: 59,
-    price: '£782.00',
-  },
-  {
-    id: 2,
-    productName: 'Modern Plastic Sausages',
-    quantity: 38,
-    price: '£175.00',
-  },
-  {
-    id: 3,
-    productName: 'Oriental Bronze Tuna',
-    quantity: 34,
-    price: '£72.00',
-  },
-  {
-    id: 4,
-    productName: 'Rustic Steel Bike',
-    quantity: 59,
-    price: '£693.00',
-  },
-  {
-    id: 5,
-    productName: 'Electronic Frozen Chips',
-    quantity: 11,
-    price: '£837.00',
-  },
-  {
-    id: 6,
-    productName: 'Small Bronze Computer',
-    quantity: 111,
-    price: '£694.00',
-  },
-  {
-    id: 7,
-    productName: 'Licensed Steel Hat',
-    quantity: 84,
-    price: '£415.00',
-  },
-  {
-    id: 8,
-    productName: 'Intelligent Steel Ball',
-    quantity: 14,
-    price: '£441.00',
-  },
-  {
-    id: 9,
-    productName: 'Licensed Concrete Bacon',
-    quantity: 68,
-    price: '£337.00',
-  },
-  {
-    id: 10,
-    productName: 'Practical Wooden Ball',
-    quantity: 10,
-    price: '£673.00',
-  },
-  {
-    id: 11,
-    productName: 'Handcrafted Wooden Table',
-    quantity: 25,
-    price: '£512.00',
-  },
-  {
-    id: 12,
-    productName: 'Ergonomic Cotton Chair',
-    quantity: 47,
-    price: '£299.00',
-  },
-  {
-    id: 13,
-    productName: 'Fantastic Granite Shoes',
-    quantity: 19,
-    price: '£120.00',
-  },
-  {
-    id: 14,
-    productName: 'Incredible Plastic Gloves',
-    quantity: 73,
-    price: '£89.00',
-  },
-  {
-    id: 15,
-    productName: 'Tasty Fresh Tuna',
-    quantity: 56,
-    price: '£230.00',
-  },
-  {
-    id: 16,
-    productName: 'Awesome Rubber Keyboard',
-    quantity: 33,
-    price: '£410.00',
-  },
-  {
-    id: 17,
-    productName: 'Refined Concrete Soap',
-    quantity: 22,
-    price: '£58.00',
-  },
-  {
-    id: 18,
-    productName: 'Sleek Steel Mouse',
-    quantity: 41,
-    price: '£199.00',
-  },
-  {
-    id: 19,
-    productName: 'Gorgeous Wooden Pizza',
-    quantity: 15,
-    price: '£320.00',
-  },
-  {
-    id: 20,
-    productName: 'Incredible Fresh Salad',
-    quantity: 60,
-    price: '£150.00',
-  },
-]
-
-const subRowsData = [
-  {
-    id: 1,
-    productName: 'Unbranded Steel Sausages',
-    quantity: 59,
-    price: '£782.00',
-    subRows: [
-      {
-        id: 2,
-        productName: 'Modern Plastic Sausages',
-        quantity: 38,
-        price: '£175.00',
-      },
-      {
-        id: 3,
-        productName: 'Oriental Bronze Tuna',
-        quantity: 34,
-        price: '£72.00',
-      },
-    ],
-  },
-  {
-    id: 4,
-    productName: 'Rustic Steel Bike',
-    quantity: 59,
-    price: '£693.00',
-    subRows: [
-      {
-        id: 5,
-        productName: 'Electronic Frozen Chips',
-        quantity: 79,
-        price: '£837.00',
-      },
-      {
-        id: 6,
-        productName: 'Small Bronze Computer',
-        quantity: 86,
-        price: '£694.00',
-      },
-    ],
-  },
-  {
-    id: 8,
-    productName: 'Intelligent Steel Ball',
-    quantity: 14,
-    price: '£111.00',
-  },
-  {
-    id: 9,
-    productName: 'Licensed Concrete Bacon',
-    quantity: 68,
-    price: '£337.00',
-  },
-  {
-    id: 10,
-    productName: 'Practical Wooden Ball',
-    quantity: 10,
-    price: '£673.00',
-  },
-]
+const subRowsData = data.map((item) => ({
+  ...item,
+  subRows: generateRandomData(3, item.id),
+}))
 
 const columns = [
   {

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
@@ -1592,4 +1592,42 @@ describe('DataGrid', () => {
       expect(screen.getByText('of 40')).toBeInTheDocument()
     })
   })
+
+  describe('Layout', () => {
+    it('should expand the container when layout is autoHeight', () => {
+      const { container } = render(
+        <DataGrid data={data} columns={columns} pageSize={0} isLoading />
+      )
+
+      expect(
+        within(container).getByTestId('styled-datagrid')
+      ).not.toHaveStyleRule('height', '100%')
+
+      expect(
+        within(container).getByTestId('styled-tablehead')
+      ).not.toHaveStyleRule('position', 'sticky')
+    })
+
+    it('should not expand when layout is normal', () => {
+      const { container } = render(
+        <DataGrid
+          data={data}
+          columns={columns}
+          pageSize={0}
+          isLoading
+          layout="scroll"
+        />
+      )
+
+      expect(within(container).getByTestId('styled-datagrid')).toHaveStyleRule(
+        'height',
+        '100%'
+      )
+
+      expect(within(container).getByTestId('styled-tablehead')).toHaveStyleRule(
+        'position',
+        'sticky'
+      )
+    })
+  })
 })

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.tsx
@@ -22,6 +22,7 @@ import { type OnChangeEventType } from '../Pagination'
 import { type ComponentWithClass } from '../../common/ComponentWithClass'
 import { useDataGridState } from './useDataGridState'
 import { getColumns } from './getColumns'
+import { TABLE_DEFAULT_LAYOUT, type TableLayout } from './constants'
 import { Table } from './Table'
 import { Footer } from './Footer'
 import { ProgressIndicator } from '../ProgressIndicator'
@@ -76,6 +77,12 @@ export interface DataGridBaseProps<T extends object>
     currentPage: number,
     totalPages: number
   ) => void
+  /**
+   * How the grid should lay out the rows.
+   * autoHeight (default) - The grid will resize to fit all visible rows.
+   * scroll - The grid will fit to the container height and scroll rows if needed.
+   */
+  layout?: TableLayout
 }
 
 export interface DataGridPropsWithExternalSorting<T extends object>
@@ -140,6 +147,7 @@ export const DataGrid = <T extends object>(props: DataGridProps<T>) => {
     onSortingChange,
     sorting: externalSorting,
     pagination: externalPagination,
+    layout = TABLE_DEFAULT_LAYOUT,
     ...rest
   } = props
 
@@ -294,9 +302,18 @@ export const DataGrid = <T extends object>(props: DataGridProps<T>) => {
 
   const paginationState = externalPagination ?? internalPagination
 
+  const hasScrolling = layout === 'scroll'
+
   return (
-    <StyledDataGrid className={className}>
-      <StyledTableContainer>
+    <StyledDataGrid
+      className={className}
+      $hasScrolling={hasScrolling}
+      data-testid="styled-datagrid"
+    >
+      <StyledTableContainer
+        $hasScrolling={hasScrolling}
+        tabIndex={hasScrolling ? 0 : undefined}
+      >
         <Table
           table={table}
           caption={caption}
@@ -305,6 +322,7 @@ export const DataGrid = <T extends object>(props: DataGridProps<T>) => {
           hasHover={!!hasHover}
           isFullWidth={!!isFullWidth}
           hasSubRows={hasSubRows}
+          layout={layout}
           totalColumns={totalColumns}
         />
         {isLoading && (

--- a/packages/react-component-library/src/components/DataGrid/Header.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Header.tsx
@@ -10,12 +10,14 @@ import {
   type SortDirection,
 } from '@tanstack/react-table'
 
+import { TABLE_DEFAULT_LAYOUT, type TableLayout } from './constants'
 import { StyledHead, StyledRow, StyledCol, StyledColButton } from './partials'
 import { FilterPopover } from './FilterPopover'
 
 interface HeaderProps<T extends object> {
   table: TanstackTable<T>
   hasGroupedHeaders: boolean
+  layout?: TableLayout
 }
 
 type AriaSortType = 'ascending' | 'descending' | 'none'
@@ -65,9 +67,11 @@ export function getAriaSort(
 export const Header = <T extends object>({
   table,
   hasGroupedHeaders,
+  layout = TABLE_DEFAULT_LAYOUT,
 }: HeaderProps<T>) => {
+  const hasScrolling = layout === 'scroll'
   return (
-    <StyledHead>
+    <StyledHead $hasScrolling={hasScrolling} data-testid="styled-tablehead">
       {table.getHeaderGroups().map((headerGroup) => (
         <StyledRow key={headerGroup.id}>
           {headerGroup.headers.map((header) => {

--- a/packages/react-component-library/src/components/DataGrid/Table.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Table.tsx
@@ -4,6 +4,8 @@ import { type Table as TanstackTable } from '@tanstack/react-table'
 import { Header } from './Header'
 import { Body } from './Body'
 import { StyledTable, StyledCaption } from './partials'
+import { TABLE_DEFAULT_LAYOUT, type TableLayout } from './constants'
+
 
 interface TableProps<T extends object> {
   table: TanstackTable<T>
@@ -14,6 +16,7 @@ interface TableProps<T extends object> {
   isFullWidth: boolean
   hasSubRows: boolean
   totalColumns: number
+  layout?: TableLayout
 }
 
 export const Table = <T extends object>({
@@ -25,6 +28,7 @@ export const Table = <T extends object>({
   isFullWidth,
   hasSubRows,
   totalColumns,
+  layout = TABLE_DEFAULT_LAYOUT,
 }: TableProps<T>) => {
   const hasGroupedHeaders = useMemo(() => {
     return table.getHeaderGroups().reduce((acc, group) => {
@@ -40,7 +44,7 @@ export const Table = <T extends object>({
       role="grid"
     >
       {caption && <StyledCaption>{caption}</StyledCaption>}
-      <Header table={table} hasGroupedHeaders={hasGroupedHeaders} />
+      <Header table={table} hasGroupedHeaders={hasGroupedHeaders} layout={layout} />
       <Body
         table={table}
         enableRowSelection={enableRowSelection}

--- a/packages/react-component-library/src/components/DataGrid/constants.ts
+++ b/packages/react-component-library/src/components/DataGrid/constants.ts
@@ -5,3 +5,6 @@ const TABLE_COLUMN_ALIGNMENT = {
 } as const
 
 export { TABLE_COLUMN_ALIGNMENT }
+
+export type TableLayout = 'scroll' | 'autoHeight'
+export const TABLE_DEFAULT_LAYOUT = 'autoHeight'

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledDataGrid.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledDataGrid.tsx
@@ -1,8 +1,21 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { color } from '@royalnavy/design-tokens'
 
-export const StyledDataGrid = styled.div`
+import { StyledLayoutProps } from './types'
+
+export const StyledDataGrid = styled.div<StyledLayoutProps>`
   display: flex;
   flex-direction: column;
   background: ${color('neutral', 'white')};
+
+  ${({ $hasScrolling }) =>
+    $hasScrolling &&
+    css`
+      height: 100%;
+    `}
+
+  border-top: 1px solid ${color('neutral', '200')};
+
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 `

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledHead.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledHead.tsx
@@ -1,14 +1,14 @@
-import styled from 'styled-components'
-import { color } from '@royalnavy/design-tokens'
+import styled, { css } from 'styled-components'
+import { color, zIndex } from '@royalnavy/design-tokens'
 
-export const StyledHead = styled.thead`
+import { StyledLayoutProps } from './types'
+
+export const StyledHead = styled.thead<StyledLayoutProps>`
   background: ${color('neutral', '000')};
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
 
-  tr,
-  th {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-  }
+  ${({$hasScrolling}) => $hasScrolling && css`
+    position: sticky;
+    top: 0;
+    z-index: ${zIndex('header', 1)};
+  `}
 `

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledTable.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledTable.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components'
-import { color, spacing } from '@royalnavy/design-tokens'
+import { spacing } from '@royalnavy/design-tokens'
 
 interface StyledTableProps {
   $hasRowSelection?: boolean
@@ -11,8 +11,6 @@ export const StyledTable = styled.table<StyledTableProps>`
   table-layout: fixed;
   width: ${({ $isFullWidth }) => ($isFullWidth ? '100%' : 'auto')};
   border-spacing: 0;
-  border-radius: 4px;
-  border: 1px solid ${color('neutral', '200')};
 
   ${({ $hasRowSelection }) =>
     $hasRowSelection &&

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledTableContainer.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledTableContainer.tsx
@@ -1,7 +1,17 @@
+import { color } from '@royalnavy/design-tokens'
 import styled from 'styled-components'
 
-export const StyledTableContainer = styled.div`
+import { StyledLayoutProps } from './types'
+
+export const StyledTableContainer = styled.div<StyledLayoutProps>`
   position: relative;
-  overflow: hidden;
+
+  overflow: ${({ $hasScrolling }) => ($hasScrolling ? 'auto' : 'hidden')};
+  height: ${({ $hasScrolling }) => ($hasScrolling ? '100%' : 'inherit')};
+
+  border-bottom: 1px solid ${color('neutral', '200')};
+  border-left: 1px solid ${color('neutral', '200')};
+  border-right: 1px solid ${color('neutral', '200')};
+
   border-radius: 4px;
 `

--- a/packages/react-component-library/src/components/DataGrid/partials/types.ts
+++ b/packages/react-component-library/src/components/DataGrid/partials/types.ts
@@ -1,0 +1,3 @@
+export interface StyledLayoutProps {
+  $hasScrolling?: boolean
+}


### PR DESCRIPTION
## Overview

Make the DataGrid contents - i.e. the rows - scroll within the grid. Keeping the header and footer on screen.

## Work carried out

- [x] New `layout` prop which can be `scroll` or `autoHeight`. Defaults to `autoHeight`
- [x] Change the behaviour of the grid to scroll when set


## Screenshot
![2025-04-30 11 37 59](https://github.com/user-attachments/assets/1503930a-212f-415d-84ad-32bf4d2aa583)

