### PR TITLE
feat(Select): Accept custom Badge props

### DIFF
--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -58,6 +58,17 @@ const TemplateWithIconsAndBadges: StoryFn<typeof Select> = (args) => (
       <SelectOption badge={100} icon={<IconAnchor />} value="one">
         One
       </SelectOption>
+      <SelectOption
+        badge="A custom badge"
+        badgeProps={{
+          color: 'supf',
+          colorVariant: 'faded',
+        }}
+        icon={<IconAnchor />}
+        value="JSX badge"
+      >
+        Two
+      </SelectOption>
       <SelectOption badge={110} icon={<IconRemove />} value="two">
         Two
       </SelectOption>

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { render, RenderResult, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { ColorDanger800 } from '@royalnavy/design-tokens'
+import {color , ColorDanger800 } from '@royalnavy/design-tokens'
 import {
   IconAgriculture,
   IconAnchor,
@@ -570,6 +570,13 @@ describe('Select', () => {
           <SelectOption badge={3} value="three">
             Three
           </SelectOption>
+          <SelectOption
+            badge="custom"
+            badgeProps={{ color: 'supf', colorVariant: 'faded' }}
+            value="custom"
+          >
+            Custom
+          </SelectOption>
         </Select>
       )
     })
@@ -579,13 +586,22 @@ describe('Select', () => {
         return userEvent.click(wrapper.getByTestId('select-input'))
       })
 
-      it('displays 3 badges', () => {
+      it('displays 4 badges', () => {
         const badges = wrapper.queryAllByTestId('select-badge')
         expect(badges[0]).toHaveTextContent('1')
         expect(badges[1]).toHaveTextContent('2')
         expect(badges[2]).toHaveTextContent('3')
-        expect(badges).toHaveLength(3)
+        expect(badges).toHaveLength(4)
       })
+
+      it('displays custom badge props', () => {
+        const customBadge = wrapper.queryAllByTestId('select-badge')[3]
+        expect(customBadge).toHaveTextContent('custom')
+
+        const backgroundColor = color('supf', '200')
+        expect(customBadge).toHaveStyleRule('background-color', backgroundColor)
+      })
+
     })
   })
 

--- a/packages/react-component-library/src/components/SelectBase/SelectBaseOption.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectBaseOption.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
 
-import { BADGE_SIZE, BADGE_VARIANT } from '../Badge'
+import { BADGE_SIZE, BADGE_VARIANT, BadgeProps } from '../Badge'
 import { StyledOption } from './partials/StyledOption'
 import { StyledOptionBadge } from './partials/StyledOptionBadge'
 import { StyledOptionText } from './partials/StyledOptionText'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 
+type CustomBadgeProps = Omit<BadgeProps, 'children'>
+
 export interface SelectBaseOptionProps extends ComponentWithClass {
   badge?: string | number
+  badgeProps?: CustomBadgeProps
   icon?: React.ReactNode
   isHighlighted?: boolean
   value: string
@@ -24,7 +27,16 @@ export const SelectBaseOption = React.forwardRef<
   SelectBaseOptionProps
 >(
   (
-    { badge, icon, children, isHighlighted, title, isDisabled, ...rest },
+    {
+      badge,
+      badgeProps,
+      icon,
+      children,
+      isHighlighted,
+      title,
+      isDisabled,
+      ...rest
+    },
     ref
   ) => {
     return (
@@ -42,6 +54,7 @@ export const SelectBaseOption = React.forwardRef<
             data-testid="select-badge"
             size={BADGE_SIZE.XSMALL}
             variant={BADGE_VARIANT.PILL}
+            {...badgeProps}
           >
             {badge}
           </StyledOptionBadge>


### PR DESCRIPTION
## Related issue
DNADB-683

## Overview

Accept custom `Badge` props in the `SelectOption` component to allow for custom styling

## Reason

User research on a downstream project 

## Work carried out

- [x] Add optional badgeProps property to the `SelectOption` component and spread against the badge

## Screenshot
<img width="350" height="317" alt="image" src="https://github.com/user-attachments/assets/33c07722-22a8-463a-9383-fc1e7ecef7a9" />


