### PR TITLE
fix(DatePicker): Adjust cursor when isRange is true

### DIFF
--- a/packages/react-component-library/src/components/DatePicker/partials/StyledInputWrapper.tsx
+++ b/packages/react-component-library/src/components/DatePicker/partials/StyledInputWrapper.tsx
@@ -12,7 +12,7 @@ export const StyledInputWrapper = styled.div<StyledInputWrapperProps>`
     $isRange &&
     css`
       input {
-        cursor: default;
+        cursor: pointer;
       }
     `}
 `


### PR DESCRIPTION
## Overview

Adjust cursor when isRange is true to show a pointer across the entire component as it is all clickable

## Reason

Provides the user with visual feedback that they can click anywhere on the DatePicker

## Work carried out

- [x] Adjust cursor to be a pointer across the entire component when isRange is true
