### PR TITLE
feat(Switch): Add variants to the switch options

### DIFF
--- a/packages/react-component-library/src/components/Switch/Switch.stories.tsx
+++ b/packages/react-component-library/src/components/Switch/Switch.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { StoryFn, Meta } from '@storybook/react'
 
-import { Switch, SwitchOption } from '.'
+import { Switch, SwitchOption, SWITCH_OPTION_VARIANT } from '.'
 import { COMPONENT_SIZE } from '../Forms'
 
 export default {
@@ -59,3 +59,28 @@ Small.args = {
   name: 'switch-small',
   size: COMPONENT_SIZE.SMALL,
 }
+
+export const Variants: StoryFn = () => (
+  <Switch key="variants" name="switch-variants" value="2">
+    <SwitchOption
+      label="Primary"
+      value="1"
+      variant={SWITCH_OPTION_VARIANT.PRIMARY}
+    />
+    <SwitchOption
+      label="Secondary"
+      value="2"
+      variant={SWITCH_OPTION_VARIANT.SECONDARY}
+    />
+    <SwitchOption
+      label="Tertiary"
+      value="3"
+      variant={SWITCH_OPTION_VARIANT.TERTIARY}
+    />
+    <SwitchOption
+      label="Danger"
+      value="4"
+      variant={SWITCH_OPTION_VARIANT.DANGER}
+    />
+  </Switch>
+)

--- a/packages/react-component-library/src/components/Switch/SwitchOption.tsx
+++ b/packages/react-component-library/src/components/Switch/SwitchOption.tsx
@@ -1,8 +1,12 @@
 import React, { useRef } from 'react'
 
 import { ComponentWithClass } from '../../common/ComponentWithClass'
+import { ValueOf } from '../../helpers'
+import { SWITCH_OPTION_VARIANT } from './constants'
 import { StyledSwitchOption } from './partials/StyledSwitchOption'
 import { SwitchInput } from './partials/SwitchInput'
+
+export type SwitchOptionVariantType = ValueOf<typeof SWITCH_OPTION_VARIANT>
 
 export interface SwitchOptionProps extends ComponentWithClass {
   /**
@@ -33,6 +37,10 @@ export interface SwitchOptionProps extends ComponentWithClass {
    */
   isActive?: boolean
   /**
+   * Type of component to display (style varies accordingly).
+   */
+  variant?: SwitchOptionVariantType
+  /**
    * Handler invoked when the option is selected by end user.
    * @private
    */
@@ -47,6 +55,7 @@ export const SwitchOption = ({
   id,
   isActive,
   onChange,
+  variant = SWITCH_OPTION_VARIANT.PRIMARY,
 }: SwitchOptionProps) => {
   const localRef = useRef<HTMLInputElement>(null)
 
@@ -64,6 +73,7 @@ export const SwitchOption = ({
       htmlFor={`${id}-${label}`}
       $isActive={isActive}
       $isDisabled={isDisabled}
+      $variant={variant}
       aria-current={isActive}
       onKeyDown={handleKeyDown}
       tabIndex={0}

--- a/packages/react-component-library/src/components/Switch/constants.ts
+++ b/packages/react-component-library/src/components/Switch/constants.ts
@@ -1,0 +1,8 @@
+const SWITCH_OPTION_VARIANT = {
+  PRIMARY: 'primary',
+  SECONDARY: 'secondary',
+  TERTIARY: 'tertiary',
+  DANGER: 'danger',
+} as const
+
+export { SWITCH_OPTION_VARIANT }

--- a/packages/react-component-library/src/components/Switch/index.ts
+++ b/packages/react-component-library/src/components/Switch/index.ts
@@ -1,2 +1,3 @@
 export * from './Switch'
 export * from './SwitchOption'
+export * from './constants'

--- a/packages/react-component-library/src/components/Switch/partials/StyledSwitchOption.tsx
+++ b/packages/react-component-library/src/components/Switch/partials/StyledSwitchOption.tsx
@@ -1,9 +1,85 @@
 import styled, { css } from 'styled-components'
 import { color, spacing } from '@royalnavy/design-tokens'
 
+import { SWITCH_OPTION_VARIANT } from '../constants'
+import { SwitchOptionVariantType } from '../SwitchOption'
+
 interface StyledSwitchOptionProps {
   $isActive?: boolean
   $isDisabled?: boolean
+  $variant?: SwitchOptionVariantType
+}
+
+type VariantActiveStyle = {
+  backgroundColor: string
+  color: string
+  borderColor: string
+  focusBorderColor: string
+  focusBoxShadow: string
+}
+
+const VARIANT_ACTIVE_STYLES: Record<string, VariantActiveStyle> = {
+  [SWITCH_OPTION_VARIANT.PRIMARY]: {
+    backgroundColor: color('action', '600'),
+    color: color('neutral', 'white'),
+    borderColor: color('action', '600'),
+    focusBorderColor: color('action', '500'),
+    focusBoxShadow: `0 0 0 2px ${color('action', '500')}, 0 0 0 5px ${color(
+      'action',
+      '100'
+    )}`,
+  },
+  [SWITCH_OPTION_VARIANT.SECONDARY]: {
+    backgroundColor: color('action', '100'),
+    color: color('action', '800'),
+    borderColor: color('action', '600'),
+    focusBorderColor: color('action', '500'),
+    focusBoxShadow: `0 0 0 2px ${color('action', '500')}, 0 0 0 5px ${color(
+      'action',
+      '100'
+    )}`,
+  },
+  [SWITCH_OPTION_VARIANT.TERTIARY]: {
+    backgroundColor: color('neutral', 'white'),
+    color: color('action', '600'),
+    borderColor: color('action', '600'),
+    focusBorderColor: color('action', '500'),
+    focusBoxShadow: `0 0 0 2px ${color('action', '500')}, 0 0 0 5px ${color(
+      'action',
+      '100'
+    )}`,
+  },
+  [SWITCH_OPTION_VARIANT.DANGER]: {
+    backgroundColor: color('danger', '700'),
+    color: color('neutral', 'white'),
+    borderColor: color('danger', '700'),
+    focusBorderColor: color('danger', '700'),
+    focusBoxShadow: `0 0 0 2px ${color('danger', '700')}, 0 0 0 5px ${color(
+      'danger',
+      '100'
+    )}`,
+  },
+}
+
+function getVariantActiveStyles(
+  $variant: SwitchOptionVariantType = SWITCH_OPTION_VARIANT.PRIMARY
+) {
+  const styles = VARIANT_ACTIVE_STYLES[$variant]
+  return css`
+    background-color: ${styles.backgroundColor};
+    color: ${styles.color};
+    border-color: ${styles.borderColor};
+    cursor: default;
+    outline: none;
+    z-index: 1;
+
+    &:focus-within,
+    &:active {
+      outline: none;
+      border-color: ${styles.focusBorderColor};
+      box-shadow: ${styles.focusBoxShadow};
+    }
+  `
 }
 
 export const StyledSwitchOption = styled.label<StyledSwitchOptionProps>`
@@ -44,24 +120,7 @@ export const StyledSwitchOption = styled.label<StyledSwitchOptionProps>`
       }
     `}
 
-  ${({ $isActive }) =>
-    $isActive &&
-    css`
-      background-color: ${color('action', '600')};
-      color: ${color('neutral', 'white')};
-      border-color: ${color('action', '600')};
-      cursor: default;
-      outline: none;
-
-      &:focus-within,
-      &:active {
-        z-index: 1;
-        outline: none;
-        border-color: ${color('action', '500')};
-        box-shadow: 0 0 0 2px ${color('action', '500')},
-          0 0 0 5px ${color('action', '100')};
-      }
-    `}
+  ${({ $isActive, $variant }) => $isActive && getVariantActiveStyles($variant)}
 
   ${({ $isDisabled, $isActive }) =>
     !$isDisabled &&


### PR DESCRIPTION
## Overview

Add variants to the switch options

## Reason

Adds variants to the switch options, allowing the component to act more like a toggle between a positive and negative option when required.

## Work carried out

- [x] Added variants prop to the `SwitchOptions.ts` in a similar way to that way variants are applied to Buttons.
- [x] Added storybook example for the new variants.
- [x] Fixed a bug caused by z-index fighting on the left border when a switch option is selected. This become more apparent when using the secondary/tertiary variants.

## Storybook Preview

https://662fa7538d7e8c16b93a98a6-omcejhddus.chromatic.com/?path=/story/components-switch--variants
