### PR TITLE
fix(Select): Fix focus ring when dropdown opens above

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/partials/StyledFooter.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledFooter.tsx
@@ -1,4 +1,4 @@
-import { spacing } from '@royalnavy/design-tokens'
+import { spacing, zIndex } from '@royalnavy/design-tokens'
 import styled, { css } from 'styled-components'
 
 export const StyledFooter = styled.div<{ $isFullWidth: boolean }>`
@@ -10,6 +10,9 @@ export const StyledFooter = styled.div<{ $isFullWidth: boolean }>`
   ${({ $isFullWidth }) =>
     $isFullWidth
       ? css`
+          position: relative;
+          z-index: ${zIndex('dropdown', 1)};
+
           & > *:nth-child(1) {
             flex: 0 0 auto;
             margin-right: auto;

--- a/packages/react-component-library/src/components/Select/Select.test.tsx
+++ b/packages/react-component-library/src/components/Select/Select.test.tsx
@@ -372,7 +372,7 @@ describe('Select', () => {
         }))
 
         wrapper = render(
-          <Select label="default props">
+          <Select label="default props" initialIsOpen>
             <SelectOption value="one">One</SelectOption>
             <SelectOption value="two">Two</SelectOption>
             <SelectOption value="three">Three</SelectOption>
@@ -399,6 +399,17 @@ describe('Select', () => {
         expect(optionsWrapper).toHaveStyleRule('top', '0', {
           modifier: '::before',
         })
+        expect(optionsWrapper).toHaveStyleRule(
+          'box-shadow',
+          expect.stringContaining('3px'),
+          {
+            modifier: '::before',
+          }
+        )
+        expect(wrapper.getByTestId('select-outer-wrapper')).toHaveStyleRule(
+          'border-radius',
+          '0 0 12px 12px'
+        )
       })
     })
   })

--- a/packages/react-component-library/src/components/Select/Select.tsx
+++ b/packages/react-component-library/src/components/Select/Select.tsx
@@ -46,7 +46,6 @@ export const Select = (props: SelectProps) => {
 
   const id = useExternalId('select', externalId)
   const inputRef = useRef<HTMLInputElement>(null)
-  const { triggerRef, popupPosition } = useDropdownDirection()
 
   const filteredItems = React.Children.toArray(children).filter(
     React.isValidElement<SelectOptionProps>
@@ -144,6 +143,8 @@ export const Select = (props: SelectProps) => {
     items,
     ...(isMulti ? isMultiHookOptions : isSingleHookOptions),
   })
+
+  const { triggerRef, popupPosition } = useDropdownDirection(230, isOpen)
 
   const { onInputFocusHandler } = useMenuVisibility(isOpen, openMenu)
   const { onMenuKeyDownHandler } = useSelectMenu(inputRef)

--- a/packages/react-component-library/src/components/Select/hooks/useDropdownDirection.ts
+++ b/packages/react-component-library/src/components/Select/hooks/useDropdownDirection.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { PopupPosition } from '../../SelectBase/SelectBaseProps'
 
-export function useDropdownDirection(dropdownHeight = 230) {
+export function useDropdownDirection(dropdownHeight = 230, isOpen = false) {
   const triggerRef = useRef<HTMLElement>(null)
   const [popupPosition, setPopupPosition] = useState<PopupPosition>('below')
 
@@ -25,14 +25,20 @@ export function useDropdownDirection(dropdownHeight = 230) {
   useEffect(() => {
     checkDirection()
 
-    window.addEventListener('scroll', checkDirection)
+    window.addEventListener('scroll', checkDirection, true)
     window.addEventListener('resize', checkDirection)
 
     return () => {
-      window.removeEventListener('scroll', checkDirection)
+      window.removeEventListener('scroll', checkDirection, true)
       window.removeEventListener('resize', checkDirection)
     }
   }, [checkDirection])
+
+  useEffect(() => {
+    if (isOpen) {
+      checkDirection()
+    }
+  }, [isOpen, checkDirection])
 
   return { triggerRef, popupPosition, checkDirection }
 }

--- a/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
+++ b/packages/react-component-library/src/components/SelectBase/SelectLayout.tsx
@@ -91,6 +91,7 @@ export const SelectLayout = ({
             $hasFocus={isOpen}
             $isDisabled={isDisabled}
             $isInvalid={isInvalid}
+            $popupPosition={popupPosition}
             data-testid="select-outer-wrapper"
           >
             <StyledInputWrapper

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledOptionsWrapper.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledOptionsWrapper.tsx
@@ -68,9 +68,10 @@ function getBoxShadow(position: PopupPosition = 'below') {
       bottom: -${TEXT_INPUT_INPUT_HEIGHT[COMPONENT_SIZE.FORMS]};
       top: 0;
       box-shadow: 0 0 0 3px ${color('action', '500')},
-      0 0 0 6px ${color('action', '100')}, 0 2px 22px rgba(0, 0, 0, 0.2);
+        0 0 0 6px ${color('action', '100')}, 0 2px 22px rgba(0, 0, 0, 0.2);
       pointer-events: none;
       border-radius: ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
+    }
   `
 }
 
