### PR TITLE
Reverse sorting arrows

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/Header.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Header.tsx
@@ -40,10 +40,10 @@ const TABLE_SORT_ORDER = {
 
 const SORT_ORDER_ICONS_MAP = {
   [TABLE_SORT_ORDER.ASCENDING]: (
-    <IconArrowDownward aria-hidden data-testid="ascending" />
+    <IconArrowUpward aria-hidden data-testid="ascending" />
   ),
   [TABLE_SORT_ORDER.DESCENDING]: (
-    <IconArrowUpward aria-hidden data-testid="descending" />
+    <IconArrowDownward aria-hidden data-testid="descending" />
   ),
 }
 


### PR DESCRIPTION
## Related issue

TDB

## Overview

Reverse the sorting arrows

## Reason

To ascend is to go up hence the arrow pointing up, and to descend is to go down hence the arrow pointing down.

A quick google this does seem to be a debate in the design community, then its an arrow and not just an arrow head the approach currently taken could be seen as valid.

The change is the PR does bring the table in line with how _SharePoint_ shows the arrows when ordering though 😂

## Work carried out

- [x] Reversed the sorting arrows