### PR TITLE
feat(MultiSelect): Add multi select variant into the current select

### DIFF
--- a/packages/react-component-library/e2e/Select/multi.spec.ts
+++ b/packages/react-component-library/e2e/Select/multi.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '../fixtures'
+import selectors from './selectors'
+
+test.describe('Select, isMulti', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(
+      '/iframe.html?id=components-select--multi-select&viewMode=story'
+    )
+  })
+
+  test('correctly shows the Multiple selected text when multiple options are selected', async ({
+    page,
+  }) => {
+    await page.click(selectors.outerWrapper)
+
+    await page.locator(selectors.option).nth(1).click()
+    await page.locator(selectors.option).nth(2).click()
+    await page.locator(selectors.option).nth(3).click()
+
+    await expect(page.locator(selectors.input)).toHaveValue(/.*,.*,.*/)
+
+    await page.locator(selectors.option).nth(4).click()
+    await page.locator(selectors.option).nth(5).click()
+
+    await expect(page.locator(selectors.input)).toHaveValue('Multiple selected')
+  })
+
+  test('allows for navigation using the arrow keys and enter', async ({
+    page,
+  }) => {
+    await page.click(selectors.outerWrapper)
+
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Enter')
+
+    await expect(page.locator(selectors.input)).not.toHaveValue('')
+
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Enter')
+
+    const inputValue = await page.locator(selectors.input).inputValue()
+    expect(inputValue).toBeTruthy()
+    expect(inputValue).not.toBe('')
+  })
+})

--- a/packages/react-component-library/jest/setupTests.js
+++ b/packages/react-component-library/jest/setupTests.js
@@ -52,3 +52,24 @@ afterEach(() => {
     )
   }
 })
+
+/**
+ * Mock ResizeObserver for tests
+ */
+global.ResizeObserver = class ResizeObserver {
+  constructor(callback) {
+    this.callback = callback
+  }
+
+  observe() {
+    // Mock observe method
+  }
+
+  unobserve() {
+    // Mock unobserve method
+  }
+
+  disconnect() {
+    // Mock disconnect method
+  }
+}

--- a/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmark.tsx
+++ b/packages/react-component-library/src/components/Checkbox/partials/StyledCheckmark.tsx
@@ -33,6 +33,11 @@ export const StyledCheckmark = styled.span<CheckmarkProps>`
     display: none;
     border-radius: 2px;
     color: ${color('neutral', 'white')};
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    line-height: 0;
   }
 
   ${({ $hasContainer }) => {

--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Meta, StoryFn } from '@storybook/react'
 import {
   IconAgriculture,
@@ -36,6 +36,16 @@ const StyledWrapper = styled.div<{ $isDisabled?: boolean }>`
   max-width: 20rem;
 `
 
+const OPTIONS = [
+  { text: 'Apple', value: 'apple' },
+  { text: 'Banana', value: 'banana' },
+  { text: 'Cherry', value: 'cherry' },
+  { text: 'Date', value: 'date' },
+  { text: 'Elderberry', value: 'elderberry' },
+  { text: 'Fig', value: 'fig' },
+  { text: 'Grape', value: 'grape' },
+]
+
 const Template: StoryFn<typeof Select> = (args) => (
   <StyledWrapper $isDisabled={args.isDisabled}>
     <Select {...args}>
@@ -70,13 +80,13 @@ const TemplateWithIconsAndBadges: StoryFn<typeof Select> = (args) => (
         Two
       </SelectOption>
       <SelectOption badge={110} icon={<IconRemove />} value="two">
-        Two
-      </SelectOption>
-      <SelectOption badge={111} icon={<IconAgriculture />} value="three">
         Three
       </SelectOption>
-      <SelectOption badge={112} icon={<IconBrightnessAuto />} value="four">
+      <SelectOption badge={111} icon={<IconAgriculture />} value="three">
         Four
+      </SelectOption>
+      <SelectOption badge={112} icon={<IconBrightnessAuto />} value="four">
+        Five
       </SelectOption>
     </Select>
   </StyledWrapper>
@@ -124,14 +134,9 @@ const StyledBottomRightWrapper = styled.div`
 export const AutoPositioning: StoryFn<typeof Select> = (args) => (
   <StyledBottomRightWrapper>
     <Select {...args}>
-      <SelectOption value="one">Option One</SelectOption>
-      <SelectOption value="two">Option Two</SelectOption>
-      <SelectOption value="three">Option Three</SelectOption>
-      <SelectOption value="four">Option Four</SelectOption>
-      <SelectOption value="five">Option Five</SelectOption>
-      <SelectOption value="six">Option Six</SelectOption>
-      <SelectOption value="seven">Option Seven</SelectOption>
-      <SelectOption value="eight">Option Eight</SelectOption>
+      {OPTIONS.map((x) => (
+        <SelectOption value={x.value}>{x.text}</SelectOption>
+      ))}
     </Select>
   </StyledBottomRightWrapper>
 )
