### PR TITLE
Use built in browser components for RowsPerPage

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -10,7 +10,7 @@ import type {
 } from '@tanstack/react-table'
 
 import { storyAccessibilityConfig } from '../../a11y/storyAccessibilityConfig'
-import { DataGrid, TABLE_COLUMN_ALIGNMENT } from '.'
+import { DataGrid, TABLE_COLUMN_ALIGNMENT, TABLE_LAYOUT } from '.'
 import { Badge } from '../Badge'
 import { Button } from '../Button'
 import { DEFAULT_ROWS_PER_PAGE } from '../RowsPerPage/RowsPerPage'
@@ -903,7 +903,7 @@ Loading.parameters = {
 
 export const RowsPerPage: StoryFn<typeof DataGrid> = (props) => {
   return (
-    <Wrapper>
+    <Wrapper $hasScrolling={props.layout === TABLE_LAYOUT.SCROLL}>
       <DataGrid {...props} />
     </Wrapper>
   )
@@ -920,11 +920,11 @@ RowsPerPage.args = {
     id: i + 1,
     productName: `Product ${i + 1}`,
   })),
-  hasRowsPerPage: true,
   isFullWidth: true,
   onSelectedRowsChange: fn(),
   onExpandedChange: fn(),
   onColumnFiltersChange: fn(),
