### PR TITLE
feat(Select): Implement vertical positioning for Select component

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
@@ -1117,10 +1117,10 @@ describe('DataGrid', () => {
       await hackyWaitFor()
 
       const rows = screen.getAllByRole('row')
-      expect(rows).toHaveLength(4) // Header row + 3 data rows
       expect(screen.getByText('alpha')).toBeInTheDocument()
       expect(screen.getByText('delta')).toBeInTheDocument()
       expect(screen.getByText('golf')).toBeInTheDocument()
+      expect(rows).toHaveLength(4) // Header row + 3 data rows
     })
 
     it('does not render filter button for columns with enableColumnFilter set to false', () => {
@@ -1627,6 +1627,7 @@ describe('DataGrid', () => {
           columns={columns}
           pageSize={0}
           isLoading
+          isFullWidth
           layout="scroll"
         />
       )

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -100,3 +100,39 @@ Value.args = {
 }
 
 export const IconsAndBadges = TemplateWithIconsAndBadges.bind({})
+
+const StyledBottomRightWrapper = styled.div`
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-end;
+  padding: 2rem;
+`
+
+export const AutoPositioning: StoryFn<typeof Select> = (args) => (
+  <StyledBottomRightWrapper>
+    <Select {...args}>
+      <SelectOption value="one">Option One</SelectOption>
+      <SelectOption value="two">Option Two</SelectOption>
+      <SelectOption value="three">Option Three</SelectOption>
+      <SelectOption value="four">Option Four</SelectOption>
+      <SelectOption value="five">Option Five</SelectOption>
+      <SelectOption value="six">Option Six</SelectOption>
+      <SelectOption value="seven">Option Seven</SelectOption>
+      <SelectOption value="eight">Option Eight</SelectOption>
+    </Select>
+  </StyledBottomRightWrapper>
+)
+AutoPositioning.args = {
+  label: 'Auto-positioning Select',
+  initialIsOpen: true,
+}
+AutoPositioning.parameters = {
+  docs: {
+    description: {
+      story:
+        'This story demonstrates the automatic positioning of the dropdown based on available space. The Select is positioned in the bottom right corner, so the dropdown should open upwards.',
+    },
+  },
+}

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -13,6 +13,7 @@ import { BORDER_WIDTH } from '../../styled-components'
 import { COMPONENT_SIZE } from '../Forms'
 import { Select } from '.'
 import { SelectOption } from './SelectOption'
+import { TEXT_INPUT_INPUT_HEIGHT } from '../TextInput/partials/StyledInput'
 
 describe('Select', () => {
   let onChangeSpy: (value: string | null) => void
@@ -105,6 +106,18 @@ describe('Select', () => {
         expect(options[1]).toHaveTextContent('Two')
         expect(options[2]).toHaveTextContent('Three')
         expect(options).toHaveLength(3)
+      })
+
+      it('displays the dropdown below the textbox', () => {
+        expect(wrapper.getByTestId('select-options-wrapper')).toHaveStyle({
+          position: 'absolute',
+          marginBottom: '999',
+        })
+
+        expect(wrapper.getByTestId('select-options-wrapper')).toHaveStyleRule(
+          'margin-bottom',
+          '5px'
+        )
       })
 
       describe('and the second item is clicked', () => {
@@ -312,6 +325,81 @@ describe('Select', () => {
         'id',
         initialId
       )
+    })
+  })
+
+  describe('popupLocation', () => {
+    describe('when unset', () => {
+      beforeEach(() => {
+        wrapper = render(
+          <Select label="default props">
+            <SelectOption value="one">One</SelectOption>
+            <SelectOption value="two">Two</SelectOption>
+            <SelectOption value="three">Three</SelectOption>
+          </Select>
+        )
+      })
+      it('should render the dropdown below the textbox', () => {
+        const optionsWrapper = wrapper.getByTestId('select-options-wrapper')
+        expect(optionsWrapper).toHaveStyleRule('margin-bottom', '5px')
+        expect(optionsWrapper).toHaveStyleRule('top', undefined)
+        expect(optionsWrapper).toHaveStyleRule('bottom', undefined)
+
+        const expectedTopPosition = `-${
+          TEXT_INPUT_INPUT_HEIGHT[COMPONENT_SIZE.FORMS]
+        }`
+        expect(optionsWrapper).toHaveStyleRule('top', expectedTopPosition, {
+          modifier: '::after',
+        })
+        expect(optionsWrapper).toHaveStyleRule('bottom', '0', {
+          modifier: '::after',
+        })
+      })
+    })
+
+    describe('when set to above', () => {
+      beforeEach(() => {
+        Element.prototype.getBoundingClientRect = jest.fn(() => ({
+          top: 900,
+          bottom: 950,
+          left: 0,
+          right: 100,
+          width: 100,
+          height: 50,
+          x: 0,
+          y: 900,
+          toJSON: () => {},
+        }))
+
+        wrapper = render(
+          <Select label="default props">
+            <SelectOption value="one">One</SelectOption>
+            <SelectOption value="two">Two</SelectOption>
+            <SelectOption value="three">Three</SelectOption>
+          </Select>
+        )
+      })
+
+      it('should render the dropdown above the textbox', () => {
+        const optionsWrapper = wrapper.getByTestId('select-options-wrapper')
+        expect(optionsWrapper).toHaveStyleRule('margin-bottom', '0')
+        expect(optionsWrapper).toHaveStyleRule('top', 'auto')
+        expect(optionsWrapper).toHaveStyleRule('bottom', '100%')
+
+        const expectedBottomPosition = `-${
+          TEXT_INPUT_INPUT_HEIGHT[COMPONENT_SIZE.FORMS]
+        }`
+        expect(optionsWrapper).toHaveStyleRule(
+          'bottom',
+          expectedBottomPosition,
+          {
+            modifier: '::before',
+          }
+        )
+        expect(optionsWrapper).toHaveStyleRule('top', '0', {
+          modifier: '::before',
+        })
+      })
     })
   })
 

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react'
 import { useSelect } from 'downshift'
 import { isNil } from 'lodash'
+import mergeRefs from 'react-merge-refs'
 
 import {
   getSelectedItem,
@@ -12,6 +13,7 @@ import { useExternalId } from '../../hooks/useExternalId'
 import { useMenuVisibility } from '../SelectBase/hooks/useMenuVisibility'
 import { useSelectMenu } from './hooks/useSelectMenu'
 import { SelectOptionProps } from './SelectOption'
+import { useDropdownDirection } from './hooks/useDropdownDirection'
 
 export const Select = ({
   children,
@@ -24,6 +26,7 @@ export const Select = ({
 }: SelectBaseProps) => {
   const id = useExternalId('select', externalId)
   const inputRef = useRef<HTMLInputElement>(null)
+  const { triggerRef, popupPosition } = useDropdownDirection()
 
   const filteredItems = React.Children.toArray(children).filter(
     React.isValidElement<SelectOptionProps>
@@ -80,7 +83,7 @@ export const Select = ({
             event.preventDefault()
           },
         }),
-        ref: inputRef,
+        ref: mergeRefs([inputRef, triggerRef]),
         'aria-expanded': undefined,
       }}
       isOpen={isOpen}
@@ -93,6 +96,7 @@ export const Select = ({
       toggleButtonProps={getToggleButtonProps()}
       tooltipText={selectedItemText}
       value={selectedItemText}
+      popupPosition={popupPosition}
       {...{
         readOnly: true,
         ...rest,

--- a/packages/react-component-library/src/components/Select/hooks/useDropdownDirection.ts
+++ b/packages/react-component-library/src/components/Select/hooks/useDropdownDirection.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { PopupPosition } from '../../SelectBase/SelectBaseProps'
+
+export function useDropdownDirection(dropdownHeight = 230) {
+  const triggerRef = useRef<HTMLElement>(null)
+  const [popupPosition, setPopupPosition] = useState<PopupPosition>('below')
+
+  const checkDirection = useCallback(() => {
+    if (!triggerRef.current) {
+      return
+    }
+
+    const rect = triggerRef.current.getBoundingClientRect()
+    const spaceBelow = window.innerHeight - rect.bottom
+    const spaceAbove = rect.top
+
+    // If there's not enough space below but more space above, position above
+    if (spaceBelow < dropdownHeight && spaceAbove > spaceBelow) {
+      setPopupPosition('above')
+    } else {
+      setPopupPosition('below')
+    }
+  }, [dropdownHeight])
+
+  useEffect(() => {
+    checkDirection()
+
+    window.addEventListener('scroll', checkDirection)
+    window.addEventListener('resize', checkDirection)
+
+    return () => {
+      window.removeEventListener('scroll', checkDirection)
+      window.removeEventListener('resize', checkDirection)
+    }
+  }, [checkDirection])
+
+  return { triggerRef, popupPosition, checkDirection }
+}

--- a/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
+++ b/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
@@ -3,6 +3,7 @@ import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { SelectChildrenType } from './types'
 
 export type OnChangeType = (value: string | null) => void
+export type PopupPosition = 'above' | 'below' // | 'auto'
 
 export interface SelectBaseProps extends ComponentWithClass {
   /**

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -19,6 +19,7 @@ import { StyledTooltip } from './partials/StyledTooltip'
 import { useExternalId } from '../../hooks/useExternalId'
 import { useStatefulRef } from '../../hooks/useStatefulRef'
 import { StyledFloatingBox } from './partials/StyledFloatingBox'
+import { PopupPosition } from './SelectBaseProps'
 
 type ComboboxReturnValueType = UseComboboxReturnValue<SelectChildWithStringType>
 type SelectReturnValueType = UseSelectReturnValue<SelectChildWithStringType>
@@ -44,6 +45,7 @@ export interface SelectLayoutProps extends ComponentWithClass {
     | ReturnType<SelectReturnValueType['getToggleButtonProps']>
   tooltipText: string
   value?: string
+  popupPosition?: PopupPosition
 }
 
 const isEllipsisActive = (el: HTMLInputElement | null): boolean => {
@@ -68,6 +70,7 @@ export const SelectLayout = ({
   toggleButtonProps,
   tooltipText,
   value,
+  popupPosition = 'below',
   ...rest
 }: SelectLayoutProps) => {
   const [hasHover, setHasHover] = useState<boolean>(false)
@@ -138,11 +141,12 @@ export const SelectLayout = ({
             </StyledInlineButtons>
           </StyledOuterWrapper>
         </StyledTextInput>
-        <StyledOptionsWrapper $isVisible={isOpen}>
+        <StyledOptionsWrapper data-testid="select-options-wrapper" $isVisible={isOpen} $position={popupPosition}>
           <StyledOptions
             {...menuProps}
             aria-labelledby={labelId}
             data-testid="select-options"
+            tabIndex={0}
           >
             {children}
           </StyledOptions>

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledOptions.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledOptions.tsx
@@ -1,16 +1,11 @@
 import styled from 'styled-components'
 
-import { BORDER_RADIUS } from '../../../styled-components'
-import { COMPONENT_SIZE } from '../../Forms'
-
 export const StyledOptions = styled.ul`
   max-height: 230px;
   overflow-y: auto;
   list-style-type: none;
   padding-left: 0;
   margin-left: 0;
-  border-radius: 0 0 ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]}
-    ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
 
   &:focus {
     outline: none;

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledOptionsWrapper.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledOptionsWrapper.tsx
@@ -5,39 +5,72 @@ import { BORDER_RADIUS } from '../../../styled-components'
 import { COMPONENT_SIZE } from '../../Forms'
 import { TEXT_INPUT_INPUT_HEIGHT } from '../../TextInput/partials/StyledInput'
 
+type PopupPosition = 'above' | 'below'
+
 interface StyledOptionsWrapperProps {
   $isVisible: boolean
+  $position?: PopupPosition
 }
 
-function getTopBorder() {
+function getTopBorder(position: PopupPosition = 'below') {
+  if (position === 'below') {
+    return css`
+      &::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0;
+        height: 1px;
+        width: 100%;
+        border-bottom: 1px solid ${color('neutral', '200')};
+      }
+    `
+  }
   return css`
-    &::before {
+    &::after {
       content: '';
       position: absolute;
       left: 0;
-      top: 0;
+      bottom: 0;
       height: 1px;
       width: 100%;
-      border-bottom: 1px solid ${color('neutral', '200')};
+      border-top: 1px solid ${color('neutral', '200')};
     }
   `
 }
 
-function getBoxShadow() {
+function getBoxShadow(position: PopupPosition = 'below') {
+  if (position === 'below') {
+    return css`
+      &::after {
+        z-index: ${zIndex('dropdown', 0)};
+        content: '';
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: -${TEXT_INPUT_INPUT_HEIGHT[COMPONENT_SIZE.FORMS]};
+        bottom: 0;
+        box-shadow: 0 0 0 3px ${color('action', '500')},
+          0 0 0 6px ${color('action', '100')}, 0 2px 22px rgba(0, 0, 0, 0.2);
+        pointer-events: none;
+        border-radius: ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
+      }
+    `
+  }
+
   return css`
-    &::after {
+    &::before {
       z-index: ${zIndex('dropdown', 0)};
       content: '';
       position: absolute;
-      top: -${TEXT_INPUT_INPUT_HEIGHT[COMPONENT_SIZE.FORMS]};
       left: 0;
       right: 0;
-      bottom: 0;
+      bottom: -${TEXT_INPUT_INPUT_HEIGHT[COMPONENT_SIZE.FORMS]};
+      top: 0;
       box-shadow: 0 0 0 3px ${color('action', '500')},
-        0 0 0 6px ${color('action', '100')}, 0 2px 22px rgba(0, 0, 0, 0.2);
+      0 0 0 6px ${color('action', '100')}, 0 2px 22px rgba(0, 0, 0, 0.2);
       pointer-events: none;
       border-radius: ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
-    }
   `
 }
 
@@ -46,10 +79,21 @@ export const StyledOptionsWrapper = styled.div<StyledOptionsWrapperProps>`
   z-index: ${zIndex('dropdown', 1)};
   position: absolute;
   width: 100%;
-  background: ${color('neutral', 'white')};
-  border-radius: 0 0 ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]}
-    ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
+
   margin-bottom: 5px;
-  ${getTopBorder()}
-  ${getBoxShadow()}
+  border-radius: 0 0 ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]}
+  ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
+
+  ${({ $position }) =>
+    $position === 'above' &&
+    css`
+      bottom: 100%;
+      top: auto;
+      margin-bottom: 0;
+      margin-top: 5px;
+      border-radius: ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]} ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]} 0 0;
+    `}
+  background: ${color('neutral', 'white')};
+  ${({ $position }) => getTopBorder($position)}
+  ${({ $position }) => getBoxShadow($position)}
 `

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledOuterWrapper.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledOuterWrapper.tsx
@@ -13,6 +13,10 @@ export const StyledOuterWrapper = styled(
   display: inline-flex;
   flex-direction: row;
 
+  // Override default styles to fix the slow border fade
+  // when the dropdown is visible
+  transition: border-color 10ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 10ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+
   ${({ $hasFocus, $size = COMPONENT_SIZE.FORMS }) => {
     if ($hasFocus) {
       return css`


### PR DESCRIPTION
## Related issue

DNADB-413

## Overview

Add a positioning hook to the Select component which allows the dropdowns to appear above the text input. Defaults to below.

## Work carried out

- [x] Add new use `useDropDownDirection` hook 
- [x] Adjust styles to place the Options list above when requested

## Screenshot
![2025-05-27 14 04 59](https://github.com/user-attachments/assets/85643006-a47e-401b-9d62-2d98e647753c)


