### PR TITLE
feat(Modal): Show loading spinner in `Modal` primary button if `onClick` is `async`

### DIFF
--- a/packages/react-component-library/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.stories.tsx
@@ -122,3 +122,18 @@ export const Blank = Template.bind({})
 Blank.args = {
   'aria-label': 'Blank modal',
 }
+
+export const AsyncAction = Template.bind({})
+AsyncAction.storyName = 'Async loading'
+AsyncAction.args = {
+  title: 'Example Title',
+  primaryButton: {
+    ...primaryButton,
+    onClick: () =>
+      new Promise((resolve) => {
+        setTimeout(resolve, 2000)
+      }),
+  },
+  secondaryButton,
+  tertiaryButton,
+}

--- a/packages/react-component-library/src/components/Modal/Modal.tsx
+++ b/packages/react-component-library/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useImperativeHandle } from 'react'
+import React, { useRef, useImperativeHandle, useState } from 'react'
 import { IconForward } from '@royalnavy/icon-library'
 
 import { ButtonProps } from '../Button'
@@ -100,10 +100,34 @@ export const Modal = React.forwardRef<ModalImperativeHandle, ModalProps>(
     ref
   ) => {
     const dialogRef = useRef<HTMLDialogElement>(null)
+    const [isLoading, setIsLoading] = useState(false)
 
     const primaryButtonWithIcon = primaryButton && {
-      icon: <IconForward data-testid="modal-primary-confirm" />,
       ...primaryButton,
+      icon:
+        'icon' in primaryButton ? (
+          primaryButton.icon
+        ) : (
+          <IconForward data-testid="modal-primary-confirm" />
+        ),
+      onClick: async (event: React.MouseEvent<HTMLButtonElement>) => {
+        setIsLoading(true)
+
+        await primaryButton.onClick?.(event)
+
+        setIsLoading(false)
+      },
+      isLoading,
+    }
+
+    const modifiedSecondaryButton = secondaryButton && {
+      ...secondaryButton,
+      isDisabled: isLoading || secondaryButton.isDisabled,
+    }
+
+    const modifiedTertiaryButton = tertiaryButton && {
+      ...tertiaryButton,
+      isDisabled: isLoading || tertiaryButton.isDisabled,
     }
 
     const descriptionId = useExternalId(
@@ -157,8 +181,8 @@ export const Modal = React.forwardRef<ModalImperativeHandle, ModalProps>(
           {(primaryButton || secondaryButton || tertiaryButton) && (
             <Footer
               primaryButton={primaryButtonWithIcon}
-              secondaryButton={secondaryButton}
-              tertiaryButton={tertiaryButton}
+              secondaryButton={modifiedSecondaryButton}
+              tertiaryButton={modifiedTertiaryButton}
             />
           )}
         </StyledMain>


### PR DESCRIPTION
## Related issue
DNADB-1005

## Overview
If the function used for onClick is async then show a loading spinner. This is useful for operations that take longer.

## Reason
Some operations take a long time so this will help show the `Modal` is working whilst the operation completes.

## Work carried out
- [x] Show loading spinner until async operation is complete

## Test instructions
1. `pnpm run storybook`
2. Browse to http://localhost:6006/?path=/story/components-modal--async-action
