### PR TITLE
feat(Button): Add showLoadingText prop to display text in loading state

### DIFF
--- a/packages/react-component-library/src/components/Button/Button.stories.tsx
+++ b/packages/react-component-library/src/components/Button/Button.stories.tsx
@@ -26,6 +26,9 @@ export default {
     isLoading: {
       control: 'boolean',
     },
+    showLoadingText: {
+      control: 'boolean',
+    },
     iconPosition: {
       control: 'select',
       options: Object.values(BUTTON_ICON_POSITION),
@@ -157,6 +160,12 @@ export const RegularButtons: StoryFn<typeof Button> = (args) => {
       <ButtonStrip {...iconRightArgs} title="With icons right" />
       <ButtonStrip {...iconOnlyArgs} title="Icon only" hideText />
       <ButtonStrip {...loadingArgs} title="Loading" hideNoContainer />
+      <ButtonStrip
+        {...loadingArgs}
+        title="Loading with text"
+        hideNoContainer
+        showLoadingText
+      />
     </>
   )
 }
@@ -164,6 +173,9 @@ export const RegularButtons: StoryFn<typeof Button> = (args) => {
 const paletteArgTypes = {
   isDisabled: { table: { disable: true } },
   isLoading: {
+    control: 'boolean',
+  },
+  showLoadingText: {
     control: 'boolean',
   },
   size: { table: { disable: true } },

--- a/packages/react-component-library/src/components/Button/Button.test.tsx
+++ b/packages/react-component-library/src/components/Button/Button.test.tsx
@@ -1,12 +1,12 @@
 import React, { FormEvent } from 'react'
 
 import { IconBrightnessLow } from '@royalnavy/icon-library'
-import { render, RenderResult, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { Button } from './index'
 
 describe('Button', () => {
-  let wrapper: RenderResult
   let onClickSpy: (event: FormEvent<HTMLButtonElement>) => void
   let button: HTMLElement
 
@@ -16,8 +16,8 @@ describe('Button', () => {
 
   describe('default props', () => {
     beforeEach(() => {
-      wrapper = render(<Button onClick={onClickSpy}>Click me</Button>)
-      button = wrapper.getByLabelText('Click me')
+      render(<Button onClick={onClickSpy}>Click me</Button>)
+      button = screen.getByLabelText('Click me')
     })
 
     it('should default the type to "button"', () => {
@@ -25,12 +25,12 @@ describe('Button', () => {
     })
 
     it('should not render an icon', () => {
-      expect(wrapper.queryByTestId('button-icon')).toBeNull()
+      expect(screen.queryByTestId('button-icon')).toBeNull()
     })
 
     describe('when the button is clicked', () => {
-      beforeEach(() => {
-        fireEvent.click(button)
+      beforeEach(async () => {
+        await userEvent.click(button)
       })
 
       it('should handle the click event', () => {
@@ -41,12 +41,12 @@ describe('Button', () => {
 
   describe('when the onClick callback has not been specified', () => {
     beforeEach(() => {
-      wrapper = render(<Button>Click me</Button>)
-      button = wrapper.getByLabelText('Click me')
+      render(<Button>Click me</Button>)
+      button = screen.getByLabelText('Click me')
     })
 
     it('does not throw an error when the button is clicked', () => {
-      expect(() => fireEvent.click(button)).not.toThrow()
+      expect(() => userEvent.click(button)).not.toThrow()
     })
   })
 
@@ -56,12 +56,12 @@ describe('Button', () => {
       ${'button'} | ${'button'}
       ${'submit'} | ${'submit'}
     `('should set the type attribute to $type', ({ type, expected }) => {
-      wrapper = render(
+      render(
         <Button onClick={onClickSpy} type={type}>
           Click me
         </Button>
       )
-      button = wrapper.getByLabelText('Click me')
+      button = screen.getByLabelText('Click me')
 
       expect(button).toHaveAttribute('type', expected)
     })
@@ -69,15 +69,15 @@ describe('Button', () => {
 
   describe('when an icon is specified', () => {
     beforeEach(() => {
-      wrapper = render(<Button icon={<IconBrightnessLow />}>Click me</Button>)
+      render(<Button icon={<IconBrightnessLow />}>Click me</Button>)
     })
 
     it('should render an icon', () => {
-      expect(wrapper.getByTestId('button-icon')).toBeInTheDocument()
+      expect(screen.getByTestId('button-icon')).toBeInTheDocument()
     })
 
     it('should render the icon with an `aria-hidden` attribute', () => {
-      expect(wrapper.queryByTestId('button-icon')).toHaveAttribute(
+      expect(screen.queryByTestId('button-icon')).toHaveAttribute(
         'aria-hidden',
         'true'
       )
@@ -86,7 +86,7 @@ describe('Button', () => {
 
   describe('when the button is loading', () => {
     beforeEach(() => {
-      wrapper = render(
+      render(
         <Button icon={<IconBrightnessLow />} isLoading>
           Click me
         </Button>
@@ -94,25 +94,57 @@ describe('Button', () => {
     })
 
     it('disables the button', () => {
-      expect(wrapper.getByTestId('button')).toBeDisabled()
+      expect(screen.getByTestId('button')).toBeDisabled()
     })
 
     it('hides the user-provided icon', () => {
-      expect(wrapper.getByTestId('button-icon')).toHaveStyleRule(
+      expect(screen.getByTestId('button-icon')).toHaveStyleRule(
         'visibility',
         'hidden'
       )
     })
 
     it('hides the button text', () => {
-      expect(wrapper.getByTestId('button-icon')).toHaveStyleRule(
+      expect(screen.getByTestId('button-icon')).toHaveStyleRule(
         'visibility',
         'hidden'
       )
     })
 
     it('shows a loading icon with the `aria-hidden` attribute', () => {
-      expect(wrapper.getByTestId('loading-icon')).toHaveAttribute(
+      expect(screen.getByTestId('loading-icon')).toHaveAttribute(
+        'aria-hidden',
+        'true'
+      )
+    })
+  })
+
+  describe('when the button is loading with text', () => {
+    beforeEach(() => {
+      render(
+        <Button icon={<IconBrightnessLow />} isLoading showLoadingText>
+          Click me
+        </Button>
+      )
+    })
+
+    it('disables the button', () => {
+      expect(screen.getByTestId('button')).toBeDisabled()
+    })
+
+    it('hides the user-provided icon', () => {
+      expect(screen.getByTestId('button-icon')).toHaveStyleRule(
+        'visibility',
+        'hidden'
+      )
+    })
+
+    it('shows the button text', () => {
+      expect(screen.getByText('Click me')).toBeInTheDocument()
+    })
+
+    it('shows a loading icon with the `aria-hidden` attribute', () => {
+      expect(screen.getByTestId('loading-icon')).toHaveAttribute(
         'aria-hidden',
         'true'
       )

--- a/packages/react-component-library/src/components/Button/Button.tsx
+++ b/packages/react-component-library/src/components/Button/Button.tsx
@@ -33,6 +33,10 @@ interface ButtonBaseProps extends Omit<ComponentWithClass, 'children'> {
    */
   isLoading?: boolean
   /**
+   * Whether to show the button text when in a loading state. Defaults to false.
+   */
+  showLoadingText?: boolean
+  /**
    * Optional handler called when the component is clicked.
    */
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>
@@ -86,6 +90,7 @@ export const Button = ({
   title,
   type = 'button',
   variant = BUTTON_VARIANT.PRIMARY,
+  showLoadingText = false,
   ...rest
 }: ButtonProps) => {
   return (
@@ -94,6 +99,7 @@ export const Button = ({
       $variant={variant}
       $size={size}
       $iconPosition={iconPosition}
+      $showLoadingText={showLoadingText}
       data-testid="button"
       disabled={isDisabled || isLoading}
       type={type}
@@ -103,11 +109,17 @@ export const Button = ({
       {...rest}
     >
       {isLoading && (
-        <StyledIconLoaderWrapper data-testid="loading-icon" aria-hidden>
+        <StyledIconLoaderWrapper
+          data-testid="loading-icon"
+          aria-hidden
+          $showLoadingText={showLoadingText}
+        >
           <IconLoader size={size === COMPONENT_SIZE.FORMS ? 26 : 21} />
         </StyledIconLoaderWrapper>
       )}
-      <StyledText $isLoading={isLoading}>{children}</StyledText>
+      <StyledText $isLoading={isLoading} $showLoadingText={showLoadingText}>
+        {children}
+      </StyledText>
       {icon && (
         <StyledIconWrapper
           $buttonHasText={Boolean(children)}

--- a/packages/react-component-library/src/components/Button/partials/StyledButton.tsx
+++ b/packages/react-component-library/src/components/Button/partials/StyledButton.tsx
@@ -1,7 +1,19 @@
 import styled from 'styled-components'
-import { getButtonStyles, StyledButtonProps } from './getButtonStyles'
+import { spacing } from '@royalnavy/design-tokens'
+
+import {
+  getButtonStyles,
+  StyledButtonProps as BaseStyledButtonProps,
+} from './getButtonStyles'
+
+interface StyledButtonProps extends BaseStyledButtonProps {
+  $showLoadingText: boolean
+}
 
 export const StyledButton = styled.button<StyledButtonProps>`
   position: relative;
   ${getButtonStyles};
+
+  gap: ${({ $showLoadingText }) =>
+    $showLoadingText ? spacing('4') : 'initial'};
 `

--- a/packages/react-component-library/src/components/Button/partials/StyledIconLoader.tsx
+++ b/packages/react-component-library/src/components/Button/partials/StyledIconLoader.tsx
@@ -1,12 +1,21 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
-export const StyledIconLoaderWrapper = styled.div`
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  left: 0;
-  top: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+interface StyledIconLoaderWrapperProps {
+  $showLoadingText: boolean
+}
+
+export const StyledIconLoaderWrapper = styled.div<StyledIconLoaderWrapperProps>`
+  display: inline-flex;
+
+  ${({ $showLoadingText }) =>
+    !$showLoadingText &&
+    css`
+      height: 100%;
+      width: 100%;
+      position: absolute;
+      left: 0;
+      top: 0;
+      align-items: center;
+      justify-content: center;
+    `}
 `

--- a/packages/react-component-library/src/components/Button/partials/StyledText.tsx
+++ b/packages/react-component-library/src/components/Button/partials/StyledText.tsx
@@ -2,8 +2,10 @@ import styled from 'styled-components'
 
 interface StyledTextProps {
   $isLoading: boolean
+  $showLoadingText: boolean
 }
 
 export const StyledText = styled.span<StyledTextProps>`
-  visibility: ${({ $isLoading }) => ($isLoading ? 'hidden' : 'initial')};
+  visibility: ${({ $isLoading, $showLoadingText }) =>
+    $isLoading && !$showLoadingText ? 'hidden' : 'initial'};
 `


### PR DESCRIPTION
## Related issue

DNADB-240

## Overview

Added Button component loading state with text visibility control via `hasLoadingText` prop.

## Reason

Enhance Button UX with loading state indicators and configurable text visibility.

## Work carried out

- [x] Added `hasLoadingText` prop to Button component
- [x] Implemented loading state styling and behavior
- [x] Added comprehensive test coverage
- [x] Update Button tests to use `screen` and `userEvent`

## Screenshot

![2025-05-09 08 54 51](https://github.com/user-attachments/assets/643ad61a-a3bb-4296-9bba-de88c17247e3)