### PR TITLE
fix(DatePicker): Add inline clear button

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,6 +1,13 @@
 import { Meta, StoryFn } from '@storybook/react'
-import { parseISO } from 'date-fns'
+import {
+  addDays,
+  endOfMonth,
+  parseISO,
+  startOfMonth,
+  subDays,
+} from 'date-fns'
 import React from 'react'
+import styled from 'styled-components'
 
 import { storyAccessibilityConfig } from '../../a11y/storyAccessibilityConfig'
 import { DatePicker } from '.'
@@ -18,7 +25,16 @@ export default {
   },
 } as Meta<typeof DatePicker>
 
-const Template: StoryFn<typeof DatePicker> = (args) => <DatePicker {...args} />
+const StyledWrapper = styled.div`
+  height: 20rem;
+  width: 20rem;
+`
+
+const Template: StoryFn<typeof DatePicker> = (args) => (
+  <StyledWrapper>
+    <DatePicker {...args} />
+  </StyledWrapper>
+)
 
 export const Default = Template.bind({})
 
@@ -55,16 +71,23 @@ Disabled.args = {
 export const DisabledDays = Template.bind({})
 DisabledDays.storyName = 'Disabled days'
 DisabledDays.args = {
-  initialStartDate: parseISO('2024-01-01'),
   disabledDays: [
-    parseISO('2024-06-12'),
-    parseISO('2024-06-18'),
-    new Date(),
+    // It isn't always obvious that today's date is disabled
+    subDays(new Date(), 1),
+    addDays(new Date(), 1),
     {
-      after: parseISO('2024-12-31'),
-      before: parseISO('2024-01-01'),
+      before: startOfMonth(new Date()),
+      after: endOfMonth(new Date()),
     },
   ],
+}
+DisabledDays.parameters = {
+  docs: {
+    description: {
+      story:
+        'Can choose dates from the current month except yesterday and tomorrow.',
+    },
+  },
 }
 
 export const Open = Template.bind({})

--- a/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-component-library/src/components/DatePicker/DatePicker.tsx
@@ -130,6 +130,10 @@ export interface DatePickerProps
    * Enable navigation via the Month and Year grids.
    */
   navigateMonthYear?: boolean
+  /**
+   * Whether to hide the clear button.
+   */
+  hideClearButton?: boolean
 }
 
 export const DatePicker = ({
@@ -156,7 +160,7 @@ export const DatePicker = ({
 
   // Formik can pass value – drop it to stop it being forwarded to the input
   value: _,
-
+  hideClearButton = false,
   ...rest
 }: DatePickerProps) => {
   const titleId = useExternalId('datepicker-title')
@@ -194,6 +198,7 @@ export const DatePicker = ({
         onChange={onChange}
         setFloatingBoxTarget={setFloatingBoxTarget}
         titleId={titleId}
+        hideClearButton={hideClearButton}
         {...rest}
       />
       <FloatingCalendar

--- a/packages/react-component-library/src/components/DatePicker/Input.tsx
+++ b/packages/react-component-library/src/components/DatePicker/Input.tsx
@@ -9,7 +9,7 @@ import { hasClass } from '../../helpers'
 import { InlineButton } from '../InlineButtons/InlineButton'
 import { isDateValid } from './utils'
 import { StyledDatePickerInput } from './partials/StyledDatePickerInput'
-import { StyledInlineButtons } from '../InlineButtons/partials/StyledInlineButtons'
+import { StyledInlineButtons, StyledInlineButtonsNoBorder } from '../InlineButtons/partials/StyledInlineButtons'
 import { StyledInput } from '../TextInput/partials/StyledInput'
 import { StyledInputWrapper } from './partials/StyledInputWrapper'
 import { StyledLabel } from '../TextInput/partials/StyledLabel'
@@ -19,6 +19,7 @@ import { useExternalId } from '../../hooks/useExternalId'
 import { useFocus } from '../../hooks/useFocus'
 import { useInput } from './useInput'
 import { useProcessDayClick } from './useProcessDayClick'
+import { ClearButton } from '../InlineButtons/ClearButton'
 
 export interface InputProps
   extends Pick<
@@ -32,6 +33,7 @@ export interface InputProps
       | 'label'
       | 'onBlur'
       | 'onChange'
+      | 'hideClearButton'
     >,
     Omit<React.ComponentPropsWithoutRef<'input'>, 'onChange' | 'onBlur'> {
   buttonRef: React.RefObject<HTMLButtonElement>
@@ -59,6 +61,7 @@ export const Input = memo(
     onChange,
     setFloatingBoxTarget,
     titleId,
+    hideClearButton,
     ...rest
   }: InputProps) => {
     const id = useExternalId(externalId)
@@ -140,6 +143,27 @@ export const Input = memo(
       })
     }, [dispatch, isOpen])
 
+    const handleOnClear = useCallback(() => {
+      dispatch({
+        type: DATEPICKER_ACTION.UPDATE,
+        data: {
+          startDate: null,
+          endDate: null,
+          inputValue: '',
+          hasError: false,
+        },
+      })
+
+      if (onChange) {
+        onChange({
+          startDate: null,
+          startDateValidity: null,
+          endDate: null,
+          endDateValidity: null,
+        })
+      }
+    }, [dispatch, onChange])
+
     return (
       <StyledDatePickerInput
         className={className}
@@ -184,6 +208,15 @@ export const Input = memo(
               {...rest}
             />
           </StyledInputWrapper>
+          {inputValue && !hideClearButton && (
+            <StyledInlineButtonsNoBorder>
+              <ClearButton
+                isDisabled={isDisabled}
+                data-testid="datepicker-clear-button"
+                onClick={handleOnClear}
+              />
+            </StyledInlineButtonsNoBorder>
+          )}
           <StyledInlineButtons>
             <InlineButton
               aria-expanded={isOpen}

--- a/packages/react-component-library/src/components/DatePicker/__tests__/DatePicker.test.tsx
+++ b/packages/react-component-library/src/components/DatePicker/__tests__/DatePicker.test.tsx
@@ -273,62 +273,67 @@ describe('DatePicker', () => {
               return user.tab()
             })
 
-            it('focuses the picker open/close button', () => {
+            it('focuses the picker clear button', () => {
               expect(
-                wrapper.getByTestId('datepicker-input-button')
+                wrapper.getByTestId('datepicker-clear-button')
               ).toHaveFocus()
             })
 
-            describe('and the space key is pressed', () => {
+            describe('and the tab key is pressed', () => {
               beforeEach(() => {
-                const button = wrapper.getByTestId('datepicker-input-button')
-
-                return user.type(button, '[Space]', { skipClick: true })
+                return user.tab()
               })
-
-              it('opens the picker container', () => {
-                expect(
-                  wrapper.getByTestId('datepicker-input-button')
-                ).toHaveAttribute('aria-label', 'Hide day picker')
-              })
-
-              describe('and the tab key is pressed again', () => {
+              describe('and the space key is pressed', () => {
                 beforeEach(() => {
-                  return user.tab()
+                  const button = wrapper.getByTestId('datepicker-input-button')
+
+                  return user.type(button, '[Space]', { skipClick: true })
                 })
 
-                it('focuses the previous month button', () => {
+                it('opens the picker container', () => {
                   expect(
-                    wrapper.getByLabelText(PREVIOUS_MONTH_BUTTON_LABEL)
-                  ).toHaveFocus()
-                })
-              })
-
-              describe('and clicks on a day', () => {
-                beforeEach(() => {
-                  return user.click(wrapper.getByText('31'))
+                    wrapper.getByTestId('datepicker-input-button')
+                  ).toHaveAttribute('aria-label', 'Hide day picker')
                 })
 
-                it('set the value of the component to this date', () => {
-                  expect(wrapper.getByTestId('datepicker-input')).toHaveValue(
-                    '31/05/2016'
-                  )
-                })
+                describe('and the tab key is pressed again', () => {
+                  beforeEach(() => {
+                    return user.tab()
+                  })
 
-                it('invokes the onChange callback', () => {
-                  expect(onChange).toHaveBeenLastCalledWith({
-                    startDate: new Date('2016-05-31T12:00:00.000Z'),
-                    startDateValidity: DATE_VALIDITY.VALID,
-                    endDate: new Date('2016-05-31T12:00:00.000Z'),
-                    endDateValidity: DATE_VALIDITY.VALID,
+                  it('focuses the previous month button', () => {
+                    expect(
+                      wrapper.getByLabelText(PREVIOUS_MONTH_BUTTON_LABEL)
+                    ).toHaveFocus()
                   })
                 })
 
-                it('hides the day picker container', () => {
-                  return waitFor(() => {
-                    expect(
-                      wrapper.queryByTestId('floating-box')
-                    ).not.toBeInTheDocument()
+                describe('and clicks on a day', () => {
+                  beforeEach(() => {
+                    return user.click(wrapper.getByText('31'))
+                  })
+
+                  it('set the value of the component to this date', () => {
+                    expect(wrapper.getByTestId('datepicker-input')).toHaveValue(
+                      '31/05/2016'
+                    )
+                  })
+
+                  it('invokes the onChange callback', () => {
+                    expect(onChange).toHaveBeenLastCalledWith({
+                      startDate: new Date('2016-05-31T12:00:00.000Z'),
+                      startDateValidity: DATE_VALIDITY.VALID,
+                      endDate: new Date('2016-05-31T12:00:00.000Z'),
+                      endDateValidity: DATE_VALIDITY.VALID,
+                    })
+                  })
+
+                  it('hides the day picker container', () => {
+                    return waitFor(() => {
+                      expect(
+                        wrapper.queryByTestId('floating-box')
+                      ).not.toBeInTheDocument()
+                    })
                   })
                 })
               })
@@ -576,6 +581,41 @@ describe('DatePicker', () => {
           startDateValidity: DATE_VALIDITY.VALID,
           endDate: new Date('2021-05-01T12:00:00.000Z'),
           endDateValidity: DATE_VALIDITY.VALID,
+        })
+      })
+    })
+  })
+
+  describe('when the `hideClearButton` prop is true', () => {
+    beforeEach(() => {
+      wrapper = render(<DatePicker hideClearButton startDate={new Date()} />)
+    })
+    it('does not render the clear button', () => {
+      expect(wrapper.queryByTestId('datepicker-clear-button')).toBeNull()
+    })
+  })
+
+  describe('when the hideClearButton prop is false', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <DatePicker onChange={onChange} startDate={new Date()} />
+      )
+    })
+    it('renders the clear button', () => {
+      expect(wrapper.getByTestId('datepicker-clear-button')).toBeInTheDocument()
+    })
+
+    describe('and the clear button is clicked', () => {
+      beforeEach(() => {
+        return user.click(wrapper.getByTestId('datepicker-clear-button'))
+      })
+
+      it('calls the `onChange` callback', () => {
+        expect(onChange).toHaveBeenLastCalledWith({
+          startDate: null,
+          startDateValidity: null,
+          endDate: null,
+          endDateValidity: null,
         })
       })
     })

--- a/packages/react-component-library/src/components/InlineButtons/ClearButton.tsx
+++ b/packages/react-component-library/src/components/InlineButtons/ClearButton.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { IconClose } from '@royalnavy/icon-library'
 
 import { COMPONENT_SIZE } from '../Forms'
-import { InlineButton } from '../InlineButtons/InlineButton'
+import { InlineButton } from './InlineButton'
 
 interface InlineButtonProps {
   isDisabled: boolean

--- a/packages/react-component-library/src/components/InlineButtons/partials/StyledInlineButtons.tsx
+++ b/packages/react-component-library/src/components/InlineButtons/partials/StyledInlineButtons.tsx
@@ -18,3 +18,7 @@ export const StyledInlineButtons = styled.div`
     }
   }
 `
+
+export const StyledInlineButtonsNoBorder = styled(StyledInlineButtons)`
+  border-left: none;
+`

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -3,10 +3,9 @@ import React, { useState } from 'react'
 import mergeRefs from 'react-merge-refs'
 
 import { ArrowButton } from '../Select/ArrowButton'
-import { ClearButton } from '../Select/ClearButton'
+import { ClearButton } from '../InlineButtons/ClearButton'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 import { SelectChildWithStringType } from './types'
-import { StyledInlineButtons } from './partials/StyledInlineButtons'
 import { StyledInput } from './partials/StyledInput'
 import { StyledInputWrapper } from './partials/StyledInputWrapper'
 import { StyledLabel } from '../TextInput/partials/StyledLabel'
@@ -20,6 +19,7 @@ import { useExternalId } from '../../hooks/useExternalId'
 import { useStatefulRef } from '../../hooks/useStatefulRef'
 import { StyledFloatingBox } from './partials/StyledFloatingBox'
 import { PopupPosition } from './SelectBaseProps'
+import { StyledInlineButtonsNoBorder } from '../InlineButtons/partials/StyledInlineButtons'
 
 type ComboboxReturnValueType = UseComboboxReturnValue<SelectChildWithStringType>
 type SelectReturnValueType = UseSelectReturnValue<SelectChildWithStringType>
@@ -36,13 +36,13 @@ export interface SelectLayoutProps extends ComponentWithClass {
   hideClearButton?: boolean
   label: string
   menuProps:
-    | ReturnType<ComboboxReturnValueType['getMenuProps']>
-    | ReturnType<SelectReturnValueType['getMenuProps']>
+  | ReturnType<ComboboxReturnValueType['getMenuProps']>
+  | ReturnType<SelectReturnValueType['getMenuProps']>
   onChange?: (value: string | null) => void
   onClearButtonClick: (event: React.MouseEvent<HTMLButtonElement>) => void
   toggleButtonProps:
-    | ReturnType<ComboboxReturnValueType['getToggleButtonProps']>
-    | ReturnType<SelectReturnValueType['getToggleButtonProps']>
+  | ReturnType<ComboboxReturnValueType['getToggleButtonProps']>
+  | ReturnType<SelectReturnValueType['getToggleButtonProps']>
   tooltipText: string
   value?: string
   popupPosition?: PopupPosition
@@ -125,7 +125,7 @@ export const SelectLayout = ({
                 id={id}
               />
             </StyledInputWrapper>
-            <StyledInlineButtons>
+            <StyledInlineButtonsNoBorder>
               {hasSelectedItem && !hideClearButton && (
                 <ClearButton
                   isDisabled={isDisabled}
@@ -138,10 +138,14 @@ export const SelectLayout = ({
                 isOpen={isOpen}
                 {...toggleButtonProps}
               />
-            </StyledInlineButtons>
+            </StyledInlineButtonsNoBorder>
           </StyledOuterWrapper>
         </StyledTextInput>
-        <StyledOptionsWrapper data-testid="select-options-wrapper" $isVisible={isOpen} $position={popupPosition}>
+        <StyledOptionsWrapper
+          data-testid="select-options-wrapper"
+          $isVisible={isOpen}
+          $position={popupPosition}
+        >
           <StyledOptions
             {...menuProps}
             aria-labelledby={labelId}

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledInlineButtons.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledInlineButtons.tsx
@@ -1,7 +1,0 @@
-import styled from 'styled-components'
-
-import { StyledInlineButtons as StyledInlineButtonsBase } from '../../InlineButtons/partials/StyledInlineButtons'
-
-export const StyledInlineButtons = styled(StyledInlineButtonsBase)`
-  border-left: none;
-`


### PR DESCRIPTION
## Related issue

DNADB-533

## Overview

Add a clear button from `Select` to the `DatePicker`

## Reason

Missing feature.

## Work carried out

- [x] Move ClearButton
- [x] Add ClearButton to the DatePicker->Input component and hook up events
- [x] Add `$hideLeftBorder` prop to StyledInlineButtons container so we can reuse

## Screenshot
![2025-06-12 15 10 45](https://github.com/user-attachments/assets/fd95c9d5-0f5f-4bcf-9c7f-b5498c321079)


