### PR TITLE
ci(Storybook): Check out PR head SHA to survive branch deletion

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -223,7 +223,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
+          # Check out the immutable head SHA rather than the branch name so the
+          # job survives the PR branch being deleted mid-run (e.g. merge races)
+          # and fork PRs. Matches CHROMATIC_SHA below.
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up environment
         uses: ./.github/actions/prepare-environment


### PR DESCRIPTION
## Related issue

N/A

## Overview

Fixes a spurious `Build_storybook` failure caused by the job re-checking-out the PR **branch by name**. When a PR is merged (and its branch auto-deleted) while the run is still in flight, the checkout fails with `A branch or tag with the name '<branch>' could not be found`. Switches to checking out the immutable head **SHA**.

## Reason

`ref: ${{ github.event.pull_request.head.ref }}` resolves the branch name on `origin` at checkout time, so it breaks on merge/branch-delete races and for fork PRs. The head SHA is immutable, remains reachable after the branch is gone, and matches the `CHROMATIC_SHA` the job already reports — so Chromatic builds exactly the commit it claims.

## Work carried out

- [x] `Build_storybook` checkout: `ref: …head.ref` → `ref: …head.sha`

## Developer notes

- Storybook itself builds fine on Node 24 — the linked failure was purely this checkout race, not a build error (confirmed: `Build_storybook` is green on `master` push runs).
- Only this one job used the branch-name ref; no other workflow is affected.
- Unrelated: `master` is currently red on `Test_react-component-library` due to the SonarQube token/admin issue, which is tracked separately.