@@ -146,4 +151,63 @@ AutoPositioning.parameters = {
         'This story demonstrates the automatic positioning of the dropdown based on available space. The Select is positioned in the bottom right corner, so the dropdown should open upwards.',
     },
   },
+}
+
+export const MultiSelect: StoryFn<typeof Select> = (args) => (
+  <StyledWrapper $isDisabled={args.isDisabled}>
+    <Select {...args} isMulti>
+      {OPTIONS.map((x) => (
+        <SelectOption value={x.value}>{x.text}</SelectOption>
+      ))}
+    </Select>
+  </StyledWrapper>
+)
+
+export const MultiSelectWithDisabledOptions: StoryFn<typeof Select> = (
+  args
+) => (
+  <StyledWrapper>
+    <Select {...args} isMulti>
+      {OPTIONS.map((x, i) => (
+        <SelectOption value={x.value} isDisabled={i % 2 === 0}>
+          {x.text}
+        </SelectOption>
+      ))}
+    </Select>
+  </StyledWrapper>
+)
+
+export const MultiSelectValue: StoryFn<typeof Select> = (args) => {
+  const [selectedItems, setSelectedItems] = useState<string[]>([
+    'apple',
+    'cherry',
+  ])
+
+  return (
+    <StyledWrapper>
+      <Select
+        {...args}
+        isMulti
+        value={selectedItems}
+        onChange={(items) => {
+          setSelectedItems(items)
+          args.onChange?.(items)
+        }}
+      >
+        {OPTIONS.map((x) => (
+          <SelectOption value={x.value}>{x.text}</SelectOption>
+        ))}
+      </Select>
+    </StyledWrapper>
+  )
+}
+
+export const MultiSelectIconsAndBadges = TemplateWithIconsAndBadges.bind({})
+MultiSelectIconsAndBadges.args = {
+  isMulti: true,
+}
+
+export const MultiSelectWithReallyLongText = Template.bind({})
+MultiSelectWithReallyLongText.args = {
+  isMulti: true,
 }

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { render, RenderResult, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {color , ColorDanger800 } from '@royalnavy/design-tokens'
+import { color, ColorDanger800 } from '@royalnavy/design-tokens'
 import {
   IconAgriculture,
   IconAnchor,
@@ -601,7 +601,6 @@ describe('Select', () => {
         const backgroundColor = color('supf', '200')
         expect(customBadge).toHaveStyleRule('background-color', backgroundColor)
       })
-
     })
   })
 
@@ -674,6 +673,109 @@ describe('Select', () => {
         expect(screen.getByText('Option 2')).toBeVisible()
         expect(screen.getByText('Option 3')).toBeVisible()
       })
