### PR TITLE
feat(DataGrid): Add support for external row selection state

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/Body.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Body.tsx
@@ -79,6 +79,7 @@ const Row = <T extends object>({
   return (
     <>
       <StyledRow
+        key={`${row.id}-main`}
         id={row.id}
         $depth={row.depth}
         $isLastInBranch={isLastInBranch(row, table.getRowModel().rows)}
@@ -136,14 +137,15 @@ export const Body = <T extends object>({
   return (
     <StyledBody>
       {table.getRowModel().rows.map((row) => (
-        <Row
-          key={row.id}
-          row={row}
-          table={table}
-          enableRowSelection={enableRowSelection}
-          hasHover={hasHover}
-          totalColumns={totalColumns}
-        />
+        <React.Fragment key={row.id}>
+          <Row
+            row={row}
+            table={table}
+            enableRowSelection={enableRowSelection}
+            hasHover={hasHover}
+            totalColumns={totalColumns}
+          />
+        </React.Fragment>
       ))}
     </StyledBody>
   )

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -241,7 +241,6 @@ const columns = [
     accessorKey: 'quantity',
     enableSorting: false,
     enableColumnFilter: false,
-    filterFn: 'equalsString',
   },
   {
     header: 'Price',
@@ -980,6 +979,85 @@ WithRowsPerPageItemRange.parameters = {
     description: {
       story:
         'The `showRowsPerPageItemRange` prop displays "Showing X to Y of Z" text next to the rows per page selector.',
+    },
+  },
+}
+
+export const ControlledRowSelection: StoryFn<typeof DataGrid> = () => {
+  const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({})
+
+  return (
+    <Wrapper>
+      <DataGrid
+        columns={columns}
+        data={data}
+        enableRowSelection
+        // Use a stable ID; defaults to `id` but we show it explicitly
+        getRowId={(row: Order) => String(row.id)}
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
+        isFullWidth
+      />
+    </Wrapper>
+  )
+}
+
+ControlledRowSelection.storyName = 'Controlled row selection (by ID)'
+ControlledRowSelection.parameters = {
+  docs: {
+    description: {
+      story:
+        'Selection is controlled externally via `rowSelection` and keyed by a stable row ID using `getRowId` (defaults to `row.id`).',
+    },
+  },
+}
+
+export const ManualPaginationWithControlledSelection: StoryFn<
+  typeof DataGrid
+> = () => {
+  const pageSize = 5
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize,
+  })
+  const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({})
+
+  const startIndex = pagination.pageIndex * pagination.pageSize
+  const endIndex = startIndex + pagination.pageSize
+  const pageData = data.slice(startIndex, endIndex)
+
+  return (
+    <Wrapper>
+      <DataGrid
+        columns={columns}
+        data={pageData}
+        enableRowSelection
+        manualPagination
+        pageCount={Math.ceil(data.length / pageSize)}
+        pagination={pagination}
+        onPaginationChange={(updaterOrValue) => {
+          const next =
+            typeof updaterOrValue === 'function'
+              ? updaterOrValue(pagination)
+              : updaterOrValue
+          setPagination(next)
+        }}
+        getRowId={(row: Order) => String(row.id)}
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
+        isFullWidth
+      />
+    </Wrapper>
+  )
+}
+
+ManualPaginationWithControlledSelection.storyName =
+  'Manual pagination with controlled selection'
+ManualPaginationWithControlledSelection.parameters = {
+  docs: {
+    description: {
+      story:
+        'Demonstrates server-side pagination with externally controlled, ID-based selection that persists across pages.',
     },
   },
 }

--- a/packages/react-component-library/src/components/DataGrid/getColumns.tsx
+++ b/packages/react-component-library/src/components/DataGrid/getColumns.tsx
@@ -22,39 +22,50 @@ export function getColumns<T>(
 
   const rowSelectExpandColumn: ColumnDef<T> = {
     id: 'select-expand',
-    header: ({
-      table: {
+    header: ({ table }) => {
+      const {
         getIsAllRowsSelected,
         getIsSomeRowsSelected,
         getToggleAllRowsSelectedHandler,
         getToggleAllRowsExpandedHandler,
         getIsAllRowsExpanded,
         getCanSomeRowsExpand,
-      },
-    }) => (
-      <>
-        {showCheckboxes && (
-          <IndeterminateCheckbox
-            checked={getIsAllRowsSelected()}
-            indeterminate={getIsSomeRowsSelected()}
-            onChange={getToggleAllRowsSelectedHandler()}
-            aria-label="Select / deselect all rows"
-          />
-        )}
-        {getCanSomeRowsExpand() && (
-          <StyledExpandButton
-            onClick={getToggleAllRowsExpandedHandler()}
-            aria-label="Expand / collapse all rows"
-          >
-            {getIsAllRowsExpanded() ? (
-              <IconKeyboardArrowDown />
-            ) : (
-              <IconKeyboardArrowRight />
-            )}
-          </StyledExpandButton>
-        )}
-      </>
-    ),
+      } = table
+
+      const anySelectedGlobally =
+        Object.keys(table.getState().rowSelection || {}).length > 0
+
+      const isAllSelectedOnPage = getIsAllRowsSelected()
+      const isSomeSelectedOnPage = getIsSomeRowsSelected()
+
+      const isIndeterminate =
+        isSomeSelectedOnPage || (anySelectedGlobally && !isAllSelectedOnPage)
+
+      return (
+        <>
+          {showCheckboxes && (
+            <IndeterminateCheckbox
+              checked={isAllSelectedOnPage}
+              indeterminate={isIndeterminate}
+              onChange={getToggleAllRowsSelectedHandler()}
+              aria-label="Select / deselect all rows"
+            />
+          )}
+          {getCanSomeRowsExpand() && (
+            <StyledExpandButton
+              onClick={getToggleAllRowsExpandedHandler()}
+              aria-label="Expand / collapse all rows"
+            >
+              {getIsAllRowsExpanded() ? (
+                <IconKeyboardArrowDown />
+              ) : (
+                <IconKeyboardArrowRight />
+              )}
+            </StyledExpandButton>
+          )}
+        </>
+      )
+    },
     cell: ({
       row: {
         getIsSelected,


### PR DESCRIPTION
## Related issue

DNADB-647

## Overview

Add optional, externally controlled row selection to `DataGrid` keyed by stable row IDs (not indices), preserving selection across server-side pagination and filtering. Default `getRowId` finds `id`/`uuid`/`key` (with hierarchical IDs for sub-rows); uncontrolled mode remains supported.

## Reason

Selections based on row indices broke when data changed due to external pagination/filters. Using stable IDs allows correct persistence across pages/filters and enables external state control.

## Work carried out

- [x] Added controlled selection props: `rowSelection`, `onRowSelectionChange`
- [x] Implemented stable `getRowId` (supports `id`/`uuid`/`key`, and nested sub-rows)
- [x] Preserved uncontrolled selection (backwards compatible)
- [x] Extended types to support External Row Selection across internal/external sorting/pagination combinations
- [x] Fixed header “select all” to show indeterminate when selections span multiple pages
- [x] Resolved duplicate key warnings in `Body.tsx` for sub-rows
- [x] Added Storybook stories for controlled selection and manual pagination
- [x] Added/updated unit tests for controlled selection across pages
- [x] Regenerated types and ensured build/tests pass

## Screenshot

![2025-08-14 11 45 25](https://github.com/user-attachments/assets/84a60cad-d902-46c7-95f5-684a6e55587c)

## Developer notes

- Default `getRowId` falls back to index only when no suitable key is present; passing a stable `getRowId` is recommended for server-side pagination.  