### PR TITLE
fix(Sidebar): Adjust user menu popover position and layout

### DIFF
--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUser.tsx
@@ -1,5 +1,7 @@
 import React, { useContext } from 'react'
+import { spacing } from '@royalnavy/design-tokens'
 import { IconExitToApp, IconPerson } from '@royalnavy/icon-library'
+import styled from 'styled-components'
 import { Transition } from 'react-transition-group'
 
 import { SidebarContext } from './context'
@@ -43,13 +45,17 @@ export interface SidebarUserProps extends ComponentWithClass {
 
 type SidebarAvatarWithItemsProps = Omit<SidebarUserProps, 'link'>
 
+const StyledSheet = styled(Sheet)`
+  margin-left: ${spacing('4')};
+`
+
 const SidebarAvatarWithItems = ({
   initials,
   initialIsOpen,
   userLink,
   exitLink,
 }: SidebarAvatarWithItemsProps) => (
-  <Sheet
+  <StyledSheet
     aria-label="User options"
     button={
       <StyledUserSheetButton
@@ -69,7 +75,7 @@ const SidebarAvatarWithItems = ({
       {userLink && <SidebarUserItem icon={<IconPerson />} link={userLink} />}
       {exitLink && <SidebarUserItem icon={<IconExitToApp />} link={exitLink} />}
     </StyledSheetList>
-  </Sheet>
+  </StyledSheet>
 )
 
 export const SidebarUser = ({

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUserItem.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/SidebarUserItem.tsx
@@ -5,6 +5,7 @@ import {
   StyledUserItemText,
 } from './partials'
 import { NavItem } from '../../../common/Nav'
+import { Group } from '../../Group'
 
 export interface SidebarUserItemProps extends NavItem {
   /**
@@ -21,12 +22,12 @@ export const SidebarUserItem = ({ icon, link }: SidebarUserItemProps) => {
       {React.cloneElement(linkElement, {
         ...link.props,
         children: (
-          <>
+          <Group gap="4">
             {icon && <StyledUserItemIcon>{icon}</StyledUserItemIcon>}
             <StyledUserItemText>
               {linkElement.props.children}
             </StyledUserItemText>
-          </>
+          </Group>
         ),
       })}
     </StyledUserItem>

--- a/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledUserItemIcon.tsx
+++ b/packages/react-component-library/src/components/TopLevelNavigation/Sidebar/partials/StyledUserItemIcon.tsx
@@ -1,11 +1,10 @@
 import styled from 'styled-components'
-import { color, spacing } from '@royalnavy/design-tokens'
+import { color } from '@royalnavy/design-tokens'
 
 import { StyledUserItem } from './StyledUserItem'
 
 export const StyledUserItemIcon = styled.div`
   display: inline-flex;
-  margin-right: ${spacing('4')};
 
   ${StyledUserItem}:hover & {
     color: ${color('action', '500')};


### PR DESCRIPTION
## Related issue

DNADB-393

## Overview

Tweak to the layout and position of the collapsed sidebar user avatar popup.

## Reason

The popup was being rendered over the sidebar

## Work carried out

- [x] Add margin to the Sheet component which is displayed when the collapsed user avatar is clicked
- [x] Align icon and text in the user popup with `Group` component

## Screenshot
Before
![2025-05-19 11 47 28](https://github.com/user-attachments/assets/8d16cdd3-9deb-4ac0-a668-4ce0f89ba350)

After
![2025-05-19 11 40 49](https://github.com/user-attachments/assets/4415b78d-eefc-45cd-9c83-ddf677c0c912)

