### PR TITLE
feat(DataGrid): Add footerLeftSlot supporting arbitrary JSX

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/Body.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Body.tsx
@@ -8,17 +8,44 @@ import {
 import { StyledBody, StyledRow, StyledCell } from './partials'
 
 interface RowProps<T extends object> {
+  /**
+   * The tanstack/react-table row instance.
+   */
   row: TanstackRow<T>
+  /**
+   * The tanstack/react-table instance.
+   */
   table: TanstackTable<T>
+  /**
+   * Whether row selection is enabled.
+   */
   enableRowSelection: boolean
+  /**
+   * Whether to apply hover styling to rows.
+   */
   hasHover: boolean
+  /**
+   * Total number of columns to display.
+   */
   totalColumns: number
 }
 
 interface BodyProps<T extends object> {
+  /**
+   * The tanstack/react-table instance.
+   */
   table: TanstackTable<T>
+  /**
+   * Whether row selection is enabled.
+   */
   enableRowSelection: boolean
+  /**
+   * Whether to apply hover styling to rows.
+   */
   hasHover: boolean
+  /**
+   * Total number of columns to display.
+   */
   totalColumns: number
 }
 

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -12,6 +12,7 @@ import type {
 import { storyAccessibilityConfig } from '../../a11y/storyAccessibilityConfig'
 import { DataGrid, TABLE_COLUMN_ALIGNMENT } from '.'
 import { Badge } from '../Badge'
+import { Button } from '../Button'
 import { DEFAULT_ROWS_PER_PAGE } from '../RowsPerPage/RowsPerPage'
 
 type Order = {
@@ -924,4 +925,34 @@ RowsPerPage.args = {
   onSelectedRowsChange: fn(),
   onExpandedChange: fn(),
   onColumnFiltersChange: fn(),
+}
+
+export const WithFooterLeftSlot: StoryFn<typeof DataGrid> = (props) => {
+  return (
+    <Wrapper>
+      <DataGrid
+        {...props}
+        footerLeftSlot={<Button variant="primary">Download</Button>}
+      />
+    </Wrapper>
+  )
+}
+
+WithFooterLeftSlot.storyName = 'With footer left slot'
+WithFooterLeftSlot.args = {
+  columns,
+  data,
+  isFullWidth: true,
+  onSelectedRowsChange: fn(),
+  onExpandedChange: fn(),
+  onColumnFiltersChange: fn(),
+}
+
+WithFooterLeftSlot.parameters = {
+  docs: {
+    description: {
+      story:
+        'The `footerLeftSlot` prop allows you to inject arbitrary content (like a button) into the left side of the DataGrid footer.',
+    },
+  },
 }

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
@@ -134,6 +134,18 @@ describe('DataGrid', () => {
     expect(screen.getByText('c6').tagName).toBe('DIV')
   })
 
+  it('renders footerLeftSlot content in the footer', () => {
+    render(
+      <DataGrid
+        data={data}
+        columns={columns}
+        footerLeftSlot={<Button>Download</Button>}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument()
+  })
+
   it('renders table with row selection', async () => {
     render(<DataGrid data={data} columns={columns} enableRowSelection />)
 

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.tsx
@@ -64,6 +64,7 @@ export interface DataGridBaseProps<T extends object>
   hasHover?: boolean
   hideCheckboxes?: boolean
   isLoading?: boolean
+  footerLeftSlot?: React.ReactNode
   onSelectedRowsChange?: (rows: T[]) => void
   onExpandedChange?: (expanded: ExpandedState) => void
   onColumnFiltersChange?: (columnFilters: ColumnFiltersState) => void
@@ -153,6 +154,7 @@ export const DataGrid = <T extends object>(props: DataGridProps<T>) => {
     sorting: externalSorting,
     pagination: externalPagination,
     layout = TABLE_DEFAULT_LAYOUT,
+    footerLeftSlot,
     ...rest
   } = props
 
@@ -357,6 +359,7 @@ export const DataGrid = <T extends object>(props: DataGridProps<T>) => {
         pageCount={pageCount!}
         pagination={paginationState}
         isFullWidth={isFullWidthOverride}
+        footerLeftSlot={footerLeftSlot}
       />
     </StyledDataGrid>
   )

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.tsx
@@ -56,24 +56,74 @@ export interface DataGridBaseProps<T extends object>
       | 'onSortingChange'
     >,
     Omit<ComponentWithClass, 'children'> {
+  /**
+   * The data to display in the table.
+   */
   data: T[]
+  /**
+   * The columns configuration for the table.
+   */
   columns: ColumnDef<T>[]
+  /**
+   * Accessible caption for the table.
+   */
   caption?: string
+  /**
+   * Initial row selection state. Use this to pre-select rows when the table renders.
+   */
   initialRowSelection?: RowSelectionState
+  /**
+   * Whether the table should take up the full width of its container.
+   */
   isFullWidth?: boolean
+  /**
+   * Whether to apply hover styling to rows.
+   */
   hasHover?: boolean
+  /**
+   * Whether to hide the selection checkboxes when row selection is enabled.
+   */
   hideCheckboxes?: boolean
+  /**
+   * Whether to display a loading indicator over the table.
+   */
   isLoading?: boolean
+  /**
+   * Content to be displayed in the left side of the footer.
+   * Useful for adding action buttons or custom controls.
+   */
   footerLeftSlot?: React.ReactNode
+  /**
+   * Callback function that is called when selected rows change.
+   * Receives the array of selected row objects.
+   */
   onSelectedRowsChange?: (rows: T[]) => void
+  /**
+   * Callback function that is called when expanded state changes.
+   * Useful for tracking which rows are expanded when using sub-rows.
+   */
   onExpandedChange?: (expanded: ExpandedState) => void
+  /**
+   * Callback function that is called when column filters change.
+   */
   onColumnFiltersChange?: (columnFilters: ColumnFiltersState) => void
+  /**
+   * Total number of pages when using manual pagination.
+   */
   pageCount?: number
   /**
    * @deprecated There is a nested RowsPerPage component that controls the page size.
    */
   pageSize?: number
+  /**
+   * Whether sorting is handled manually (externally).
+   * When true, the component will not sort data internally.
+   */
   manualSorting?: boolean
+  /**
+   * Initial sorting state. Defines which column(s) to sort by initially.
+   * @deprecated Use 'sorting' prop instead.
+   */
   sortingState?: SortingState
   /**
    * @deprecated Use onPaginationChange instead
@@ -94,31 +144,75 @@ export interface DataGridBaseProps<T extends object>
 export interface DataGridPropsWithExternalSorting<T extends object>
   extends DataGridBaseProps<T>,
     Pick<TableOptions<T>, 'onSortingChange'> {
+  /**
+   * Flag indicating sorting is handled manually.
+   * Must be set to true for external sorting to work.
+   */
   manualSorting: true
+  /**
+   * Current sorting state, required when using external sorting.
+   * Controls which column(s) are sorted and in which direction.
+   */
   sorting: SortingState
 }
 
 export interface DataGridPropsWithInternalSorting<T extends object>
   extends DataGridBaseProps<T> {
+  /**
+   * Not needed when using internal sorting.
+   */
   onSortingChange?: never
+  /**
+   * Must be omitted or set to false when using internal sorting.
+   */
   manualSorting?: false
+  /**
+   * Not needed when using internal sorting.
+   */
   sorting?: never
 }
 
 export interface DataGridPropsWithExternalPagination<T extends object>
   extends DataGridBaseProps<T>,
     Pick<TableOptions<T>, 'onPaginationChange'> {
+  /**
+   * Flag indicating pagination is handled manually.
+   * Must be set to true for external pagination to work.
+   */
   manualPagination: true
+  /**
+   * Current pagination state, required when using external pagination.
+   * Controls the current page index and page size.
+   */
   pagination: PaginationState
 }
 
 export interface DataGridPropsWithInternalPagination<T extends object>
   extends DataGridBaseProps<T> {
+  /**
+   * Not needed when using internal pagination.
+   */
   onPaginationChange?: never
+  /**
+   * Must be omitted or set to false when using internal pagination.
+   */
   manualPagination?: false
+  /**
+   * Not needed when using internal pagination.
+   */
   pagination?: never
 }
 
+/**
+ * DataGrid props type - a union of the four possible combinations:
+ * 1. External sorting + External pagination
+ * 2. External sorting + Internal pagination
+ * 3. Internal sorting + External pagination
+ * 4. Internal sorting + Internal pagination
+ *
+ * This allows TypeScript to enforce the correct props based on whether
+ * sorting and pagination are handled internally or externally.
+ */
 export type DataGridProps<T extends object> =
   | (DataGridPropsWithExternalSorting<T> &
       DataGridPropsWithExternalPagination<T>)
@@ -131,30 +225,30 @@ export type DataGridProps<T extends object> =
 
 export const DataGrid = <T extends object>(props: DataGridProps<T>) => {
   const {
-    data,
-    columns,
     caption,
+    className,
+    columns,
+    data,
     debugTable,
     enableRowSelection,
+    footerLeftSlot,
     hasHover,
     hideCheckboxes,
     initialRowSelection,
     isFullWidth,
     isLoading,
-    className,
+    layout = TABLE_DEFAULT_LAYOUT,
+    manualPagination,
+    manualSorting,
     onColumnFiltersChange,
-    onSelectedRowsChange,
     onExpandedChange,
     onPageChange,
-    manualPagination,
     onPaginationChange,
-    pageCount,
-    manualSorting,
+    onSelectedRowsChange,
     onSortingChange,
-    sorting: externalSorting,
+    pageCount,
     pagination: externalPagination,
-    layout = TABLE_DEFAULT_LAYOUT,
-    footerLeftSlot,
+    sorting: externalSorting,
     ...rest
   } = props
 

--- a/packages/react-component-library/src/components/DataGrid/FilterPopover.tsx
+++ b/packages/react-component-library/src/components/DataGrid/FilterPopover.tsx
@@ -9,7 +9,13 @@ import { Popover } from '../Popover'
 import { StyledFilterInput, StyledColButton } from './partials'
 
 interface FilterPopoverProps<T extends object> {
+  /**
+   * The tanstack/react-table header instance.
+   */
   header: TanstackHeader<T, unknown>
+  /**
+   * The tanstack/react-table instance.
+   */
   table: TanstackTable<T>
 }
 

--- a/packages/react-component-library/src/components/DataGrid/Footer.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Footer.tsx
@@ -10,13 +10,38 @@ import { RowsPerPage } from '../RowsPerPage/RowsPerPage'
 import { OnChangeType as BaseSelectOnChangeType } from '../SelectBase'
 
 interface FooterProps {
+  /**
+   * Total number of data items when pagination is used.
+   */
   dataLength?: number
+  /**
+   * Whether the footer includes pagination controls.
+   */
   isPaginated: boolean
+  /**
+   * Callback function triggered when pagination is changed.
+   */
   onPaginationChange: BasePaginationOnChangeType
+  /**
+   * Callback function triggered when the rows-per-page value changes.
+   */
   onRowsPerPageChange: BaseSelectOnChangeType
+  /**
+   * Current pagination state object.
+   */
   pagination: PaginationState
+  /**
+   * Total number of pages when using manual pagination.
+   */
   pageCount: number
+  /**
+   * Whether the footer should take up the full width of its container.
+   */
   isFullWidth: boolean
+  /**
+   * Optional content to be displayed in the left side of the footer.
+   * Useful for adding action buttons or custom controls.
+   */
   footerLeftSlot?: React.ReactNode
 }
 

--- a/packages/react-component-library/src/components/DataGrid/Footer.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Footer.tsx
@@ -17,6 +17,7 @@ interface FooterProps {
   pagination: PaginationState
   pageCount: number
   isFullWidth: boolean
+  footerLeftSlot?: React.ReactNode
 }
 
 export const Footer = ({
@@ -27,8 +28,10 @@ export const Footer = ({
   pageCount,
   pagination,
   isFullWidth,
+  footerLeftSlot,
 }: FooterProps) => (
   <StyledFooter $isFullWidth={isFullWidth}>
+    {footerLeftSlot || <div />}
     {isPaginated && (
       <Pagination
         name="datagrid-pagination"

--- a/packages/react-component-library/src/components/DataGrid/Header.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Header.tsx
@@ -15,8 +15,19 @@ import { StyledHead, StyledRow, StyledCol, StyledColButton } from './partials'
 import { FilterPopover } from './FilterPopover'
 
 interface HeaderProps<T extends object> {
+  /**
+   * The tanstack/react-table instance.
+   */
   table: TanstackTable<T>
+  /**
+   * Whether the table has grouped headers (multi-level column headers).
+   */
   hasGroupedHeaders: boolean
+  /**
+   * How the table should lay out the rows.
+   * autoHeight (default) - The table will resize to fit all visible rows.
+   * scroll - The table will fit to the container height and scroll rows if needed.
+   */
   layout?: TableLayout
 }
 

--- a/packages/react-component-library/src/components/DataGrid/Table.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Table.tsx
@@ -6,16 +6,44 @@ import { Body } from './Body'
 import { StyledTable, StyledCaption } from './partials'
 import { TABLE_DEFAULT_LAYOUT, type TableLayout } from './constants'
 
-
 interface TableProps<T extends object> {
+  /**
+   * The tanstack/react-table instance.
+   */
   table: TanstackTable<T>
+  /**
+   * Accessible caption for the table.
+   */
   caption?: string
+  /**
+   * Whether row selection is enabled.
+   */
   enableRowSelection: boolean
+  /**
+   * Whether to hide checkboxes for row selection.
+   */
   hideCheckboxes: boolean
+  /**
+   * Whether to apply hover styling to rows.
+   */
   hasHover: boolean
+  /**
+   * Whether the table should take up the full width of its container.
+   */
   isFullWidth: boolean
+  /**
+   * Whether the table contains expandable sub-rows.
+   */
   hasSubRows: boolean
+  /**
+   * Total number of columns to display.
+   */
   totalColumns: number
+  /**
+   * How the table should lay out the rows.
+   * autoHeight (default) - The table will resize to fit all visible rows.
+   * scroll - The table will fit to the container height and scroll rows if needed.
+   */
   layout?: TableLayout
 }
 
@@ -44,7 +72,11 @@ export const Table = <T extends object>({
       role="grid"
     >
       {caption && <StyledCaption>{caption}</StyledCaption>}
-      <Header table={table} hasGroupedHeaders={hasGroupedHeaders} layout={layout} />
+      <Header
+        table={table}
+        hasGroupedHeaders={hasGroupedHeaders}
+        layout={layout}
+      />
       <Body
         table={table}
         enableRowSelection={enableRowSelection}

--- a/packages/react-component-library/src/components/DataGrid/constants.ts
+++ b/packages/react-component-library/src/components/DataGrid/constants.ts
@@ -1,15 +1,27 @@
 import { ValueOf } from '../../helpers'
 
+/**
+ * Alignment options for table columns.
+ */
 export const TABLE_COLUMN_ALIGNMENT = {
   LEFT: 'left',
   CENTER: 'center',
   RIGHT: 'right',
 } as const
 
+/**
+ * Layout options for the DataGrid.
+ */
 export const TABLE_LAYOUT = {
   SCROLL: 'scroll',
   AUTO_HEIGHT: 'autoHeight',
 } as const
 
+/**
+ * Type representing the possible layout values for the DataGrid.
+ */
 export type TableLayout = ValueOf<typeof TABLE_LAYOUT>
+/**
+ * Default layout type for the DataGrid (autoHeight).
+ */
 export const TABLE_DEFAULT_LAYOUT: TableLayout = TABLE_LAYOUT.AUTO_HEIGHT

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledFooter.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledFooter.tsx
@@ -4,16 +4,39 @@ import styled, { css } from 'styled-components'
 export const StyledFooter = styled.div<{ $isFullWidth: boolean }>`
   display: flex;
   align-items: center;
-  justify-content: space-between;
   margin-top: ${spacing('8')};
+  padding: 0 ${spacing('1')};
 
   ${({ $isFullWidth }) =>
-    !$isFullWidth &&
-    css`
-      position: absolute;
-      bottom: -${spacing('8')};
-      transform: translateY(100%);
-      width: max-content;
-      gap: ${spacing('8')};
-    `}
+    $isFullWidth
+      ? css`
+          & > *:nth-child(1) {
+            flex: 0 0 auto;
+            margin-right: auto;
+          }
+
+          & > *:nth-child(2) {
+            flex: 0 1 auto;
+            position: absolute;
+            left: 50%;
+            transform: translateX(-50%);
+          }
+
+          & > *:nth-child(3) {
+            flex: 0 0 auto;
+            margin-left: auto;
+          }
+        `
+      : css`
+          justify-content: space-between;
+          position: absolute;
+          bottom: -${spacing('8')};
+          transform: translateY(100%);
+          width: max-content;
+          gap: ${spacing('8')};
+
+          & > * {
+            flex: 0 0 auto;
+          }
+        `}
 `


### PR DESCRIPTION
## Related issue

#[issueid]

## Overview

Added comments to all DataGrid component interfaces and props, including the new footerLeftSlot feature.

## Reason

Improves developer experience through better documentation, enhancing auto-complete hints and Storybook docs.

## Screenshot

![Screenshot 2025-05-05 at 20 05 48](https://github.com/user-attachments/assets/6d4c0a18-4b66-446d-a49e-6552e57de66b)

## Work carried out

- [x] Added JSDoc comments to all DataGrid interfaces and props
- [x] Documented new footerLeftSlot functionality
- [x] Ensured consistent documentation style across components