### PR TITLE
build(Release): Use OIDC trusted publishing for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
   release:
     name: 'Release & Publish'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC trusted publishing
+      contents: write  # Required for creating releases
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -32,6 +35,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install
@@ -70,8 +76,6 @@ jobs:
 
       - name: Publish NPM packages
         if: steps.initversion.outputs.version != steps.extractver.outputs.version
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         run: |
           npm publish --tag latest ./packages/design-tokens
           npm publish --tag latest ./packages/eslint-config-react


### PR DESCRIPTION
## Overview

Updated the release workflow to use NPM's new trusted publishing with OIDC authentication instead of token-based authentication, improving security by using short-lived, automatically-managed credentials.

## Reason

NPM has introduced trusted publishing as the recommended authentication method for publishing packages from CI/CD environments. This approach is more secure than using long-lived tokens as it uses OIDC tokens that are automatically generated per workflow run and cannot be extracted or compromised.

## Work carried out

- [x] Added OIDC permissions (`id-token: write`) to the release job
- [x] Added step to update npm to latest version (required for trusted publishing support)
- [x] Removed `NODE_AUTH_TOKEN` secret usage from publish step
- [x] Configured trusted publishers on npmjs.com for all 5 packages

## Developer notes

- Trusted publishers have been configured on npmjs.com for each package
- The workflow will now authenticate using OIDC tokens generated by GitHub Actions
- Provenance attestations will be automatically generated for published packages
- The `NPM_AUTH_TOKEN` repository secret can be deleted once this is merged and verified working
- Reference: https://docs.npmjs.com/trusted-publishers