### PR TITLE
fix(DataGrid): Keep footer below floating overlays in z-index stack

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/partials/StyledFooter.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledFooter.tsx
@@ -11,7 +11,10 @@ export const StyledFooter = styled.div<{ $isFullWidth: boolean }>`
     $isFullWidth
       ? css`
           position: relative;
-          z-index: ${zIndex('dropdown', 1)};
+          // Lift the footer's upward-opening "rows per page" dropdown above the
+          // sticky table header (header tier), while staying below floating
+          // overlays such as the DatePicker FloatingBox (dropdown + 1).
+          z-index: ${zIndex('dropdown', 0)};
 
           & > *:nth-child(1) {
             flex: 0 0 auto;


### PR DESCRIPTION
## Related issue

N/A — regression introduced by #4053 (`fix(Select): Fix focus ring when dropdown opens above`).

## Overview

The DataGrid full-width footer was raised to `zIndex('dropdown', 1)` (5001) so its upward-opening "Rows per page" select clears the sticky table header. That value collides exactly with the `FloatingBox` overlay (also `dropdown + 1` / 5001), and on a z-index tie the later DOM element wins — so the footer toolbar paints over the DatePicker calendar. This lowers the footer to `dropdown + 0` (5000): still above the sticky header (`header + 1` / 4001), now below floating overlays.

## Reason

Fix a z-index regression where the DataGrid footer (pagination, download/delete actions, rows-per-page) renders on top of the DatePicker calendar popup, making the lower calendar rows unusable.

## Work carried out

- [x] Lower DataGrid full-width footer `z-index` from `dropdown + 1` to `dropdown + 0`
- [x] Add a comment documenting the intended footer < floating-overlay ordering

## Screenshot

Calendar popup is no longer buried by the footer toolbar.

## Developer notes

- Footer must stay **above** the sticky table header (`header + 1` = 4001) so the upward-opening rows-per-page select isn't clipped, and **below** the `FloatingBox` overlay (`dropdown + 1` = 5001). `dropdown + 0` (5000) satisfies both.
- The in-flight `feat/dark-mode-token-set` branch previously fixed the same bug by globally bumping `FloatingBox` to `dropdown + 2`; that branch has been updated to use this surgical footer fix instead and the global bump reverted, so the two approaches don't diverge on merge.