### PR TITLE
feat(SectionDivider): Add icon support to the left of the title

### DIFF
--- a/packages/react-component-library/src/components/SectionDivider/SectionDivider.stories.tsx
+++ b/packages/react-component-library/src/components/SectionDivider/SectionDivider.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { StoryFn, Meta } from '@storybook/react'
+import { IconInbox } from '@royalnavy/icon-library'
 
 import { SectionDivider } from './index'
 
@@ -39,3 +40,12 @@ DescriptionTitle.args = {
     "She must have hidden the plans in the escape pod. Send a detachment down to retrieve them, and see to it personally, Commander. There'll be no one to stop us this time! Don't underestimate the Force.",
 }
 DescriptionTitle.storyName = 'Title & Description'
+
+export const WithIcon = Template.bind({})
+WithIcon.args = {
+  icon: <IconInbox size={24} />,
+  title: 'Section title',
+  children:
+    "She must have hidden the plans in the escape pod. Send a detachment down to retrieve them, and see to it personally, Commander. There'll be no one to stop us this time! Don't underestimate the Force.",
+}
+WithIcon.storyName = 'Icon, Title & Description'

--- a/packages/react-component-library/src/components/SectionDivider/SectionDivider.test.tsx
+++ b/packages/react-component-library/src/components/SectionDivider/SectionDivider.test.tsx
@@ -42,4 +42,37 @@ describe('SectionDivider', () => {
       expect(wrapper.queryByText('Example description')).toBeInTheDocument()
     })
   })
+
+  describe('with icon', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <SectionDivider
+          icon={<svg data-testid="example-icon" />}
+          title="Example title"
+        >
+          Example description
+        </SectionDivider>
+      )
+    })
+
+    it('renders the icon', () => {
+      expect(wrapper.queryByTestId('example-icon')).toBeInTheDocument()
+    })
+
+    it('renders the title text', () => {
+      expect(wrapper.queryByText('Example title')).toBeInTheDocument()
+    })
+  })
+
+  describe('without icon', () => {
+    beforeEach(() => {
+      wrapper = render(<SectionDivider title="Example title" />)
+    })
+
+    it('does not render an icon', () => {
+      expect(
+        wrapper.queryByTestId('sectiondivider-icon')
+      ).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/react-component-library/src/components/SectionDivider/SectionDivider.tsx
+++ b/packages/react-component-library/src/components/SectionDivider/SectionDivider.tsx
@@ -1,22 +1,31 @@
 import React from 'react'
 
 import { StyledSectionDivider } from './partials/StyledSectionDivider'
+import { StyledIcon } from './partials/StyledIcon'
 import { StyledTitle } from './partials/StyledTitle'
 import { StyledDescription } from './partials/StyledDescription'
 import { ComponentWithClass } from '../../common/ComponentWithClass'
 
 export interface SectionDividerProps extends ComponentWithClass {
+  /**
+   * Optional icon to display to the left of the title.
+   */
+  icon?: React.ReactNode
   title?: string
   children?: string
 }
 
 export const SectionDivider = ({
+  icon,
   title,
   children,
   className,
 }: SectionDividerProps) => {
   return (
     <StyledSectionDivider className={className}>
+      {icon && (
+        <StyledIcon data-testid="sectiondivider-icon">{icon}</StyledIcon>
+      )}
       {title && (
         <StyledTitle data-testid="sectiondivider-title">{title}</StyledTitle>
       )}

--- a/packages/react-component-library/src/components/SectionDivider/partials/StyledDescription.tsx
+++ b/packages/react-component-library/src/components/SectionDivider/partials/StyledDescription.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import { color, fontSize } from '@royalnavy/design-tokens'
 
 export const StyledDescription = styled.p`
+  grid-area: description;
   color: ${color('neutral', '400')};
   font-size: ${fontSize('m')};
 `

--- a/packages/react-component-library/src/components/SectionDivider/partials/StyledIcon.tsx
+++ b/packages/react-component-library/src/components/SectionDivider/partials/StyledIcon.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { color } from '@royalnavy/design-tokens'
+
+export const StyledIcon = styled.span`
+  grid-area: icon;
+  display: flex;
+  align-items: center;
+  align-self: center;
+  margin-right: 8px;
+  color: ${color('neutral', '600')};
+`

--- a/packages/react-component-library/src/components/SectionDivider/partials/StyledSectionDivider.tsx
+++ b/packages/react-component-library/src/components/SectionDivider/partials/StyledSectionDivider.tsx
@@ -2,6 +2,12 @@ import styled from 'styled-components'
 import { color } from '@royalnavy/design-tokens'
 
 export const StyledSectionDivider = styled.div`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-areas:
+    'icon title'
+    'description description';
+  row-gap: 8px;
   border-bottom: 1px solid ${color('neutral', '100')};
   padding: 8px 0;
 `

--- a/packages/react-component-library/src/components/SectionDivider/partials/StyledTitle.tsx
+++ b/packages/react-component-library/src/components/SectionDivider/partials/StyledTitle.tsx
@@ -2,13 +2,10 @@ import styled from 'styled-components'
 import { color, fontSize } from '@royalnavy/design-tokens'
 
 export const StyledTitle = styled.span`
+  grid-area: title;
+  align-self: center;
   display: block;
-  padding-bottom: 8px;
   color: ${color('neutral', '600')};
   font-size: ${fontSize('l')};
   font-weight: 700;
-
-  &:only-child {
-    padding-bottom: 0;
-  }
 `


### PR DESCRIPTION
## Related issue

N/A

## Overview

Adds an optional `icon` prop to `SectionDivider`, rendered to the left of the title. The component now uses a CSS grid so the icon sits beside the title (vertically centred against the title text) while the description spans the full width below. When no `icon` is supplied, the existing DOM, styling, and spacing are unchanged.

## Reason

Consumers (e.g. section headings on a landing page) need an icon alongside the `SectionDivider` title. Previously this had to be hacked in around the component; supporting it natively keeps the title/icon alignment correct and reusable.

## Work carried out

- [x] Add optional `icon?: React.ReactNode` prop to `SectionDivider`
- [x] Lay out icon/title/description with CSS grid, keeping title & description as direct children (preserves the existing `className` drilling behaviour)
- [x] Centre the icon against the title text (move the title's bottom gap to a grid `row-gap`)
- [x] Add `Icon, Title & Description` Storybook story
- [x] Add tests covering icon present / absent

## Screenshot

<img width="1553" height="379" alt="Screenshot 2026-06-15 at 14 35 36" src="https://github.com/user-attachments/assets/ef0353fe-98c0-4b5b-9cbf-45b29ef2804c" />

## Developer notes

- Backwards compatible: with no `icon`, output is structurally and visually identical to before. The empty grid column collapses to zero width, so existing usages are unaffected.
- Icon colour inherits via `currentColor` (defaults to `neutral.600`); consumers control size by passing e.g. `<IconInbox size={24} />`.