### PR TITLE
ci(Actions): Bump actions to Node 24 compatible versions

### DIFF
--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -8,19 +8,18 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v3
+    - uses: pnpm/action-setup@v6
       with:
-        version: 9.1.1
         run_install: false
         standalone: true
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version-file: .nvmrc
         cache: pnpm
 
     - name: Cache Node modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: '**/node_modules'
         key: node-modules-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -32,7 +31,7 @@ runs:
 
     - name: Download icon-library and design-tokens
       if: inputs.unpack-prebuilt-libraries
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: dist
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
@@ -31,7 +31,7 @@ jobs:
           tar -czvf dist.tar.gz distil distdt
 
       - name: Persist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: ./dist.tar.gz
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
@@ -53,13 +53,13 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
 
       - name: Check commits
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { runCommitLint } = await import('${{ github.workspace }}/scripts/github-actions/runCommitlint.mjs')
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
@@ -86,7 +86,7 @@ jobs:
     needs: [Build_icon_library, Lint_react-component-library]
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
@@ -102,7 +102,7 @@ jobs:
     needs: [Build_icon_library, Lint_react-component-library]
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
@@ -128,7 +128,7 @@ jobs:
     needs: [Build_icon_library, Lint_react-component-library]
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -143,7 +143,7 @@ jobs:
           tar -czvf /tmp/storybook-static-e2e.tar.gz packages/react-component-library/.static_storybook
 
       - name: Upload Storybook artefact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: storybook-static-e2e
           path: /tmp/storybook-static-e2e.tar.gz
@@ -159,7 +159,7 @@ jobs:
         total_shards: [3]
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
@@ -167,7 +167,7 @@ jobs:
           unpack-prebuilt-libraries: true
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -178,7 +178,7 @@ jobs:
         run: pnpm --prefix packages/react-component-library run test:e2e:install
 
       - name: Download pre-built storybook
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: storybook-static-e2e
           path: /tmp
@@ -191,7 +191,7 @@ jobs:
           NODE_OPTIONS: --dns-result-order=ipv4first
         run: pnpm --prefix packages/react-component-library run test:e2e --shard ${{ matrix.shard }}/${{ matrix.total_shards }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-test-results-${{ matrix.shard }}
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
@@ -220,7 +220,7 @@ jobs:
     needs: [Build_icon_library, Lint_react-component-library]
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
@@ -242,7 +242,7 @@ jobs:
           echo "$CHROMATIC_SLUG" > packages/react-component-library/.static_storybook/slug
 
       - name: Upload Storybook artefact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: storybook-static
           path: packages/react-component-library/.static_storybook
@@ -254,13 +254,13 @@ jobs:
     needs: [Build_storybook]
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: '~/.cache/ms-playwright'
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -268,7 +268,7 @@ jobs:
             playwright-${{ runner.os }}-
 
       - name: Attach workspace
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: storybook-static
           path: packages/react-component-library/.static_storybook

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,15 +24,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment
@@ -35,7 +35,7 @@ jobs:
         run: echo "storybook.design-system.navy.digital.mod.uk" > ./packages/react-component-library/.static_storybook/CNAME
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./packages/react-component-library/.static_storybook
 
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/npmsmoketest.yml
+++ b/.github/workflows/npmsmoketest.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment

--- a/.github/workflows/post_build_and_test.yml
+++ b/.github/workflows/post_build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Git clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -24,7 +24,7 @@ jobs:
         uses: ./.github/actions/prepare-environment
 
       - name: Download pre-built Storybook
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { downloadStorybookArtifact } = await import('${{ github.workspace }}/scripts/github-actions/downloadStorybookArtifact.mjs')

--- a/.github/workflows/project_issues.yml
+++ b/.github/workflows/project_issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Move issue to project column
-        uses: m7kvqbe1/github-action-move-issues@v1.0.7
+        uses: m7kvqbe1/github-action-move-issues@v1.3.0
         with:
           github-token: ${{ secrets.GHA_ISSUES_TOKEN }}
           project-url: 'https://github.com/orgs/Royal-Navy/projects/9'

--- a/.github/workflows/project_stale_issues.yml
+++ b/.github/workflows/project_stale_issues.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add label & comment to stale issues
-        uses: actions/stale@v5
+        uses: actions/stale@v10
         with:
           stale-issue-message: 'This issue has been marked as stale because it has been open for 60 days with no activity'
           days-before-stale: 60

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,19 +2,19 @@ name: Release
 
 on:
   schedule:
-    - cron: "0 4 * * 1-5"
+    - cron: '0 4 * * 1-5'
   workflow_dispatch:
 
 jobs:
   release:
-    name: "Release & Publish"
+    name: 'Release & Publish'
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Required for OIDC trusted publishing
       contents: write # Required for creating releases
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # pulls all commits (needed for lerna / semantic release to correctly version)
           fetch-depth: 0
@@ -24,17 +24,16 @@ jobs:
         # pulls all tags (needed for lerna / semantic release to correctly version)
         run: git fetch --all --tags
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v6
         with:
-          version: 9.1.1
           run_install: false
           standalone: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for trusted publishing
         run: npm install -g npm@latest


### PR DESCRIPTION
## Related issue

N/A

## Overview

Bumps every GitHub Action across our workflows (and the `prepare-environment` composite) to versions that run on the Node 24 runtime, clearing the "Node.js 20 is deprecated" warnings on every job.

## Reason

GitHub Actions runners now force Node 20 actions onto Node 24 and emit a deprecation warning for each one. Updating to Node 24-native action versions removes the warnings and keeps us ahead of the runtime being dropped entirely.

## Work carried out

- [x] `actions/checkout` `v4 → v5`, `actions/setup-node` `v4 → v5`, `actions/cache` `v4 → v5`
- [x] `actions/upload-artifact` `v4 → v7`, `actions/download-artifact` `v4 → v8`
- [x] `actions/github-script` `v7 → v8`, `actions/stale` `v5 → v10`
- [x] `actions/deploy-pages` `v4 → v5`, `actions/upload-pages-artifact` `v3 → v5`
- [x] `pnpm/action-setup` `v3 → v6` (+ removed the `version:` input — see notes)
- [x] `github/codeql-action/*` `v2 → v4` (v2 was also end-of-life)
- [x] `m7kvqbe1/github-action-move-issues` `v1.0.7 → v1.3.0`

## Developer notes

- **pnpm version source:** `pnpm/action-setup@v6` errors if the `version:` input is set *and* `package.json` has a `packageManager` field (we have `pnpm@9.1.1`). Removed the `version: 9.1.1` input from both pnpm steps so the version is read from `packageManager` — same pnpm version, no behaviour change.
- **Two warnings remain, no upstream fix yet:** `chromaui/action` and `m7kvqbe1/github-action-move-issues` have no Node 24 release. The latter is ours — clearing it means bumping that action's own `action.yml` to `using: node24` and cutting a release.
- `.nvmrc` (Node 20.18.0) is the project build runtime and is intentionally untouched — separate from the action runtimes.
- Several are large major jumps (e.g. `upload-artifact` v4→v7). Runtimes and tag existence were verified; the artifact up/download steps and the release flow are the bits most worth eyeing on first run.
