### PR TITLE
fix(Select): Resolve errors cause by select isMulti feature

### DIFF
--- a/packages/react-component-library/src/components/Select/Select.stories.tsx
+++ b/packages/react-component-library/src/components/Select/Select.stories.tsx
@@ -135,7 +135,9 @@ export const AutoPositioning: StoryFn<typeof Select> = (args) => (
   <StyledBottomRightWrapper>
     <Select {...args}>
       {OPTIONS.map((x) => (
-        <SelectOption value={x.value}>{x.text}</SelectOption>
+        <SelectOption key={x.value} value={x.value}>
+          {x.text}
+        </SelectOption>
       ))}
     </Select>
   </StyledBottomRightWrapper>
@@ -157,7 +159,9 @@ export const MultiSelect: StoryFn<typeof Select> = (args) => (
   <StyledWrapper $isDisabled={args.isDisabled}>
     <Select {...args} isMulti>
       {OPTIONS.map((x) => (
-        <SelectOption value={x.value}>{x.text}</SelectOption>
+        <SelectOption key={x.value} value={x.value}>
+          {x.text}
+        </SelectOption>
       ))}
     </Select>
   </StyledWrapper>
@@ -169,7 +173,7 @@ export const MultiSelectWithDisabledOptions: StoryFn<typeof Select> = (
   <StyledWrapper>
     <Select {...args} isMulti>
       {OPTIONS.map((x, i) => (
-        <SelectOption value={x.value} isDisabled={i % 2 === 0}>
+        <SelectOption key={x.value} value={x.value} isDisabled={i % 2 === 0}>
           {x.text}
         </SelectOption>
       ))}
@@ -195,7 +199,9 @@ export const MultiSelectValue: StoryFn<typeof Select> = (args) => {
         }}
       >
         {OPTIONS.map((x) => (
-          <SelectOption value={x.value}>{x.text}</SelectOption>
+          <SelectOption key={x.value} value={x.value}>
+            {x.text}
+          </SelectOption>
         ))}
       </Select>
     </StyledWrapper>

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -171,27 +171,23 @@ export const Select = (props: SelectProps) => {
     [isMulti, selectedItems, selectedItem]
   )
 
-  const defaultOptions = {
-    onFocus: onInputFocusHandler,
-    onMouseDown: (event: React.MouseEvent<HTMLInputElement>) => {
-      // This is crucial for correct focus and click behavior
-      // Without this, Downshift internal state gets mixed up
-      event.preventDefault()
-    },
-  }
-  const toggleButtonOptions = isMulti
-    ? multipleSelection.getDropdownProps(defaultOptions)
-    : defaultOptions
-
   return (
     <SelectLayout
       hasSelectedItem={hasSelectedItem}
       id={id}
       inputProps={{
-        ...getToggleButtonProps(toggleButtonOptions),
+        ...getToggleButtonProps({
+          onFocus: onInputFocusHandler,
+          onMouseDown: (event) => {
+            // This is crucial for correct focus and click behavior
+            // Without this, Downshift internal state gets mixed up
+            event.preventDefault()
+          },
+        }),
         ref: mergeRefs([inputRef, triggerRef]),
         'aria-expanded': undefined,
       }}
+      inputWrapperProps={multipleSelection.getDropdownProps()}
       isOpen={isOpen}
       menuProps={getMenuProps({
         onKeyDown: onMenuKeyDownHandler,


### PR DESCRIPTION
## Overview

Resolve errors cause by select isMulti feature

## Reason

Some missed non-breaking console errors when the select was in multi mode which are resolved in this PR

## Work carried out

- [x] Fix console errors

## Developer notes

Load up the storybook and try and Select and isMulti variants, view that no errors now exist but functionality maintains complete