+  footerLeftSlotContent: <Button size="small">Download</Button>
 }
 
 export const WithFooterLeftSlot: StoryFn<typeof DataGrid> = (props) => {

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
@@ -2,15 +2,15 @@ import React, { useState } from 'react'
 import {
   render,
   screen,
-  within,
   waitForElementToBeRemoved,
+  within,
 } from '@testing-library/react'
 import type {
   ColumnDef,
-  SortingState,
   PaginationState,
+  SortingState,
 } from '@tanstack/react-table'
-import { userEvent, PointerEventsCheckLevel } from '@testing-library/user-event'
+import { PointerEventsCheckLevel, userEvent } from '@testing-library/user-event'
 import { color } from '@royalnavy/design-tokens'
 
 import { DataGrid } from './DataGrid'
@@ -1515,11 +1515,9 @@ describe('DataGrid', () => {
         />
       )
 
-      await userEvent.click(screen.getByTestId('select-arrow-button'))
+      const select = screen.getByRole('combobox', { name: 'Rows per page' })
 
-      const options = screen.getAllByRole('option')
-
-      await userEvent.click(options[1])
+      await userEvent.selectOptions(select, '25');
 
       expect(onPaginationChangeSpy).toHaveBeenCalledWith({
         pageIndex: 0,
@@ -1577,11 +1575,8 @@ describe('DataGrid', () => {
     it('updates the page size when the rows per page component is changed', async () => {
       render(<DataGrid data={PAGINATED_DATA} columns={columns} />)
 
-      await userEvent.click(screen.getByTestId('select-arrow-button'))
-
-      const options = screen.getAllByRole('option')
-
-      await userEvent.click(options[1])
+      const select = screen.getByRole('combobox', { name: 'Rows per page' })
+      await userEvent.selectOptions(select, '25');
 
       expect(screen.getByLabelText('Enter page number')).toHaveValue('1')
       expect(screen.getByText('of 40')).toBeInTheDocument()
@@ -1594,11 +1589,8 @@ describe('DataGrid', () => {
 
       expect(screen.getByLabelText('Enter page number')).toHaveValue('2')
 
-      await userEvent.click(screen.getByTestId('select-arrow-button'))
-
-      const options = screen.getAllByRole('option')
-
-      await userEvent.click(options[1])
+      const select = screen.getByRole('combobox', { name: 'Rows per page' })
+      await userEvent.selectOptions(select, '25');
 
       expect(screen.getByLabelText('Enter page number')).toHaveValue('1')
       expect(screen.getByText('of 40')).toBeInTheDocument()

--- a/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.stories.tsx
+++ b/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.stories.tsx
@@ -11,6 +11,12 @@ export default {
   },
 } as Meta<typeof RowsPerPage>
 
-export const Default: StoryFn<typeof RowsPerPage> = () => {
-  return <RowsPerPage />
+export const Default: StoryFn<typeof RowsPerPage> = (props) => {
+  return <RowsPerPage {...props} />
 }
+
+Default.args = {
+  value: 10,
+  isDisabled: false,
+}
+

--- a/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.stories.tsx
+++ b/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.stories.tsx
@@ -16,7 +16,6 @@ export const Default: StoryFn<typeof RowsPerPage> = (props) => {
 }
 
 Default.args = {
-  value: 10,
   isDisabled: false,
 }
 

--- a/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.test.tsx
+++ b/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.test.tsx
@@ -8,21 +8,45 @@ describe('RowsPerPage', () => {
   it('renders the component', () => {
     render(<RowsPerPage />)
 
-    expect(
-      screen.getByLabelText('Rows per page', { selector: 'input' })
-    ).toHaveValue(ROWS_PER_PAGE_OPTIONS[0])
-    expect(screen.queryByLabelText('Clear value')).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Rows per page' })).toHaveValue(
+      ROWS_PER_PAGE_OPTIONS[0].toString()
+    )
+
+    expect(screen.getByLabelText('Rows per page')).toBeInTheDocument()
+  })
+
+  it('sets focus to the select on label click', async () => {
+    render(<RowsPerPage />)
+    const label = screen.getByLabelText('Rows per page')
+    await userEvent.click(label)
+
+    const select = screen.getByRole('combobox', { name: 'Rows per page' })
+    expect(select).toHaveFocus()
   })
 
   it('renders all the options', async () => {
     render(<RowsPerPage />)
 
-    await userEvent.click(screen.getByTestId('select-arrow-button'))
+    const select = screen.getByRole('combobox', { name: 'Rows per page' })
+    await userEvent.click(select)
+
+    const options = screen.getAllByRole('option')
+    expect(options.length).toBe(ROWS_PER_PAGE_OPTIONS.length)
+
+    options.forEach((option, index) => {
+      expect(option).toHaveTextContent(ROWS_PER_PAGE_OPTIONS[index].toString())
+    })
+  })
+
+  it('renders all the options with additional value', async () => {
+    render(<RowsPerPage value={3} />)
+
+    const select = screen.getByRole('combobox', { name: 'Rows per page' })
+    await userEvent.click(select)
 
     const options = screen.getAllByRole('option')
 
-    options.forEach((option, index) => {
-      expect(option).toHaveTextContent(ROWS_PER_PAGE_OPTIONS[index])
-    })
+    expect(options.length).toBe(ROWS_PER_PAGE_OPTIONS.length + 1)
+    expect(options[0]).toHaveTextContent('3')
   })
 })

--- a/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.tsx
+++ b/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.tsx
@@ -1,28 +1,41 @@
-import React from 'react'
+import { color, fontSize, spacing } from '@royalnavy/design-tokens'
+import React, { useMemo } from 'react'
+import styled, { css } from 'styled-components'
 
-import { Select, SelectOption } from '../Select'
+import { useExternalId } from '../../hooks/useExternalId'
+import { useFocus } from '../../hooks/useFocus'
+import { StyledOuterWrapper } from '../../styled-components'
+import { Group } from '../Group'
+
+const StyledLabel = styled.label<{ $isDisabled: boolean }>`
+  color: ${color('neutral', '400')};
+  font-size: ${fontSize('base')};
+  ${({ $isDisabled }) =>
+    $isDisabled &&
+    css`
+      opacity: 0.5;
+    `}
+`
+const StyledSelect = styled.select<{ $isDisabled: boolean }>`
+  margin-left: ${spacing('4')};
+  color: ${color('neutral', '600')};
+  ${({ $isDisabled }) =>
+    $isDisabled &&
+    css`
+      opacity: 0.5;
+      cursor: not-allowed;
+    `}
+  outline: 0;
+  border: 0;
+  height: 31px;
+  border-radius: 12px;
+`
 
 interface RowsPerPageProps {
-  /**
-   * Optional HTML `id` attribute to apply to the component.
-   */
-  id?: string
-  /**
-   * Toggles whether the list is open on first render.
-   */
-  initialIsOpen?: boolean
-  /**
-   * The initially selected item when the component is uncontrolled.
-   */
-  initialValue?: string | null
   /**
    * Toggles whether the component is disabled or not (preventing user interaction).
    */
   isDisabled?: boolean
-  /**
-   * Toggles whether the component is invalid or not.
-   */
-  isInvalid?: boolean
   /**
    * Optional handler invoked when the selected value changes.
    */
@@ -30,26 +43,54 @@ interface RowsPerPageProps {
   /**
    * The selected value when the component is controlled.
    */
-  value?: string | null
+  value?: number | null
 }
 
-export const ROWS_PER_PAGE_OPTIONS = ['10', '25', '50', '100']
+export const ROWS_PER_PAGE_OPTIONS = [10, 25, 50, 100]
 
 export const DEFAULT_ROWS_PER_PAGE = Number(ROWS_PER_PAGE_OPTIONS[0])
 
-export const RowsPerPage = (props: RowsPerPageProps) => (
-  <Select
-    hideClearButton
-    initialValue={DEFAULT_ROWS_PER_PAGE.toString()}
-    label="Rows per page"
-    {...props}
-  >
-    {ROWS_PER_PAGE_OPTIONS.map((option) => (
-      <SelectOption key={option} value={option}>
-        {option}
-      </SelectOption>
-    ))}
-  </Select>
-)
+export const RowsPerPage = ({
+  isDisabled,
+  onChange,
+  value,
+}: RowsPerPageProps) => {
+  const id = useExternalId('rows-per-page')
+
+  const options = useMemo(() => {
+    if (!value) {
+      return ROWS_PER_PAGE_OPTIONS
+    }
+
+    const defaults = new Set([...ROWS_PER_PAGE_OPTIONS, value])
+    return Array.from(defaults).sort((a, b) => a - b)
+  }, [value])
+
+  const { hasFocus, onLocalBlur, onLocalFocus } = useFocus()
+
+  return (
+    <Group gap="4">
+      <StyledLabel htmlFor={id} $isDisabled={!!isDisabled}>
+        Rows per page
+      </StyledLabel>
+      <StyledOuterWrapper $hasFocus={hasFocus}>
+        <StyledSelect
+          $isDisabled={!!isDisabled}
+          id={id}
+          onBlur={onLocalBlur}
+          onFocus={onLocalFocus}
+          onChange={(e) => onChange?.(e.target.value)}
+          value={value?.toString()}
+        >
+          {options.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </StyledSelect>
+      </StyledOuterWrapper>
+    </Group>
+  )
+}
 
 RowsPerPage.displayName = 'RowsPerPage'

--- a/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.tsx
+++ b/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.tsx
@@ -17,8 +17,7 @@ const StyledLabel = styled.label<{ $isDisabled: boolean }>`
     `}
 `
 const StyledSelect = styled.select<{ $isDisabled: boolean }>`
-  margin-left: ${spacing('4')};
-  color: ${color('neutral', '600')};
+  color: ${color('neutral', '400')};
   ${({ $isDisabled }) =>
     $isDisabled &&
     css`
@@ -28,7 +27,39 @@ const StyledSelect = styled.select<{ $isDisabled: boolean }>`
   outline: 0;
   border: 0;
   height: 31px;
+  line-height: 31px;
+  padding: 0 0.5rem;
   border-radius: 12px;
+
+  @supports (appearance: base-select) {
+    &, &::picker(select) {
+      appearance: base-select;
+    }
+
+    &::picker(select) {
+      border: 0;
+      top: calc(anchor(bottom) + 5px);
+      left: anchor(10%);
+      border-radius: 12px;
+      box-shadow: 0 0 0 1px ${color('neutral', '200')};
+    }
+
+    &::picker-icon {
+      color: ${color('neutral', '200')};
+      transition: 0.1s rotate;
+    }
+
+    &:open::picker-icon {
+      rotate: 180deg;
+    }
+
+    option {
+      padding: 0 ${spacing('4')};
+    }
+
+  }
+
+
 `
 
 interface RowsPerPageProps {

--- a/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.tsx
+++ b/packages/react-component-library/src/components/RowsPerPage/RowsPerPage.tsx
@@ -31,6 +31,7 @@ const StyledSelect = styled.select<{ $isDisabled: boolean }>`
   padding: 0 0.5rem;
   border-radius: 12px;
 
+  // @ts-ignore - Will only apply styles when supported by the browser
   @supports (appearance: base-select) {
     &, &::picker(select) {
       appearance: base-select;
@@ -38,8 +39,6 @@ const StyledSelect = styled.select<{ $isDisabled: boolean }>`
 
     &::picker(select) {
       border: 0;
-      top: calc(anchor(bottom) + 5px);
-      left: anchor(10%);
       border-radius: 12px;
       box-shadow: 0 0 0 1px ${color('neutral', '200')};
     }


### PR DESCRIPTION
## Related issue

DNADB-396

## Overview

Use browser native components for the RowsPerPage select

## Reason

This automagically handles the positioning when the component is at viewport extents.  Particularly bottom left.

## Work carried out
//
[A list of work you have done, use markdown checklist format, if you leave any boxes unchecked, be sure to set this PR as a WIP]

**Example.**

- [x] A bit of work I completed
- [ ] A bit of work I did not complete

## Screenshot

[If the work is UI related then paste a screenshot of the update here.]

## Developer notes

[Sometimes, extra notes are needed to add clarity to a PR, add them here]