+    })
+  })
+
+  describe('when isMulti', () => {
+    let onChangeIsMultiSpy: (value: string[] | null) => void
+
+    beforeEach(() => {
+      onChangeIsMultiSpy = jest.fn()
+
+      wrapper = render(
+        <Select
+          className="custom-class"
+          id="select-id"
+          label="Label"
+          isMulti
+          onChange={onChangeIsMultiSpy}
+        >
+          <SelectOption value="one">One</SelectOption>
+          <SelectOption value="two">Two</SelectOption>
+          <SelectOption value="three">Three</SelectOption>
+        </Select>
+      )
+    })
+
+    it('displays checkboxes next to the options', async () => {
+      await userEvent.click(wrapper.getByTestId('select-input'))
+
+      const checkboxes = wrapper.getAllByRole('checkbox')
+      expect(checkboxes).toHaveLength(3)
+    })
+
+    it('calls onChange with an array of selections', async () => {
+      await userEvent.click(wrapper.getByTestId('select-input'))
+
+      await userEvent.click(wrapper.getByText('One'))
+      expect(onChangeIsMultiSpy).toHaveBeenCalledWith(['one'])
+
+      await userEvent.click(wrapper.getByText('Two'))
+      expect(onChangeIsMultiSpy).toHaveBeenCalledWith(['one', 'two'])
+
+      await userEvent.click(wrapper.getByText('One'))
+      expect(onChangeIsMultiSpy).toHaveBeenCalledWith(['two'])
+    })
+
+    it('correctly selects the initial selected values', async () => {
+      wrapper.unmount()
+      wrapper = render(
+        <Select
+          className="custom-class"
+          id="select-id"
+          label="Label"
+          isMulti
+          initialValue={['one', 'two']}
+          onChange={onChangeIsMultiSpy}
+        >
+          <SelectOption value="one">One</SelectOption>
+          <SelectOption value="two">Two</SelectOption>
+          <SelectOption value="three">Three</SelectOption>
+        </Select>
+      )
+
+      expect(wrapper.getByTestId('select-input')).not.toHaveValue('')
+
+      await userEvent.click(wrapper.getByTestId('select-input'))
+
+      const checkboxes = wrapper.getAllByRole('checkbox')
+      expect(checkboxes[0]).toBeChecked()
+      expect(checkboxes[1]).toBeChecked()
+      expect(checkboxes[2]).not.toBeChecked()
+    })
+
+    it('correctly handles being in controlled mode', async () => {
+      wrapper.unmount()
+      wrapper = render(
+        <Select
+          className="custom-class"
+          id="select-id"
+          label="Label"
+          isMulti
+          value={['one', 'two']}
+          onChange={onChangeIsMultiSpy}
+        >
+          <SelectOption value="one">One</SelectOption>
+          <SelectOption value="two">Two</SelectOption>
+          <SelectOption value="three">Three</SelectOption>
+        </Select>
+      )
+
+      expect(wrapper.getByTestId('select-input')).not.toHaveValue('')
+
+      await userEvent.click(wrapper.getByTestId('select-input'))
+
+      const checkboxes = wrapper.getAllByRole('checkbox')
+      expect(checkboxes[0]).toBeChecked()
+      expect(checkboxes[1]).toBeChecked()
+      expect(checkboxes[2]).not.toBeChecked()
+
+      // Because we don't handle the value updating in this test expect the third checkbox to still be unchecked
+      await userEvent.click(wrapper.getByText('Three'))
+
+      expect(checkboxes[0]).toBeChecked()
+      expect(checkboxes[1]).toBeChecked()
+      expect(checkboxes[2]).not.toBeChecked()
     })
   })
 })

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -1,5 +1,5 @@
-import React, { useRef } from 'react'
-import { useSelect } from 'downshift'
+import React, { useRef, useCallback, useMemo } from 'react'
+import { useSelect, useMultipleSelection, UseSelectProps } from 'downshift'
 import { isNil } from 'lodash'
 import mergeRefs from 'react-merge-refs'
 
