### PR TITLE
fix(Popover): Fix popovers from staying open on fast mouse movements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @m7kvqbe1, @thyhjwb6 and @markhigham will be requested for
+# @m7kvqbe1, @thyhjwb6 and @markhigham @ollie-sutton will be requested for
 # review when someone opens a pull request.
-*       @m7kvqbe1 @thyhjwb6 @markhigham
+*       @m7kvqbe1 @thyhjwb6 @markhigham @ollie-sutton

--- a/packages/react-component-library/e2e/Popover/default.spec.ts
+++ b/packages/react-component-library/e2e/Popover/default.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '../fixtures'
+import selectors from './selectors'
+
+test.describe('Popover', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/iframe.html?id=components-popover--default&viewMode=story')
+  })
+
+  test('handles rapid mouse movements in and out 100x and confirms popover is closed', async ({
+    page,
+  }) => {
+    const target = page.locator(selectors.target)
+    const content = page.locator(selectors.content)
+
+    // Perform 100 rapid mouse in/out movements
+    const movements = Array.from({ length: 100 }, async () => {
+      await target.hover()
+      await page.mouse.move(0, 0)
+    })
+    await Promise.all(movements)
+
+    // Wait for popover to be hidden after rapid movements
+    await expect(content).toBeHidden()
+  })
+})

--- a/packages/react-component-library/e2e/Popover/selectors.ts
+++ b/packages/react-component-library/e2e/Popover/selectors.ts
@@ -1,0 +1,5 @@
+export default {
+  target: '[id="storybook-root"] > div:first-child',
+  popover: '[data-testid="popover"]',
+  content: '[data-testid="popover-content"]',
+} as const

--- a/packages/react-component-library/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.stories.tsx
@@ -51,3 +51,48 @@ export const Open = Template.bind({})
 Open.args = {
   isVisible: true,
 }
+
+export const Multi: StoryFn<typeof Popover> = (args) => (
+  <div>
+    <Popover {...args}>
+      <div
+        css={`
+          display: inline-block;
+          padding: 1rem;
+          background-color: #c9c9c9;
+          margin-bottom: 10px;
+        `}
+      >
+        Hover on me
+      </div>
+    </Popover>
+    <br />
+    <Popover {...args}>
+      <div
+        css={`
+          display: inline-block;
+          padding: 1rem;
+          background-color: #c9c9c9;
+          margin-bottom: 10px;
+        `}
+      >
+        Hover on me
+      </div>
+    </Popover>
+    <br />
+    <Popover {...args}>
+      <div
+        css={`
+          display: inline-block;
+          padding: 1rem;
+          background-color: #c9c9c9;
+          margin-bottom: 10px;
+        `}
+      >
+        Hover on me
+      </div>
+    </Popover>
+  </div>
+)
+Multi.storyName = 'Multiple Popovers'
+Multi.args = {}

--- a/packages/react-component-library/src/components/Popover/Popover.tsx
+++ b/packages/react-component-library/src/components/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { Placement } from '@popperjs/core'
 
 import {
@@ -91,13 +91,13 @@ export const Popover = ({
 
   const contentId = useExternalId('popover-content')
 
-  const PopoverTarget = () => {
+  const PopoverTarget = useCallback(() => {
     return React.Children.map(children, (item: React.ReactElement) =>
       React.cloneElement(item, {
         ...getMouseEvents(isClick, item, mouseEvents),
       })
     )[0]
-  }
+  }, [isClick, children, mouseEvents])
 
   return (
     <FloatingBox

--- a/packages/react-component-library/src/hooks/useHideShow.ts
+++ b/packages/react-component-library/src/hooks/useHideShow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useDocumentClick } from '.'
 
@@ -20,11 +20,20 @@ export function useHideShow(
   initialIsVisible = false
 ) {
   const [isVisible, setIsVisible] = useState(initialIsVisible)
+
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const floatingBoxChildrenRef = useRef(null)
+  const isVisibleRef = useRef(isVisible)
+  const mouseEventsRef = useRef<HideShowMouseEvents>()
+
+  isVisibleRef.current = isVisible
+
+  useEffect(() => {
+    mouseEventsRef.current = undefined
+  }, [closeDelay])
 
   const hideElement = useCallback(() => {
-    if (!isVisible) {
+    if (!isVisibleRef.current) {
       return
     }
 
@@ -37,10 +46,10 @@ export function useHideShow(
       setIsVisible(false)
       timerRef.current = null
     }, closeDelay)
-  }, [closeDelay, isVisible])
+  }, [closeDelay])
 
-  function showElement() {
-    if (isVisible) {
+  const showElement = useCallback(() => {
+    if (isVisibleRef.current) {
       return
     }
 
@@ -49,23 +58,22 @@ export function useHideShow(
     }
 
     setIsVisible(true)
-  }
+  }, [])
 
   useDocumentClick(floatingBoxChildrenRef, hideElement, isClick)
 
-  function getMouseEvents() {
-    if (isClick) {
-      return {
-        onClick: isVisible ? hideElement : showElement,
+  mouseEventsRef.current ??= isClick
+    ? {
+        onClick: () => (isVisibleRef.current ? hideElement() : showElement()),
       }
-    }
-
-    return { onMouseEnter: showElement, onMouseLeave: hideElement }
-  }
+    : {
+        onMouseEnter: showElement,
+        onMouseLeave: hideElement,
+      }
 
   return {
     floatingBoxChildrenRef,
     isVisible,
-    mouseEvents: getMouseEvents(),
+    mouseEvents: mouseEventsRef.current,
   }
 }


### PR DESCRIPTION
## Overview

Fix popovers from staying open on fast mouse movements

## Reason

Due to the way the mouse events where re-created ever time isVisible changed it caused the popover to sometimes miss events which meant you could get them staying open when they shouldn't

## Work carried out

- [x] Update useHideShow hook to handle mouse events by ref
- [x] Add useCallback to the popover target

## Developer notes

I think if we go for this change then we can park the FloatingUI change for now as per Lees comment on them currently being breaking.

I've added a Multi story for testing, happy to remove this before merging and it doesn't provide anything other than being able to reproduce the bug
