### PR TITLE
fix(Build): Emit type declarations under dist/types/src

### DIFF
--- a/packages/react-component-library/tsconfig.json
+++ b/packages/react-component-library/tsconfig.json
@@ -14,6 +14,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "outDir": "dist/types",
+    "rootDir": ".",
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "strict": true,


### PR DESCRIPTION
## Related issue

N/A

## Overview

Adds `"rootDir": "."` to `react-component-library/tsconfig.json` so type declarations emit to `dist/types/src/…`, matching the package's `types` / `exports.types` fields.

## Link to preview

N/A

## Reason

Since `4.51.3`, consumers with `moduleResolution: bundler`/`node16` get `TS7016 — Could not find a declaration file for '@royalnavy/react-component-library'` on **every** import: `types`/`exports.types` point at `dist/types/src/index.d.ts`, which no longer exists (the barrel moved to `dist/types/index.d.ts`).

Root cause: `8f6bba9ed` ("Exclude stories from declaration build") switched the type build to exclude `*.stories.tsx`. The stories were the only files importing outside `src/`, which had forced tsc's inferred `rootDir` to the package root (emitting under `dist/types/src/`). Without them, `rootDir` collapsed to `src`, stripping the prefix — but the `types` fields weren't updated. Setting `rootDir` explicitly decouples the output path from which files happen to be compiled, so it can't silently regress again.

Not caused by any component change — it was latent from `4.51.3` and only surfaced now because `4.52.0` is the first release consumed off a lockfile newer than `4.51.2`. DS CI doesn't resolve the package as an external module, so the mismatch was invisible in-repo.

## Work carried out

- [x] Add `"rootDir": "."` to `react-component-library/tsconfig.json`
- [x] Verified `dist/types/src/index.d.ts` emits and re-exports all components (incl. `NavigationCard`); no stray root barrel
- [x] Packed the build and confirmed a downstream app (`moduleResolution: bundler`) typechecks cleanly — `TS7016` gone

## Screenshot

N/A

## Developer notes

- Fix only, no source/API changes. Needs a patch release (`4.52.1`) so consumers can move off broken `4.51.3`/`4.52.0`.