### PR TITLE
fix(Alert): Remove margin on top of Dismiss button

### DIFF
--- a/packages/react-component-library/src/components/Alert/partials/StyledCloseButton.tsx
+++ b/packages/react-component-library/src/components/Alert/partials/StyledCloseButton.tsx
@@ -17,7 +17,6 @@ export const StyledCloseButton = styled.button`
   transition: all 0.3s;
   border-radius: 2px;
   padding: ${spacing('4')};
-  margin-top: ${spacing('4')};
   background-color: ${ALERT_CLOSE_BACKGROUND_COLOR};
   text-align: center;
 


### PR DESCRIPTION
## Related issue
DNADB-1005

## Overview
Remove top margin from `Dismiss` button.

## Reason
This gives the button the correct spacing. Another option would have been to add bottom margin but this negatively impacted the `Without title` example.

## Work carried out
- [x] Remove top margin

## Screenshot
<img width="897" height="93" alt="Screenshot 2025-11-25 at 11 09 26" src="https://github.com/user-attachments/assets/a6497636-2428-48f3-b9db-8eae437ddb99" />