### PR TITLE
feat(DataGrid): Add compact table prop for tighter spacing between rows

### DIFF
--- a/packages/react-component-library/src/components/DataGrid/Body.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Body.tsx
@@ -28,6 +28,10 @@ interface RowProps<T extends object> {
    * Total number of columns to display.
    */
   totalColumns: number
+  /**
+   * Whether to render the rows with tighter spacing.
+   */
+  compact?: boolean
 }
 
 interface BodyProps<T extends object> {
@@ -47,6 +51,10 @@ interface BodyProps<T extends object> {
    * Total number of columns to display.
    */
   totalColumns: number
+  /**
+   * Whether to render the rows with tighter spacing.
+   */
+  compact?: boolean
 }
 
 function isLastInBranch<T>(row: TanstackRow<T>, allRows: TanstackRow<T>[]) {
@@ -67,6 +75,7 @@ const Row = <T extends object>({
   enableRowSelection,
   hasHover,
   totalColumns,
+  compact,
 }: RowProps<T>) => {
   const normalCells = row
     .getVisibleCells()
@@ -91,6 +100,7 @@ const Row = <T extends object>({
             key={cell.id}
             as="td"
             $alignment={cell.column.columnDef.meta?.align}
+            $compact={compact}
             colSpan={1}
             $width={
               cell.column.getSize() === 150 ? undefined : cell.column.getSize()
@@ -118,6 +128,7 @@ const Row = <T extends object>({
             as="td"
             colSpan={totalColumns}
             $alignment={cell.column.columnDef.meta?.align}
+            $compact={compact}
             $hasBorder={index === fullSpanCells.length - 1}
           >
             {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -133,6 +144,7 @@ export const Body = <T extends object>({
   enableRowSelection,
   hasHover,
   totalColumns,
+  compact,
 }: BodyProps<T>) => {
   return (
     <StyledBody>
@@ -144,6 +156,7 @@ export const Body = <T extends object>({
             enableRowSelection={enableRowSelection}
             hasHover={hasHover}
             totalColumns={totalColumns}
+            compact={compact}
           />
         </React.Fragment>
       ))}

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.stories.tsx
@@ -166,6 +166,9 @@ export default {
     autoResetPageIndex: {
       control: 'boolean',
     },
+    compact: {
+      control: 'boolean',
+    },
   },
 } as Meta<typeof DataGrid>
 
@@ -184,6 +187,19 @@ Default.args = {
   onSelectedRowsChange: fn(),
   onExpandedChange: fn(),
   onColumnFiltersChange: fn(),
+}
+
+export const Compact: StoryFn<typeof DataGrid> = (props) => {
+  return (
+    <Wrapper>
+      <DataGrid {...props} />
+    </Wrapper>
+  )
+}
+
+Compact.args = {
+  ...Default.args,
+  compact: true,
 }
 
 export const ScrollingContent: StoryFn<typeof DataGrid> = (props) => {

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.test.tsx
@@ -11,7 +11,7 @@ import type {
   PaginationState,
 } from '@tanstack/react-table'
 import { userEvent, PointerEventsCheckLevel } from '@testing-library/user-event'
-import { color } from '@royalnavy/design-tokens'
+import { color, spacing } from '@royalnavy/design-tokens'
 
 import { DataGrid } from './DataGrid'
 import { Button } from '../Button'
@@ -1849,6 +1849,35 @@ describe('DataGrid', () => {
       expect(within(container).getByTestId('styled-tablehead')).toHaveStyleRule(
         'position',
         'sticky'
+      )
+    })
+  })
+
+  describe('compact', () => {
+    it('uses the default spacing when compact is not set', () => {
+      render(<DataGrid data={data} columns={columns} />)
+
+      expect(screen.getAllByRole('cell')[0]).toHaveStyleRule(
+        'padding',
+        `${spacing('9')} ${spacing('4')} ${spacing('9')} ${spacing('8')}`
+      )
+    })
+
+    it('tightens the row spacing when compact is set', () => {
+      render(<DataGrid data={data} columns={columns} compact />)
+
+      expect(screen.getAllByRole('cell')[0]).toHaveStyleRule(
+        'padding',
+        `${spacing('6')} ${spacing('4')} ${spacing('6')} ${spacing('8')}`
+      )
+    })
+
+    it('does not change the header spacing when compact is set', () => {
+      render(<DataGrid data={data} columns={columns} compact />)
+
+      expect(screen.getAllByRole('columnheader')[0]).toHaveStyleRule(
+        'padding',
+        `${spacing('9')} ${spacing('4')} ${spacing('9')} ${spacing('8')}`
       )
     })
   })

--- a/packages/react-component-library/src/components/DataGrid/DataGrid.tsx
+++ b/packages/react-component-library/src/components/DataGrid/DataGrid.tsx
@@ -155,6 +155,10 @@ export interface DataGridBaseProps<T extends object>
    * Defaults to true.
    */
   autoResetPageIndex?: boolean
+  /**
+   * Whether to render the grid rows with tighter spacing.
+   */
+  compact?: boolean
 }
 
 export interface DataGridPropsWithExternalSorting<T extends object>
@@ -311,6 +315,7 @@ export const DataGrid = <T extends object>(props: DataGridProps<T>) => {
     showRowsPerPageItemRange,
     totalCount,
     autoResetPageIndex,
+    compact,
     ...rest
   } = props
 
@@ -553,6 +558,7 @@ export const DataGrid = <T extends object>(props: DataGridProps<T>) => {
           hasSubRows={hasSubRows}
           layout={layout}
           totalColumns={totalColumns}
+          compact={compact}
         />
         {isLoading && (
           <StyledLoadingOverlay>

--- a/packages/react-component-library/src/components/DataGrid/Table.tsx
+++ b/packages/react-component-library/src/components/DataGrid/Table.tsx
@@ -45,6 +45,10 @@ interface TableProps<T extends object> {
    * scroll - The table will fit to the container height and scroll rows if needed.
    */
   layout?: TableLayout
+  /**
+   * Whether to render the table rows with tighter spacing.
+   */
+  compact?: boolean
 }
 
 export const Table = <T extends object>({
@@ -57,6 +61,7 @@ export const Table = <T extends object>({
   hasSubRows,
   totalColumns,
   layout = TABLE_DEFAULT_LAYOUT,
+  compact,
 }: TableProps<T>) => {
   const hasGroupedHeaders = useMemo(() => {
     return table.getHeaderGroups().reduce((acc, group) => {
@@ -82,6 +87,7 @@ export const Table = <T extends object>({
         enableRowSelection={enableRowSelection}
         hasHover={hasHover}
         totalColumns={totalColumns}
+        compact={compact}
       />
     </StyledTable>
   )

--- a/packages/react-component-library/src/components/DataGrid/partials/StyledCell.tsx
+++ b/packages/react-component-library/src/components/DataGrid/partials/StyledCell.tsx
@@ -5,10 +5,15 @@ interface StyledCellProps {
   $alignment?: 'left' | 'right' | 'center'
   $width?: number
   $hasBorder?: boolean
+  $compact?: boolean
 }
 
 export const StyledCell = styled.td<StyledCellProps>`
-  padding: ${spacing('9')} ${spacing('4')} ${spacing('9')} ${spacing('8')};
+  padding: ${({ $compact }) => {
+    const vertical = $compact ? spacing('6') : spacing('9')
+
+    return `${vertical} ${spacing('4')} ${vertical} ${spacing('8')}`
+  }};
   width: ${({ $width }) => ($width ? `${$width}px` : 'auto')};
   font-size: ${fontSize('s')};
   color: ${color('neutral', '400')};


### PR DESCRIPTION
## Overview

Adds an optional `compact` prop to `DataGrid`. When set, body cells use a tighter vertical padding of `spacing('6')` (0.75rem) instead of the default `spacing('9')` (1.125rem), reducing the row height so more rows fit in the same space. Horizontal cell padding and column header padding are unchanged, so column alignment and the header treatment stay exactly as they are today. The prop is threaded from `DataGrid` through `Table` and `Body` down to `StyledCell`, and defaults to off so existing usage is unaffected.

## Reason

MDDB are looking to tighten the data grid spacing in order to get more information on the screen. This change allows for a prop to be set instead of targetting the css within our app.

## Work carried out

- [x] Added a `compact` prop to `DataGridBaseProps` with documentation, destructured it in `DataGrid` so it is no longer spread into the tanstack table options
- [x] Passed `compact` through `Table` and `Body` (including full-span cells) to `StyledCell`
- [x] Updated `StyledCell` to use `spacing('6')` vertical padding when compact, `spacing('9')` otherwise
- [x] Left column header (`StyledCol`) padding untouched
- [x] Added a `Compact` Storybook story and a `compact` argType control

## Screenshot

<img width="1744" height="696" alt="Screenshot 2026-08-18 at 14 52 06" src="https://github.com/user-attachments/assets/e4bb0f4b-a788-4608-ac3b-ce1349a7e9c1" />

## Developer notes

`compact` is opt-in and defaults to `undefined`, so all existing DataGrid usage renders identically. Only the vertical padding changes; the horizontal `spacing('4')` / `spacing('8')` padding is preserved so columns stay aligned with the headers.
