### PR TITLE
ci(Sonar): Migrate to sonarqube-scan-action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -116,8 +116,8 @@ jobs:
         run: |
           pnpm --prefix packages/react-component-library run test --ci --coverage --silent --no-cache --reporters=default --reporters=jest-junit --runInBand --testResultsProcessor=jest-sonar-reporter
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v2
+      - name: SonarQube Cloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
         if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Related issue

N/A

## Overview

Replaces the deprecated `SonarSource/sonarcloud-github-action@v2` with the maintained `SonarSource/sonarqube-scan-action@v5` in the Build & Test workflow.

## Reason

The old action bootstraps a scanner that hits legacy SonarCloud endpoints and now fails against SonarQube Cloud with `HTTP 404 on https://api.sonarcloud.io/analysis/analyses`. SonarSource has deprecated `sonarcloud-github-action` in favour of `sonarqube-scan-action`.

## Work carried out

- [x] Swap the SonarCloud scan step to `sonarqube-scan-action@v5` (same `SONAR_TOKEN`/`GITHUB_TOKEN`, same run condition, `sonar-project.properties` unchanged)

## Developer notes

- Surfaced on https://github.com/Royal-Navy/design-system/pull/4050 — the first non-dependabot PR in months to actually run the Sonar step.
- If the 404 persists after this, check whether Automatic Analysis is enabled on the project (Administration → Analysis Method), as it rejects CI-based analysis.

## How to test

CI: the `Test_react-component-library` job's Sonar step should complete instead of erroring with the 404.