@@ -14,16 +14,36 @@ import { useMenuVisibility } from '../SelectBase/hooks/useMenuVisibility'
 import { useSelectMenu } from './hooks/useSelectMenu'
 import { SelectOptionProps } from './SelectOption'
 import { useDropdownDirection } from './hooks/useDropdownDirection'
+import {
+  isRemovalAction,
+  isSelectionAction,
+  toggleItemInArray,
+} from './helpers/multiSelectHelpers'
+import { useMultiSelect } from './hooks/useMultiSelect'
+import { useDisplayText } from './hooks/useDisplayText'
 
-export const Select = ({
-  children,
-  id: externalId,
-  initialIsOpen,
-  initialValue,
-  onChange,
-  value,
-  ...rest
-}: SelectBaseProps) => {
+export interface SingleSelectProps extends SelectBaseProps {
+  isMulti?: false
+}
+
+export interface MultiSelectProps extends SelectBaseProps<string[]> {
+  isMulti: true
+}
+
+export type SelectProps = SingleSelectProps | MultiSelectProps
+
+export const Select = (props: SelectProps) => {
+  const {
+    children,
+    id: externalId,
+    initialIsOpen,
+    initialValue,
+    onChange,
+    value,
+    isMulti = false,
+    ...rest
+  } = props
+
   const id = useExternalId('select', externalId)
   const inputRef = useRef<HTMLInputElement>(null)
   const { triggerRef, popupPosition } = useDropdownDirection()
@@ -36,7 +56,78 @@ export const Select = ({
     filteredItems.map((item) => [item.props.value, item])
   )
 
+  const { selectedItems, setSelectedItems } = useMultiSelect({
+    isMulti,
+    initialValue,
+    value,
+  })
+
+  const callMultiOnChange = useCallback(
+    (newValue: string[]) => {
+      const handler = onChange as MultiSelectProps['onChange']
+      handler?.(newValue)
+    },
+    [onChange]
+  )
+
+  const callSingleOnChange = useCallback(
+    (newValue: string | null) => {
+      const handler = onChange as SingleSelectProps['onChange']
+      handler?.(newValue)
+    },
+    [onChange]
+  )
+
+  const multipleSelection = useMultipleSelection({
+    selectedItems: isMulti ? selectedItems : [],
+    onStateChange({ selectedItems: newSelectedItems, type }) {
+      if (isRemovalAction(type) && newSelectedItems) {
+        setSelectedItems(newSelectedItems)
+        callMultiOnChange(newSelectedItems)
+      }
+    },
+  })
+
+  const isMultiHookOptions: Partial<UseSelectProps<string>> = {
+    selectedItem: null,
+    stateReducer(state, actionAndChanges) {
+      const { changes, type } = actionAndChanges
+
+      if (isSelectionAction(type)) {
+        return {
+          ...changes,
+          isOpen: true, // Keeps menu open after selection is made
+          highlightedIndex: state.highlightedIndex,
+        }
+      }
+
+      return changes
+    },
+    onStateChange({ type, selectedItem: newSelectedItem }) {
+      if (isSelectionAction(type) && newSelectedItem) {
+        const newSelectedItems = toggleItemInArray(
+          selectedItems,
+          newSelectedItem
+        )
+
+        setSelectedItems(newSelectedItems)
+        callMultiOnChange(newSelectedItems)
+      }
+    },
+  }
+
   const isControlled = value !== undefined
+
+  const isSingleHookOptions: Partial<UseSelectProps<string>> = {
+    selectedItem: undefined,
+    onSelectedItemChange: ({ selectedItem: newItem }) => {
+      callSingleOnChange(newItem ?? null)
+    },
+    [isControlled ? 'selectedItem' : 'initialSelectedItem']: getSelectedItem(
+      isControlled ? (value as string | null) : (initialValue as string | null),
+      itemsMap
+    ),
+  }
 
   const {
     getItemProps,
@@ -51,38 +142,53 @@ export const Select = ({
     itemToString: (item) => itemToString(item, itemsMap),
     initialIsOpen,
     items,
-    onSelectedItemChange: ({ selectedItem: newItem }) => {
-      onChange?.(newItem ?? null)
-    },
-    ...{
-      [isControlled ? 'selectedItem' : 'initialSelectedItem']: getSelectedItem(
-        isControlled ? value : initialValue,
-        itemsMap
-      ),
-    },
+    ...(isMulti ? isMultiHookOptions : isSingleHookOptions),
   })
 
   const { onInputFocusHandler } = useMenuVisibility(isOpen, openMenu)
-
   const { onMenuKeyDownHandler } = useSelectMenu(inputRef)
 
-  const selectedItemText = isNil(selectedItem)
-    ? ''
-    : itemsMap[selectedItem].props.children
+  const handleClearButtonClick = useCallback(() => {
+    if (!isMulti) {
+      reset()
+      return
+    }
+
+    setSelectedItems([])
+    callMultiOnChange([])
+  }, [isMulti, reset, setSelectedItems, callMultiOnChange])
+
+  const displayText = useDisplayText({
+    isMulti,
+    selectedItem,
+    selectedItems,
+    itemsMap,
+    inputRef,
+  })
+
+  const hasSelectedItem = useMemo(
+    () => (isMulti ? selectedItems.length > 0 : !isNil(selectedItem)),
+    [isMulti, selectedItems, selectedItem]
+  )
+
+  const defaultOptions = {
+    onFocus: onInputFocusHandler,
+    onMouseDown: (event: React.MouseEvent<HTMLInputElement>) => {
+      // This is crucial for correct focus and click behavior
+      // Without this, Downshift internal state gets mixed up
+      event.preventDefault()
+    },
+  }
+  const toggleButtonOptions = isMulti
+    ? multipleSelection.getDropdownProps(defaultOptions)
+    : defaultOptions
 
   return (
     <SelectLayout
-      hasSelectedItem={!isNil(selectedItem)}
+      hasSelectedItem={hasSelectedItem}
       id={id}
       inputProps={{
-        ...getToggleButtonProps({
-          onFocus: onInputFocusHandler,
-          onMouseDown: (event) => {
-            // This is crucial for correct focus and click behavior
-            // Without this, Downshift internal state gets mixed up
-            event.preventDefault()
-          },
-        }),
+        ...getToggleButtonProps(toggleButtonOptions),
         ref: mergeRefs([inputRef, triggerRef]),
         'aria-expanded': undefined,
       }}
@@ -90,12 +196,10 @@ export const Select = ({
       menuProps={getMenuProps({
         onKeyDown: onMenuKeyDownHandler,
       })}
-      onClearButtonClick={() => {
-        reset()
-      }}
+      onClearButtonClick={handleClearButtonClick}
       toggleButtonProps={getToggleButtonProps()}
-      tooltipText={selectedItemText}
-      value={selectedItemText}
+      tooltipText={displayText}
+      value={displayText}
       popupPosition={popupPosition}
       {...{
         readOnly: true,
@@ -104,6 +208,10 @@ export const Select = ({
     >
       {isOpen &&
         filteredItems.map((child, index) => {
+          const isSelected = isMulti
+            ? selectedItems.includes(child.props.value)
+            : selectedItem === child.props.value
+
           return React.cloneElement(child, {
             ...child.props,
             ...getItemProps({
@@ -113,6 +221,8 @@ export const Select = ({
               key: `select-option-${child.props.value}`,
             }),
             isHighlighted: highlightedIndex === index,
+            isSelected,
+            showCheckbox: isMulti,
             title: child.props.children,
           })
         })}

--- a/packages/react-component-library/src/components/Select/SelectOption.tsx
+++ b/packages/react-component-library/src/components/Select/SelectOption.tsx
@@ -3,12 +3,12 @@ import React from 'react'
 import { SelectBaseOption, SelectBaseOptionAsStringProps } from '../SelectBase'
 
 export interface SelectOptionProps
-  extends Omit<SelectBaseOptionAsStringProps, 'title'> {
-  isDisabled?: boolean
-}
+  extends Omit<SelectBaseOptionAsStringProps, 'title'> {}
 
 export const SelectOption = React.forwardRef<HTMLLIElement, SelectOptionProps>(
-  (props, ref) => <SelectBaseOption {...props} ref={ref} />
+  (props, ref) => {
+    return <SelectBaseOption {...props} ref={ref} />
+  }
 )
 
 SelectOption.displayName = 'SelectOption'

--- a/packages/react-component-library/src/components/Select/helpers/multiSelectHelpers.ts
+++ b/packages/react-component-library/src/components/Select/helpers/multiSelectHelpers.ts
@@ -1,0 +1,48 @@
+import { useMultipleSelection, useSelect } from 'downshift'
+
+/**
+ * Maps Downshift state change types to their corresponding actions
+ */
+const MULTI_SELECTION_REMOVE_ACTIONS = new Set<string>([
+  useMultipleSelection.stateChangeTypes.SelectedItemKeyDownBackspace,
+  useMultipleSelection.stateChangeTypes.SelectedItemKeyDownDelete,
+  useMultipleSelection.stateChangeTypes.DropdownKeyDownBackspace,
+  useMultipleSelection.stateChangeTypes.FunctionRemoveSelectedItem,
+])
+
+const SELECT_ITEM_ACTIONS = new Set<string>([
+  useSelect.stateChangeTypes.MenuKeyDownEnter,
+  useSelect.stateChangeTypes.MenuKeyDownSpaceButton,
+  useSelect.stateChangeTypes.ItemClick,
+])
+
+/**
+ * Determines if the state change type represents a removal action in multi-select
+ */
+export function isRemovalAction(type: string): boolean {
+  return MULTI_SELECTION_REMOVE_ACTIONS.has(type)
+}
+
+/**
+ * Determines if the state change type represents an item selection action
+ */
+export function isSelectionAction(type: string): boolean {
+  return SELECT_ITEM_ACTIONS.has(type)
+}
+
+/**
+ * Toggles an item in the selected items array
+ * If item exists, removes it. If it doesn't exist, adds it.
+ */
+export function toggleItemInArray(
+  items: string[],
+  itemToToggle: string
+): string[] {
+  const index = items.indexOf(itemToToggle)
+
+  if (index === -1) {
+    return [...items, itemToToggle]
+  }
+
+  return items.filter((_, i) => i !== index)
+}

--- a/packages/react-component-library/src/components/Select/hooks/useDisplayText.ts
+++ b/packages/react-component-library/src/components/Select/hooks/useDisplayText.ts
@@ -1,0 +1,100 @@
+import { useState, useEffect, useMemo, useCallback, RefObject } from 'react'
+import { isNil } from 'lodash'
+
+const FULL_TEXT_BUFFER = 60
+
+interface UseDisplayTextParams {
+  isMulti: boolean
+  selectedItem: string | null
+  selectedItems: string[]
+  itemsMap: Record<string, React.ReactElement>
+  inputRef: RefObject<HTMLInputElement>
+}
+
+export const useDisplayText = ({
+  isMulti,
+  selectedItem,
+  selectedItems,
+  itemsMap,
+  inputRef,
+}: UseDisplayTextParams): string => {
+  const [useMultipleText, setUseMultipleText] = useState(false)
+
+  const getFullText = useCallback(
+    (selectedValues: string[]): string => {
+      if (selectedValues.length === 0) {
+        return ''
+      }
+
+      return selectedValues
+        .map((itemValue) => itemsMap[itemValue]?.props.children || itemValue)
+        .sort((a, b) => a.localeCompare(b))
+        .join(', ')
+    },
+    [itemsMap]
+  )
+
+  const displayText = useMemo(() => {
+    if (!isMulti) {
+      return isNil(selectedItem) ? '' : itemsMap[selectedItem].props.children
+    }
+
+    return useMultipleText ? 'Multiple selected' : getFullText(selectedItems)
+  }, [
+    isMulti,
+    selectedItem,
+    itemsMap,
+    useMultipleText,
+    getFullText,
+    selectedItems,
+  ])
+
+  useEffect(() => {
+    if (!isMulti || !inputRef.current) {
+      return () => {}
+    }
+
+    const checkTextFit = () => {
+      if (!inputRef.current) {
+        return
+      }
+
+      // Having one item means we always want to show it regardless of how long the text is
+      if (selectedItems.length === 1) {
+        setUseMultipleText(false)
+        return
+      }
+
+      const fullText = getFullText(selectedItems)
+      const inputWidth = inputRef.current.offsetWidth
+
+      // Measure text width using canvas
+      const canvas = document.createElement('canvas')
+      const context = canvas.getContext('2d')
+      if (!context) {
+        setUseMultipleText(false)
+        return
+      }
+
+      const computedStyle = globalThis.getComputedStyle(inputRef.current)
+      context.font = `${computedStyle.fontSize} ${computedStyle.fontFamily}`
+      const textWidth = context.measureText(fullText).width
+
+      setUseMultipleText(textWidth > inputWidth - FULL_TEXT_BUFFER)
+    }
+
+    checkTextFit()
+
+    const resizeObserver = new ResizeObserver(() => {
+      checkTextFit()
+    })
+
+    resizeObserver.observe(inputRef.current)
+
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [inputRef, isMulti, getFullText, selectedItems])
+
+  return displayText
+}

--- a/packages/react-component-library/src/components/Select/hooks/useMultiSelect.ts
+++ b/packages/react-component-library/src/components/Select/hooks/useMultiSelect.ts
@@ -1,0 +1,49 @@
+import { useCallback, useMemo, useState } from 'react'
+import { SelectProps } from '../Select'
+
+interface UseMultiSelectOptions {
+  isMulti: boolean
+  initialValue?: SelectProps['initialValue']
+  value: SelectProps['value']
+}
+
+export function useMultiSelect({
+  isMulti,
+  initialValue,
+  value,
+}: UseMultiSelectOptions): {
+  selectedItems: string[]
+  setSelectedItems: (selectedItems: string[]) => void
+} {
+  const isControlled = value !== undefined
+
+  const [selectedItems, setSelectedItems] = useState<string[]>(() => {
+    if (isMulti && initialValue && Array.isArray(initialValue)) {
+      return initialValue
+    }
+
+    return []
+  })
+
+  const currentSelectedItems = useMemo(() => {
+    if (!isMulti) {
+      return []
+    }
+
+    return isControlled && Array.isArray(value) ? value : selectedItems
+  }, [isMulti, isControlled, value, selectedItems])
+
+  const setSelectedItemsIfNotControlled = useCallback(
+    (newSelectedItems: string[]) => {
+      if (!isControlled) {
+        setSelectedItems(newSelectedItems)
+      }
+    },
+    [isControlled, setSelectedItems]
+  )
+
+  return {
+    selectedItems: currentSelectedItems,
+    setSelectedItems: setSelectedItemsIfNotControlled,
+  }
+}

--- a/packages/react-component-library/src/components/SelectBase/SelectBaseOption.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectBaseOption.tsx
@@ -5,6 +5,8 @@ import { StyledOption } from './partials/StyledOption'
 import { StyledOptionBadge } from './partials/StyledOptionBadge'
 import { StyledOptionText } from './partials/StyledOptionText'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { CHECKBOX_RADIO_VARIANT } from '../CheckboxRadioBase'
+import { StyledCheckbox } from './partials/StyledCheckbox'
 
 type CustomBadgeProps = Omit<BadgeProps, 'children'>
 
@@ -16,6 +18,8 @@ export interface SelectBaseOptionProps extends ComponentWithClass {
   value: string
   title?: string
   isDisabled?: boolean
+  showCheckbox?: boolean
+  isSelected?: boolean
 }
 
 export interface SelectBaseOptionAsStringProps extends SelectBaseOptionProps {
@@ -35,6 +39,8 @@ export const SelectBaseOption = React.forwardRef<
       isHighlighted,
       title,
       isDisabled,
+      showCheckbox,
+      isSelected,
       ...rest
     },
     ref
@@ -47,6 +53,13 @@ export const SelectBaseOption = React.forwardRef<
         disabled={isDisabled}
         {...rest}
       >
+        {showCheckbox && (
+          <StyledCheckbox
+            isDisabled={isDisabled}
+            checked={isSelected}
+            variant={CHECKBOX_RADIO_VARIANT.NO_CONTAINER}
+          />
+        )}
         {icon}
         <StyledOptionText title={title}>{children}</StyledOptionText>
         {badge && (

--- a/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
+++ b/packages/react-component-library/src/components/SelectBase/SelectBaseProps.ts
@@ -2,10 +2,10 @@ import { ComponentWithClass } from '../../common/ComponentWithClass'
 
 import { SelectChildrenType } from './types'
 
-export type OnChangeType = (value: string | null) => void
+export type OnChangeType<T = string | null> = (value: T) => void
 export type PopupPosition = 'above' | 'below' // | 'auto'
 
-export interface SelectBaseProps extends ComponentWithClass {
+export interface SelectBaseProps<T = string | null> extends ComponentWithClass {
   /**
    * Collection of options to display within the Select.
    */
@@ -21,7 +21,7 @@ export interface SelectBaseProps extends ComponentWithClass {
   /**
    * The initially selected item when the component is uncontrolled.
    */
-  initialValue?: string | null
+  initialValue?: T
   /**
    * Toggles whether the component is disabled or not (preventing user interaction).
    */
@@ -41,9 +41,9 @@ export interface SelectBaseProps extends ComponentWithClass {
   /**
    * Optional handler invoked when the selected value changes.
    */
-  onChange?: OnChangeType
+  onChange?: OnChangeType<T>
   /**
    * The selected value when the component is controlled.
    */
-  value?: string | null
+  value?: T
 }

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -36,13 +36,13 @@ export interface SelectLayoutProps extends ComponentWithClass {
   hideClearButton?: boolean
   label: string
   menuProps:
-  | ReturnType<ComboboxReturnValueType['getMenuProps']>
-  | ReturnType<SelectReturnValueType['getMenuProps']>
+    | ReturnType<ComboboxReturnValueType['getMenuProps']>
+    | ReturnType<SelectReturnValueType['getMenuProps']>
   onChange?: (value: string | null) => void
   onClearButtonClick: (event: React.MouseEvent<HTMLButtonElement>) => void
   toggleButtonProps:
-  | ReturnType<ComboboxReturnValueType['getToggleButtonProps']>
-  | ReturnType<SelectReturnValueType['getToggleButtonProps']>
+    | ReturnType<ComboboxReturnValueType['getToggleButtonProps']>
+    | ReturnType<SelectReturnValueType['getToggleButtonProps']>
   tooltipText: string
   value?: string
   popupPosition?: PopupPosition

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledCheckbox.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledCheckbox.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+import { Checkbox } from '../../Checkbox'
+
+export const StyledCheckbox = styled(Checkbox)`
+  transform: translateY(-4px);
+  margin-right: 8px;
+`


### PR DESCRIPTION
## Overview

Add a multi-select variant onto the current select component, maintaining backwards compatibility

## Reason

Required for DNADB-989

## Work carried out

- [x] Add a new isMulti prop into the Select to enable multi-select
- [x] Add new storybooks for the isMulti Select variant
- [x] Fix styling issues with the slight vertical offset on the checkbox
- [x] Decide on the order of icon -> checkbox -> text -> badge or checkbox -> icon -> text -> badge (I think option 2 is correct but isn't the current behaviour, see storybook preview)
- [x] Add unit tests for isMulti variant