@@ -78,11 +79,12 @@ export const StyledOptionsWrapper = styled.div<StyledOptionsWrapperProps>`
   display: ${({ $isVisible }) => ($isVisible ? 'block' : 'none')};
   z-index: ${zIndex('dropdown', 1)};
   position: absolute;
+  overflow: visible;
   width: 100%;
 
   margin-bottom: 5px;
   border-radius: 0 0 ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]}
-  ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
+    ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]};
 
   ${({ $position }) =>
     $position === 'above' &&
@@ -91,7 +93,8 @@ export const StyledOptionsWrapper = styled.div<StyledOptionsWrapperProps>`
       top: auto;
       margin-bottom: 0;
       margin-top: 5px;
-      border-radius: ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]} ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]} 0 0;
+      border-radius: ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]}
+        ${BORDER_RADIUS[COMPONENT_SIZE.FORMS]} 0 0;
     `}
   background: ${color('neutral', 'white')};
   ${({ $position }) => getTopBorder($position)}

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledOuterWrapper.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledOuterWrapper.tsx
@@ -6,21 +6,32 @@ import {
   StyledOuterWrapper as StyledOuterWrapperBase,
   StyledOuterWrapperProps,
 } from '../../../styled-components/partials/StyledOuterWrapper'
+import { PopupPosition } from '../SelectBaseProps'
+
+interface SelectStyledOuterWrapperProps extends StyledOuterWrapperProps {
+  $popupPosition?: PopupPosition
+}
 
 export const StyledOuterWrapper = styled(
   StyledOuterWrapperBase
-)<StyledOuterWrapperProps>`
+)<SelectStyledOuterWrapperProps>`
   display: inline-flex;
   flex-direction: row;
 
   // Override default styles to fix the slow border fade
   // when the dropdown is visible
-  transition: border-color 10ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 10ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: border-color 10ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
+    box-shadow 10ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 
-  ${({ $hasFocus, $size = COMPONENT_SIZE.FORMS }) => {
+  ${({ $hasFocus, $popupPosition, $size = COMPONENT_SIZE.FORMS }) => {
     if ($hasFocus) {
+      const borderRadius =
+        $popupPosition === 'above'
+          ? `0 0 ${BORDER_RADIUS[$size]} ${BORDER_RADIUS[$size]}`
+          : `${BORDER_RADIUS[$size]} ${BORDER_RADIUS[$size]} 0 0`
+
       return css`
-        border-radius: ${BORDER_RADIUS[$size]} ${BORDER_RADIUS[$size]} 0 0;
+        border-radius: ${borderRadius};
         box-shadow: unset;
       `
     }

--- a/packages/react-component-library/src/components/SelectBase/partials/StyledSelect.tsx
+++ b/packages/react-component-library/src/components/SelectBase/partials/StyledSelect.tsx
@@ -2,4 +2,5 @@ import styled from 'styled-components'
 
 export const StyledSelect = styled.div`
   position: relative;
+  overflow: visible;
 `


### PR DESCRIPTION
## Related issue

N/A

## Overview

Fixes the missing blue focus ring on Select (and Rows per page in DataGrid) when the dropdown opens above the trigger at the viewport edge.

## Reason

Vertical positioning for Select was added in #89eac17f6, but the above-position focus ring had a broken `::before` CSS block (missing closing brace), the trigger used below-only border-radius when open, and the DataGrid footer could paint under the dropdown menu.

## Work carried out

- [x] Fix malformed `getBoxShadow` CSS for above positioning in `StyledOptionsWrapper`
- [x] Apply position-aware border-radius on `StyledOuterWrapper` when open
- [x] Recalculate dropdown direction when the menu opens and on scroll (capture phase)
- [x] Raise DataGrid footer stacking context for full-width layouts
- [x] Allow focus ring overflow on select wrappers
- [x] Add regression tests for above-position box-shadow and border-radius

## How to test

1. Open a DataGrid with pagination (e.g. portal Sent Files / Transfer Queue)
2. Scroll so the footer sits at the bottom of the viewport
3. Open **Rows per page** — confirm the blue focus ring appears on all sides of the menu and trigger